### PR TITLE
Changelog: improve package changelog by leveraging github and tag

### DIFF
--- a/change/beachball-2020-03-25-16-31-15-xgao-changelog-group.json
+++ b/change/beachball-2020-03-25-16-31-15-xgao-changelog-group.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Changelog: improve package changelog by leveraging github and tag",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-25T23:31:15.804Z"
+}

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -11,6 +11,7 @@ describe('mergeChangelogs', () => {
       name: 'master',
       date: mockDate,
       version: '1.0.0',
+      tag: 'master_v1.0.0',
       comments: {
         patch: [
           {
@@ -29,6 +30,7 @@ describe('mergeChangelogs', () => {
         name: 'foo',
         date: mockDate2,
         version: '1.0.0',
+        tag: 'foo_v1.0.0',
         comments: {
           patch: [
             {
@@ -56,6 +58,7 @@ describe('mergeChangelogs', () => {
         name: 'foo',
         date: mockDate2,
         version: '1.0.0',
+        tag: 'foo_v1.0.0',
         comments: {
           patch: [
             {

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -1,6 +1,7 @@
 import { ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
+import { generateTag } from '../tag';
 
 export function getPackageChangelogs(
   changeSet: ChangeSet,
@@ -13,11 +14,17 @@ export function getPackageChangelogs(
   } = {};
   for (let [_, change] of changeSet) {
     const { packageName } = change;
-    changelogs[packageName] = changelogs[packageName] || {
-      name: packageName,
-      version: packageInfos[packageName].version,
-      date: new Date(),
-    };
+    if (!changelogs[packageName]) {
+      const version = packageInfos[packageName].version;
+      changelogs[packageName] = {
+        name: packageName,
+        version,
+        tag: generateTag(packageName, version),
+        date: new Date(),
+        comments: {},
+      };
+    }
+
     changelogs[packageName].comments = changelogs[packageName].comments || {};
     changelogs[packageName].comments[change.type] = changelogs[packageName].comments[change.type] || [];
     changelogs[packageName].comments[change.type]!.push({

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { PackageChangelog } from '../types/ChangeLog';
 import { PackageInfo } from '../types/PackageInfo';
+import { generateTag } from '../tag';
 
 /**
  * Merge multiple PackageChangelog into one.
@@ -17,6 +18,7 @@ export function mergeChangelogs(
   const result: PackageChangelog = {
     name: masterPackage.name,
     version: masterPackage.version,
+    tag: generateTag(masterPackage.name, masterPackage.version),
     date: new Date(),
     comments: {},
   };

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,12 +1,16 @@
-import { PackageChangelog } from '../types/ChangeLog';
-import { renderPackageChangelog } from './renderPackageChangelog';
+import { renderPackageChangelog, PackageChangelogRenderOptions } from './renderPackageChangelog';
 
-export function renderChangelog(previous: string, changelog: PackageChangelog, isGroupedChangelog: boolean): string {
-  const previousLogEntries = previous ? '\n' + previous.substring(previous.indexOf('##')) : '';
+export interface ChangelogRenderOptions extends PackageChangelogRenderOptions {
+  previousContent: string;
+}
+
+export function renderChangelog(options: ChangelogRenderOptions): string {
+  const { previousContent, changelog } = options;
+  const previousLogEntries = previousContent ? '\n' + previousContent.substring(previousContent.indexOf('##')) : '';
   return (
     `# Change Log - ${changelog.name}\n\n` +
     `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n` +
-    renderPackageChangelog(changelog, isGroupedChangelog) +
+    renderPackageChangelog(options) +
     previousLogEntries
   );
 }

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -1,10 +1,30 @@
-import { PackageChangelog, ChangelogEntry } from '../types/ChangeLog';
+import { PackageChangelog, ChangelogEntry, ChangelogJsonEntry } from '../types/ChangeLog';
 import _ from 'lodash';
+import { GitHubInfo } from '../types/BeachballOptions';
 
-export function renderPackageChangelog(changelog: PackageChangelog, isGroupedChangelog: boolean = false) {
+export interface PackageChangelogRenderOptions {
+  changelog: PackageChangelog;
+  isGroupedChangelog: boolean;
+  previousChangelogEntry: ChangelogJsonEntry | undefined;
+  github?: GitHubInfo;
+}
+
+export function renderPackageChangelog(options: PackageChangelogRenderOptions): string {
+  const { changelog, isGroupedChangelog, previousChangelogEntry, github } = options;
+  const header =
+    github && changelog.tag
+      ? `[${changelog.version}](https://github.com/${github.owner}/${github.repo}/tree/${changelog.tag})`
+      : changelog.version;
+
+  let subHeader = changelog.date.toUTCString();
+  subHeader +=
+    github && previousChangelogEntry?.tag
+      ? `\n[Compare changes](https://github.com/${github.owner}/${github.repo}/tree/${previousChangelogEntry?.tag}..${changelog.tag})`
+      : '';
+
   return (
-    `\n## ${changelog.version}\n` +
-    `${changelog.date.toUTCString()}\n` +
+    `\n## ${header}\n` +
+    `${subHeader}\n` +
     (changelog.comments.major
       ? '\n### Major\n\n' + renderChangelogEntries(changelog.comments.major, isGroupedChangelog)
       : '') +

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -19,7 +19,7 @@ export function renderPackageChangelog(options: PackageChangelogRenderOptions): 
   let subHeader = changelog.date.toUTCString();
   subHeader +=
     github && previousChangelogEntry?.tag
-      ? `\n[Compare changes](https://github.com/${github.owner}/${github.repo}/tree/${previousChangelogEntry?.tag}..${changelog.tag})`
+      ? `\n[Compare changes](https://github.com/${github.owner}/${github.repo}/compare/${previousChangelogEntry?.tag}..${changelog.tag})`
       : '';
 
   return (

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -8,7 +8,7 @@ import { renderChangelog } from './renderChangelog';
 import { renderJsonChangelog } from './renderJsonChangelog';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { isPathIncluded } from '../monorepo/utils';
-import { PackageChangelog } from '../types/ChangeLog';
+import { PackageChangelog, ChangelogJsonEntry } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
 
 export function writeChangelog(
@@ -27,7 +27,7 @@ export function writeChangelog(
     if (groupedChangelogPathSet?.has(packagePath)) {
       console.log(`Changelog for ${pkg} has been written as a group here: ${packagePath}`);
     } else {
-      writeChangelogFiles(changelogs[pkg], packagePath, false);
+      writeChangelogFiles(options, changelogs[pkg], packagePath, false);
     }
   });
 }
@@ -87,7 +87,7 @@ function writeGroupedChangelog(
     const { masterPackage, changelogs } = groupedChangelogs[changelogPath];
     const groupedChangelog = mergeChangelogs(changelogs, masterPackage);
     if (groupedChangelog) {
-      writeChangelogFiles(groupedChangelog, changelogPath, true);
+      writeChangelogFiles(options, groupedChangelog, changelogPath, true);
       changelogAbsolutePaths.push(path.resolve(changelogPath));
     }
   }
@@ -95,7 +95,25 @@ function writeGroupedChangelog(
   return changelogAbsolutePaths;
 }
 
-function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string, isGroupedChangelog: boolean): void {
+function writeChangelogFiles(
+  options: BeachballOptions,
+  changelog: PackageChangelog,
+  changelogPath: string,
+  isGroupedChangelog: boolean
+): void {
+  let previousJsonEntry: ChangelogJsonEntry | undefined;
+  try {
+    const changelogJsonFile = path.join(changelogPath, 'CHANGELOG.json');
+    const previousJson = fs.existsSync(changelogJsonFile)
+      ? JSON.parse(fs.readFileSync(changelogJsonFile).toString())
+      : { entries: [] };
+    previousJsonEntry = previousJson.entries[0];
+    const nextJson = renderJsonChangelog(previousJson, changelog);
+    fs.writeFileSync(changelogJsonFile, JSON.stringify(nextJson, null, 2));
+  } catch (e) {
+    console.warn('The CHANGELOG.json file is invalid, skipping writing to it', e);
+  }
+
   if (
     changelog.comments.major ||
     changelog.comments.minor ||
@@ -105,17 +123,13 @@ function writeChangelogFiles(changelog: PackageChangelog, changelogPath: string,
     const changelogFile = path.join(changelogPath, 'CHANGELOG.md');
     const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
 
-    const nextContent = renderChangelog(previousContent, changelog, isGroupedChangelog);
+    const nextContent = renderChangelog({
+      previousContent,
+      changelog,
+      isGroupedChangelog,
+      previousChangelogEntry: previousJsonEntry,
+      github: options.github,
+    });
     fs.writeFileSync(changelogFile, nextContent);
-  }
-  try {
-    const changelogJsonFile = path.join(changelogPath, 'CHANGELOG.json');
-    const previousJson = fs.existsSync(changelogJsonFile)
-      ? JSON.parse(fs.readFileSync(changelogJsonFile).toString())
-      : { entries: [] };
-    const nextJson = renderJsonChangelog(previousJson, changelog);
-    fs.writeFileSync(changelogJsonFile, JSON.stringify(nextJson, null, 2));
-  } catch (e) {
-    console.warn('The CHANGELOG.json file is invalid, skipping writing to it', e);
   }
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -39,8 +39,19 @@ export interface RepoOptions {
   changehint: string;
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
+  github?: GitHubInfo;
   groups?: VersionGroupOptions[];
   changelog?: ChangelogOptions;
+}
+
+/**
+ * If user is using GitHub, provide essential information to beachball to generate better changelog.
+ */
+export interface GitHubInfo {
+  /** name of the respository (e.g. beachball for https://github.com/microsoft/beachball) */
+  repo: string;
+  /** owner of the repository, which can be GitHub username or organization name. (e.g. microsoft for https://github.com/microsoft/beachball) */
+  owner: string;
 }
 
 export interface PackageOptions {

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -9,6 +9,7 @@ export interface PackageChangelog {
   name: string;
   date: Date;
   version: string;
+  tag: string;
   comments: {
     prerelease?: ChangelogEntry[];
     patch?: ChangelogEntry[];


### PR DESCRIPTION
### Change descriptions
1. Added `github` to beachball options to collect basic GitHub info (e.g repo, owner)
2. Made version header a link using tag
3. Added "Compare changes" link using tag

**Before change:**
## 7.105.3
Wed, 25 Mar 2020 23:28:35 GMT

**After change:**
## [7.105.3](https://github.com/microsoft/fluentui/tree/office-ui-fabric-react_v7.105.3)
Wed, 25 Mar 2020 23:28:35 GMT
[Compare changes](https://github.com/microsoft/fluentui/compare/office-ui-fabric-react_v7.105.2..office-ui-fabric-react_v7.105.3)

