### PR TITLE
Ignore private package publishing

### DIFF
--- a/change/beachball-2019-10-04-08-03-36-private.json
+++ b/change/beachball-2019-10-04-08-03-36-private.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "fixed package publishing for private packages",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "commit": "72363ccc692514ac2129ecf46e73cd9d562762f1",
+  "date": "2019-10-04T15:03:36.210Z",
+  "file": "/Users/ken/workspace/beachball/change/beachball-2019-10-04-08-03-36-private.json"
+}

--- a/packages/beachball/src/PackageInfo.ts
+++ b/packages/beachball/src/PackageInfo.ts
@@ -1,0 +1,10 @@
+export interface PackageInfo {
+  name: string;
+  packageJsonPath: string;
+  version: string;
+  dependencies?: { [dep: string]: string };
+  devDependencies?: { [dep: string]: string };
+  disallowedChangeTypes: string[];
+  defaultNpmTag: string;
+  private: boolean;
+}

--- a/packages/beachball/src/changefile.ts
+++ b/packages/beachball/src/changefile.ts
@@ -8,6 +8,7 @@ import prompts from 'prompts';
 import { getPackageInfos } from './monorepo';
 import { prerelease } from 'semver';
 import { CliOptions } from './CliOptions';
+import { PackageInfo } from './PackageInfo';
 
 /**
  * Uses `prompts` package to prompt for change type and description, fills in git user.email, scope, and the commit hash
@@ -146,7 +147,7 @@ ${changeFiles.map(f => ` - ${f}`).join('\n')}
  * @param changes existing change files to be removed
  * @param cwd
  */
-export function unlinkChangeFiles(changes: ChangeInfo[], cwd: string) {
+export function unlinkChangeFiles(changes: ChangeInfo[], packageInfos: { [pkg: string]: PackageInfo }, cwd: string) {
   const changePath = getChangePath(cwd);
 
   if (!changePath || !changes) {
@@ -155,7 +156,7 @@ export function unlinkChangeFiles(changes: ChangeInfo[], cwd: string) {
 
   console.log('Removing change files:');
   for (const change of changes) {
-    if (change.file) {
+    if (change.file && packageInfos[change.packageName] && !packageInfos[change.packageName].private) {
       console.log(`- ${change.file}`);
       fs.removeSync(path.join(changePath, change.file));
     }

--- a/packages/beachball/src/fixtures/package.ts
+++ b/packages/beachball/src/fixtures/package.ts
@@ -1,17 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 import * as tmp from 'tmp';
-import { PackageInfo } from '../monorepo';
+import { PackageInfo } from '../PackageInfo';
 
 export const testTag = 'testbeachballtag';
 
 const testPackage = {
-  name: "testbeachballpackage",
-  version: "0.6.0"
+  name: 'testbeachballpackage',
+  version: '0.6.0',
 };
 
 // Create a test package.json in a temporary location for use in tests.
-var tmpPackageFile = path.join(tmp.dirSync().name, 'package.json')
+var tmpPackageFile = path.join(tmp.dirSync().name, 'package.json');
 
 var testPackageJson = JSON.stringify(testPackage);
 fs.writeFileSync(tmpPackageFile, testPackageJson, 'utf8');
@@ -22,5 +22,5 @@ export const testPackageInfo: PackageInfo = {
   defaultNpmTag: 'latest',
   version: testPackage.version,
   disallowedChangeTypes: [],
-  private: false
+  private: false,
 };

--- a/packages/beachball/src/monorepo.ts
+++ b/packages/beachball/src/monorepo.ts
@@ -2,17 +2,7 @@ import { findPackageRoot, findGitRoot } from './paths';
 import fs from 'fs';
 import path from 'path';
 import { listAllTrackedFiles } from './git';
-
-export interface PackageInfo {
-  name: string;
-  packageJsonPath: string;
-  version: string;
-  dependencies?: { [dep: string]: string };
-  devDependencies?: { [dep: string]: string };
-  disallowedChangeTypes: string[];
-  defaultNpmTag: string;
-  private: boolean;
-}
+import { PackageInfo } from './PackageInfo';
 
 interface BeachBallPackageConfig {
   defaultNpmTag?: string;

--- a/packages/beachball/src/publish.ts
+++ b/packages/beachball/src/publish.ts
@@ -200,6 +200,12 @@ function createTag(tag: string, cwd: string) {
 function tagPackages(bumpInfo: BumpInfo, tag: string, cwd: string) {
   Object.keys(bumpInfo.packageChangeTypes).forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
+
+    // Skip tagging for private packages
+    if (packageInfo.private) {
+      return;
+    }
+
     console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
     const generatedTag = generateTag(packageInfo.name, packageInfo.version);
     createTag(generatedTag, cwd);
@@ -216,6 +222,11 @@ function validatePackageVersions(bumpInfo: BumpInfo, registry: string) {
 
   Object.keys(bumpInfo.packageChangeTypes).forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
+
+    // Ignore private packages
+    if (packageInfo.private) {
+      return;
+    }
 
     process.stdout.write(`Validating package version - ${packageInfo.name}@${packageInfo.version}`);
 


### PR DESCRIPTION
Through some manual testing, private package publishes causes the publish to try to delete the change files for those private packages still. We should skip those actions as well as tagging.