### PR TITLE
Allow packages to opt out of publishing

### DIFF
--- a/packages/beachball/src/changefile.ts
+++ b/packages/beachball/src/changefile.ts
@@ -29,11 +29,11 @@ export async function promptForChange(branch: string, specificPackage: string, c
       name: 'type',
       message: 'Change type',
       choices: [
-        ...(showPrereleaseOption ? [{value:'prerelease', title: 'Prerelease - bump prerelease version'}] : []),
-        { value: 'patch', title: 'Patch      - bug fixes; no backwards incompatible changes.' },
-        { value: 'minor', title: 'Minor      - small feature; backwards compatible changes.' },
-        { value: 'none', title: 'None       - this change does not affect the published package in any way.' },
-        { value: 'major', title: 'Major      - major feature; breaking changes.' }
+        ...(showPrereleaseOption ? [{value:'prerelease', title: ' [1mPrerelease[22m - bump prerelease version'}] : []),
+        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no backwards incompatible changes.' },
+        { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible changes.' },
+        { value: 'none', title: ' [1mNone[22m       - this change does not affect the published package in any way.' },
+        { value: 'major', title: ' [1mMajor[22m      - major feature; breaking changes.' }
       ].filter(choice => !packageInfos[pkg].disallowedChangeTypes.includes(choice.value))
     };
 

--- a/packages/beachball/src/getChangedPackages.ts
+++ b/packages/beachball/src/getChangedPackages.ts
@@ -21,7 +21,7 @@ function getAllChangedPackages(branch: string, cwd: string) {
         try {
           const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json')).toString());
 
-          if (!packageJson.private) {
+          if (!packageJson.private && (!packageJson.beachball || !packageJson.beachball.shouldPublish)) {
             const packageName = packageJson.name;
             packageRoots[root] = packageName;
           }

--- a/packages/website/content/docs/overview/configuration.md
+++ b/packages/website/content/docs/overview/configuration.md
@@ -1,0 +1,40 @@
+---
+title: 'Additional Configuration'
+tags: overview
+category: doc
+---
+
+For most uses you probably do not need any specific configuration on each package within your repository.  But there are a couple of options to customize `beachball`'s behavior.  These settings are specified in a `beachball` property in each package's `package.json`.  
+
+
+### disallowedChangeTypes
+
+If you want to restrict the change types that are available within a specific package `beachball` you can specify a list of change types that will be hidden from the options when creating change files.
+
+
+```json
+{
+  "beachball": {
+    "disallowedChangeTypes": [
+      "major",
+      "minor"
+    ]
+  }
+}
+```
+
+This will prevent the user from selecting `major` or `minor` for their change types for this package.  Effectively restricting the change types to `patch`.
+
+
+### shouldPublish
+
+By default `beachball` will not create change files for packages that are marked as private.  If you have a package that is not marked private, but that you want to manage the publishing of manually you can specify `shouldPublish` to be false.
+
+
+```json
+{
+  "beachball": {
+    "shouldPublish": false
+  }
+}
+```

--- a/packages/website/content/docs/table-of-contents.json
+++ b/packages/website/content/docs/table-of-contents.json
@@ -7,7 +7,8 @@
         { "entry": "./overview/getting-started.md" },
         { "entry": "./overview/installation.md" },
         { "entry": "./overview/change-files.md" },
-        { "entry": "./overview/ci-integration.md" }
+        { "entry": "./overview/ci-integration.md" },
+        { "entry": "./overview/configuration.md" }
       ],
       "chapters": []
     },


### PR DESCRIPTION
- Adds a new option that packages can specify in their package.json to have beachball ignore that package.  This package would be ignored the same as if the package was marked as private.
- Fixes #1  by bolding the changetype in the choices menu.
- Fixes #28 by adding some documentation.