### PR TITLE
Don't publish private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,21 @@ target branch from origin (default: master)
 
 custom message for the checkin (default: applying package updates)
 
+### `--no-push`
+
+skip pushing changes back to git remote origin
+
+### `--no-publish`
+
+skip publishing to the npm registry
+
 ### --help, -?, -h
 
-help message
+show help message
+
+### `--yes, -y`
+
+skips the prompts for publish
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ target branch from origin (default: master)
 
 custom message for the checkin (default: applying package updates)
 
-### `--no-push`
+### --no-push
 
 skip pushing changes back to git remote origin
 
-### `--no-publish`
+### --no-publish
 
 skip publishing to the npm registry
 
@@ -64,7 +64,7 @@ skip publishing to the npm registry
 
 show help message
 
-### `--yes, -y`
+### --yes, -y
 
 skips the prompts for publish
 

--- a/change/beachball-2019-08-21-16-55-19-dontPublishPrivate.json
+++ b/change/beachball-2019-08-21-16-55-19-dontPublishPrivate.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "modify logic to not run on private packages",
+  "packageName": "beachball",
+  "email": "legray@microsoft.com",
+  "commit": "0d6a560425d15d376c7382bb822fb8aa99315eb5",
+  "date": "2019-08-21T23:55:19.258Z"
+}

--- a/packages/beachball/src/bump.ts
+++ b/packages/beachball/src/bump.ts
@@ -1,6 +1,6 @@
 import { findGitRoot } from './paths';
 import { getPackageChangeTypes } from './changefile';
-import { getPackageInfos, PackageInfo } from './monorepo';
+import { getPublicPackageInfos, PackageInfo } from './monorepo';
 import { writeChangelog } from './changelog';
 import fs from 'fs';
 import path from 'path';
@@ -17,14 +17,14 @@ export function bump(cwd: string) {
   const packageChangeTypes = getPackageChangeTypes(cwd);
 
   // Gather all package info from package.json
-  const packageInfos = getPackageInfos(cwd);
+  const packageInfos = getPublicPackageInfos(cwd);
 
   // Apply package.json version updates
   Object.keys(packageChangeTypes).forEach(pkgName => {
     const info = packageInfos[pkgName];
 
     if (!info) {
-      console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
+      console.log(`Unknown public package named "${pkgName}" detected from change files, skipping!`);
       return;
     }
 

--- a/packages/beachball/src/changefile.ts
+++ b/packages/beachball/src/changefile.ts
@@ -5,7 +5,7 @@ import { getRecentCommitMessages, getUserEmail, getBranchName, getCurrentHash, s
 import fs from 'fs-extra';
 import path from 'path';
 import prompts from 'prompts';
-import { getPackageInfos } from './monorepo';
+import { getPublicPackageInfos } from './monorepo';
 import { prerelease } from 'semver';
 import { CliOptions } from './CliOptions';
 
@@ -20,7 +20,7 @@ export async function promptForChange(options: CliOptions) {
   const recentMessages = getRecentCommitMessages(branch, cwd) || [];
   const packageChangeInfo: { [pkgname: string]: ChangeInfo } = {};
 
-  const packageInfos = getPackageInfos(cwd);
+  const packageInfos = getPublicPackageInfos(cwd);
 
   for (let pkg of changedPackages) {
     console.log('');


### PR DESCRIPTION
Right now we assume that all valid packages mentioned in change files should be published to, but some of the packages - though valid - are private and should not be valid. This check filters our operational package information to only public ones.