### PR TITLE
Allow uncommitted changes as well as allowing staged changes

### DIFF
--- a/change/beachball-2019-09-03-12-47-10-uncommitted.json
+++ b/change/beachball-2019-09-03-12-47-10-uncommitted.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "allow staged files to be counted for changes as well",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "commit": "7c4f51cdf4131bbf415781dc8af98cc575a78f73",
+  "date": "2019-09-03T19:47:10.719Z"
+}

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -1,8 +1,13 @@
 import { bump } from './bump';
 import { CliOptions } from './CliOptions';
 import { findGitRoot } from './paths';
-import { getUncommittedChanges, getDefaultRemoteBranch } from './git';
-import { isChangeFileNeeded as checkChangeFileNeeded, isGitAvailable, isValidPackageName, isValidChangeType } from './validation';
+import { getUntrackedChanges, getDefaultRemoteBranch } from './git';
+import {
+  isChangeFileNeeded as checkChangeFileNeeded,
+  isGitAvailable,
+  isValidPackageName,
+  isValidChangeType,
+} from './validation';
 import { promptForChange, writeChangeFiles } from './changefile';
 import { publish } from './publish';
 import parser from 'yargs-parser';
@@ -18,8 +23,8 @@ let args = parser(argv, {
     token: ['n'],
     help: ['h', '?'],
     yes: ['y'],
-    package: ['p']
-  }
+    package: ['p'],
+  },
 });
 
 if (args.help) {
@@ -48,7 +53,7 @@ const options: CliOptions = {
   package: args.package || '',
   changehint: args.changehint || 'Run "beachball change" to create a change file',
   type: args.type || null,
-  fetch: args.fetch !== false
+  fetch: args.fetch !== false,
 };
 
 (async () => {
@@ -59,12 +64,12 @@ const options: CliOptions = {
     process.exit(1);
   }
 
-  const uncommitted = getUncommittedChanges(options.path);
+  const untracked = getUntrackedChanges(options.path);
 
-  if (uncommitted && uncommitted.length > 0) {
-    console.error('ERROR: There are uncommitted changes in your repository. Please commit these files first:');
-    console.error('- ' + uncommitted.join('\n- '));
-    process.exit(1);
+  if (untracked && untracked.length > 0) {
+    console.warn('WARN: There are untracked changes in your repository:');
+    console.warn('- ' + untracked.join('\n- '));
+    console.warn('Changes in these files will not trigger a prompt for change descriptions');
   }
 
   const isChangeNeeded = checkChangeFileNeeded(options.branch, options.path, options.fetch);

--- a/packages/beachball/src/getChangedPackages.ts
+++ b/packages/beachball/src/getChangedPackages.ts
@@ -1,6 +1,6 @@
 import { ChangeInfo } from './ChangeInfo';
 import { findPackageRoot, getChangePath } from './paths';
-import { getChanges, git, fetchAll } from './git';
+import { getChanges, getStagedChanges, git, fetchAll } from './git';
 import fs from 'fs';
 import path from 'path';
 
@@ -9,7 +9,7 @@ import path from 'path';
  * @param cwd
  */
 function getAllChangedPackages(branch: string, cwd: string) {
-  const changes = getChanges(branch, cwd);
+  const changes = [...(getChanges(branch, cwd) || []), ...(getStagedChanges(branch, cwd) || [])];
   const ignoredFiles = ['CHANGELOG.md', 'CHANGELOG.json'];
   const packageRoots: { [pathName: string]: string } = {};
   if (changes) {

--- a/packages/beachball/src/git.ts
+++ b/packages/beachball/src/git.ts
@@ -14,15 +14,15 @@ export function git(args: string[], options?: { cwd: string }) {
 
   if (results.status === 0) {
     return {
-      stderr: results.stderr.toString().trim(),
-      stdout: results.stdout.toString().trim(),
-      success: true
+      stderr: results.stderr.toString().trimRight(),
+      stdout: results.stdout.toString().trimRight(),
+      success: true,
     };
   } else {
     return {
-      stderr: results.stderr.toString().trim(),
-      stdout: results.stdout.toString().trim(),
-      success: false
+      stderr: results.stderr.toString().trimRight(),
+      stdout: results.stdout.toString().trimRight(),
+      success: false,
     };
   }
 }
@@ -36,15 +36,15 @@ export function gitFailFast(args: string[], options?: { cwd: string }) {
   const gitResult = git(args, options);
   if (!gitResult.success) {
     console.error(`CRITICAL ERROR: running git command: git ${args.join(' ')}!`);
-    console.error(gitResult.stdout && gitResult.stdout.toString().trim());
-    console.error(gitResult.stderr && gitResult.stderr.toString().trim());
+    console.error(gitResult.stdout && gitResult.stdout.toString().trimRight());
+    console.error(gitResult.stderr && gitResult.stderr.toString().trimRight());
     process.exit(1);
   }
 }
 
-export function getUncommittedChanges(cwd: string) {
+export function getUntrackedChanges(cwd: string) {
   try {
-    const results = git(['status', '--porcelain'], { cwd });
+    const results = git(['status', '-z'], { cwd });
 
     if (!results.success) {
       return [];
@@ -56,9 +56,20 @@ export function getUncommittedChanges(cwd: string) {
       return [];
     }
 
-    const lines = changes.split(/\n/) || [];
+    const lines = changes.split(/\0/).filter(line => line) || [];
 
-    return lines.map(line => line.trim().split(/\s+/)[1]);
+    const untracked: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line[0] === ' ' || line[0] === '?') {
+        untracked.push(line.substr(3));
+      } else if (line[0] === 'R') {
+        i++;
+      }
+    }
+
+    return untracked;
   } catch (e) {
     console.error('Cannot gather information about changes: ', e.message);
   }
@@ -75,6 +86,27 @@ export function fetchAll(cwd: string) {
 export function getChanges(branch: string, cwd: string) {
   try {
     const results = git(['--no-pager', 'diff', '--name-only', branch + '...'], { cwd });
+
+    if (!results.success) {
+      return [];
+    }
+
+    let changes = results.stdout;
+
+    let lines = changes.split(/\n/) || [];
+
+    return lines
+      .filter(line => line.trim() !== '')
+      .map(line => line.trim())
+      .filter(line => !line.includes('node_modules'));
+  } catch (e) {
+    console.error('Cannot gather information about changes: ', e.message);
+  }
+}
+
+export function getStagedChanges(branch: string, cwd: string) {
+  try {
+    const results = git(['--no-pager', 'diff', '--staged', '--name-only'], { cwd });
 
     if (!results.success) {
       return [];
@@ -219,7 +251,9 @@ export function getParentBranch(cwd: string) {
 
   if (showBranchResult.success) {
     const showBranchLines = showBranchResult.stdout.split(/\n/);
-    const parentLine = showBranchLines.find(line => line.indexOf('*') > -1 && line.indexOf(branchName) < 0 && line.indexOf('publish_') < 0);
+    const parentLine = showBranchLines.find(
+      line => line.indexOf('*') > -1 && line.indexOf(branchName) < 0 && line.indexOf('publish_') < 0
+    );
 
     if (!parentLine) {
       return null;
@@ -254,7 +288,7 @@ export function parseRemoteBranch(branch: string) {
 
   return {
     remote,
-    remoteBranch
+    remoteBranch,
   };
 }
 


### PR DESCRIPTION
#107 brought to the attention that during publish build jobs, uncommitted files can be generated. This should in no way affect `beachball check` or `beachball publish`. This change brings two features:

1. allows untracked files to be present - would not count towards change checks or publish. CAVEAT: those changes are published to npm registry as well, but will be lost from origin git repo after publish unless explicitly pushed by another process

2. allows staged files to be counted towards change file prompts - this can allow someone to work on the change file before the commit of the feature

