### PR TITLE
ChangeLog: support grouped change log generation

### DIFF
--- a/change/beachball-2020-03-24-16-57-33-xgao-changelog-group.json
+++ b/change/beachball-2020-03-24-16-57-33-xgao-changelog-group.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ChangeLog: support grouped change log generation",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-24T23:57:33.391Z"
+}

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -180,6 +180,20 @@ describe('changelog generation', () => {
         monoRepo.rootPath
       );
 
+      writeChangeFiles(
+        {
+          bar: {
+            comment: 'comment 3',
+            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
+            email: 'test@testtestme.com',
+            packageName: 'bar',
+            type: 'patch',
+            dependentChangeType: 'patch',
+          },
+        },
+        monoRepo.rootPath
+      );
+
       const beachballOptions = {
         path: monoRepo.rootPath,
         changelog: {
@@ -225,8 +239,9 @@ describe('changelog generation', () => {
       expect(barChangelogHeadings[2].value).toEqual('Patches');
 
       const barChangelogListItems = selectAll('listItem paragraph text', barChangelogTree);
-      expect(barChangelogListItems.length).toEqual(1);
-      expect(barChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(barChangelogListItems.length).toEqual(2);
+      expect(barChangelogListItems[0].value).toEqual('comment 3 (test@testtestme.com)');
+      expect(barChangelogListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
 
       // Validate grouped changelog for foo and bar packages
       const groupedChangelogFile = path.join(monoRepo.rootPath, 'CHANGELOG.md');
@@ -245,9 +260,10 @@ describe('changelog generation', () => {
       expect(groupedChangelogPackageNameListItems[1].value).toEqual('foo');
 
       const groupedChangelogCommentListItems = selectAll('listItem paragraph text', groupedChangelogTree);
-      expect(groupedChangelogCommentListItems.length).toEqual(2);
-      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
-      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
+      expect(groupedChangelogCommentListItems.length).toEqual(3);
+      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 3 (test@testtestme.com)');
+      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogCommentListItems[2].value).toEqual('comment 1 (test@testtestme.com)');
     });
 
     it('generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog', async () => {

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -241,8 +241,8 @@ describe('changelog generation', () => {
 
       const groupedChangelogListItems = selectAll('listItem paragraph text', groupedChangelogTree);
       expect(groupedChangelogListItems.length).toEqual(2);
-      expect(groupedChangelogListItems[0].value).toEqual('comment 1 (test@testtestme.com)');
-      expect(groupedChangelogListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
     });
 
     it('generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog', async () => {
@@ -323,8 +323,8 @@ describe('changelog generation', () => {
 
       const groupedChangelogListItems = selectAll('listItem paragraph text', groupedChangelogTree);
       expect(groupedChangelogListItems.length).toEqual(2);
-      expect(groupedChangelogListItems[0].value).toEqual('comment 1 (test@testtestme.com)');
-      expect(groupedChangelogListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
     });
   });
 });

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -239,10 +239,15 @@ describe('changelog generation', () => {
       expect(groupedChangelogHeadings[1].value).toEqual('1.0.0');
       expect(groupedChangelogHeadings[2].value).toEqual('Patches');
 
-      const groupedChangelogListItems = selectAll('listItem paragraph text', groupedChangelogTree);
-      expect(groupedChangelogListItems.length).toEqual(2);
-      expect(groupedChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
-      expect(groupedChangelogListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
+      const groupedChangelogPackageNameListItems = selectAll('listItem paragraph inlineCode', groupedChangelogTree);
+      expect(groupedChangelogPackageNameListItems.length).toEqual(2);
+      expect(groupedChangelogPackageNameListItems[0].value).toEqual('bar');
+      expect(groupedChangelogPackageNameListItems[1].value).toEqual('foo');
+
+      const groupedChangelogCommentListItems = selectAll('listItem paragraph text', groupedChangelogTree);
+      expect(groupedChangelogCommentListItems.length).toEqual(2);
+      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
     });
 
     it('generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog', async () => {
@@ -321,10 +326,15 @@ describe('changelog generation', () => {
       expect(groupedChangelogHeadings[1].value).toEqual('1.0.0');
       expect(groupedChangelogHeadings[2].value).toEqual('Patches');
 
-      const groupedChangelogListItems = selectAll('listItem paragraph text', groupedChangelogTree);
-      expect(groupedChangelogListItems.length).toEqual(2);
-      expect(groupedChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
-      expect(groupedChangelogListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
+      const groupedChangelogPackageNameListItems = selectAll('listItem paragraph inlineCode', groupedChangelogTree);
+      expect(groupedChangelogPackageNameListItems.length).toEqual(2);
+      expect(groupedChangelogPackageNameListItems[0].value).toEqual('bar');
+      expect(groupedChangelogPackageNameListItems[1].value).toEqual('foo');
+
+      const groupedChangelogCommentListItems = selectAll('listItem paragraph text', groupedChangelogTree);
+      expect(groupedChangelogCommentListItems.length).toEqual(2);
+      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
     });
   });
 });

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -147,6 +147,23 @@ describe('changelog generation', () => {
 
       expect(listItems.find(item => item.value === 'comment 2 (test@testtestme.com)')).toBeTruthy();
       expect(listItems.find(item => item.value === 'comment 1 (test@testtestme.com)')).toBeTruthy();
+
+      const changelogJsonFile = path.join(repository.rootPath, 'CHANGELOG.json');
+      const jsonText = await readFileAsync(changelogJsonFile, 'utf-8');
+      const changelogJson = JSON.parse(jsonText);
+      expect(changelogJson.name).toEqual('foo');
+      expect(changelogJson.entries.length).toEqual(1);
+      expect(changelogJson.entries[0].date).toBeTruthy();
+      expect(changelogJson.entries[0].tag).toEqual('foo_v1.0.0');
+      expect(changelogJson.entries[0].version).toEqual('1.0.0');
+      expect(changelogJson.entries[0].comments.patch).toBeDefined();
+      expect(changelogJson.entries[0].comments.patch.length).toEqual(2);
+
+      const comment = changelogJson.entries[0].comments.patch[0];
+      expect(comment.author).toEqual('test@testtestme.com');
+      expect(comment.comment).toEqual('comment 2');
+      expect(comment.commit).toBeTruthy();
+      expect(comment.package).toEqual('foo');
     });
 
     it('generates correct grouped changelog', async () => {

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -1,0 +1,76 @@
+import { PackageChangelog } from '../../types/ChangeLog';
+import { mergeChangelogs } from '../../changelog/mergeChangelogs';
+import { PackageInfo } from '../../types/PackageInfo';
+
+describe('mergeChangelogs', () => {
+  const mockDate = new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)');
+  const mockDate2 = new Date('Thu Aug 22 2020 14:20:40 GMT-0700 (Pacific Daylight Time)');
+
+  it('merge changelogs when master package has change', () => {
+    const masterChangelog: PackageChangelog = {
+      name: 'master',
+      date: mockDate,
+      version: '1.0.0',
+      comments: {
+        patch: [
+          {
+            comment: 'comment_master',
+            author: 'author_master',
+            commit: 'commit_master',
+          },
+        ],
+      },
+    };
+
+    const changelogs: PackageChangelog[] = [
+      masterChangelog,
+      {
+        name: 'foo',
+        date: mockDate2,
+        version: '1.0.0',
+        comments: {
+          patch: [
+            {
+              comment: 'comment_foo',
+              author: 'author_foo',
+              commit: 'commit_foo',
+            },
+          ],
+        },
+      },
+    ];
+
+    const mergedChangelog = mergeChangelogs(changelogs, { name: 'master', version: '1.2.3' } as PackageInfo);
+    expect(mergedChangelog).toBeDefined();
+    expect(mergedChangelog!.name).toBe('master');
+    expect(mergedChangelog!.version).toBe('1.2.3');
+    expect(mergedChangelog!.date).toBeDefined();
+    expect(mergedChangelog!.comments.patch?.length).toBe(2);
+  });
+
+  it('merge changelogs when master package has no change', () => {
+    const changelogs: PackageChangelog[] = [
+      {
+        name: 'foo',
+        date: mockDate2,
+        version: '1.0.0',
+        comments: {
+          patch: [
+            {
+              comment: 'comment_foo',
+              author: 'author_foo',
+              commit: 'commit_foo',
+            },
+          ],
+        },
+      },
+    ];
+
+    const mergedChangelog = mergeChangelogs(changelogs, { name: 'master', version: '1.2.3' } as PackageInfo);
+    expect(mergedChangelog).toBeDefined();
+    expect(mergedChangelog!.name).toBe('master');
+    expect(mergedChangelog!.version).toBe('1.2.3');
+    expect(mergedChangelog!.date).toBeDefined();
+    expect(mergedChangelog!.comments.patch).toEqual(changelogs[0].comments.patch);
+  });
+});

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -17,9 +17,7 @@ describe('mergeChangelogs', () => {
             comment: 'comment_master',
             author: 'author_master',
             commit: 'commit_master',
-            package: {
-              name: 'master',
-            } as PackageInfo,
+            package: 'master',
           },
         ],
       },
@@ -37,9 +35,7 @@ describe('mergeChangelogs', () => {
               comment: 'comment_foo',
               author: 'author_foo',
               commit: 'commit_foo',
-              package: {
-                name: 'foo',
-              } as PackageInfo,
+              package: 'foo',
             },
           ],
         },
@@ -66,9 +62,7 @@ describe('mergeChangelogs', () => {
               comment: 'comment_foo',
               author: 'author_foo',
               commit: 'commit_foo',
-              package: {
-                name: 'foo',
-              } as PackageInfo,
+              package: 'foo',
             },
           ],
         },

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -17,6 +17,9 @@ describe('mergeChangelogs', () => {
             comment: 'comment_master',
             author: 'author_master',
             commit: 'commit_master',
+            package: {
+              name: 'master',
+            } as PackageInfo,
           },
         ],
       },
@@ -34,6 +37,9 @@ describe('mergeChangelogs', () => {
               comment: 'comment_foo',
               author: 'author_foo',
               commit: 'commit_foo',
+              package: {
+                name: 'foo',
+              } as PackageInfo,
             },
           ],
         },
@@ -60,6 +66,9 @@ describe('mergeChangelogs', () => {
               comment: 'comment_foo',
               author: 'author_foo',
               commit: 'commit_foo',
+              package: {
+                name: 'foo',
+              } as PackageInfo,
             },
           ],
         },

--- a/packages/beachball/src/__tests__/monorepo/utils.test.ts
+++ b/packages/beachball/src/__tests__/monorepo/utils.test.ts
@@ -1,0 +1,23 @@
+import { isPathIncluded } from '../../monorepo/utils';
+
+describe('isPathIncluded', () => {
+  it('should return true if path is included with single include path', () => {
+    expect(isPathIncluded('packages/a', 'packages/*')).toBeTruthy();
+  });
+
+  it('should return false if path is excluded with single exclude path', () => {
+    expect(isPathIncluded('packages/a', 'packages/*', '!packages/a')).toBeFalsy();
+  });
+
+  it('should return true if path is included with multiple include paths', () => {
+    expect(isPathIncluded('packages/a', ['packages/b', 'packages/a'], ['!packages/b'])).toBeTruthy();
+  });
+
+  it('should return false if path is excluded with multiple exclude paths', () => {
+    expect(isPathIncluded('packages/a', ['packages/*'], ['!packages/a'])).toBeFalsy();
+  });
+
+  it('should return false if include path is empty', () => {
+    expect(isPathIncluded('packages/a', '')).toBeFalsy();
+  });
+});

--- a/packages/beachball/src/bump/performBump.ts
+++ b/packages/beachball/src/bump/performBump.ts
@@ -1,10 +1,8 @@
 import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
-import { writeChangelog } from '../changelog/writeChangelog';
+import { writeChangelog, writeGroupedChangelog } from '../changelog/writeChangelog';
 import fs from 'fs';
 import { BumpInfo } from '../types/BumpInfo';
-import { bumpInPlace } from './bumpInPlace';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getNewPackages } from '../publish/getNewPackages';
 
 /**
  * Performs the bump, writes to the file system
@@ -35,6 +33,7 @@ export function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   // Generate changelog
   writeChangelog(changes, packageInfos);
+  writeGroupedChangelog(changes, packageInfos, options);
 
   // Unlink changelogs
   unlinkChangeFiles(changes, packageInfos, options.path);

--- a/packages/beachball/src/bump/performBump.ts
+++ b/packages/beachball/src/bump/performBump.ts
@@ -1,5 +1,5 @@
 import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
-import { writeChangelog, writeGroupedChangelog } from '../changelog/writeChangelog';
+import { writeChangelog } from '../changelog/writeChangelog';
 import fs from 'fs';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -32,8 +32,7 @@ export function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
   }
 
   // Generate changelog
-  writeChangelog(changes, packageInfos);
-  writeGroupedChangelog(changes, packageInfos, options);
+  writeChangelog(options, changes, packageInfos);
 
   // Unlink changelogs
   unlinkChangeFiles(changes, packageInfos, options.path);

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -24,7 +24,7 @@ export function getPackageChangelogs(
       comment: change.comment,
       author: change.email,
       commit: change.commit,
-      package: packageInfos[packageName],
+      package: packageName,
     });
   }
   return changelogs;

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -1,9 +1,13 @@
 import { ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
-export function getPackageChangelogs(changeSet: ChangeSet, packageInfos: {
-  [pkg: string]: PackageInfo;
-}) {
+
+export function getPackageChangelogs(
+  changeSet: ChangeSet,
+  packageInfos: {
+    [pkg: string]: PackageInfo;
+  }
+) {
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};
@@ -20,6 +24,7 @@ export function getPackageChangelogs(changeSet: ChangeSet, packageInfos: {
       comment: change.comment,
       author: change.email,
       commit: change.commit,
+      package: packageInfos[packageName],
     });
   }
   return changelogs;

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+import { PackageChangelog } from '../types/ChangeLog';
+
+/**
+ * Merge multiple PackageChangelog into one.
+ * `name`, `date` and `version` will be using the values from master changelog. `comments` are merged.
+ */
+export function mergeChangelogs(masterChangelog: PackageChangelog, changelogs: PackageChangelog[]): PackageChangelog {
+  if (changelogs.length < 1) {
+    return masterChangelog;
+  }
+
+  const result = _.cloneDeep(masterChangelog);
+
+  changelogs
+    .filter(cl => cl.name !== masterChangelog.name)
+    .forEach(changelog => {
+      Object.keys(changelog.comments).forEach(changeType => {
+        if (changelog.comments[changeType]) {
+          result.comments[changeType] = (result.comments[changeType] || []).concat(changelog.comments[changeType]);
+        }
+      });
+    });
+
+  return result;
+}

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -1,26 +1,33 @@
 import _ from 'lodash';
 import { PackageChangelog } from '../types/ChangeLog';
+import { PackageInfo } from '../types/PackageInfo';
 
 /**
  * Merge multiple PackageChangelog into one.
  * `name`, `date` and `version` will be using the values from master changelog. `comments` are merged.
  */
-export function mergeChangelogs(masterChangelog: PackageChangelog, changelogs: PackageChangelog[]): PackageChangelog {
-  if (changelogs.length < 1) {
-    return masterChangelog;
+export function mergeChangelogs(
+  changelogs: PackageChangelog[],
+  masterPackage: PackageInfo
+): PackageChangelog | undefined {
+  if (changelogs.length < 1 || !masterPackage) {
+    return undefined;
   }
 
-  const result = _.cloneDeep(masterChangelog);
+  const result: PackageChangelog = {
+    name: masterPackage.name,
+    version: masterPackage.version,
+    date: new Date(),
+    comments: {},
+  };
 
-  changelogs
-    .filter(cl => cl.name !== masterChangelog.name)
-    .forEach(changelog => {
-      Object.keys(changelog.comments).forEach(changeType => {
-        if (changelog.comments[changeType]) {
-          result.comments[changeType] = (result.comments[changeType] || []).concat(changelog.comments[changeType]);
-        }
-      });
+  changelogs.forEach(changelog => {
+    Object.keys(changelog.comments).forEach(changeType => {
+      if (changelog.comments[changeType]) {
+        result.comments[changeType] = (result.comments[changeType] || []).concat(changelog.comments[changeType]);
+      }
     });
+  });
 
   return result;
 }

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,9 +1,12 @@
 import { PackageChangelog } from '../types/ChangeLog';
 import { renderPackageChangelog } from './renderPackageChangelog';
-export function renderChangelog(previous: string, changelog: PackageChangelog) {
+
+export function renderChangelog(previous: string, changelog: PackageChangelog, isGroupedChangelog: boolean): string {
   const previousLogEntries = previous ? '\n' + previous.substring(previous.indexOf('##')) : '';
-  return (`# Change Log - ${changelog.name}\n\n` +
+  return (
+    `# Change Log - ${changelog.name}\n\n` +
     `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n` +
-    renderPackageChangelog(changelog) +
-    previousLogEntries);
+    renderPackageChangelog(changelog, isGroupedChangelog) +
+    previousLogEntries
+  );
 }

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,12 +1,9 @@
 import { PackageChangelog } from '../types/ChangeLog';
 import { renderPackageChangelog } from './renderPackageChangelog';
-
-export function renderChangelog(previous: string, changelog: PackageChangelog): string {
+export function renderChangelog(previous: string, changelog: PackageChangelog) {
   const previousLogEntries = previous ? '\n' + previous.substring(previous.indexOf('##')) : '';
-  return (
-    `# Change Log - ${changelog.name}\n\n` +
+  return (`# Change Log - ${changelog.name}\n\n` +
     `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n` +
     renderPackageChangelog(changelog) +
-    previousLogEntries
-  );
+    previousLogEntries);
 }

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,9 +1,12 @@
 import { PackageChangelog } from '../types/ChangeLog';
 import { renderPackageChangelog } from './renderPackageChangelog';
-export function renderChangelog(previous: string, changelog: PackageChangelog) {
+
+export function renderChangelog(previous: string, changelog: PackageChangelog): string {
   const previousLogEntries = previous ? '\n' + previous.substring(previous.indexOf('##')) : '';
-  return (`# Change Log - ${changelog.name}\n\n` +
+  return (
+    `# Change Log - ${changelog.name}\n\n` +
     `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n` +
     renderPackageChangelog(changelog) +
-    previousLogEntries);
+    previousLogEntries
+  );
 }

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -1,20 +1,32 @@
-import { PackageChangelog } from '../types/ChangeLog';
-export function renderPackageChangelog(changelog: PackageChangelog) {
-  return (`\n## ${changelog.version}\n` +
+import { PackageChangelog, ChangelogEntry } from '../types/ChangeLog';
+
+export function renderPackageChangelog(changelog: PackageChangelog, isGroupedChangelog: boolean = false) {
+  return (
+    `\n## ${changelog.version}\n` +
     `${changelog.date.toUTCString()}\n` +
     (changelog.comments.major
-      ? '\n### Major\n\n' + changelog.comments.major.map(change => `- ${change.comment} (${change.author})`).join('\n')
+      ? '\n### Major\n\n' +
+        changelog.comments.major.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
       : '') +
     (changelog.comments.minor
       ? '\n### Minor changes\n\n' +
-      changelog.comments.minor.map(change => `- ${change.comment} (${change.author})`).join('\n')
+        changelog.comments.minor.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
       : '') +
     (changelog.comments.patch
       ? '\n### Patches\n\n' +
-      changelog.comments.patch.map(change => `- ${change.comment} (${change.author})`).join('\n')
+        changelog.comments.patch.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
       : '') +
     (changelog.comments.prerelease
       ? '\n### Changes\n\n' +
-      changelog.comments.prerelease.map(change => `- ${change.comment} (${change.author})`).join('\n')
-      : ''));
+        changelog.comments.prerelease.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
+      : '')
+  );
+}
+
+function renderChangelogEntry(entry: ChangelogEntry, includePackageInfo: boolean = false): string {
+  if (includePackageInfo && entry.package.name) {
+    return `- \`${entry.package.name}\`\n  - ${entry.comment} (${entry.author})`;
+  }
+
+  return `- ${entry.comment} (${entry.author})`;
 }

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -1,32 +1,44 @@
 import { PackageChangelog, ChangelogEntry } from '../types/ChangeLog';
+import _ from 'lodash';
 
 export function renderPackageChangelog(changelog: PackageChangelog, isGroupedChangelog: boolean = false) {
   return (
     `\n## ${changelog.version}\n` +
     `${changelog.date.toUTCString()}\n` +
     (changelog.comments.major
-      ? '\n### Major\n\n' +
-        changelog.comments.major.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
+      ? '\n### Major\n\n' + renderChangelogEntries(changelog.comments.major, isGroupedChangelog)
       : '') +
     (changelog.comments.minor
-      ? '\n### Minor changes\n\n' +
-        changelog.comments.minor.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
+      ? '\n### Minor changes\n\n' + renderChangelogEntries(changelog.comments.minor, isGroupedChangelog)
       : '') +
     (changelog.comments.patch
-      ? '\n### Patches\n\n' +
-        changelog.comments.patch.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
+      ? '\n### Patches\n\n' + renderChangelogEntries(changelog.comments.patch, isGroupedChangelog)
       : '') +
     (changelog.comments.prerelease
-      ? '\n### Changes\n\n' +
-        changelog.comments.prerelease.map(change => renderChangelogEntry(change, isGroupedChangelog)).join('\n')
+      ? '\n### Changes\n\n' + renderChangelogEntries(changelog.comments.prerelease, isGroupedChangelog)
       : '')
   );
 }
 
-function renderChangelogEntry(entry: ChangelogEntry, includePackageInfo: boolean = false): string {
-  if (includePackageInfo && entry.package.name) {
-    return `- \`${entry.package.name}\`\n  - ${entry.comment} (${entry.author})`;
+function renderChangelogEntries(entries: ChangelogEntry[], includePackageInfo: boolean = false): string {
+  if (includePackageInfo) {
+    const entriesMap = _.groupBy(entries, entry => entry.package);
+
+    let result = '';
+    Object.keys(entriesMap).forEach(pkgName => {
+      const entries = entriesMap[pkgName];
+      result += `- \`${pkgName}\`\n`;
+      entries.forEach(entry => {
+        result += `  - ${entry.comment} (${entry.author})\n`;
+      });
+    });
+
+    return result;
   }
 
-  return `- ${entry.comment} (${entry.author})`;
+  return entries
+    .map(entry => {
+      return `- ${entry.comment} (${entry.author})`;
+    })
+    .join('\n');
 }

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import _ from 'lodash';
 import { ChangeSet } from '../types/ChangeInfo';
-import { PackageInfo, PackageInfos } from '../types/PackageInfo';
+import { PackageInfo } from '../types/PackageInfo';
 import { getPackageChangelogs } from './getPackageChangelogs';
 import { renderChangelog } from './renderChangelog';
 import { renderJsonChangelog } from './renderJsonChangelog';
@@ -25,9 +25,9 @@ export function writeChangelog(
   Object.keys(changelogs).forEach(pkg => {
     const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
     if (groupedChangelogPathSet?.has(packagePath)) {
-      console.log(`Skip writing change log to ${packagePath} because grouped change log has generated here.`);
+      console.log(`Changelog for ${pkg} has been written as a group here: ${packagePath}`);
     } else {
-      writeChangelogFiles(changelogs[pkg], packagePath);
+      writeChangelogFiles(changelogs[pkg], packagePath, false);
     }
   });
 }
@@ -87,7 +87,7 @@ function writeGroupedChangelog(
     const { masterPackage, changelogs } = groupedChangelogs[changelogPath];
     const groupedChangelog = mergeChangelogs(changelogs, masterPackage);
     if (groupedChangelog) {
-      writeChangelogFiles(groupedChangelog, changelogPath);
+      writeChangelogFiles(groupedChangelog, changelogPath, true);
       changelogAbsolutePaths.push(path.resolve(changelogPath));
     }
   }
@@ -95,7 +95,7 @@ function writeGroupedChangelog(
   return changelogAbsolutePaths;
 }
 
-function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string): void {
+function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string, isGroupedChangelog: boolean): void {
   if (
     changelog.comments.major ||
     changelog.comments.minor ||
@@ -105,7 +105,7 @@ function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string)
     const changelogFile = path.join(changelogPath, 'CHANGELOG.md');
     const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
 
-    const nextContent = renderChangelog(previousContent, changelog);
+    const nextContent = renderChangelog(previousContent, changelog, isGroupedChangelog);
     fs.writeFileSync(changelogFile, nextContent);
   }
   try {

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -24,9 +24,8 @@ export function writeChangelog(
   const changelogs = getPackageChangelogs(changeSet, packageInfos);
   Object.keys(changelogs).forEach(pkg => {
     const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
-    console.log('excludedChangelogPaths', { groupedChangelogPathSet, packagePath });
     if (groupedChangelogPathSet?.has(packagePath)) {
-      console.log(`Skip writing change log to ${packagePath}.`);
+      console.log(`Skip writing change log to ${packagePath} because grouped change log has generated here.`);
     } else {
       writeChangelogFiles(changelogs[pkg], packagePath);
     }

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -1,35 +1,103 @@
 import path from 'path';
 import fs from 'fs';
+import _ from 'lodash';
 import { ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
-import { getPackageChangelogs } from "./getPackageChangelogs";
-import { renderChangelog } from "./renderChangelog";
-import { renderJsonChangelog } from "./renderJsonChangelog";
-export function writeChangelog(changeSet: ChangeSet, packageInfos: {
-  [pkg: string]: PackageInfo;
-}) {
+import { getPackageChangelogs } from './getPackageChangelogs';
+import { renderChangelog } from './renderChangelog';
+import { renderJsonChangelog } from './renderJsonChangelog';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { isPathIncluded } from '../monorepo/utils';
+import { PackageChangelog } from '../types/ChangeLog';
+import { mergeChangelogs } from './mergeChangelogs';
+
+export function writeChangelog(
+  changeSet: ChangeSet,
+  packageInfos: {
+    [pkg: string]: PackageInfo;
+  }
+): void {
   const changelogs = getPackageChangelogs(changeSet, packageInfos);
   Object.keys(changelogs).forEach(pkg => {
     const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
-    if (changelogs[pkg].comments.major ||
-      changelogs[pkg].comments.minor ||
-      changelogs[pkg].comments.patch ||
-      changelogs[pkg].comments.prerelease) {
-      const changelogFile = path.join(packagePath, 'CHANGELOG.md');
-      const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
-      const nextContent = renderChangelog(previousContent, changelogs[pkg]);
-      fs.writeFileSync(changelogFile, nextContent);
-    }
-    try {
-      const changelogJsonFile = path.join(packagePath, 'CHANGELOG.json');
-      const previousJson = fs.existsSync(changelogJsonFile)
-        ? JSON.parse(fs.readFileSync(changelogJsonFile).toString())
-        : { entries: [] };
-      const nextJson = renderJsonChangelog(previousJson, changelogs[pkg]);
-      fs.writeFileSync(changelogJsonFile, JSON.stringify(nextJson, null, 2));
-    }
-    catch (e) {
-      console.warn('The CHANGELOG.json file is invalid, skipping writing to it', e);
-    }
+    writeChangelogFiles(changelogs[pkg], packagePath);
   });
+}
+
+export function writeGroupedChangelog(
+  changeSet: ChangeSet,
+  packageInfos: {
+    [pkg: string]: PackageInfo;
+  },
+  options: BeachballOptions
+): void {
+  if (!options.changelog) {
+    return;
+  }
+
+  const { groups: changelogGroups } = options.changelog;
+  if (!changelogGroups || changelogGroups.length < 1) {
+    return;
+  }
+
+  const changelogs = getPackageChangelogs(changeSet, packageInfos);
+  const groupedChangelogs: {
+    [path: string]: { changelogs: PackageChangelog[]; masterChangelog: PackageChangelog };
+  } = {};
+
+  for (const pkg in changelogs) {
+    const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
+    const relativePath = path.relative(options.path, packagePath);
+    changelogGroups.forEach(group => {
+      const isInGroup = isPathIncluded(relativePath, group.include, group.exclude);
+      const { changelogPath } = group;
+      if (!fs.existsSync(changelogPath)) {
+        console.warn(`changelog path doesn't exist: ${changelogPath}`);
+        return;
+      }
+
+      if (isInGroup) {
+        if (!groupedChangelogs[changelogPath]) {
+          groupedChangelogs[changelogPath] = {
+            changelogs: [],
+            masterChangelog: changelogs[group.masterPackageName],
+          };
+        }
+
+        groupedChangelogs[changelogPath].changelogs.push(changelogs[pkg]);
+      }
+    });
+  }
+
+  for (const changelogPath in groupedChangelogs) {
+    const { masterChangelog, changelogs } = groupedChangelogs[changelogPath];
+    const groupedChangelog = mergeChangelogs(masterChangelog, changelogs);
+
+    writeChangelogFiles(groupedChangelog, changelogPath);
+  }
+}
+
+function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string): void {
+  if (
+    changelog.comments.major ||
+    changelog.comments.minor ||
+    changelog.comments.patch ||
+    changelog.comments.prerelease
+  ) {
+    const changelogFile = path.join(changelogPath, 'CHANGELOG.md');
+    const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
+
+    const nextContent = renderChangelog(previousContent, changelog);
+    fs.writeFileSync(changelogFile, nextContent);
+  }
+  try {
+    const changelogJsonFile = path.join(changelogPath, 'CHANGELOG.json');
+    const previousJson = fs.existsSync(changelogJsonFile)
+      ? JSON.parse(fs.readFileSync(changelogJsonFile).toString())
+      : { entries: [] };
+    const nextJson = renderJsonChangelog(previousJson, changelog);
+    fs.writeFileSync(changelogJsonFile, JSON.stringify(nextJson, null, 2));
+  } catch (e) {
+    console.warn('The CHANGELOG.json file is invalid, skipping writing to it', e);
+  }
 }

--- a/packages/beachball/src/monorepo/getPackageGroups.ts
+++ b/packages/beachball/src/monorepo/getPackageGroups.ts
@@ -1,24 +1,7 @@
 import { VersionGroupOptions } from '../types/BeachballOptions';
 import path from 'path';
-import minimatch from 'minimatch';
 import { PackageInfos, PackageGroups } from '../types/PackageInfo';
-
-function isInGroup(relativePath: string, group: VersionGroupOptions) {
-  const includePatterns = typeof group.include === 'string' ? [group.include] : group.include;
-  let includedFlag = includePatterns.reduce((included, pattern) => included || minimatch(relativePath, pattern), false);
-
-  let excludedFlag = false;
-
-  if (group.exclude) {
-    const excludePatterns = typeof group.exclude === 'string' ? [group.exclude] : group.exclude;
-    excludedFlag = excludePatterns.reduce(
-      (excluded: boolean, pattern: string) => excluded || minimatch(relativePath, pattern),
-      false
-    );
-  }
-
-  return includedFlag && !excludedFlag;
-}
+import { isPathIncluded } from './utils';
 
 export function getPackageGroups(packageInfos: PackageInfos, root: string, groups: VersionGroupOptions[] | undefined) {
   const packageGroups: PackageGroups = {};
@@ -30,7 +13,7 @@ export function getPackageGroups(packageInfos: PackageInfos, root: string, group
       const relativePath = path.relative(root, packagePath);
 
       for (const groupOption of groups) {
-        if (isInGroup(relativePath, groupOption)) {
+        if (isPathIncluded(relativePath, groupOption.include, groupOption.exclude)) {
           const groupName = groupOption.name;
 
           if (packageInfos[pkgName].group) {

--- a/packages/beachball/src/monorepo/getScopedPackages.ts
+++ b/packages/beachball/src/monorepo/getScopedPackages.ts
@@ -1,7 +1,7 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getPackageInfos } from './getPackageInfos';
-import minimatch from 'minimatch';
 import path from 'path';
+import { isPathIncluded } from './utils';
 
 export function getScopedPackages(options: BeachballOptions) {
   const packageInfos = getPackageInfos(options.path);
@@ -18,10 +18,7 @@ export function getScopedPackages(options: BeachballOptions) {
   for (let [pkgName, info] of Object.entries(packageInfos)) {
     const relativePath = path.relative(options.path, path.dirname(info.packageJsonPath));
 
-    let shouldInclude = includeScopes.reduce((flag, scope) => flag || minimatch(relativePath, scope), false);
-
-    shouldInclude = excludeScopes.reduce((flag, scope) => flag && minimatch(relativePath, scope), shouldInclude);
-
+    const shouldInclude = isPathIncluded(relativePath, includeScopes, excludeScopes);
     if (shouldInclude) {
       scopedPackages.push(pkgName);
     }

--- a/packages/beachball/src/monorepo/utils.ts
+++ b/packages/beachball/src/monorepo/utils.ts
@@ -1,18 +1,22 @@
 import minimatch from 'minimatch';
 
+/**
+ * Check if a relative path should be included given include and exclude patterns using minimatch.
+ */
 export function isPathIncluded(relativePath: string, include: string | string[], exclude?: string | string[]) {
   const includePatterns = typeof include === 'string' ? [include] : include;
-  let includedFlag = includePatterns.reduce((included, pattern) => included || minimatch(relativePath, pattern), false);
-
-  let excludedFlag = false;
+  let shouldInclude = includePatterns.reduce(
+    (included, pattern) => included || minimatch(relativePath, pattern),
+    false
+  );
 
   if (exclude) {
     const excludePatterns = typeof exclude === 'string' ? [exclude] : exclude;
-    excludedFlag = excludePatterns.reduce(
-      (excluded: boolean, pattern: string) => excluded || minimatch(relativePath, pattern),
-      false
+    shouldInclude = excludePatterns.reduce(
+      (excluded: boolean, pattern: string) => excluded && minimatch(relativePath, pattern),
+      shouldInclude
     );
   }
 
-  return includedFlag && !excludedFlag;
+  return shouldInclude;
 }

--- a/packages/beachball/src/monorepo/utils.ts
+++ b/packages/beachball/src/monorepo/utils.ts
@@ -1,0 +1,18 @@
+import minimatch from 'minimatch';
+
+export function isPathIncluded(relativePath: string, include: string | string[], exclude?: string | string[]) {
+  const includePatterns = typeof include === 'string' ? [include] : include;
+  let includedFlag = includePatterns.reduce((included, pattern) => included || minimatch(relativePath, pattern), false);
+
+  let excludedFlag = false;
+
+  if (exclude) {
+    const excludePatterns = typeof exclude === 'string' ? [exclude] : exclude;
+    excludedFlag = excludePatterns.reduce(
+      (excluded: boolean, pattern: string) => excluded || minimatch(relativePath, pattern),
+      false
+    );
+  }
+
+  return includedFlag && !excludedFlag;
+}

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -64,4 +64,16 @@ export interface VersionGroupOptions {
 /**
  * Options for change log related configurations.
  */
-export interface ChangeLogOptions {}
+export interface ChangeLogOptions {
+  groups: ChangeLogGroupOptions[];
+}
+
+export interface ChangeLogGroupOptions {
+  /** minimatch pattern (or array of minimatch) to detect which packages should be included in this group */
+  include: string | string[];
+
+  /** minimatch pattern (or array of minimatch) to detect which packages should be excluded in this group */
+  exclude?: string | string[];
+
+  changeLogPath: string;
+}

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -69,6 +69,7 @@ export interface ChangelogOptions {
 }
 
 export interface ChangelogGroupOptions {
+  /** the main package which a group of changes bubbles up to. all changes within the group are used to describe changes for the master package. */
   masterPackageName: string;
 
   /** minimatch pattern (or array of minimatch) to detect which packages should be included in this group */

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -40,7 +40,7 @@ export interface RepoOptions {
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
   groups?: VersionGroupOptions[];
-  changeLog?: ChangeLogOptions;
+  changelog?: ChangelogOptions;
 }
 
 export interface PackageOptions {
@@ -64,16 +64,18 @@ export interface VersionGroupOptions {
 /**
  * Options for change log related configurations.
  */
-export interface ChangeLogOptions {
-  groups: ChangeLogGroupOptions[];
+export interface ChangelogOptions {
+  groups: ChangelogGroupOptions[];
 }
 
-export interface ChangeLogGroupOptions {
+export interface ChangelogGroupOptions {
+  masterPackageName: string;
+
   /** minimatch pattern (or array of minimatch) to detect which packages should be included in this group */
   include: string | string[];
 
   /** minimatch pattern (or array of minimatch) to detect which packages should be excluded in this group */
   exclude?: string | string[];
 
-  changeLogPath: string;
+  changelogPath: string;
 }

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -1,10 +1,8 @@
-import { PackageInfo } from './PackageInfo';
-
 export interface ChangelogEntry {
   comment: string;
   author: string;
   commit: string;
-  package: PackageInfo;
+  package: string;
 }
 
 export interface PackageChangelog {

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -1,7 +1,10 @@
+import { PackageInfo } from './PackageInfo';
+
 export interface ChangelogEntry {
   comment: string;
   author: string;
   commit: string;
+  package: PackageInfo;
 }
 
 export interface PackageChangelog {

--- a/packages/beachball/src/validation/isValidChangelogOptions.ts
+++ b/packages/beachball/src/validation/isValidChangelogOptions.ts
@@ -1,0 +1,31 @@
+import { ChangelogOptions, ChangelogGroupOptions } from '../types/BeachballOptions';
+
+export function isValidChangelogOptions(options: ChangelogOptions): boolean {
+  if (options.groups) {
+    if (!isValidChangelogGroupOptions(options.groups)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isValidChangelogGroupOptions(groupOptions: ChangelogGroupOptions[]): boolean {
+  for (const options of groupOptions) {
+    if (!options.changelogPath) {
+      console.log('changelog group options cannot contain empty changelogPath.');
+      return false;
+    }
+
+    if (!options.masterPackageName) {
+      console.log('changelog group options cannot contain empty masterPackageName.');
+      return false;
+    }
+
+    if (!options.include) {
+      console.log('changelog group options cannot contain empty include.');
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -5,6 +5,7 @@ import { isValidChangeType } from './isValidChangeType';
 import { isChangeFileNeeded } from './isChangeFileNeeded';
 import { isValidGroupOptions } from './isValidGroupOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { isValidChangelogOptions } from './isValidChangelogOptions';
 
 export function validate(
   options: BeachballOptions,
@@ -45,6 +46,12 @@ export function validate(
   if (options.groups && !isValidGroupOptions(options.path, options.groups)) {
     console.error('ERROR: Groups defined inside the configuration is invalid');
     console.log(options.groups);
+    process.exit(1);
+  }
+
+  if (options.changelog && !isValidChangelogOptions(options.changelog)) {
+    console.error('ERROR: Changelog defined inside the configuration is invalid');
+    console.log(options.changelog);
     process.exit(1);
   }
 


### PR DESCRIPTION
Address issue #277

Say we have:
```
\pacakges
--\foo
----\foo-change-file.json

\pacakges
--\bar
----\bar-change-file.json
```

in `foo-change-file.json`:
```
{
  "type": "patch",
  "comment": "make a change in foo",
  "packageName": "foo",
  "email": "xgao@microsoft.com",
  "dependentChangeType": "patch",
  "date": "2020-03-24T18:40:15.042Z"
}
```

in `bar-change-file.json`: 
```
{
  "type": "patch",
  "comment": "make a change in bar",
  "packageName": "bar",
  "email": "xgao@microsoft.com",
  "dependentChangeType": "patch",
  "date": "2020-03-24T18:40:15.042Z"
}
```

if we define to create grouped change file with new changelog beachball option:
```
  "beachball": {
    "changelog": {
      "groups": [
        {
          "masterPackageName": "foo",
          "changelogPath": "packages",
          "include": [
            "packages/foo",
            "packages/bar",
          ]
        }
      ]
    },
```

beachball will generate the following CHANGELOG files during bump:
1. `packages/foo/CHANGELOG.md` and `packages/foo/CHANGELOG.json` (as current behavior)
2. `packages/bar/CHANGELOG.md` and `packages/bar/CHANGELOG.json` (as current behavior)
3. `packages/CHANGELOG.md` and `packages/CHANGELOG.json` (**new**: grouped changelog)

New `CHANGELOG.md` will be adding the following content:
```
## {new version of the master package}
{timestamp}

### Patches
- `foo` 
  - make a change in foo (xgao@microsoft.com)
- `bar`
  - make a change in bar (xgao@microsoft.com)
```

rendered markdown example:
![image](https://user-images.githubusercontent.com/1207059/77577304-c2764480-6e93-11ea-9987-1c4f7d29c5e5.png)
