### PR TITLE
Fix version group bumping with none change type

### DIFF
--- a/change/beachball-2020-03-20-16-02-29-xgao-version-group-fix.json
+++ b/change/beachball-2020-03-20-16-02-29-xgao-version-group-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix version group bumping logic",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "commit": "42fc3bc037fbaf2bdf27d4b501af011f3652e145",
+  "dependentChangeType": "patch",
+  "date": "2020-03-20T23:02:29.230Z"
+}

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -78,7 +78,7 @@ describe('updateRelatedChangeType', () => {
     expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
   });
 
-  it('should bump all packages in a group together', () => {
+  it('should bump all packages in a group together as minor', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       dependentChangeTypes: {
         foo: 'minor',
@@ -99,6 +99,81 @@ describe('updateRelatedChangeType', () => {
 
     expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+  });
+
+  it('should bump all packages in a group together as patch', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependentChangeTypes: {
+        foo: 'patch',
+      },
+      packageInfos: {
+        foo: {
+          group: 'grp',
+        },
+        bar: {
+          group: 'grp',
+        },
+        unrelated: {},
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+    });
+
+    updateRelatedChangeType('foo', 'patch', bumpInfo, true);
+
+    expect(bumpInfo.packageChangeTypes['foo']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+  });
+
+  it('should bump all packages in a group together as none', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependentChangeTypes: {
+        foo: 'patch',
+      },
+      packageInfos: {
+        foo: {
+          group: 'grp',
+        },
+        bar: {
+          group: 'grp',
+        },
+        unrelated: {},
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+    });
+
+    updateRelatedChangeType('foo', 'none', bumpInfo, true);
+
+    expect(bumpInfo.packageChangeTypes['foo']).toBe('none');
+    expect(bumpInfo.packageChangeTypes['bar']).toBe('none');
+    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+  });
+
+  it('should bump all packages in a group together as none with dependents', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependents: {
+        foo: ['bar'],
+      },
+      dependentChangeTypes: {
+        foo: 'none',
+      },
+      packageInfos: {
+        foo: {
+          group: 'grp',
+        },
+        bar: {
+          group: 'grp',
+        },
+        unrelated: {},
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+    });
+
+    updateRelatedChangeType('foo', 'none', bumpInfo, true);
+
+    expect(bumpInfo.packageChangeTypes['foo']).toBe('none');
+    expect(bumpInfo.packageChangeTypes['bar']).toBe('none');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -1,4 +1,4 @@
-import { getMaxChangeType, getAllowedChangeType } from '../changefile/getPackageChangeTypes';
+import { getMaxChangeType, MinChangeType } from '../changefile/getPackageChangeTypes';
 import { ChangeType } from '../types/ChangeInfo';
 import { BumpInfo } from '../types/BumpInfo';
 
@@ -22,7 +22,7 @@ export function updateRelatedChangeType(
 
   const disallowedChangeTypes = packageInfos[pkgName].options?.disallowedChangeTypes ?? [];
 
-  let depChangeType = getMaxChangeType('patch', dependentChangeTypes[pkgName], disallowedChangeTypes);
+  let depChangeType = getMaxChangeType(MinChangeType, dependentChangeTypes[pkgName], disallowedChangeTypes);
   let dependentPackages = dependents[pkgName];
 
   // Handle groups
@@ -30,7 +30,7 @@ export function updateRelatedChangeType(
 
   const groupName = packageInfos[pkgName].group;
   if (groupName) {
-    let maxGroupChangeType = depChangeType;
+    let maxGroupChangeType: ChangeType = MinChangeType;
 
     // calculate maxChangeType
     packageGroups[groupName].packageNames.forEach(groupPkgName => {

--- a/packages/beachball/src/changefile/getPackageChangeTypes.ts
+++ b/packages/beachball/src/changefile/getPackageChangeTypes.ts
@@ -3,6 +3,11 @@ import { ChangeInfo, ChangeSet, ChangeType } from '../types/ChangeInfo';
 const SortedChangeTypes: ChangeType[] = ['none', 'prerelease', 'patch', 'minor', 'major'];
 
 /**
+ * Change type with the smallest weight.
+ */
+export const MinChangeType = SortedChangeTypes[0];
+
+/**
  *  Change type weights
  *  Note: the order in which this is defined is IMPORTANT
  */

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -87,7 +87,7 @@ export async function promptForChange(options: BeachballOptions) {
       packageName: pkg,
       email: getUserEmail(cwd) || 'email not defined',
       commit: getCurrentHash(cwd) || 'hash not available',
-      dependentChangeType: 'patch',
+      dependentChangeType: response.type === 'none' ? 'none' : 'patch',
       date: new Date(),
     };
   }


### PR DESCRIPTION
when a package inside a group is bumped with `none` change type, it's always bumped as `patch` due to we use `patch` as default in `updateRelatedChangeType`

also fixed default `dependentChangeType` value in change file. if change is `none`, do not set `dependentChangeType` to `patch`