### PR TITLE
ChangeLog: add empty options interface

### DIFF
--- a/change/beachball-2020-03-23-13-52-29-xgao-changelog-1.json
+++ b/change/beachball-2020-03-23-13-52-29-xgao-changelog-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ChangeLog: add empty options interface",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T20:52:29.418Z"
+}

--- a/packages/beachball/src/options/getOptions.ts
+++ b/packages/beachball/src/options/getOptions.ts
@@ -6,5 +6,11 @@ import { getDefaultOptions } from './getDefaultOptions';
  * Gets all repo level options (default + root options + cli options)
  */
 export function getOptions(): BeachballOptions {
-  return { ...getDefaultOptions(), ...getRootOptions(), ...getCliOptions() };
+  const defaultOptions = getDefaultOptions();
+  const rootOptions = getRootOptions();
+  const cliOptions = getCliOptions();
+
+  console.log('rootOptionss', rootOptions);
+  console.log('cliOptions', cliOptions);
+  return { ...defaultOptions, ...rootOptions, ...cliOptions };
 }

--- a/packages/beachball/src/options/getOptions.ts
+++ b/packages/beachball/src/options/getOptions.ts
@@ -6,11 +6,5 @@ import { getDefaultOptions } from './getDefaultOptions';
  * Gets all repo level options (default + root options + cli options)
  */
 export function getOptions(): BeachballOptions {
-  const defaultOptions = getDefaultOptions();
-  const rootOptions = getRootOptions();
-  const cliOptions = getCliOptions();
-
-  console.log('rootOptionss', rootOptions);
-  console.log('cliOptions', cliOptions);
-  return { ...defaultOptions, ...rootOptions, ...cliOptions };
+  return { ...getDefaultOptions(), ...getRootOptions(), ...getCliOptions() };
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -22,7 +22,6 @@ export interface CliOptions {
   type?: ChangeType | null;
   help?: boolean;
   version?: boolean;
-  groups?: VersionGroupOptions[];
   scope?: string[] | null;
 }
 
@@ -40,6 +39,8 @@ export interface RepoOptions {
   changehint: string;
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
+  groups?: VersionGroupOptions[];
+  changeLog?: ChangeLogOptions;
 }
 
 export interface PackageOptions {
@@ -59,3 +60,8 @@ export interface VersionGroupOptions {
   /** name of the version group */
   name: string;
 }
+
+/**
+ * Options for change log related configurations.
+ */
+export interface ChangeLogOptions {}


### PR DESCRIPTION
We will later add options such as:
`enablePRLink` to enable adding PR link for each change (#274)
 `groups` to enable generating aggregated change log for multiple packages (#277)

Note: parsing logic is already done in `getRootOptions`