### PR TITLE
deletes none type change files

### DIFF
--- a/change/beachball-2019-11-04-15-51-13-delete.json
+++ b/change/beachball-2019-11-04-15-51-13-delete.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "deletes none type change files",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "commit": "979cd078441993ad8b0ad5617003c9e204f47679",
+  "date": "2019-11-04T23:51:13.367Z"
+}

--- a/packages/beachball/src/CliOptions.ts
+++ b/packages/beachball/src/CliOptions.ts
@@ -14,4 +14,5 @@ export interface CliOptions {
   package: string;
   changehint: string;
   type?: 'patch' | 'minor' | 'major' | 'prerelease' | null;
+  version?: boolean;
 }

--- a/packages/beachball/src/bump.ts
+++ b/packages/beachball/src/bump.ts
@@ -56,6 +56,11 @@ export function performBump(
       return;
     }
 
+    if (packageChangeTypes[pkgName] === 'none') {
+      console.log(`"${pkgName}" has a "none" change type, no version bump is required.`);
+      return;
+    }
+
     if (info.private) {
       console.log(`Skipping bumping private package "${pkgName}"`);
       return;

--- a/packages/beachball/src/changefile.ts
+++ b/packages/beachball/src/changefile.ts
@@ -217,10 +217,6 @@ export function getPackageChangeTypes(changeSet: ChangeSet) {
   for (let [_, change] of changeSet) {
     const { packageName } = change;
 
-    if (change.type === 'none') {
-      continue;
-    }
-
     if (
       !changePerPackage[packageName] ||
       changeTypeWeights[change.type] > changeTypeWeights[changePerPackage[packageName]]

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -24,11 +24,17 @@ let args = parser(argv, {
     help: ['h', '?'],
     yes: ['y'],
     package: ['p'],
+    version: ['v'],
   },
 });
 
 if (args.help) {
   showHelp();
+  process.exit(0);
+}
+
+if (args.version) {
+  showVersion();
   process.exit(0);
 }
 
@@ -54,6 +60,7 @@ const options: CliOptions = {
   changehint: args.changehint || 'Run "beachball change" to create a change file',
   type: args.type || null,
   fetch: args.fetch !== false,
+  version: args.version === true || false,
 };
 
 (async () => {
@@ -122,11 +129,15 @@ const options: CliOptions = {
   }
 })();
 
-function showHelp() {
+function showVersion() {
   const packageJson = require('../package.json');
-  console.log(`beachball v${packageJson.version} - the sunniest version bumping tool
+  console.log(`beachball v${packageJson.version} - the sunniest version bumping tool`);
+}
 
-Prerequisites:
+function showHelp() {
+  showVersion();
+
+  console.log(`Prerequisites:
 
   git and a remote named "origin"
 

--- a/packages/beachball/src/publish.ts
+++ b/packages/beachball/src/publish.ts
@@ -19,6 +19,11 @@ export function publishToRegistry(bumpInfo: BumpInfo, options: CliOptions) {
 
   Object.keys(bumpInfo.packageChangeTypes).forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
+    const changeType = bumpInfo.packageChangeTypes[pkg];
+
+    if (changeType === 'none') {
+      return;
+    }
 
     if (!packageInfo.private) {
       console.log(`Publishing - ${packageInfo.name}@${packageInfo.version}`);
@@ -200,9 +205,10 @@ function createTag(tag: string, cwd: string) {
 function tagPackages(bumpInfo: BumpInfo, tag: string, cwd: string) {
   Object.keys(bumpInfo.packageChangeTypes).forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
+    const changeType = bumpInfo.packageChangeTypes[pkg];
 
-    // Skip tagging for private packages
-    if (packageInfo.private) {
+    // Do not tag change type of "none" or private packages
+    if (changeType === 'none' || packageInfo.private) {
       return;
     }
 
@@ -222,9 +228,10 @@ function validatePackageVersions(bumpInfo: BumpInfo, registry: string) {
 
   Object.keys(bumpInfo.packageChangeTypes).forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
+    const changeType = bumpInfo.packageChangeTypes[pkg];
 
-    // Ignore private packages
-    if (packageInfo.private) {
+    // Ignore private packages or change type "none" packages
+    if (changeType === 'none' || packageInfo.private) {
       return;
     }
 


### PR DESCRIPTION
Currently, if a package only has "none" type change files, the publish process does not even run the bump. This change allows the publish step to run and will delete the none change files.