### PR TITLE
Improve manual recovery message if some packages succeeded; allow longer output

### DIFF
--- a/change/beachball-2020-03-26-17-18-49-manual-recovery.json
+++ b/change/beachball-2020-03-26-17-18-49-manual-recovery.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Improve manual recovery message if some packages succeeded",
+  "comment": "Improve manual recovery message if some packages succeeded; increase maxBuffer for publish",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/beachball-2020-03-26-17-18-49-manual-recovery.json
+++ b/change/beachball-2020-03-26-17-18-49-manual-recovery.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Improve manual recovery message if some packages succeeded",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T00:18:49.686Z"
+}

--- a/packages/beachball/src/packageManager/npm.ts
+++ b/packages/beachball/src/packageManager/npm.ts
@@ -1,13 +1,10 @@
-import { spawnSync } from 'child_process';
+import { spawnSync, SpawnSyncOptions } from 'child_process';
 import os from 'os';
-export function npm(
-  args: string[],
-  options?: {
-    cwd: string;
-  }
-) {
+
+export function npm(args: string[], options: SpawnSyncOptions = {}) {
   const npmCmd = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-  const results = spawnSync(npmCmd, args, options);
+  const results = spawnSync(npmCmd, args, { maxBuffer: 1024 * 1024, ...options });
+
   if (results.status === 0) {
     return {
       stderr: results.stderr.toString().trim(),

--- a/packages/beachball/src/publish/displayManualRecovery.ts
+++ b/packages/beachball/src/publish/displayManualRecovery.ts
@@ -1,8 +1,24 @@
 import { BumpInfo } from '../types/BumpInfo';
-export function displayManualRecovery(bumpInfo: BumpInfo) {
+
+export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()) {
   console.error('Something went wrong with the publish! Manually update these package and versions:');
+  const succeededLines: string[] = [];
+
   bumpInfo.modifiedPackages.forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    console.error(`- ${packageInfo.name}@${packageInfo.version}`);
+    const entry = `- ${packageInfo.name}@${packageInfo.version}`;
+    if (succeededPackages.has(packageInfo.name)) {
+      succeededLines.push(entry);
+    } else {
+      console.error(entry);
+    }
   });
+
+  if (succeededLines.length) {
+    console.warn(
+      'These packages and versions were successfully published, but may be invalid due to depending on ' +
+        'package versions for which publishing failed:'
+    );
+    succeededLines.forEach(console.warn);
+  }
 }

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -4,15 +4,17 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { packagePublish } from '../packageManager/packagePublish';
 import { validatePackageVersions } from './validatePackageVersions';
 import { displayManualRecovery } from './displayManualRecovery';
-import { getNewPackages } from './getNewPackages';
+
 export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { registry, tag, token, access } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
   performBump(bumpInfo, options);
 
+  const succeededPackages = new Set<string>();
+
   if (!validatePackageVersions(bumpInfo, registry)) {
-    displayManualRecovery(bumpInfo);
+    displayManualRecovery(bumpInfo, succeededPackages);
     console.error('No packages have been published');
     process.exit(1);
   }
@@ -33,11 +35,11 @@ export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions)
       const result = packagePublish(packageInfo, registry, token, tag, access);
       if (result.success) {
         console.log('Published!');
+        succeededPackages.add(pkg);
       } else {
-        displayManualRecovery(bumpInfo);
+        displayManualRecovery(bumpInfo, succeededPackages);
         console.error(result.stderr);
         process.exit(1);
-        return;
       }
     } else {
       console.warn(


### PR DESCRIPTION
If publishing failed partway through but some packages succeeded, the manual recovery message should list the packages that succeeded (with a warning that they might be broken). Fixes #291.

When spawning publish process, increase `maxBuffer` to `1024 * 1024` so that packages with lots of files don't cause the process to be killed. (This is the default in newer Node versions, but version 10 still has a default of only 200k.) Fixes #293.