### PR TITLE
Scoped publish: make sure to skip validation/publish for out-of-scope package

### DIFF
--- a/change/beachball-2020-03-06-15-22-54-xgao-publish-fix.json
+++ b/change/beachball-2020-03-06-15-22-54-xgao-publish-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Scoped publish: make sure toskip validation/publish for out-of-scope package",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "commit": "ffe05b2858745d25f6a4b6810fa5dc87ad8ed271",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T23:22:54.807Z"
+}

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -18,6 +18,11 @@ export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions)
   }
 
   [...modifiedPackages, ...newPackages].forEach(pkg => {
+    if (!bumpInfo.scopedPackages.has(pkg)) {
+      console.log(`Skipping publish for out-of-scope package ${pkg}`);
+      return;
+    }
+
     const packageInfo = bumpInfo.packageInfos[pkg];
     const changeType = bumpInfo.packageChangeTypes[pkg];
     if (changeType === 'none') {

--- a/packages/beachball/src/publish/validatePackageVersions.ts
+++ b/packages/beachball/src/publish/validatePackageVersions.ts
@@ -1,14 +1,26 @@
 import { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
+
 export function validatePackageVersions(bumpInfo: BumpInfo, registry: string) {
   let hasErrors: boolean = false;
   bumpInfo.modifiedPackages.forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
     const changeType = bumpInfo.packageChangeTypes[pkg];
-    // Ignore private packages or change type "none" packages
-    if (changeType === 'none' || packageInfo.private) {
+
+    if (changeType === 'none') {
+      console.log(`Skipping change type as none package ${pkg}`);
       return;
     }
+
+    if (packageInfo.private) {
+      console.log(`Skipping private package ${pkg}`);
+      return;
+    }
+    if (!bumpInfo.scopedPackages.has(pkg)) {
+      console.log(`Skipping out-of-scope package ${pkg}`);
+      return;
+    }
+
     process.stdout.write(`Validating package version - ${packageInfo.name}@${packageInfo.version}`);
     const publishedVersions = listPackageVersions(packageInfo.name, registry);
     if (publishedVersions.includes(packageInfo.version)) {


### PR DESCRIPTION
To fix :
https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=56802&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=0db80ebc-3da9-5105-8df1-43c3063dee76&l=153

`modifiedPackages` can included the out-of-scoped package bc we still update `dependencies` for scoped out package