### PR TITLE
Fix promptChangeFiles to honor disallowedChangeTypes defined in version groups

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--runInBand",
         "--config",
         "${workspaceRoot}/packages/beachball/jest.config.js",
-        "${fileBasenameNoExtension}}"
+        "${fileBasenameNoExtension}"
       ],
       "windows": {
         "args": [

--- a/change/beachball-2020-03-20-13-12-52-xgao-fix-disallow-type-groups.json
+++ b/change/beachball-2020-03-20-13-12-52-xgao-fix-disallow-type-groups.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix promptChangeFiles to honor disallowedChangeTypes defined in version groups",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "commit": "632170f7e1bcf16cfdf06551cd671a45d754a857",
+  "dependentChangeType": "patch",
+  "date": "2020-03-20T20:12:52.561Z"
+}

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -92,7 +92,7 @@ describe('updateRelatedChangeType', () => {
         },
         unrelated: {},
       },
-      packageGroups: { grp: ['foo', 'bar'] },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
     updateRelatedChangeType('foo', 'minor', bumpInfo, true);
@@ -129,7 +129,7 @@ describe('updateRelatedChangeType', () => {
           options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
-      packageGroups: { grp: ['foo', 'bar'] },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
     updateRelatedChangeType('dep', 'patch', bumpInfo, true);
@@ -171,7 +171,7 @@ describe('updateRelatedChangeType', () => {
           options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
-      packageGroups: { grp: ['foo', 'bar'] },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
     updateRelatedChangeType('dep', 'patch', bumpInfo, true);
@@ -228,7 +228,7 @@ describe('updateRelatedChangeType', () => {
           name: 'app',
         },
       },
-      packageGroups: { grp: ['foo', 'bar'] },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
     updateRelatedChangeType('mergeStyles', 'patch', bumpInfo, true);

--- a/packages/beachball/src/__tests__/changefile/getPackageChangeTypes.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getPackageChangeTypes.test.ts
@@ -6,7 +6,7 @@ describe('getAllowedChangeTypes', () => {
     expect(changeType).toBe('patch');
   });
 
-  fit('can handle prerelease only case', () => {
+  it('can handle prerelease only case', () => {
     const changeType = getAllowedChangeType('patch', ['major', 'minor', 'patch']);
     expect(changeType).toBe('prerelease');
   });

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -28,12 +28,12 @@ export function updateRelatedChangeType(
   // Handle groups
   packageChangeTypes[pkgName] = getMaxChangeType(changeType, packageChangeTypes[pkgName], disallowedChangeTypes);
 
-  if (packageInfos[pkgName].group) {
+  const groupName = packageInfos[pkgName].group;
+  if (groupName) {
     let maxGroupChangeType = depChangeType;
-    const groupName = packageInfos[pkgName].group!;
 
     // calculate maxChangeType
-    packageGroups[groupName].forEach(groupPkgName => {
+    packageGroups[groupName].packageNames.forEach(groupPkgName => {
       maxGroupChangeType = getMaxChangeType(
         maxGroupChangeType,
         packageChangeTypes[groupPkgName],
@@ -44,7 +44,7 @@ export function updateRelatedChangeType(
       dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeType, dependentChangeTypes[groupPkgName], []);
     });
 
-    packageGroups[groupName].forEach(groupPkgName => {
+    packageGroups[groupName].packageNames.forEach(groupPkgName => {
       if (packageChangeTypes[groupPkgName] !== maxGroupChangeType) {
         updateRelatedChangeType(groupPkgName, maxGroupChangeType, bumpInfo, bumpDeps);
       }

--- a/packages/beachball/src/monorepo/getPackageGroups.ts
+++ b/packages/beachball/src/monorepo/getPackageGroups.ts
@@ -1,5 +1,4 @@
-import { BeachballOptions, VersionGroupOptions } from '../types/BeachballOptions';
-import { getPackageInfos } from './getPackageInfos';
+import { VersionGroupOptions } from '../types/BeachballOptions';
 import path from 'path';
 import minimatch from 'minimatch';
 import { PackageInfos, PackageGroups } from '../types/PackageInfo';
@@ -32,16 +31,25 @@ export function getPackageGroups(packageInfos: PackageInfos, root: string, group
 
       for (const groupOption of groups) {
         if (isInGroup(relativePath, groupOption)) {
+          const groupName = groupOption.name;
+
           if (packageInfos[pkgName].group) {
             console.error(
-              `Error: ${pkgName} cannot belong to multiple groups: [${groupOption.name}, ${packageInfos[pkgName].group}]!`
+              `Error: ${pkgName} cannot belong to multiple groups: [${groupName}, ${packageInfos[pkgName].group}]!`
             );
             process.exit(1);
           }
 
-          packageInfos[pkgName].group = groupOption.name;
-          packageGroups[groupOption.name] = packageGroups[groupOption.name] || [];
-          packageGroups[groupOption.name].push(pkgName);
+          packageInfos[pkgName].group = groupName;
+
+          if (!packageGroups[groupName]) {
+            packageGroups[groupName] = {
+              packageNames: [],
+              disallowedChangeTypes: groupOption.disallowedChangeTypes,
+            };
+          }
+
+          packageGroups[groupName].packageNames.push(pkgName);
         }
       }
     }

--- a/packages/beachball/src/types/PackageInfo.ts
+++ b/packages/beachball/src/types/PackageInfo.ts
@@ -1,4 +1,5 @@
 import { PackageOptions } from './BeachballOptions';
+import { ChangeType } from './ChangeInfo';
 
 export interface PackageInfo {
   name: string;
@@ -16,4 +17,9 @@ export interface PackageInfos {
   [pkgName: string]: PackageInfo;
 }
 
-export type PackageGroups = { [pkgName: string]: string[] };
+export interface PackageGroupsInfo {
+  packageNames: string[];
+  disallowedChangeTypes: ChangeType[] | null;
+}
+
+export type PackageGroups = { [groupName: string]: PackageGroupsInfo };

--- a/packages/beachball/src/validation/isValidGroupOptions.ts
+++ b/packages/beachball/src/validation/isValidGroupOptions.ts
@@ -18,7 +18,7 @@ export function isValidGroupOptions(root: string, groups: VersionGroupOptions[])
   // make sure no disallowed changetype options exist inside an individual package
 
   for (const grp of Object.keys(packageGroups)) {
-    const pkgs = packageGroups[grp];
+    const pkgs = packageGroups[grp].packageNames;
     for (const pkgName of pkgs) {
       if (packageInfos[pkgName].options.disallowedChangeTypes) {
         console.error(


### PR DESCRIPTION
Currently when prompting change type for change files, we only filter using `disallowedChangeTypes` defined at top level. Instead we should be looking at the `disallowedChangeTypes` defined in version groups as well.