### PR TITLE
Add prerelease option

### DIFF
--- a/packages/beachball/src/ChangeInfo.ts
+++ b/packages/beachball/src/ChangeInfo.ts
@@ -1,5 +1,7 @@
+export type ChangeType = 'prerelease' | 'patch' | 'minor' | 'major' | 'none';
+
 export interface ChangeInfo {
-  type: 'patch' | 'minor' | 'major' | 'none';
+  type: ChangeType;
   comment: string;
   packageName: string;
   email: string;

--- a/packages/beachball/src/bump.ts
+++ b/packages/beachball/src/bump.ts
@@ -1,19 +1,12 @@
-import { findPackageRoot, findGitRoot } from './paths';
+import { findGitRoot } from './paths';
 import { getPackageChangeTypes } from './changefile';
-import { getPackageInfos } from './monorepo';
+import { getPackageInfos, PackageInfo } from './monorepo';
 import { writeChangelog } from './changelog';
 import fs from 'fs';
-import glob from 'glob';
 import path from 'path';
 import semver from 'semver';
 
-export interface PackageInfo {
-  name: string;
-  packageJsonPath: string;
-  version: string;
-  dependencies: { [dep: string]: string };
-  devDependencies: { [dep: string]: string };
-}
+export type PackageInfo = PackageInfo;
 
 export type BumpInfo = ReturnType<typeof bump>;
 

--- a/packages/beachball/src/changelog.ts
+++ b/packages/beachball/src/changelog.ts
@@ -15,6 +15,7 @@ interface PackageChangelog {
   date: Date;
   version: string;
   comments: {
+    prerelease?: ChangelogEntry[];
     patch?: ChangelogEntry[];
     minor?: ChangelogEntry[];
     major?: ChangelogEntry[];
@@ -27,6 +28,7 @@ interface ChangelogJsonEntry {
   version: string;
   tag: string;
   comments: {
+    prerelease?: ChangelogEntry[];
     patch?: ChangelogEntry[];
     minor?: ChangelogEntry[];
     major?: ChangelogEntry[];
@@ -69,7 +71,7 @@ export function writeChangelog(packageInfos: { [pkg: string]: PackageInfo }, cwd
   Object.keys(changelogs).forEach(pkg => {
     const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
 
-    if (changelogs[pkg].comments.major || changelogs[pkg].comments.minor || changelogs[pkg].comments.patch) {
+    if (changelogs[pkg].comments.major || changelogs[pkg].comments.minor || changelogs[pkg].comments.patch || changelogs[pkg].comments.prerelease) {
       const changelogFile = path.join(packagePath, 'CHANGELOG.md');
       const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
       const nextContent = renderChangelog(previousContent, changelogs[pkg]);
@@ -130,6 +132,9 @@ function renderPackageChangelog(changelog: PackageChangelog) {
       : '') +
     (changelog.comments.patch
       ? '\n### Patches\n\n' + changelog.comments.patch.map(change => `- ${change.comment} (${change.author})\n`)
-      : '')
+      : '') +
+      (changelog.comments.prerelease
+        ? '\n### Changes\n\n' + changelog.comments.prerelease.map(change => `- ${change.comment} (${change.author})\n`)
+        : '')
   );
 }

--- a/packages/beachball/src/monorepo.ts
+++ b/packages/beachball/src/monorepo.ts
@@ -1,15 +1,19 @@
-import { searchUp, findPackageRoot } from './paths';
+import { findPackageRoot } from './paths';
 import fs from 'fs';
 import path from 'path';
 import { listAllTrackedFiles } from './git';
-import { fileURLToPath } from 'url';
 
 export interface PackageInfo {
   name: string;
   packageJsonPath: string;
   version: string;
-  dependencies: { [dep: string]: string };
-  devDependencies: { [dep: string]: string };
+  dependencies?: { [dep: string]: string };
+  devDependencies?: { [dep: string]: string };
+  disallowedChangeTypes: string[];
+}
+
+interface BeachBallPackageConfig {
+  disallowedChangeTypes?: string[];
 }
 
 export function getAllPackages(cwd: string): string[] {
@@ -17,23 +21,44 @@ export function getAllPackages(cwd: string): string[] {
   return Object.keys(infos);
 }
 
+function infoFromPackageJson(
+  packageJson: {
+    name: string;
+    version: string;
+    dependencies?: { [dep: string]: string };
+    devDependencies?: { [dep: string]: string };
+    beachball?: BeachBallPackageConfig;
+  },
+  packageJsonPath: string
+): PackageInfo {
+  return {
+    name: packageJson.name!,
+    version: packageJson.version,
+    packageJsonPath,
+    dependencies: packageJson.dependencies,
+    devDependencies: packageJson.devDependencies,
+    disallowedChangeTypes:
+      packageJson.beachball && packageJson.beachball.disallowedChangeTypes
+        ? packageJson.beachball.disallowedChangeTypes
+        : []
+  };
+}
+
 export function getPackageInfos(cwd: string) {
   const trackedFiles = listAllTrackedFiles(cwd);
-  const packageJsonFiles = trackedFiles.filter(file => path.basename(file) === 'package.json');
+  const packageJsonFiles = trackedFiles.filter(
+    file => path.basename(file) === 'package.json'
+  );
   const packageInfos: { [pkgName: string]: PackageInfo } = {};
 
   if (packageJsonFiles && packageJsonFiles.length > 0) {
     packageJsonFiles.forEach(packageJsonPath => {
       try {
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+        const packageJson = JSON.parse(
+          fs.readFileSync(packageJsonPath, 'utf-8')
+        );
 
-        packageInfos[packageJson.name] = {
-          name: packageJson.name,
-          version: packageJson.version,
-          packageJsonPath,
-          dependencies: packageJson.dependencies,
-          devDependencies: packageJson.devDependencies
-        };
+        return infoFromPackageJson(packageJson, packageJsonPath);
       } catch (e) {
         // Pass, the package.json is invalid
         console.warn(`Invalid package.json file detected ${packageJsonPath}`);
@@ -43,14 +68,10 @@ export function getPackageInfos(cwd: string) {
     const packageJsonPath = path.join(findPackageRoot(cwd)!, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
-    packageInfos[packageJson.name] = {
-      name: packageJson.name,
-      version: packageJson.version,
-      packageJsonPath,
-      dependencies: packageJson.dependencies,
-      devDependencies: packageJson.devDependencies
-    };
+    packageInfos[packageJson.name] = infoFromPackageJson(
+      packageJson,
+      packageJsonPath
+    );
   }
-
   return packageInfos;
 }

--- a/packages/beachball/src/monorepo.ts
+++ b/packages/beachball/src/monorepo.ts
@@ -58,7 +58,7 @@ export function getPackageInfos(cwd: string) {
           fs.readFileSync(packageJsonPath, 'utf-8')
         );
 
-        return infoFromPackageJson(packageJson, packageJsonPath);
+        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
       } catch (e) {
         // Pass, the package.json is invalid
         console.warn(`Invalid package.json file detected ${packageJsonPath}`);

--- a/packages/beachball/src/publish.ts
+++ b/packages/beachball/src/publish.ts
@@ -1,6 +1,6 @@
 import { bump, BumpInfo } from './bump';
 import { CliOptions } from './CliOptions';
-import { git, revertLocalChanges, getRemoteBranch, parseRemoteBranch, getBranchName, getFullBranchRef, getShortBranchName } from './git';
+import { git, revertLocalChanges, parseRemoteBranch, getBranchName } from './git';
 import { packagePublish, listPackageVersions } from './packageManager';
 import prompts from 'prompts';
 import { generateTag } from './tag';


### PR DESCRIPTION
Partial fix for #21.  I only expose the prerelease type if a package is already using a prerelease version number. -- which avoids adding the additional question and format change of storing the prerelease name.

I also added the ability for packages to disable changetypes on a per package basis.  -- I'm open to where to store that setting.  Currently its as a prop in package.json.