### PR TITLE
Propagate dependent package change type

### DIFF
--- a/change/beachball-2020-01-16-11-55-27-propagate.json
+++ b/change/beachball-2020-01-16-11-55-27-propagate.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update depedent package bump logic to propagate the change types",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "commit": "39146f5f7094b19732e04659c7df8f7a3fc9922a",
+  "date": "2020-01-16T19:55:27.469Z"
+}

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -328,7 +328,7 @@ describe('version bumping', () => {
     expect(packageInfos['pkg-2'].version).toBe('1.1.0');
     expect(packageInfos['pkg-3'].version).toBe('1.1.0');
     expect(packageInfos['commonlib'].version).toBe('1.1.0');
-    expect(packageInfos['app'].version).toBe('1.0.1');
+    expect(packageInfos['app'].version).toBe('1.1.0');
     expect(packageInfos['unrelated'].version).toBe('1.0.0');
   });
 });

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -182,6 +182,65 @@ describe('updateRelatedChangeType', () => {
     expect(bumpInfo.packageChangeTypes['app']).toBe('minor');
   });
 
+  it('should propagate dependent change type across group', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependentChangeTypes: {
+        mergeStyles: 'minor',
+      },
+      dependents: {
+        mergeStyles: ['styling'],
+        styling: ['bar'],
+        utils: ['bar'],
+        bar: ['datetime'],
+        datetimeUtils: ['datetime'],
+      },
+      packageInfos: {
+        styling: {
+          name: 'styling',
+          dependencies: {
+            mergeStyles: '1.0.0',
+          },
+        },
+        utils: {
+          name: 'utils',
+        },
+        mergeStyles: {
+          name: 'mergeStyles',
+        },
+        foo: {
+          group: 'grp',
+        },
+        bar: {
+          group: 'grp',
+          dependencies: {
+            styling: '1.0.0',
+            utils: '1.0.0',
+          },
+        },
+        datetime: {
+          name: 'datetime',
+          dependencies: {
+            bar: '1.0.0',
+            datetimeUtils: '1.0.0',
+          },
+        },
+        datetimeUtils: {
+          name: 'app',
+        },
+      },
+      packageGroups: { grp: ['foo', 'bar'] },
+    });
+
+    updateRelatedChangeType('mergeStyles', 'patch', bumpInfo, true);
+    updateRelatedChangeType('datetimeUtils', 'patch', bumpInfo, true);
+
+    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['mergeStyles']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['datetime']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['datetimeUtils']).toBe('patch');
+  });
+
   it('should respect disallowed change type', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       packageInfos: {

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -179,7 +179,7 @@ describe('updateRelatedChangeType', () => {
     expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
     expect(bumpInfo.packageChangeTypes['dep']).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['app']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['app']).toBe('minor');
   });
 
   it('should respect disallowed change type', () => {

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -40,6 +40,7 @@ export function updateRelatedChangeType(
         groupOptions[groupName]?.disallowedChangeTypes
       );
 
+      // disregard the target disallowed types for now and will be culled at the subsequent update steps
       dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeType, dependentChangeTypes[groupPkgName], []);
     });
 
@@ -54,6 +55,8 @@ export function updateRelatedChangeType(
     new Set(dependentPackages).forEach(parent => {
       if (packageChangeTypes[parent] !== depChangeType) {
         // propagate the dependentChangeType of the current package to the subsequent related packages
+        dependentChangeTypes[parent] = depChangeType;
+
         updateRelatedChangeType(parent, depChangeType, bumpInfo, bumpDeps);
       }
     });

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -20,7 +20,7 @@ export function updateRelatedChangeType(
 ) {
   const { packageChangeTypes, packageGroups, dependents, packageInfos, dependentChangeTypes, groupOptions } = bumpInfo;
 
-  const disallowedChangeTypes = packageInfos[pkgName].options.disallowedChangeTypes;
+  const disallowedChangeTypes = packageInfos[pkgName].options?.disallowedChangeTypes ?? [];
 
   let depChangeType = getMaxChangeType('patch', dependentChangeTypes[pkgName], disallowedChangeTypes);
   let dependentPackages = dependents[pkgName];


### PR DESCRIPTION
I've also added an example of this in an unit test. The example is drawn / inspired by UI Fabric's orgnaization.