### PR TITLE
Add a readme back to the beachball package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!--
+If making changes, don't forget to update the version under packages/beachball/README.md too!
+-->
+
 # beachball
 
 the sunniest version bumping tool
@@ -77,3 +81,7 @@ skips the prompts for publish
 
   $ beachball publish -r http://localhost:4873 -t beta
 ```
+
+<!--
+If making changes, don't forget to update the version under packages/beachball/README.md too!
+-->

--- a/change/beachball-2020-03-24-17-36-31-readme.json
+++ b/change/beachball-2020-03-24-17-36-31-readme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add readme to beachball package",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-25T00:36:31.445Z"
+}

--- a/packages/beachball/README.md
+++ b/packages/beachball/README.md
@@ -1,3 +1,7 @@
+<!--
+If making changes, don't forget to update the version at the repo root too!
+-->
+
 # beachball
 
 the sunniest version bumping tool
@@ -77,3 +81,7 @@ skips the prompts for publish
 
   $ beachball publish -r http://localhost:4873 -t beta
 ```
+
+<!--
+If making changes, don't forget to update the version at the repo root too!
+-->

--- a/packages/beachball/README.md
+++ b/packages/beachball/README.md
@@ -1,0 +1,79 @@
+# beachball
+
+the sunniest version bumping tool
+
+## Prerequisites
+
+git and a remote named "origin"
+
+## Usage
+
+```
+beachball [command] [options]
+```
+
+## Commands
+
+### change (default)
+
+a tool to help create change files in the change/ folder
+
+### check
+
+checks whether a change file is needed for this branch
+
+### changelog
+
+based on change files, create changelogs and then unlinks the change files
+
+### bump
+
+bumps versions as well as generating changelogs
+
+### publish
+
+bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
+
+## Options
+
+### --registry, -r
+
+registry, defaults to https://registry.npmjs.org
+
+### --tag, -t
+
+dist-tag for npm publishes
+
+### --branch, -b
+
+target branch from origin (default: master)
+
+### --message, -m
+
+custom message for the checkin (default: applying package updates)
+
+### --no-push
+
+skip pushing changes back to git remote origin
+
+### --no-publish
+
+skip publishing to the npm registry
+
+### --help, -?, -h
+
+show help message
+
+### --yes, -y
+
+skips the prompts for publish
+
+## Examples
+
+```
+  $ beachball
+
+  $ beachball check
+
+  $ beachball publish -r http://localhost:4873 -t beta
+```


### PR DESCRIPTION
Copy the readme from the root to the beachball package so it gets published with the npm package.

This might be a good example of a place where pre-release scripts would be useful, so we can have only one copy of this file checked in. :)