### PR TITLE
This adds a --scope for check and change that can be applied to repos that manages several groups of packages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--runInBand",
         "--config",
         "${workspaceRoot}/packages/beachball/jest.config.js",
-        "${fileBasename}"
+        "${fileBasenameNoExtension}}"
       ],
       "windows": {
         "args": [
@@ -24,7 +24,33 @@
           "--runInBand",
           "--config",
           "${workspaceRoot}/packages/beachball/jest.config.js",
-          "${fileBasename}"
+          "${fileBasenameNoExtension}"
+        ]
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest E2E Tests",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceRoot}/packages/beachball/jest.e2e.js",
+        "${fileBasenameNoExtension}"
+      ],
+      "windows": {
+        "args": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/jest/bin/jest.js",
+          "--runInBand",
+          "--config",
+          "${workspaceRoot}/packages/beachball/jest.config.js",
+          "${fileBasenameNoExtension}"
         ]
       },
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "Debug Unit Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "--inspect-brk",
@@ -33,7 +33,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest E2E Tests",
+      "name": "Debug E2E Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "--inspect-brk",
@@ -49,7 +49,7 @@
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
           "--config",
-          "${workspaceRoot}/packages/beachball/jest.config.js",
+          "${workspaceRoot}/packages/beachball/jest.e2e.js",
           "${fileBasenameNoExtension}"
         ]
       },

--- a/change/beachball-2020-03-03-14-54-02-scoped-check.json
+++ b/change/beachball-2020-03-03-14-54-02-scoped-check.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Adds a new feature to do scoping of checks and change",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "commit": "a0abcc58d5b41011d370b5751fce768339dff2d5",
+  "dependentChangeType": "patch",
+  "date": "2020-03-03T22:54:02.412Z"
+}

--- a/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
+++ b/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
@@ -1,0 +1,22 @@
+import { getScopedPackages } from '../../monorepo/getScopedPackages';
+import { BeachballOptions } from '../../types/BeachballOptions';
+import { MonoRepoFactory } from '../../fixtures/monorepo';
+
+describe('getScopedPackages', () => {
+  it('can scope packages', async () => {
+    const repoFactory = new MonoRepoFactory();
+    await repoFactory.create();
+    const repo = await repoFactory.cloneRepository();
+
+    const scopedPackages = getScopedPackages({
+      path: repo.rootPath,
+      scope: ['packages/grouped/*'],
+    } as BeachballOptions);
+
+    expect(scopedPackages.includes('a')).toBeTruthy();
+    expect(scopedPackages.includes('b')).toBeTruthy();
+
+    expect(scopedPackages.includes('foo')).toBeFalsy();
+    expect(scopedPackages.includes('bar')).toBeFalsy();
+  });
+});

--- a/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
+++ b/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
@@ -1,13 +1,18 @@
 import { getScopedPackages } from '../../monorepo/getScopedPackages';
 import { BeachballOptions } from '../../types/BeachballOptions';
 import { MonoRepoFactory } from '../../fixtures/monorepo';
+import { Repository } from '../../fixtures/repository';
 
 describe('getScopedPackages', () => {
-  it('can scope packages', async () => {
+  let repo: Repository;
+
+  beforeAll(async () => {
     const repoFactory = new MonoRepoFactory();
     await repoFactory.create();
-    const repo = await repoFactory.cloneRepository();
+    repo = await repoFactory.cloneRepository();
+  });
 
+  it('can scope packages', async () => {
     const scopedPackages = getScopedPackages({
       path: repo.rootPath,
       scope: ['packages/grouped/*'],
@@ -18,5 +23,31 @@ describe('getScopedPackages', () => {
 
     expect(scopedPackages.includes('foo')).toBeFalsy();
     expect(scopedPackages.includes('bar')).toBeFalsy();
+  });
+
+  it('can scope with excluded packages', async () => {
+    const scopedPackages = getScopedPackages({
+      path: repo.rootPath,
+      scope: ['!packages/grouped/*'],
+    } as BeachballOptions);
+
+    expect(scopedPackages.includes('a')).toBeFalsy();
+    expect(scopedPackages.includes('b')).toBeFalsy();
+
+    expect(scopedPackages.includes('foo')).toBeTruthy();
+    expect(scopedPackages.includes('bar')).toBeTruthy();
+  });
+
+  fit('can mix and match with excluded packages', async () => {
+    const scopedPackages = getScopedPackages({
+      path: repo.rootPath,
+      scope: ['packages/b*', '!packages/grouped/*'],
+    } as BeachballOptions);
+
+    expect(scopedPackages.includes('a')).toBeFalsy();
+    expect(scopedPackages.includes('b')).toBeFalsy();
+
+    expect(scopedPackages.includes('foo')).toBeFalsy();
+    expect(scopedPackages.includes('bar')).toBeTruthy();
   });
 });

--- a/packages/beachball/src/__e2e__/validation.test.ts
+++ b/packages/beachball/src/__e2e__/validation.test.ts
@@ -1,5 +1,6 @@
 import { RepositoryFactory, Repository } from '../fixtures/repository';
 import { isChangeFileNeeded } from '../validation/isChangeFileNeeded';
+import { BeachballOptions } from '../types/BeachballOptions';
 
 describe('validation', () => {
   let repositoryFactory: RepositoryFactory;
@@ -16,21 +17,33 @@ describe('validation', () => {
     });
 
     it('is false when no changes have been made', async () => {
-      const result = isChangeFileNeeded('origin/master', repository.rootPath, false);
+      const result = isChangeFileNeeded({
+        branch: 'origin/master',
+        path: repository.rootPath,
+        fetch: false,
+      } as BeachballOptions);
       expect(result).toBeFalsy();
     });
 
     it('is true when changes exist in a new branch', async () => {
       await repository.branch('feature-0');
       await repository.commitChange('myFilename');
-      const result = isChangeFileNeeded('origin/master', repository.rootPath, false);
+      const result = isChangeFileNeeded({
+        branch: 'origin/master',
+        path: repository.rootPath,
+        fetch: false,
+      } as BeachballOptions);
       expect(result).toBeTruthy();
     });
 
     it('is false when changes are CHANGELOG files', async () => {
       await repository.branch('feature-0');
       await repository.commitChange('CHANGELOG.md');
-      const result = isChangeFileNeeded('origin/master', repository.rootPath, false);
+      const result = isChangeFileNeeded({
+        branch: 'origin/master',
+        path: repository.rootPath,
+        fetch: false,
+      } as BeachballOptions);
       expect(result).toBeFalsy();
     });
 
@@ -40,7 +53,11 @@ describe('validation', () => {
       await repository.commitChange('CHANGELOG.md');
 
       expect(() => {
-        isChangeFileNeeded('origin/master', repository.rootPath, true);
+        isChangeFileNeeded({
+          branch: 'origin/master',
+          path: repository.rootPath,
+          fetch: true,
+        } as BeachballOptions);
       }).toThrow();
     });
   });

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -11,9 +11,9 @@ import { BeachballOptions } from '../types/BeachballOptions';
  * @param cwd
  */
 export async function promptForChange(options: BeachballOptions) {
-  const { branch, path: cwd, package: specificPackage, fetch } = options;
+  const { branch, path: cwd, package: specificPackage } = options;
 
-  const changedPackages = specificPackage ? [specificPackage] : getChangedPackages(branch, cwd, fetch);
+  const changedPackages = specificPackage ? [specificPackage] : getChangedPackages(options);
   const recentMessages = getRecentCommitMessages(branch, cwd) || [];
   const packageChangeInfo: { [pkgname: string]: ChangeInfo } = {};
 

--- a/packages/beachball/src/fixtures/exec.ts
+++ b/packages/beachball/src/fixtures/exec.ts
@@ -1,0 +1,46 @@
+import { exec as nativeExec } from 'child_process';
+
+export interface PsResult {
+  stderr: string;
+  status: Error | null;
+  stdout: string;
+}
+
+export function exec(command: string): Promise<PsResult> {
+  return new Promise(function(resolve, reject) {
+    nativeExec(command, (status, stdout, stderr) => {
+      const result = {
+        stderr,
+        stdout,
+        status,
+      };
+      if (status) {
+        reject(result);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+export async function runCommands(commands: string[]): Promise<void> {
+  for (let i = 0; i < commands.length; i++) {
+    try {
+      await exec(commands[i]);
+    } catch (e) {
+      console.error('runCommands failed:');
+      console.error(e.stdout);
+      console.error(e.stderr);
+      console.error(e);
+      console.error(e.message);
+      throw e;
+    }
+  }
+}
+
+export async function runInDirectory(targetDirectory: string, commands: string[]) {
+  const originalDirectory = process.cwd();
+  process.chdir(targetDirectory);
+  await runCommands(commands);
+  process.chdir(originalDirectory);
+}

--- a/packages/beachball/src/fixtures/monorepo.ts
+++ b/packages/beachball/src/fixtures/monorepo.ts
@@ -1,0 +1,93 @@
+import * as process from 'process';
+import path from 'path';
+import * as fs from 'fs-extra';
+import { promisify } from 'util';
+import { runCommands } from './exec';
+import { tmpdir, DirResult } from './tmpdir';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { Repository } from './repository';
+
+const writeFileAsync = promisify(fs.writeFile);
+
+export const packageJsonFixtures = {
+  'packages/foo': {
+    name: 'foo',
+    version: '1.0.0',
+    dependencies: {
+      bar: '^1.3.4',
+    },
+  },
+
+  'packages/bar': {
+    name: 'bar',
+    version: '1.3.4',
+  },
+
+  'packages/grouped/a': {
+    name: 'a',
+    version: '3.1.2',
+  },
+
+  'packages/grouped/b': {
+    name: 'b',
+    version: '3.1.2',
+    dependencies: ['bar'],
+  },
+};
+
+const beachballConfigFixture = {
+  groups: [
+    {
+      disallowedChangeTypes: null,
+      name: 'grouped',
+      include: 'grouped*',
+    },
+  ],
+} as BeachballOptions;
+
+export class MonoRepoFactory {
+  root?: DirResult;
+
+  async create(): Promise<void> {
+    const originalDirectory = process.cwd();
+
+    this.root = await tmpdir({ prefix: 'beachball-monorepository-upstream-' });
+    process.chdir(this.root!.name);
+    await runCommands(['git init --bare']);
+
+    const tmpRepo = new Repository();
+    await tmpRepo.initialize();
+    await tmpRepo.cloneFrom(this.root.name);
+    await tmpRepo.commitChange('README');
+
+    await Object.keys(packageJsonFixtures).reduce(async (p, pkg) => {
+      await p;
+      const packageJsonFixture = packageJsonFixtures[pkg];
+      const packageJsonFile = path.join(tmpRepo.rootPath, pkg, 'package.json');
+
+      fs.mkdirpSync(path.dirname(packageJsonFile));
+
+      await writeFileAsync(packageJsonFile, JSON.stringify(packageJsonFixture, null, 2));
+      await tmpRepo.commitChange(packageJsonFile);
+    }, Promise.resolve());
+
+    await tmpRepo.commitChange('package.json', JSON.stringify({ name: 'monorepo-fixture', version: '1.0.0' }, null, 2));
+    await tmpRepo.commitChange(
+      'beachball.config.js',
+      'module.exports = ' + JSON.stringify(beachballConfigFixture, null, 2)
+    );
+    await tmpRepo.push('origin', 'HEAD:master');
+
+    process.chdir(originalDirectory);
+  }
+
+  async cloneRepository(): Promise<Repository> {
+    if (!this.root) {
+      throw new Error('Must create before cloning');
+    }
+    const newRepo = new Repository();
+    await newRepo.initialize();
+    await newRepo.cloneFrom(this.root.name);
+    return newRepo;
+  }
+}

--- a/packages/beachball/src/fixtures/repository.ts
+++ b/packages/beachball/src/fixtures/repository.ts
@@ -1,9 +1,9 @@
-import { exec as nativeExec } from 'child_process';
 import * as process from 'process';
-import * as tmp from 'tmp';
 import path from 'path';
 import * as fs from 'fs-extra';
 import { promisify } from 'util';
+import { runCommands, runInDirectory } from './exec';
+import { tmpdir, DirResult } from './tmpdir';
 
 const writeFileAsync = promisify(fs.writeFile);
 const removeAsync = promisify(fs.remove);
@@ -13,70 +13,13 @@ export const packageJsonFixture = {
   version: '1.0.0',
 };
 
-async function dirAsync(options: tmp.DirOptions): Promise<tmp.DirResult> {
-  return new Promise((resolve, reject) => {
-    tmp.dir(options, (err, name, removeCallback) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve({ name, removeCallback });
-      }
-    });
-  });
-}
-
-interface PsResult {
-  stderr: string;
-  status: Error | null;
-  stdout: string;
-}
-
-function exec(command: string): Promise<PsResult> {
-  return new Promise(function(resolve, reject) {
-    nativeExec(command, (status, stdout, stderr) => {
-      const result = {
-        stderr,
-        stdout,
-        status,
-      };
-      if (status) {
-        reject(result);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-}
-
-async function runCommands(commands: string[]): Promise<void> {
-  for (let i = 0; i < commands.length; i++) {
-    try {
-      await exec(commands[i]);
-    } catch (e) {
-      console.error('runCommands failed:');
-      console.error(e.stdout);
-      console.error(e.stderr);
-      console.error(e);
-      console.error(e.message);
-      throw e;
-    }
-  }
-}
-
-async function runInDirectory(targetDirectory: string, commands: string[]) {
-  const originalDirectory = process.cwd();
-  process.chdir(targetDirectory);
-  await runCommands(commands);
-  process.chdir(originalDirectory);
-}
-
 export class RepositoryFactory {
-  root?: tmp.DirResult;
+  root?: DirResult;
 
   async create(): Promise<void> {
     const originalDirectory = process.cwd();
 
-    this.root = await dirAsync({ prefix: 'beachball-repository-upstream-' });
+    this.root = await tmpdir({ prefix: 'beachball-repository-upstream-' });
     process.chdir(this.root!.name);
     await runCommands(['git init --bare']);
 
@@ -106,10 +49,10 @@ export class RepositoryFactory {
 export class Repository {
   origin?: string;
 
-  root?: tmp.DirResult;
+  root?: DirResult;
 
   async initialize() {
-    this.root = await dirAsync({ prefix: 'beachball-repository-cloned-' });
+    this.root = await tmpdir({ prefix: 'beachball-repository-cloned-' });
   }
 
   get rootPath(): string {

--- a/packages/beachball/src/fixtures/tmpdir.ts
+++ b/packages/beachball/src/fixtures/tmpdir.ts
@@ -1,0 +1,15 @@
+import * as tmp from 'tmp';
+
+export type DirResult = tmp.DirResult;
+
+export async function tmpdir(options: tmp.DirOptions): Promise<tmp.DirResult> {
+  return new Promise((resolve, reject) => {
+    tmp.dir(options, (err, name, removeCallback) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ name, removeCallback });
+      }
+    });
+  });
+}

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -2,7 +2,7 @@ import { findPackageRoot, findGitRoot } from '../paths';
 import fs from 'fs';
 import path from 'path';
 import { listAllTrackedFiles } from '../git';
-import { PackageInfo, PackageInfos } from '../types/PackageInfo';
+import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 export function getPackageInfos(cwd: string) {
   const gitRoot = findGitRoot(cwd)!;

--- a/packages/beachball/src/monorepo/getScopedPackages.ts
+++ b/packages/beachball/src/monorepo/getScopedPackages.ts
@@ -1,0 +1,14 @@
+import { BeachballOptions } from '../types/BeachballOptions';
+import { getAllPackages } from './getAllPackages';
+import minimatch from 'minimatch';
+
+export function getScopedPackages(options: BeachballOptions) {
+  const allPackages = getAllPackages(options.path);
+  if (!options.scope) {
+    return allPackages;
+  }
+
+  return allPackages.filter(pkg => {
+    return options.scope?.some(scope => minimatch(pkg, scope));
+  });
+}

--- a/packages/beachball/src/monorepo/getScopedPackages.ts
+++ b/packages/beachball/src/monorepo/getScopedPackages.ts
@@ -6,7 +6,7 @@ import path from 'path';
 export function getScopedPackages(options: BeachballOptions) {
   const packageInfos = getPackageInfos(options.path);
   if (!options.scope) {
-    return packageInfos;
+    return Object.keys(packageInfos);
   }
 
   const scopes = options.scope!.map(scope => path.join(options.path, scope));

--- a/packages/beachball/src/monorepo/getScopedPackages.ts
+++ b/packages/beachball/src/monorepo/getScopedPackages.ts
@@ -1,14 +1,22 @@
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getAllPackages } from './getAllPackages';
+import { getPackageInfos } from './getPackageInfos';
 import minimatch from 'minimatch';
+import path from 'path';
 
 export function getScopedPackages(options: BeachballOptions) {
-  const allPackages = getAllPackages(options.path);
+  const packageInfos = getPackageInfos(options.path);
   if (!options.scope) {
-    return allPackages;
+    return packageInfos;
   }
 
-  return allPackages.filter(pkg => {
-    return options.scope?.some(scope => minimatch(pkg, scope));
-  });
+  const scopes = options.scope!.map(scope => path.join(options.path, scope));
+  const scopedPackages: string[] = [];
+
+  for (let [pkgName, info] of Object.entries(packageInfos)) {
+    if (scopes.some(scope => minimatch(path.dirname(info.packageJsonPath), scope))) {
+      scopedPackages.push(pkgName);
+    }
+  }
+
+  return scopedPackages;
 }

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -14,6 +14,7 @@ export function getCliOptions(): CliOptions {
   const argv = process.argv.splice(2);
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package'],
+    array: ['scope'],
     alias: {
       branch: ['b'],
       tag: ['t'],

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -19,5 +19,6 @@ export function getDefaultOptions() {
     version: false,
     disallowedChangeTypes: null,
     defaultNpmTag: 'latest',
+    scope: null,
   } as BeachballOptions;
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -23,6 +23,7 @@ export interface CliOptions {
   help?: boolean;
   version?: boolean;
   groups?: VersionGroupOptions[];
+  scope?: string[] | null;
 }
 
 export interface RepoOptions {

--- a/packages/beachball/src/validation/isChangeFileNeeded.ts
+++ b/packages/beachball/src/validation/isChangeFileNeeded.ts
@@ -1,7 +1,10 @@
 import { getChangedPackages } from '../changefile/getChangedPackages';
-export function isChangeFileNeeded(branch: string, cwd: string, fetch: boolean) {
+import { BeachballOptions } from '../types/BeachballOptions';
+export function isChangeFileNeeded(options: BeachballOptions) {
+  const { branch, path: cwd, fetch } = options;
+
   console.log(`Checking for changes against "${branch}"`);
-  const changedPackages = getChangedPackages(branch, cwd, fetch);
+  const changedPackages = getChangedPackages(options);
   if (changedPackages.length > 0) {
     console.log(
       `Found changes in the following packages: ${[...changedPackages]

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -34,7 +34,7 @@ export function validate(
     process.exit(1);
   }
 
-  const isChangeNeeded = isChangeFileNeeded(options.branch, options.path, options.fetch);
+  const isChangeNeeded = isChangeFileNeeded(options);
 
   if (isChangeNeeded && !validateOptions.allowMissingChangeFiles) {
     console.error('ERROR: Change files are needed!');


### PR DESCRIPTION
In this change, we added a param called "scope". For now, it applies to change and check so that those commands can make checks / change files only for scoped packages.

For example: 

```
beachball change --scope packages/grouped/*
```