### PR TITLE
fix unstable tests by having change files read in deterministic order

### DIFF
--- a/change/beachball-2020-03-27-09-52-31-xgao-fix-test.json
+++ b/change/beachball-2020-03-27-09-52-31-xgao-fix-test.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "fix unstable tests by having change files read in deterministic order",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-03-27T16:52:31.027Z"
+}

--- a/packages/beachball/src/changefile/readChangeFiles.ts
+++ b/packages/beachball/src/changefile/readChangeFiles.ts
@@ -15,6 +15,17 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
     return changeSet;
   }
   const changeFiles = fs.readdirSync(changePath);
+  try {
+    // sort the change files by modified time. Most recent modified file comes first.
+    changeFiles.sort(function(f1, f2) {
+      return (
+        fs.statSync(path.join(changePath, f2)).mtime.getTime() - fs.statSync(path.join(changePath, f1)).mtime.getTime()
+      );
+    });
+  } catch (err) {
+    console.warn('Failed to sort change files', err);
+  }
+
   changeFiles.forEach(changeFile => {
     try {
       const changeInfo: ChangeInfo = {


### PR DESCRIPTION
Change log entires ordering change because change files are read in nondeterministic order.

test failure: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=61612&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=bd05475d-acb5-5619-3ccb-c46842dbc997