### PR TITLE
Add custom render functions for changelog parts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
         "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
+        "--watch",
         "--config",
         "${workspaceRoot}/packages/beachball/jest.config.js",
         "${fileBasenameNoExtension}"
@@ -22,6 +23,7 @@
           "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
+          "--watch",
           "--config",
           "${workspaceRoot}/packages/beachball/jest.config.js",
           "${fileBasenameNoExtension}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,7 @@
         "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
+        "--watch",
         "--config",
         "${workspaceRoot}/packages/beachball/jest.e2e.js",
         "${fileBasenameNoExtension}"
@@ -50,6 +51,7 @@
           "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
+          "--watch",
           "--config",
           "${workspaceRoot}/packages/beachball/jest.e2e.js",
           "${fileBasenameNoExtension}"

--- a/change/beachball-2020-03-27-18-25-51-changelog-render.json
+++ b/change/beachball-2020-03-27-18-25-51-changelog-render.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add custom render functions for changelog parts",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-28T01:25:51.983Z"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -16,9 +16,10 @@
     "jest": "jest",
     "start": "tsc -w --preserveWatchOutput",
     "test": "yarn test:unit && yarn test:e2e",
-    "test-watch": "jest --watch",
+    "test:watch": "jest --watch",
     "test:e2e": "jest --runInBand --config jest.e2e.js",
-    "test:unit": "jest --config jest.config.js"
+    "test:unit": "jest --config jest.config.js",
+    "update-snapshots": "jest --config jest.config.js --updateSnapshot"
   },
   "dependencies": {
     "cosmiconfig": "^6.0.0",

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -47,12 +47,9 @@
     "@types/yargs-parser": "^13.0.0",
     "find-free-port": "~2.0.0",
     "jest": "^24.8.0",
-    "remark-parse": "~7.0.1",
     "tmp": "^0.1.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.7.3",
-    "unified": "^8.3.2",
-    "unist-util-select": "^2.0.2",
     "verdaccio": "^4.2.2",
     "verdaccio-memory": "^8.0.0"
   },

--- a/packages/beachball/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/packages/beachball/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`changelog generation writeChangelog generates correct changelog 1`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- comment 2 (test@testtestme.com)
+- comment 1 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct changelog 2`] = `
+Object {
+  "entries": Array [
+    Object {
+      "comments": Object {
+        "patch": Array [
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "comment 2",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "comment 1",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+        ],
+      },
+      "date": "(date)",
+      "tag": "foo_v1.0.0",
+      "version": "1.0.0",
+    },
+  ],
+  "name": "foo",
+}
+`;
+
+exports[`changelog generation writeChangelog generates correct grouped changelog 1`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- comment 1 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct grouped changelog 2`] = `
+"# Change Log - bar
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.3.4
+
+(date)
+
+### Patches
+
+- comment 3 (test@testtestme.com)
+- comment 2 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct grouped changelog 3`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- \`bar\`
+  - comment 3 (test@testtestme.com)
+  - comment 2 (test@testtestme.com)
+- \`foo\`
+  - comment 1 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog 1`] = `
+"# Change Log - bar
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.3.4
+
+(date)
+
+### Patches
+
+- comment 2 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog 2`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- \`bar\`
+  - comment 2 (test@testtestme.com)
+- \`foo\`
+  - comment 1 (test@testtestme.com)
+"
+`;

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -95,7 +95,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({ path: repo.rootPath, bumpDeps: false } as BeachballOptions);
+    await bump({ path: repo.rootPath, bumpDeps: false } as BeachballOptions);
 
     const packageInfos = getPackageInfos(repo.rootPath);
 
@@ -182,7 +182,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({ path: repo.rootPath, bumpDeps: true } as BeachballOptions);
+    await bump({ path: repo.rootPath, bumpDeps: true } as BeachballOptions);
 
     const packageInfos = getPackageInfos(repo.rootPath);
 
@@ -251,7 +251,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({ path: repo.rootPath, groups: [{ include: 'packages/*', name: 'testgroup' }] } as BeachballOptions);
+    await bump({ path: repo.rootPath, groups: [{ include: 'packages/*', name: 'testgroup' }] } as BeachballOptions);
 
     const packageInfos = getPackageInfos(repo.rootPath);
 
@@ -339,7 +339,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({
+    await bump({
       path: repo.rootPath,
       groups: [{ include: 'packages/grp/*', name: 'grp' }],
       bumpDeps: true,
@@ -379,7 +379,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({ path: repo.rootPath, bumpDeps: true, scope: ['!packages/foo'] } as BeachballOptions);
+    await bump({ path: repo.rootPath, bumpDeps: true, scope: ['!packages/foo'] } as BeachballOptions);
 
     const packageInfos = getPackageInfos(repo.rootPath);
     expect(packageInfos['foo'].version).toBe('1.0.0');
@@ -410,7 +410,7 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    bump({ path: repo.rootPath, bumpDeps: true, scope: ['!packages/foo'] } as BeachballOptions);
+    await bump({ path: repo.rootPath, bumpDeps: true, scope: ['!packages/foo'] } as BeachballOptions);
 
     const packageInfos = getPackageInfos(repo.rootPath);
     expect(packageInfos['foo'].version).toBe('1.0.0');

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -1,28 +1,49 @@
 import path from 'path';
 import fs from 'fs-extra';
+import _ from 'lodash';
 
 import { RepositoryFactory } from '../fixtures/repository';
 import { writeChangelog } from '../changelog/writeChangelog';
 
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 
-import unified from 'unified';
-import remarkParse from 'remark-parse';
-import { selectAll as _selectAll } from 'unist-util-select';
-import { Node } from 'unist';
-
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { readChangeFiles } from '../changefile/readChangeFiles';
+import { SortedChangeTypes } from '../changefile/getPackageChangeTypes';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { MonoRepoFactory } from '../fixtures/monorepo';
+import { ChangelogJson } from '../types/ChangeLog';
 
-const selectAll: (selector: string, tree: Node) => Node[] = _selectAll;
+function getChange(partialChange: Partial<ChangeFileInfo> = {}): ChangeFileInfo {
+  return {
+    comment: 'comment 1',
+    date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
+    email: 'test@testtestme.com',
+    packageName: 'foo',
+    type: 'patch',
+    dependentChangeType: 'patch',
+    ...partialChange,
+  };
+}
 
-function parseMarkdown(markdown: string) {
-  return unified()
-    .use(remarkParse)
-    .parse(markdown);
+function cleanMarkdownForSnapshot(text: string) {
+  return text.replace(/\w\w\w, \d\d \w\w\w [\d :]+?GMT/gm, '(date)');
+}
+
+function cleanJsonForSnapshot(changelog: ChangelogJson) {
+  changelog = _.cloneDeep(changelog);
+  for (const entry of changelog.entries) {
+    entry.date = '(date)';
+    for (const changeType of SortedChangeTypes) {
+      if (entry.comments[changeType]) {
+        for (const comment of entry.comments[changeType]!) {
+          comment.commit = '(sha1)';
+        }
+      }
+    }
+  }
+  return changelog;
 }
 
 describe('changelog generation', () => {
@@ -45,19 +66,7 @@ describe('changelog generation', () => {
     it('adds actual commit hash', async () => {
       const repository = await repositoryFactory.cloneRepository();
       await repository.commitChange('foo');
-      writeChangeFiles(
-        {
-          foo: {
-            comment: 'comment 1',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'foo',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        repository.rootPath
-      );
+      writeChangeFiles({ foo: getChange() }, repository.rootPath);
 
       const currentHash = await repository.getCurrentHash();
       const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions);
@@ -67,15 +76,7 @@ describe('changelog generation', () => {
     });
 
     it('uses hash of original commit', async () => {
-      const repository = await repositoryFactory.cloneRepository();
-      const changeInfo: ChangeFileInfo = {
-        comment: 'comment 1',
-        date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-        email: 'test@testtestme.com',
-        packageName: 'foo',
-        type: 'patch',
-        dependentChangeType: 'patch',
-      };
+      const changeInfo: ChangeFileInfo = getChange();
 
       await repository.commitChange('foo');
       const changeFilePaths = writeChangeFiles({ foo: changeInfo }, repository.rootPath);
@@ -98,34 +99,10 @@ describe('changelog generation', () => {
     it('generates correct changelog', async () => {
       const repository = await repositoryFactory.cloneRepository();
       await repository.commitChange('foo');
-      writeChangeFiles(
-        {
-          foo: {
-            comment: 'comment 1',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'foo',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        repository.rootPath
-      );
+      writeChangeFiles({ foo: getChange() }, repository.rootPath);
 
       await repository.commitChange('bar');
-      writeChangeFiles(
-        {
-          foo: {
-            comment: 'comment 2',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'foo',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        repository.rootPath
-      );
+      writeChangeFiles({ foo: getChange({ comment: 'comment 2' }) }, repository.rootPath);
 
       const beachballOptions = { path: repository.rootPath } as BeachballOptions;
       const changes = readChangeFiles(beachballOptions);
@@ -136,76 +113,24 @@ describe('changelog generation', () => {
       writeChangelog(beachballOptions, changes, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
-      const text = await fs.readFile(changelogFile, 'utf-8');
-
-      const tree = parseMarkdown(text);
-      const listItems = selectAll('listItem paragraph text', tree);
-
-      expect(listItems.find(item => item.value === 'comment 2 (test@testtestme.com)')).toBeTruthy();
-      expect(listItems.find(item => item.value === 'comment 1 (test@testtestme.com)')).toBeTruthy();
+      const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(text)).toMatchSnapshot();
 
       const changelogJsonFile = path.join(repository.rootPath, 'CHANGELOG.json');
-      const changelogJson = await fs.readJSON(changelogJsonFile);
-      expect(changelogJson.name).toEqual('foo');
-      expect(changelogJson.entries.length).toEqual(1);
-      expect(changelogJson.entries[0].date).toBeTruthy();
-      expect(changelogJson.entries[0].tag).toEqual('foo_v1.0.0');
-      expect(changelogJson.entries[0].version).toEqual('1.0.0');
-      expect(changelogJson.entries[0].comments.patch).toBeDefined();
-      expect(changelogJson.entries[0].comments.patch.length).toEqual(2);
-
-      const comment = changelogJson.entries[0].comments.patch[0];
-      expect(comment.author).toEqual('test@testtestme.com');
-      expect(comment.comment).toEqual('comment 2');
-      expect(comment.commit).toBeTruthy();
-      expect(comment.package).toEqual('foo');
+      const jsonText = await fs.readFile(changelogJsonFile, { encoding: 'utf-8' });
+      const changelogJson = JSON.parse(jsonText);
+      expect(cleanJsonForSnapshot(changelogJson)).toMatchSnapshot();
     });
 
     it('generates correct grouped changelog', async () => {
       const monoRepo = await monoRepoFactory.cloneRepository();
       await monoRepo.commitChange('foo');
-      writeChangeFiles(
-        {
-          foo: {
-            comment: 'comment 1',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'foo',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        monoRepo.rootPath
-      );
+      writeChangeFiles({ foo: getChange() }, monoRepo.rootPath);
 
       await monoRepo.commitChange('bar');
-      writeChangeFiles(
-        {
-          bar: {
-            comment: 'comment 2',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'bar',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        monoRepo.rootPath
-      );
+      writeChangeFiles({ bar: getChange({ packageName: 'bar', comment: 'comment 2' }) }, monoRepo.rootPath);
 
-      writeChangeFiles(
-        {
-          bar: {
-            comment: 'comment 3',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'bar',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        monoRepo.rootPath
-      );
+      writeChangeFiles({ bar: getChange({ packageName: 'bar', comment: 'comment 3' }) }, monoRepo.rootPath);
 
       const beachballOptions = {
         path: monoRepo.rootPath,
@@ -229,87 +154,27 @@ describe('changelog generation', () => {
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
-      const fooChangelogText = await fs.readFile(fooChangelogFile, 'utf-8');
-      const fooChangelogTree = parseMarkdown(fooChangelogText);
-      const fooChangelogHeadings = selectAll('heading text', fooChangelogTree);
-      expect(fooChangelogHeadings.length).toEqual(3);
-      expect(fooChangelogHeadings[0].value).toEqual('Change Log - foo');
-      expect(fooChangelogHeadings[1].value).toEqual('1.0.0');
-      expect(fooChangelogHeadings[2].value).toEqual('Patches');
-
-      const fooChangelogListItems = selectAll('listItem paragraph text', fooChangelogTree);
-      expect(fooChangelogListItems.length).toEqual(1);
-      expect(fooChangelogListItems[0].value).toEqual('comment 1 (test@testtestme.com)');
+      const fooChangelogText = await fs.readFile(fooChangelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(fooChangelogText)).toMatchSnapshot();
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');
-      const barChangelogText = await fs.readFile(barChangelogFile, 'utf-8');
-      const barChangelogTree = parseMarkdown(barChangelogText);
-      const barChangelogHeadings = selectAll('heading text', barChangelogTree);
-      expect(barChangelogHeadings.length).toEqual(3);
-      expect(barChangelogHeadings[0].value).toEqual('Change Log - bar');
-      expect(barChangelogHeadings[1].value).toEqual('1.3.4');
-      expect(barChangelogHeadings[2].value).toEqual('Patches');
-
-      const barChangelogListItems = selectAll('listItem paragraph text', barChangelogTree);
-      expect(barChangelogListItems.length).toEqual(2);
-      expect(barChangelogListItems[0].value).toEqual('comment 3 (test@testtestme.com)');
-      expect(barChangelogListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
+      const barChangelogText = await fs.readFile(barChangelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(barChangelogText)).toMatchSnapshot();
 
       // Validate grouped changelog for foo and bar packages
       const groupedChangelogFile = path.join(monoRepo.rootPath, 'CHANGELOG.md');
-      const groupedChangelogText = await fs.readFile(groupedChangelogFile, 'utf-8');
-      const groupedChangelogTree = parseMarkdown(groupedChangelogText);
-
-      const groupedChangelogHeadings = selectAll('heading text', groupedChangelogTree);
-      expect(groupedChangelogHeadings.length).toEqual(3);
-      expect(groupedChangelogHeadings[0].value).toEqual('Change Log - foo');
-      expect(groupedChangelogHeadings[1].value).toEqual('1.0.0');
-      expect(groupedChangelogHeadings[2].value).toEqual('Patches');
-
-      const groupedChangelogPackageNameListItems = selectAll('listItem paragraph inlineCode', groupedChangelogTree);
-      expect(groupedChangelogPackageNameListItems.length).toEqual(2);
-      expect(groupedChangelogPackageNameListItems[0].value).toEqual('bar');
-      expect(groupedChangelogPackageNameListItems[1].value).toEqual('foo');
-
-      const groupedChangelogCommentListItems = selectAll('listItem paragraph text', groupedChangelogTree);
-      expect(groupedChangelogCommentListItems.length).toEqual(3);
-      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 3 (test@testtestme.com)');
-      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 2 (test@testtestme.com)');
-      expect(groupedChangelogCommentListItems[2].value).toEqual('comment 1 (test@testtestme.com)');
+      const groupedChangelogText = await fs.readFile(groupedChangelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(groupedChangelogText)).toMatchSnapshot();
     });
 
     it('generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog', async () => {
       const monoRepo = await monoRepoFactory.cloneRepository();
       await monoRepo.commitChange('foo');
-      writeChangeFiles(
-        {
-          foo: {
-            comment: 'comment 1',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'foo',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        monoRepo.rootPath
-      );
+      writeChangeFiles({ foo: getChange() }, monoRepo.rootPath);
 
       await monoRepo.commitChange('bar');
-      writeChangeFiles(
-        {
-          bar: {
-            comment: 'comment 2',
-            date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
-            email: 'test@testtestme.com',
-            packageName: 'bar',
-            type: 'patch',
-            dependentChangeType: 'patch',
-          },
-        },
-        monoRepo.rootPath
-      );
+      writeChangeFiles({ bar: getChange({ packageName: 'bar', comment: 'comment 2' }) }, monoRepo.rootPath);
 
       const beachballOptions = {
         path: monoRepo.rootPath,
@@ -333,38 +198,13 @@ describe('changelog generation', () => {
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');
-      const barChangelogText = await fs.readFile(barChangelogFile, 'utf-8');
-      const barChangelogTree = parseMarkdown(barChangelogText);
-      const barChangelogHeadings = selectAll('heading text', barChangelogTree);
-      expect(barChangelogHeadings.length).toEqual(3);
-      expect(barChangelogHeadings[0].value).toEqual('Change Log - bar');
-      expect(barChangelogHeadings[1].value).toEqual('1.3.4');
-      expect(barChangelogHeadings[2].value).toEqual('Patches');
-
-      const barChangelogListItems = selectAll('listItem paragraph text', barChangelogTree);
-      expect(barChangelogListItems.length).toEqual(1);
-      expect(barChangelogListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
+      const barChangelogText = await fs.readFile(barChangelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(barChangelogText)).toMatchSnapshot();
 
       // Validate grouped changelog for foo and bar packages
       const groupedChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
-      const groupedChangelogText = await fs.readFile(groupedChangelogFile, 'utf-8');
-      const groupedChangelogTree = parseMarkdown(groupedChangelogText);
-
-      const groupedChangelogHeadings = selectAll('heading text', groupedChangelogTree);
-      expect(groupedChangelogHeadings.length).toEqual(3);
-      expect(groupedChangelogHeadings[0].value).toEqual('Change Log - foo');
-      expect(groupedChangelogHeadings[1].value).toEqual('1.0.0');
-      expect(groupedChangelogHeadings[2].value).toEqual('Patches');
-
-      const groupedChangelogPackageNameListItems = selectAll('listItem paragraph inlineCode', groupedChangelogTree);
-      expect(groupedChangelogPackageNameListItems.length).toEqual(2);
-      expect(groupedChangelogPackageNameListItems[0].value).toEqual('bar');
-      expect(groupedChangelogPackageNameListItems[1].value).toEqual('foo');
-
-      const groupedChangelogCommentListItems = selectAll('listItem paragraph text', groupedChangelogTree);
-      expect(groupedChangelogCommentListItems.length).toEqual(2);
-      expect(groupedChangelogCommentListItems[0].value).toEqual('comment 2 (test@testtestme.com)');
-      expect(groupedChangelogCommentListItems[1].value).toEqual('comment 1 (test@testtestme.com)');
+      const groupedChangelogText = await fs.readFile(groupedChangelogFile, { encoding: 'utf-8' });
+      expect(cleanMarkdownForSnapshot(groupedChangelogText)).toMatchSnapshot();
     });
   });
 });

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -76,6 +76,7 @@ describe('changelog generation', () => {
     });
 
     it('uses hash of original commit', async () => {
+      const repository = await repositoryFactory.cloneRepository();
       const changeInfo: ChangeFileInfo = getChange();
 
       await repository.commitChange('foo');

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -110,7 +110,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
 
-      writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });
@@ -150,7 +150,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, packageInfos);
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
@@ -194,7 +194,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, packageInfos);
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');

--- a/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
+++ b/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
@@ -5,6 +5,8 @@ exports[`renderChangelog handles no previous content 1`] = `
 
 This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
 
+<!-- Start content -->
+
 ## 1.2.3
 
 Thu, 22 Aug 2019 21:20:40 GMT
@@ -21,10 +23,39 @@ Thu, 22 Aug 2019 21:20:40 GMT
 "
 `;
 
+exports[`renderChangelog keeps previous content if no marker or h2 is found 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)
+
+# Change Log - foo
+
+This log was last generated on Mon, 02 Mar 2020 12:25:44 GMT and should not be manually modified.
+"
+`;
+
 exports[`renderChangelog merges default and custom renderers 1`] = `
 "# Change Log - foo
 
 This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+<!-- Start content -->
 
 ## 1.2.3
 Thu, 22 Aug 2019 21:20:40 GMT
@@ -46,10 +77,39 @@ Thu, 22 Aug 2019 21:20:40 GMT
 "
 `;
 
-exports[`renderChangelog merges with previous content 1`] = `
+exports[`renderChangelog merges with previous content using h2 1`] = `
 "# Change Log - foo
 
 This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)
+
+## 1.2.0
+
+(content here)
+"
+`;
+
+exports[`renderChangelog merges with previous content using marker 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+<!-- Start content -->
 
 ## 1.2.3
 
@@ -75,6 +135,8 @@ exports[`renderChangelog uses full custom renderer 1`] = `
 "# Change Log - foo
 
 This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+<!-- Start content -->
 
 ## 1.2.3
 

--- a/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
+++ b/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
@@ -46,7 +46,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 
 # Change Log - foo
 
-This log was last generated on Mon, 02 Mar 2020 12:25:44 GMT and should not be manually modified.
+This log was last generated on Wed, 21 Aug 2019 21:20:40 GMT and should not be manually modified.
 "
 `;
 

--- a/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
+++ b/packages/beachball/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderChangelog handles no previous content 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)
+"
+`;
+
+exports[`renderChangelog merges default and custom renderers 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+## 1.2.3
+Thu, 22 Aug 2019 21:20:40 GMT
+[Compare changes](http://real-github-compare-link)
+
+### Minor changes
+
+- Awesome change (user1@example.com, PR #123)
+- Boring change (user2@example.com, PR #123)
+
+### Patches
+
+- Fix (user1@example.com, PR #123)
+- stuff (user2@example.com, PR #123)
+
+## 1.2.0
+
+(content here)
+"
+`;
+
+exports[`renderChangelog merges with previous content 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)
+
+## 1.2.0
+
+(content here)
+"
+`;
+
+exports[`renderChangelog uses full custom renderer 1`] = `
+"# Change Log - foo
+
+This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+## 1.2.3
+
+no notes for you
+
+## 1.2.0
+
+(content here)
+"
+`;

--- a/packages/beachball/src/__tests__/changelog/__snapshots__/renderPackageChangelog.test.ts.snap
+++ b/packages/beachball/src/__tests__/changelog/__snapshots__/renderPackageChangelog.test.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`changelog renderers - renderChangeTypeHeader has correct grouped output 1`] = `"### Minor changes"`;
+
+exports[`changelog renderers - renderChangeTypeHeader has correct output 1`] = `"### Minor changes"`;
+
+exports[`changelog renderers - renderChangeTypeSection has correct grouped output 1`] = `
+"### Minor changes
+
+- \`bar\`
+  - Awesome change (user1@example.com)
+- \`foo\`
+  - Boring change (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderChangeTypeSection has correct output 1`] = `
+"### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderEntries has correct grouped output 1`] = `
+"- \`bar\`
+  - Awesome change (user1@example.com)
+- \`foo\`
+  - Boring change (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderEntries has correct output 1`] = `
+"- Awesome change (user1@example.com)
+- Boring change (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderEntry has correct grouped output 1`] = `"- Awesome change (user1@example.com)"`;
+
+exports[`changelog renderers - renderEntry has correct output 1`] = `"- Awesome change (user1@example.com)"`;
+
+exports[`changelog renderers - renderHeader has correct grouped output 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT"
+`;
+
+exports[`changelog renderers - renderHeader has correct output 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT"
+`;
+
+exports[`changelog renderers - renderPackageChangelog has correct grouped output 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- \`bar\`
+  - Awesome change (user1@example.com)
+- \`foo\`
+  - Boring change (user2@example.com)
+
+### Patches
+
+- \`foo\`
+  - Fix (user1@example.com)
+- \`bar\`
+  - stuff (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderPackageChangelog has correct output 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderPackageChangelog uses custom renderChangeTypeHeader 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Important stuff
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Boring stuff
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderPackageChangelog uses custom renderChangeTypeSection 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)"
+`;
+
+exports[`changelog renderers - renderPackageChangelog uses custom renderEntries 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+Awesome change!!!
+
+Boring change!!!
+
+### Patches
+
+Fix!!!
+
+stuff!!!"
+`;
+
+exports[`changelog renderers - renderPackageChangelog uses custom renderEntry 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- \`bar\`
+  - Awesome change (#123)
+- \`foo\`
+  - Boring change (#123)
+
+### Patches
+
+- \`foo\`
+  - Fix (#123)
+- \`bar\`
+  - stuff (#123)"
+`;
+
+exports[`changelog renderers - renderPackageChangelog uses custom renderHeader 1`] = `
+"## 1.2.3
+Thu, 22 Aug 2019 21:20:40 GMT
+[Compare changes](http://real-github-compare-link)
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)"
+`;

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -1,4 +1,4 @@
-import { PackageChangelog } from '../../types/ChangeLog';
+import { PackageChangelog } from '../../types/Changelog';
 import { mergeChangelogs } from '../../changelog/mergeChangelogs';
 import { PackageInfo } from '../../types/PackageInfo';
 
@@ -11,6 +11,7 @@ describe('mergeChangelogs', () => {
       name: 'master',
       date: mockDate,
       version: '1.0.0',
+      tag: 'master_v1.0.0',
       comments: {
         patch: [
           {
@@ -29,6 +30,7 @@ describe('mergeChangelogs', () => {
         name: 'foo',
         date: mockDate2,
         version: '1.0.0',
+        tag: 'foo_v1.0.0',
         comments: {
           patch: [
             {
@@ -56,6 +58,7 @@ describe('mergeChangelogs', () => {
         name: 'foo',
         date: mockDate2,
         version: '1.0.0',
+        tag: 'foo_v1.0.0',
         comments: {
           patch: [
             {

--- a/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -1,4 +1,4 @@
-import { PackageChangelog } from '../../types/Changelog';
+import { PackageChangelog } from '../../types/ChangeLog';
 import { mergeChangelogs } from '../../changelog/mergeChangelogs';
 import { PackageInfo } from '../../types/PackageInfo';
 

--- a/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
+++ b/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
@@ -1,0 +1,85 @@
+import { MarkdownChangelogRenderOptions, renderChangelog } from '../../changelog/renderChangelog';
+
+const previousContent = `# Change Log - foo
+
+This log was last generated on Wed, 21 Aug 2019 21:20:40 GMT and should not be manually modified.
+
+## 1.2.0
+
+(content here)
+`;
+
+describe('renderChangelog', () => {
+  function getOptions(): MarkdownChangelogRenderOptions {
+    return {
+      isGrouped: false,
+      newVersionChangelog: {
+        date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
+        name: 'foo',
+        tag: 'foo_v1.2.3',
+        version: '1.2.3',
+        comments: {
+          major: [],
+          minor: [
+            { comment: 'Awesome change', author: 'user1@example.com', commit: 'sha1', package: 'foo' },
+            { comment: 'Boring change', author: 'user2@example.com', commit: 'sha2', package: 'foo' },
+          ],
+          patch: [
+            { comment: 'Fix', author: 'user1@example.com', commit: 'sha3', package: 'foo' },
+            { comment: 'stuff', author: 'user2@example.com', commit: 'sha4', package: 'foo' },
+          ],
+        },
+      },
+      previousContent,
+      previousJson: {} as any,
+      changelogOptions: {},
+    };
+  }
+
+  it('handles no previous content', () => {
+    const options = getOptions();
+    options.previousContent = '';
+    expect(renderChangelog(options)).toMatchSnapshot();
+  });
+
+  it('merges with previous content', () => {
+    const options = getOptions();
+    const result = renderChangelog(options);
+    expect(result).toContain('last generated on Thu, 22 Aug 2019 21:20:40 GMT'); // uses new date
+    expect(result).toMatchSnapshot();
+  });
+
+  it('merges default and custom renderers', () => {
+    const options = getOptions();
+    options.changelogOptions = {
+      customRenderers: {
+        renderHeader: renderInfo => {
+          return [
+            `## ${renderInfo.newVersionChangelog.version}`,
+            renderInfo.newVersionChangelog.date.toUTCString(),
+            `[Compare changes](http://real-github-compare-link)`,
+          ].join('\n');
+        },
+        renderEntry: (entry, renderInfo) => `- ${entry.comment} (${entry.author}, PR #123)`,
+      },
+    };
+
+    const result = renderChangelog(options);
+    expect(result).toContain('Compare changes');
+    expect(result).toContain('PR #123');
+    expect(result).toMatchSnapshot();
+  });
+
+  it('uses full custom renderer', () => {
+    const options = getOptions();
+    options.changelogOptions = {
+      renderPackageChangelog: renderInfo => `## ${renderInfo.newVersionChangelog.version}\n\nno notes for you`,
+    };
+
+    const result = renderChangelog(options);
+    expect(result).toContain('# Change Log - foo'); // still includes header
+    expect(result).toContain('no notes for you'); // uses custom version body
+    expect(result).toContain('content here'); // includes previous content
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
+++ b/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
@@ -36,34 +36,34 @@ describe('renderChangelog', () => {
     };
   }
 
-  it('handles no previous content', () => {
+  it('handles no previous content', async () => {
     const options = getOptions();
     options.previousContent = '';
-    expect(renderChangelog(options)).toMatchSnapshot();
+    expect(await renderChangelog(options)).toMatchSnapshot();
   });
 
-  it('merges with previous content using marker', () => {
+  it('merges with previous content using marker', async () => {
     const options = getOptions();
-    const result = renderChangelog(options);
+    const result = await renderChangelog(options);
     expect(result).toContain('last generated on Thu, 22 Aug 2019 21:20:40 GMT'); // uses new date
     expect(result).toContain(markerComment);
     expect(result.match(new RegExp(markerComment, 'g'))).toHaveLength(1); // old marker comment removed
     expect(result).toMatchSnapshot();
   });
 
-  it('merges with previous content using h2', () => {
+  it('merges with previous content using h2', async () => {
     const options = getOptions();
     options.previousContent = [previousHeader, previousVersion].join('\n\n');
-    const result = renderChangelog(options);
+    const result = await renderChangelog(options);
     expect(result).toContain('last generated on Thu, 22 Aug 2019 21:20:40 GMT'); // uses new date
     expect(result).toContain(markerComment);
     expect(result).toMatchSnapshot();
   });
 
-  it('keeps previous content if no marker or h2 is found', () => {
+  it('keeps previous content if no marker or h2 is found', async () => {
     const options = getOptions();
     options.previousContent = previousHeader;
-    const result = renderChangelog(options);
+    const result = await renderChangelog(options);
     expect(result).toContain('last generated on Thu, 22 Aug 2019 21:20:40 GMT'); // uses new date
     // keeps the old content in case it's relevant--even though it doesn't make sense in this case
     expect(result).toContain('Wed, 21 Aug 2019 21:20:40 GMT');
@@ -71,31 +71,31 @@ describe('renderChangelog', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('merges default and custom renderers', () => {
+  it('merges default and custom renderers', async () => {
     const options = getOptions();
     options.changelogOptions.customRenderers = {
-      renderHeader: renderInfo => {
+      renderHeader: async renderInfo => {
         return [
           `## ${renderInfo.newVersionChangelog.version}`,
           renderInfo.newVersionChangelog.date.toUTCString(),
           `[Compare changes](http://real-github-compare-link)`,
         ].join('\n');
       },
-      renderEntry: (entry, renderInfo) => `- ${entry.comment} (${entry.author}, PR #123)`,
+      renderEntry: async (entry, renderInfo) => `- ${entry.comment} (${entry.author}, PR #123)`,
     };
 
-    const result = renderChangelog(options);
+    const result = await renderChangelog(options);
     expect(result).toContain('Compare changes');
     expect(result).toContain('PR #123');
     expect(result).toMatchSnapshot();
   });
 
-  it('uses full custom renderer', () => {
+  it('uses full custom renderer', async () => {
     const options = getOptions();
-    options.changelogOptions.renderPackageChangelog = renderInfo =>
+    options.changelogOptions.renderPackageChangelog = async renderInfo =>
       `## ${renderInfo.newVersionChangelog.version}\n\nno notes for you`;
 
-    const result = renderChangelog(options);
+    const result = await renderChangelog(options);
     expect(result).toContain('# Change Log - foo'); // still includes header
     expect(result).toContain(markerComment); // still includes marker comment
     expect(result).toContain('no notes for you'); // uses custom version body

--- a/packages/beachball/src/__tests__/changelog/renderPackageChangelog.test.ts
+++ b/packages/beachball/src/__tests__/changelog/renderPackageChangelog.test.ts
@@ -47,139 +47,139 @@ describe('changelog renderers -', () => {
   }
 
   describe('renderEntry', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
+      const result = await renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
+      const result = await renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
       doBasicTests(result);
     });
   });
 
   describe('renderEntries', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderEntries('minor', renderInfo);
+      const result = await renderEntries('minor', renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderEntries('minor', renderInfo);
+      const result = await renderEntries('minor', renderInfo);
       doBasicTests(result);
     });
   });
 
   describe('renderChangeTypeHeader', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderChangeTypeHeader('minor', renderInfo);
+      const result = await renderChangeTypeHeader('minor', renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderChangeTypeHeader('minor', renderInfo);
+      const result = await renderChangeTypeHeader('minor', renderInfo);
       doBasicTests(result);
     });
   });
 
   describe('renderChangeTypeSection', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderChangeTypeSection('minor', renderInfo);
+      const result = await renderChangeTypeSection('minor', renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderChangeTypeSection('minor', renderInfo);
+      const result = await renderChangeTypeSection('minor', renderInfo);
       doBasicTests(result);
     });
   });
 
   describe('renderHeader', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderHeader(renderInfo);
+      const result = await renderHeader(renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderHeader(renderInfo);
+      const result = await renderHeader(renderInfo);
       doBasicTests(result);
     });
   });
 
   describe('renderPackageChangelog', () => {
-    it('has correct output', () => {
+    it('has correct output', async () => {
       const renderInfo = getRenderInfo();
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       doBasicTests(result);
     });
 
-    it('has correct grouped output', () => {
+    it('has correct grouped output', async () => {
       const renderInfo = getGroupedRenderInfo();
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       doBasicTests(result);
     });
 
-    it('uses custom renderEntry', () => {
+    it('uses custom renderEntry', async () => {
       const renderInfo = getGroupedRenderInfo();
-      renderInfo.renderers.renderEntry = (entry, renderInfo) => `- ${entry.comment} (#123)`;
+      renderInfo.renderers.renderEntry = async (entry, renderInfo) => `- ${entry.comment} (#123)`;
 
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       expect(result).toContain('#123');
       expect(result).toMatchSnapshot();
     });
 
-    it('uses custom renderEntries', () => {
+    it('uses custom renderEntries', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderEntries = (changeType, renderInfo) => {
+      renderInfo.renderers.renderEntries = async (changeType, renderInfo) => {
         const entries = renderInfo.newVersionChangelog.comments[changeType];
         return entries ? entries.map(entry => `${entry.comment}!!!`).join('\n\n') : '';
       };
 
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       expect(result).toContain('!!!');
       expect(result).toMatchSnapshot();
     });
 
-    it('uses custom renderChangeTypeHeader', () => {
+    it('uses custom renderChangeTypeHeader', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderChangeTypeHeader = (changeType, renderInfo) =>
+      renderInfo.renderers.renderChangeTypeHeader = async (changeType, renderInfo) =>
         changeType === 'minor' || changeType === 'major' ? '### Important stuff' : '### Boring stuff';
 
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       expect(result).toContain('### Important stuff');
       expect(result).toMatchSnapshot();
     });
 
-    it('uses custom renderChangeTypeSection', () => {
+    it('uses custom renderChangeTypeSection', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderChangeTypeSection = (changeType, renderInfo) =>
+      renderInfo.renderers.renderChangeTypeSection = async (changeType, renderInfo) =>
         changeType === 'minor' || changeType === 'major' ? renderChangeTypeSection(changeType, renderInfo) : '';
 
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       expect(result).not.toContain('Patches');
       expect(result).toMatchSnapshot();
     });
 
-    it('uses custom renderHeader', () => {
+    it('uses custom renderHeader', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderHeader = renderInfo =>
+      renderInfo.renderers.renderHeader = async renderInfo =>
         [
           `## ${renderInfo.newVersionChangelog.version}`,
           renderInfo.newVersionChangelog.date.toUTCString(),
           `[Compare changes](http://real-github-compare-link)`,
         ].join('\n');
 
-      const result = renderPackageChangelog(renderInfo);
+      const result = await renderPackageChangelog(renderInfo);
       expect(result).toContain('Compare changes');
       expect(result).toMatchSnapshot();
     });

--- a/packages/beachball/src/__tests__/changelog/renderPackageChangelog.test.ts
+++ b/packages/beachball/src/__tests__/changelog/renderPackageChangelog.test.ts
@@ -1,0 +1,187 @@
+import { PackageChangelogRenderInfo } from '../../types/ChangelogOptions';
+import { defaultRenderers, renderPackageChangelog } from '../../changelog/renderPackageChangelog';
+
+const { renderEntry, renderEntries, renderChangeTypeHeader, renderChangeTypeSection, renderHeader } = defaultRenderers;
+
+const leadingNewlineRegex = /^\n/;
+const trailingNewlineRegex = /\n$/;
+
+describe('changelog renderers -', () => {
+  function getRenderInfo(): PackageChangelogRenderInfo {
+    return {
+      isGrouped: false,
+      newVersionChangelog: {
+        date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
+        name: 'foo',
+        tag: 'foo_v1.2.3',
+        version: '1.2.3',
+        comments: {
+          major: [],
+          minor: [
+            { comment: 'Awesome change', author: 'user1@example.com', commit: 'sha1', package: 'foo' },
+            { comment: 'Boring change', author: 'user2@example.com', commit: 'sha2', package: 'foo' },
+          ],
+          patch: [
+            { comment: 'Fix', author: 'user1@example.com', commit: 'sha3', package: 'foo' },
+            { comment: 'stuff', author: 'user2@example.com', commit: 'sha4', package: 'foo' },
+          ],
+        },
+      },
+      previousJson: {} as any,
+      renderers: { ...defaultRenderers }, // copy in case of modification
+    };
+  }
+
+  function getGroupedRenderInfo(): PackageChangelogRenderInfo {
+    const renderInfo = getRenderInfo();
+    renderInfo.isGrouped = true;
+    renderInfo.newVersionChangelog.comments.minor![0].package = 'bar';
+    renderInfo.newVersionChangelog.comments.patch![1].package = 'bar';
+    return renderInfo;
+  }
+
+  function doBasicTests(result: string) {
+    expect(result).not.toMatch(leadingNewlineRegex);
+    expect(result).not.toMatch(trailingNewlineRegex);
+    expect(result).toMatchSnapshot();
+  }
+
+  describe('renderEntry', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderEntry(renderInfo.newVersionChangelog.comments.minor![0], renderInfo);
+      doBasicTests(result);
+    });
+  });
+
+  describe('renderEntries', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderEntries('minor', renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderEntries('minor', renderInfo);
+      doBasicTests(result);
+    });
+  });
+
+  describe('renderChangeTypeHeader', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderChangeTypeHeader('minor', renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderChangeTypeHeader('minor', renderInfo);
+      doBasicTests(result);
+    });
+  });
+
+  describe('renderChangeTypeSection', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderChangeTypeSection('minor', renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderChangeTypeSection('minor', renderInfo);
+      doBasicTests(result);
+    });
+  });
+
+  describe('renderHeader', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderHeader(renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderHeader(renderInfo);
+      doBasicTests(result);
+    });
+  });
+
+  describe('renderPackageChangelog', () => {
+    it('has correct output', () => {
+      const renderInfo = getRenderInfo();
+      const result = renderPackageChangelog(renderInfo);
+      doBasicTests(result);
+    });
+
+    it('has correct grouped output', () => {
+      const renderInfo = getGroupedRenderInfo();
+      const result = renderPackageChangelog(renderInfo);
+      doBasicTests(result);
+    });
+
+    it('uses custom renderEntry', () => {
+      const renderInfo = getGroupedRenderInfo();
+      renderInfo.renderers.renderEntry = (entry, renderInfo) => `- ${entry.comment} (#123)`;
+
+      const result = renderPackageChangelog(renderInfo);
+      expect(result).toContain('#123');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('uses custom renderEntries', () => {
+      const renderInfo = getRenderInfo();
+      renderInfo.renderers.renderEntries = (changeType, renderInfo) => {
+        const entries = renderInfo.newVersionChangelog.comments[changeType];
+        return entries ? entries.map(entry => `${entry.comment}!!!`).join('\n\n') : '';
+      };
+
+      const result = renderPackageChangelog(renderInfo);
+      expect(result).toContain('!!!');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('uses custom renderChangeTypeHeader', () => {
+      const renderInfo = getRenderInfo();
+      renderInfo.renderers.renderChangeTypeHeader = (changeType, renderInfo) =>
+        changeType === 'minor' || changeType === 'major' ? '### Important stuff' : '### Boring stuff';
+
+      const result = renderPackageChangelog(renderInfo);
+      expect(result).toContain('### Important stuff');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('uses custom renderChangeTypeSection', () => {
+      const renderInfo = getRenderInfo();
+      renderInfo.renderers.renderChangeTypeSection = (changeType, renderInfo) =>
+        changeType === 'minor' || changeType === 'major' ? renderChangeTypeSection(changeType, renderInfo) : '';
+
+      const result = renderPackageChangelog(renderInfo);
+      expect(result).not.toContain('Patches');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('uses custom renderHeader', () => {
+      const renderInfo = getRenderInfo();
+      renderInfo.renderers.renderHeader = renderInfo =>
+        [
+          `## ${renderInfo.newVersionChangelog.version}`,
+          renderInfo.newVersionChangelog.date.toUTCString(),
+          `[Compare changes](http://real-github-compare-link)`,
+        ].join('\n');
+
+      const result = renderPackageChangelog(renderInfo);
+      expect(result).toContain('Compare changes');
+      expect(result).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/beachball/src/bump/performBump.ts
+++ b/packages/beachball/src/bump/performBump.ts
@@ -8,12 +8,8 @@ import { BeachballOptions } from '../types/BeachballOptions';
  * Performs the bump, writes to the file system
  *
  * deletes change files, update package.json, and changelogs
- *
- * @param bumpInfo
- * @param cwd
- * @param bumpDeps
  */
-export function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
+export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { modifiedPackages, packageInfos, changes } = bumpInfo;
 
   for (const pkgName of modifiedPackages) {
@@ -32,7 +28,7 @@ export function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
   }
 
   // Generate changelog
-  writeChangelog(options, changes, packageInfos);
+  await writeChangelog(options, changes, packageInfos);
 
   // Unlink changelogs
   unlinkChangeFiles(changes, packageInfos, options.path);

--- a/packages/beachball/src/changefile/getPackageChangeTypes.ts
+++ b/packages/beachball/src/changefile/getPackageChangeTypes.ts
@@ -1,6 +1,9 @@
 import { ChangeFileInfo, ChangeSet, ChangeType } from '../types/ChangeInfo';
 
-const SortedChangeTypes: ChangeType[] = ['none', 'prerelease', 'patch', 'minor', 'major'];
+/**
+ * List of all change types from least to most significant.
+ */
+export const SortedChangeTypes: ChangeType[] = ['none', 'prerelease', 'patch', 'minor', 'major'];
 
 /**
  * Change type with the smallest weight.
@@ -8,8 +11,8 @@ const SortedChangeTypes: ChangeType[] = ['none', 'prerelease', 'patch', 'minor',
 export const MinChangeType = SortedChangeTypes[0];
 
 /**
- *  Change type weights
- *  Note: the order in which this is defined is IMPORTANT
+ * Change type weights
+ * Note: the order in which this is defined is IMPORTANT
  */
 const ChangeTypeWeights = SortedChangeTypes.reduce((weights, changeType, index) => {
   weights[changeType] = index;

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -1,6 +1,7 @@
 import { ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
-import { PackageChangelog } from '../types/ChangeLog';
+import { PackageChangelog } from '../types/Changelog';
+import { generateTag } from '../tag';
 
 export function getPackageChangelogs(
   changeSet: ChangeSet,
@@ -13,11 +14,17 @@ export function getPackageChangelogs(
   } = {};
   for (let [_, change] of changeSet) {
     const { packageName } = change;
-    changelogs[packageName] = changelogs[packageName] || {
-      name: packageName,
-      version: packageInfos[packageName].version,
-      date: new Date(),
-    };
+    if (!changelogs[packageName]) {
+      const version = packageInfos[packageName].version;
+      changelogs[packageName] = {
+        name: packageName,
+        version,
+        tag: generateTag(packageName, version),
+        date: new Date(),
+        comments: {},
+      };
+    }
+
     changelogs[packageName].comments = changelogs[packageName].comments || {};
     changelogs[packageName].comments[change.type] = changelogs[packageName].comments[change.type] || [];
     changelogs[packageName].comments[change.type]!.push({

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -1,6 +1,6 @@
 import { ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
-import { PackageChangelog } from '../types/Changelog';
+import { PackageChangelog } from '../types/ChangeLog';
 import { generateTag } from '../tag';
 
 export function getPackageChangelogs(

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { PackageChangelog } from '../types/Changelog';
+import { PackageChangelog } from '../types/ChangeLog';
 import { PackageInfo } from '../types/PackageInfo';
 import { generateTag } from '../tag';
 

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
-import { PackageChangelog } from '../types/ChangeLog';
+import { PackageChangelog } from '../types/Changelog';
 import { PackageInfo } from '../types/PackageInfo';
+import { generateTag } from '../tag';
 
 /**
  * Merge multiple PackageChangelog into one.
@@ -17,6 +18,7 @@ export function mergeChangelogs(
   const result: PackageChangelog = {
     name: masterPackage.name,
     version: masterPackage.version,
+    tag: generateTag(masterPackage.name, masterPackage.version),
     date: new Date(),
     comments: {},
   };

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,12 +1,49 @@
-import { PackageChangelog } from '../types/ChangeLog';
-import { renderPackageChangelog } from './renderPackageChangelog';
+import { PackageChangelog } from '../types/Changelog';
+import { renderPackageChangelog, defaultRenderers } from './renderPackageChangelog';
+import { ChangelogOptions, PackageChangelogRenderInfo } from '../types/ChangelogOptions';
 
-export function renderChangelog(previous: string, changelog: PackageChangelog, isGroupedChangelog: boolean): string {
-  const previousLogEntries = previous ? '\n' + previous.substring(previous.indexOf('##')) : '';
+export interface MarkdownChangelogRenderOptions extends Omit<PackageChangelogRenderInfo, 'renderers'> {
+  previousContent: string;
+  changelogOptions: ChangelogOptions;
+}
+
+export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): string {
+  const {
+    previousJson,
+    previousContent,
+    newEntry,
+    isGrouped,
+    changelogOptions: { renderPackageChangelog: customRenderPackageChangelog, customRenderers = {} },
+  } = renderOptions;
+
+  const previousLogEntries = previousContent ? previousContent.substring(previousContent.indexOf('##')) : '';
+
+  try {
+    if (customRenderPackageChangelog || customRenderers) {
+      console.log('Using custom renderer for package version changelog.');
+    }
+
+    const renderInfo: PackageChangelogRenderInfo = {
+      previousJson,
+      newEntry,
+      isGrouped,
+      renderers: {
+        ...defaultRenderers,
+        ...customRenderers,
+      },
+    };
+    const packageChangelogContent = (customRenderPackageChangelog || renderPackageChangelog)(renderInfo);
+
+    return [renderChangelogHeader(newEntry), packageChangelogContent, previousLogEntries].join('\n\n');
+  } catch (err) {
+    console.log('Error occurred rendering package version changelog:', err);
+    return '';
+  }
+}
+
+function renderChangelogHeader(changelog: PackageChangelog): string {
   return (
     `# Change Log - ${changelog.name}\n\n` +
-    `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n` +
-    renderPackageChangelog(changelog, isGroupedChangelog) +
-    previousLogEntries
+    `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n`
   );
 }

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -1,4 +1,4 @@
-import { PackageChangelog } from '../types/Changelog';
+import { PackageChangelog } from '../types/ChangeLog';
 import { renderPackageChangelog, defaultRenderers } from './renderPackageChangelog';
 import { ChangelogOptions, PackageChangelogRenderInfo } from '../types/ChangelogOptions';
 

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -11,9 +11,9 @@ export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): 
   const {
     previousJson,
     previousContent,
-    newEntry,
+    newVersionChangelog,
     isGrouped,
-    changelogOptions: { renderPackageChangelog: customRenderPackageChangelog, customRenderers = {} },
+    changelogOptions: { renderPackageChangelog: customRenderPackageChangelog, customRenderers },
   } = renderOptions;
 
   const previousLogEntries = previousContent ? previousContent.substring(previousContent.indexOf('##')) : '';
@@ -25,16 +25,23 @@ export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): 
 
     const renderInfo: PackageChangelogRenderInfo = {
       previousJson,
-      newEntry,
+      newVersionChangelog,
       isGrouped,
       renderers: {
         ...defaultRenderers,
         ...customRenderers,
       },
     };
-    const packageChangelogContent = (customRenderPackageChangelog || renderPackageChangelog)(renderInfo);
 
-    return [renderChangelogHeader(newEntry), packageChangelogContent, previousLogEntries].join('\n\n');
+    return (
+      [
+        renderChangelogHeader(newVersionChangelog),
+        (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
+        previousLogEntries,
+      ]
+        .join('\n\n')
+        .trim() + '\n'
+    );
   } catch (err) {
     console.log('Error occurred rendering package version changelog:', err);
     return '';
@@ -44,6 +51,6 @@ export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): 
 function renderChangelogHeader(changelog: PackageChangelog): string {
   return (
     `# Change Log - ${changelog.name}\n\n` +
-    `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.\n`
+    `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.`
   );
 }

--- a/packages/beachball/src/changelog/renderChangelog.ts
+++ b/packages/beachball/src/changelog/renderChangelog.ts
@@ -9,7 +9,7 @@ export interface MarkdownChangelogRenderOptions extends Omit<PackageChangelogRen
 
 export const markerComment = '<!-- Start content -->';
 
-export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): string {
+export async function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): Promise<string> {
   const {
     previousJson,
     previousContent = '',
@@ -48,7 +48,7 @@ export function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): 
       [
         renderChangelogHeader(newVersionChangelog),
         markerComment,
-        (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
+        await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
         previousLogEntries,
       ]
         .join('\n\n')

--- a/packages/beachball/src/changelog/renderJsonChangelog.ts
+++ b/packages/beachball/src/changelog/renderJsonChangelog.ts
@@ -1,5 +1,5 @@
 import { generateTag } from '../tag';
-import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/Changelog';
+import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/ChangeLog';
 
 export function renderJsonChangelog(changelog: PackageChangelog, previousChangelog: ChangelogJson | undefined) {
   const result: ChangelogJson = {

--- a/packages/beachball/src/changelog/renderJsonChangelog.ts
+++ b/packages/beachball/src/changelog/renderJsonChangelog.ts
@@ -1,9 +1,10 @@
 import { generateTag } from '../tag';
-import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/ChangeLog';
-export function renderJsonChangelog(previous: ChangelogJson, changelog: PackageChangelog) {
+import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/Changelog';
+
+export function renderJsonChangelog(changelog: PackageChangelog, previousChangelog: ChangelogJson | undefined) {
   const result: ChangelogJson = {
     name: changelog.name,
-    entries: [...previous.entries] || [],
+    entries: previousChangelog?.entries ? [...previousChangelog.entries] : [],
   };
   const newEntry: ChangelogJsonEntry = {
     date: changelog.date.toUTCString(),

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -1,27 +1,57 @@
-import { PackageChangelog, ChangelogEntry } from '../types/ChangeLog';
+import { ChangelogEntry } from '../types/Changelog';
 import _ from 'lodash';
+import { PackageChangelogRenderInfo, ChangelogRenderers } from '../types/ChangelogOptions';
+import { ChangeType } from '../types/ChangeInfo';
 
-export function renderPackageChangelog(changelog: PackageChangelog, isGroupedChangelog: boolean = false) {
-  return (
-    `\n## ${changelog.version}\n` +
-    `${changelog.date.toUTCString()}\n` +
-    (changelog.comments.major
-      ? '\n### Major\n\n' + renderChangelogEntries(changelog.comments.major, isGroupedChangelog)
-      : '') +
-    (changelog.comments.minor
-      ? '\n### Minor changes\n\n' + renderChangelogEntries(changelog.comments.minor, isGroupedChangelog)
-      : '') +
-    (changelog.comments.patch
-      ? '\n### Patches\n\n' + renderChangelogEntries(changelog.comments.patch, isGroupedChangelog)
-      : '') +
-    (changelog.comments.prerelease
-      ? '\n### Changes\n\n' + renderChangelogEntries(changelog.comments.prerelease, isGroupedChangelog)
-      : '')
-  );
+const groupNames: { [k in ChangeType]: string } = {
+  major: 'Major changes',
+  minor: 'Minor changes',
+  patch: 'Patches',
+  prerelease: 'Changes',
+  none: '', // not used
+};
+
+export const defaultRenderers: Required<ChangelogRenderers> = {
+  renderHeader: _renderHeader,
+  renderChangeTypeSection: _renderChangeTypeSection,
+  renderChangeTypeHeader: _renderChangeTypeHeader,
+  renderEntry: _renderEntry,
+};
+
+export function renderPackageChangelog(renderInfo: PackageChangelogRenderInfo) {
+  const { renderHeader, renderChangeTypeSection } = renderInfo.renderers;
+  const versionHeader = renderHeader(renderInfo);
+
+  return [
+    versionHeader,
+    renderChangeTypeSection('major', renderInfo),
+    renderChangeTypeSection('minor', renderInfo),
+    renderChangeTypeSection('patch', renderInfo),
+    renderChangeTypeSection('prerelease', renderInfo),
+  ]
+    .filter(Boolean)
+    .join('\n\n');
 }
 
-function renderChangelogEntries(entries: ChangelogEntry[], includePackageInfo: boolean = false): string {
-  if (includePackageInfo) {
+function _renderHeader(renderInfo: PackageChangelogRenderInfo): string {
+  return `## ${renderInfo.newEntry.version}\n${renderInfo.newEntry.date.toUTCString()}`;
+}
+
+function _renderChangeTypeSection(changeType: ChangeType, renderInfo: PackageChangelogRenderInfo): string {
+  const { renderChangeTypeHeader } = renderInfo.renderers;
+  const entries = renderInfo.newEntry.comments[changeType];
+  return entries
+    ? `${renderChangeTypeHeader(changeType, renderInfo)}\n\n${_renderChangelogEntries(entries, renderInfo)}`
+    : '';
+}
+
+function _renderChangeTypeHeader(changeType: ChangeType, renderInfo: PackageChangelogRenderInfo): string {
+  return `### ${groupNames[changeType]}`;
+}
+
+function _renderChangelogEntries(entries: ChangelogEntry[], renderInfo: PackageChangelogRenderInfo): string {
+  const { renderEntry } = renderInfo.renderers;
+  if (renderInfo.isGrouped) {
     const entriesMap = _.groupBy(entries, entry => entry.package);
 
     let result = '';
@@ -29,16 +59,16 @@ function renderChangelogEntries(entries: ChangelogEntry[], includePackageInfo: b
       const entries = entriesMap[pkgName];
       result += `- \`${pkgName}\`\n`;
       entries.forEach(entry => {
-        result += `  - ${entry.comment} (${entry.author})\n`;
+        result += `  ${renderEntry(entry, renderInfo)}\n`;
       });
     });
 
     return result;
   }
 
-  return entries
-    .map(entry => {
-      return `- ${entry.comment} (${entry.author})`;
-    })
-    .join('\n');
+  return entries.map(entry => renderEntry(entry, renderInfo)).join('\n');
+}
+
+function _renderEntry(entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo): string {
+  return `- ${entry.comment} (${entry.author})`;
 }

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -1,4 +1,4 @@
-import { ChangelogEntry } from '../types/Changelog';
+import { ChangelogEntry } from '../types/ChangeLog';
 import _ from 'lodash';
 import { PackageChangelogRenderInfo, ChangelogRenderers } from '../types/ChangelogOptions';
 import { ChangeType } from '../types/ChangeInfo';

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -97,7 +97,7 @@ function writeGroupedChangelog(
 
 function writeChangelogFiles(
   options: BeachballOptions,
-  newEntry: PackageChangelog,
+  newVersionChangelog: PackageChangelog,
   changelogPath: string,
   isGrouped: boolean
 ): void {
@@ -112,7 +112,7 @@ function writeChangelogFiles(
   }
   if (previousJson) {
     try {
-      const nextJson = renderJsonChangelog(newEntry, previousJson);
+      const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
       fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
     } catch (e) {
       console.warn('Problem writing to CHANGELOG.json:', e);
@@ -120,14 +120,19 @@ function writeChangelogFiles(
   }
 
   // Update CHANGELOG.md
-  if (newEntry.comments.major || newEntry.comments.minor || newEntry.comments.patch || newEntry.comments.prerelease) {
+  if (
+    newVersionChangelog.comments.major ||
+    newVersionChangelog.comments.minor ||
+    newVersionChangelog.comments.patch ||
+    newVersionChangelog.comments.prerelease
+  ) {
     const changelogFile = path.join(changelogPath, 'CHANGELOG.md');
     const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
 
     const newChangelog = renderChangelog({
       previousJson,
       previousContent,
-      newEntry,
+      newVersionChangelog,
       isGrouped,
       changelogOptions: options.changelog || {},
     });

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -108,15 +108,13 @@ function writeChangelogFiles(
   try {
     previousJson = fs.existsSync(changelogJsonFile) ? fs.readJSONSync(changelogJsonFile) : undefined;
   } catch (e) {
-    console.warn('CHANGELOG.json is invalid. Skipping writing to it.', e);
+    console.warn('CHANGELOG.json is invalid:', e);
   }
-  if (previousJson) {
-    try {
-      const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
-      fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
-    } catch (e) {
-      console.warn('Problem writing to CHANGELOG.json:', e);
-    }
+  try {
+    const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
+    fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
+  } catch (e) {
+    console.warn('Problem writing to CHANGELOG.json:', e);
   }
 
   // Update CHANGELOG.md

--- a/packages/beachball/src/changelog/writeChangelog.ts
+++ b/packages/beachball/src/changelog/writeChangelog.ts
@@ -8,7 +8,7 @@ import { renderChangelog } from './renderChangelog';
 import { renderJsonChangelog } from './renderJsonChangelog';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { isPathIncluded } from '../monorepo/utils';
-import { PackageChangelog, ChangelogJson } from '../types/Changelog';
+import { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
 
 export function writeChangelog(

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -31,12 +31,12 @@ import { validate } from './validation/validate';
       validate(options);
       // set a default publish message
       options.message = options.message || 'applying package updates';
-      publish(options);
+      await publish(options);
       break;
 
     case 'bump':
       validate(options);
-      bump(options);
+      await bump(options);
       break;
 
 

--- a/packages/beachball/src/commands/bump.ts
+++ b/packages/beachball/src/commands/bump.ts
@@ -2,6 +2,6 @@ import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { performBump } from '../bump/performBump';
 import { BeachballOptions } from '../types/BeachballOptions';
 
-export function bump(options: BeachballOptions) {
-  return performBump(gatherBumpInfo(options), options);
+export async function bump(options: BeachballOptions) {
+  return await performBump(gatherBumpInfo(options), options);
 }

--- a/packages/beachball/src/commands/publish.ts
+++ b/packages/beachball/src/commands/publish.ts
@@ -54,14 +54,14 @@ export async function publish(options: BeachballOptions) {
   // Step 1. Bump + npm publish
   // npm / yarn publish
   if (options.publish) {
-    publishToRegistry(bumpInfo, options);
+    await publishToRegistry(bumpInfo, options);
   } else {
     console.log('Skipping publish');
   }
   // Step 2.
   // - reset, fetch latest from origin/master (to ensure less chance of conflict), then bump again + commit
   if (branch && options.push) {
-    bumpAndPush(bumpInfo, publishBranch, options);
+    await bumpAndPush(bumpInfo, publishBranch, options);
   } else {
     console.log('Skipping git push and tagging');
   }

--- a/packages/beachball/src/publish/bumpAndPush.ts
+++ b/packages/beachball/src/publish/bumpAndPush.ts
@@ -5,13 +5,15 @@ import { git, gitFailFast, revertLocalChanges, parseRemoteBranch } from '../git'
 import { tagPackages } from './tagPackages';
 import { mergePublishBranch } from './mergePublishBranch';
 import { displayManualRecovery } from './displayManualRecovery';
-export function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
+
+export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
   const { path: cwd, branch, tag, message } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
   console.log('Reverting');
   revertLocalChanges(cwd);
-  console.log('Fetching from remote');
+
   // pull in latest from origin branch
+  console.log('Fetching from remote');
   gitFailFast(['fetch', remote], { cwd });
   const mergeResult = git(['merge', '-X', 'theirs', `${branch}`], { cwd });
   if (!mergeResult.success) {
@@ -19,9 +21,11 @@ export function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: 
     console.error(mergeResult.stderr);
     process.exit(1);
   }
+
   // bump the version
   console.log('Bumping the versions for git push');
-  performBump(bumpInfo, options);
+  await performBump(bumpInfo, options);
+
   // checkin
   const mergePublishBranchResult = mergePublishBranch(publishBranch, branch, message, cwd);
   if (!mergePublishBranchResult.success) {
@@ -29,11 +33,13 @@ export function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: 
     displayManualRecovery(bumpInfo);
     process.exit(1);
   }
+
   // Step 3. Tag & Push to remote
   tagPackages(bumpInfo, tag, cwd);
   console.log(`pushing to ${branch}, running the following command for git push:`);
   const pushArgs = ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`];
   console.log('git ' + pushArgs.join(' '));
+
   const pushResult = git(pushArgs, { cwd });
   if (!pushResult.success) {
     console.error(`CRITICAL ERROR: push to ${branch} has failed!`);

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -5,11 +5,11 @@ import { packagePublish } from '../packageManager/packagePublish';
 import { validatePackageVersions } from './validatePackageVersions';
 import { displayManualRecovery } from './displayManualRecovery';
 
-export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions) {
+export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { registry, tag, token, access, timeout } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
-  performBump(bumpInfo, options);
+  await performBump(bumpInfo, options);
 
   const succeededPackages = new Set<string>();
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -1,5 +1,6 @@
 import { ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
+import { ChangelogOptions } from './ChangelogOptions';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -67,24 +68,4 @@ export interface VersionGroupOptions {
 
   /** name of the version group */
   name: string;
-}
-
-/**
- * Options for change log related configurations.
- */
-export interface ChangelogOptions {
-  groups: ChangelogGroupOptions[];
-}
-
-export interface ChangelogGroupOptions {
-  /** the main package which a group of changes bubbles up to. all changes within the group are used to describe changes for the master package. */
-  masterPackageName: string;
-
-  /** minimatch pattern (or array of minimatch) to detect which packages should be included in this group */
-  include: string | string[];
-
-  /** minimatch pattern (or array of minimatch) to detect which packages should be excluded in this group */
-  exclude?: string | string[];
-
-  changelogPath: string;
 }

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -21,13 +21,13 @@ export interface ChangelogEntry {
  * If using grouped changelogs, it could be for multiple packages.
  */
 export interface PackageChangelog {
-  /** Package name */
+  /** Package name (if a grouped changelog, for the primary package) */
   name: string;
   /** Version creation date */
   date: Date;
-  /** Version number */
+  /** Version number (if a grouped changelog, for the primary package) */
   version: string;
-  /** Corresponding git tag name */
+  /** Corresponding git tag name (if a grouped changelog, for the primary package) */
   tag: string;
   /** Changes in this version */
   comments: { [k in ChangeType]?: ChangelogEntry[] };

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -1,35 +1,46 @@
+/**
+ * !!!! IMPORTANT !!!!
+ * Changes made to interfaces here can affect custom changelog rendering done by end-user.
+ */
+
+import { ChangeType } from './ChangeInfo';
+
 export interface ChangelogEntry {
+  /** Change comment */
   comment: string;
+  /** Author email */
   author: string;
+  /** Commit hash */
   commit: string;
+  /** Package name the change was in */
   package: string;
 }
 
+/**
+ * Changelog info for an individual version. Usually this is for a single package.
+ * If using grouped changelogs, it could be for multiple packages.
+ */
 export interface PackageChangelog {
+  /** Package name */
   name: string;
+  /** Version creation date */
   date: Date;
+  /** Version number */
   version: string;
-  comments: {
-    prerelease?: ChangelogEntry[];
-    patch?: ChangelogEntry[];
-    minor?: ChangelogEntry[];
-    major?: ChangelogEntry[];
-    none?: ChangelogEntry[];
-  };
+  /** Corresponding git tag name */
+  tag: string;
+  /** Changes in this version */
+  comments: { [k in ChangeType]?: ChangelogEntry[] };
 }
 
-export interface ChangelogJsonEntry {
+/**
+ * CHANGELOG.json entry for an individual version. Usually this is for a single package.
+ * If using grouped changelogs, it could be for multiple packages.
+ */
+export type ChangelogJsonEntry = Omit<PackageChangelog, 'name' | 'date'> & {
+  /** Version creation date as a string */
   date: string;
-  version: string;
-  tag: string;
-  comments: {
-    prerelease?: ChangelogEntry[];
-    patch?: ChangelogEntry[];
-    minor?: ChangelogEntry[];
-    major?: ChangelogEntry[];
-    none?: ChangelogEntry[];
-  };
-}
+};
 
 export interface ChangelogJson {
   name: string;

--- a/packages/beachball/src/types/ChangelogOptions.ts
+++ b/packages/beachball/src/types/ChangelogOptions.ts
@@ -14,6 +14,8 @@ export interface ChangelogOptions {
 
   /**
    * Use this for full custom rendering of the entire changelog markdown for a particular package version.
+   * Default renderers (and `customRenderers` if provided) will be available in `renderInfo.renderers`
+   * but will not be called automatically.
    */
   renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => string;
 
@@ -51,7 +53,7 @@ export interface PackageChangelogRenderInfo {
   previousJson: ChangelogJson | undefined;
 
   /** Changelog for a package version that is going to be added to full changelog. */
-  newEntry: PackageChangelog;
+  newVersionChangelog: PackageChangelog;
 
   /** True if this is a grouped changelog. */
   isGrouped: boolean;
@@ -68,7 +70,7 @@ export interface ChangelogRenderers {
   /**
    * Custom renderer for the header for a particular package version.
    *
-   * Default is like this:
+   * Default is like this (no leading or trailing newlines):
    * ```txt
    * ## 1.23.1
    * Wed, 25 Mar 2020 20:20:02 GMT
@@ -79,11 +81,11 @@ export interface ChangelogRenderers {
   /**
    * Custom renderer for the section about `changeType` changes for a particular package version.
    *
-   * Default is like this:
+   * Default is like this (no leading or trailing newlines):
    * ```txt
    * ### Minor changes
    *
-   * - ChangeLog: add empty options interface (xgao@microsoft.com)
+   * - Really interesting change (user1@microsoft.com)
    * ```
    */
   renderChangeTypeSection?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
@@ -91,7 +93,7 @@ export interface ChangelogRenderers {
   /**
    * Custom renderer for the section header about `changeType` changes for a particular package version.
    *
-   * Default is like this:
+   * Default is like this (no leading or trailing newlines):
    * ```txt
    * ### Minor changes
    * ```
@@ -99,11 +101,31 @@ export interface ChangelogRenderers {
   renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
 
   /**
+   * Custom renderer for the list of `changeType` changes (not including the change type header)
+   * for a particular package version.
+   *
+   * Default is like this for non-grouped changelogs (no leading or trailing newlines):
+   * ```txt
+   * - Really interesting change (user1@microsoft.com)
+   * - Boring change (user2@microsoft.com)
+   * ```
+   *
+   * Or like this for grouped changelogs:
+   * ```txt
+   * - `foo`
+   *   - Really interesting change (user1@microsoft.com)
+   * - `bar`
+   *   - Boring change (user2@microsoft.com)
+   * ```
+   */
+  renderEntries?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+
+  /**
    * Custom renderer for an individual change entry.
    *
-   * Default is like this:
+   * Default is like this (no leading or trailing newlines):
    * ```txt
-   * - ChangeLog: add empty options interface (xgao@microsoft.com)
+   * - Really interesting change (user1@microsoft.com)
    * ```
    */
   renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => string;

--- a/packages/beachball/src/types/ChangelogOptions.ts
+++ b/packages/beachball/src/types/ChangelogOptions.ts
@@ -1,4 +1,4 @@
-import { ChangelogJson, PackageChangelog, ChangelogEntry } from './Changelog';
+import { ChangelogJson, PackageChangelog, ChangelogEntry } from './ChangeLog';
 import { ChangeType } from './ChangeInfo';
 
 /**

--- a/packages/beachball/src/types/ChangelogOptions.ts
+++ b/packages/beachball/src/types/ChangelogOptions.ts
@@ -1,0 +1,110 @@
+import { ChangelogJson, PackageChangelog, ChangelogEntry } from './Changelog';
+import { ChangeType } from './ChangeInfo';
+
+/**
+ * Options for changelog-related configuration.
+ *
+ * If you would like to entirely customize rendering, use `renderPackageChangelog`.
+ * Otherwise, you can provide as many or as few of the other custom renderer options as you'd like
+ * to achieve the desired level of customization.
+ */
+export interface ChangelogOptions {
+  /** Options for grouping packages together in a single changelog. */
+  groups?: ChangelogGroupOptions[];
+
+  /**
+   * Use this for full custom rendering of the entire changelog markdown for a particular package version.
+   */
+  renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => string;
+
+  /**
+   * Fine-grained custom renderers for individual parts of the changelog.
+   * If using a custom `renderPackageChangelog`, these will not be called automatically.
+   */
+  customRenderers?: ChangelogRenderers;
+}
+
+/**
+ * Options for generating a changelog for a group of packages.
+ */
+export interface ChangelogGroupOptions {
+  /**
+   * The main package which a group of changes bubbles up to.
+   * All changes within the group are used to describe changes for the master package.
+   */
+  masterPackageName: string;
+
+  /** minimatch pattern (or array of minimatch) to detect which packages should be included in this group */
+  include: string | string[];
+
+  /** minimatch pattern (or array of minimatch) to detect which packages should be excluded in this group */
+  exclude?: string | string[];
+
+  changelogPath: string;
+}
+
+/**
+ * Info used for rendering the changelog markdown for a particular package version.
+ */
+export interface PackageChangelogRenderInfo {
+  /** Existing json in CHANGELOG.json.  */
+  previousJson: ChangelogJson | undefined;
+
+  /** Changelog for a package version that is going to be added to full changelog. */
+  newEntry: PackageChangelog;
+
+  /** True if this is a grouped changelog. */
+  isGrouped: boolean;
+
+  /**
+   * Renderers for individual elements of the changelog.
+   * If any custom renderers were provided in `ChangelogOptions.customRenderers`, they will be included here.
+   * Default renderers will be included in cases where a custom option wasn't provided.
+   */
+  renderers: Required<ChangelogRenderers>;
+}
+
+export interface ChangelogRenderers {
+  /**
+   * Custom renderer for the header for a particular package version.
+   *
+   * Default is like this:
+   * ```txt
+   * ## 1.23.1
+   * Wed, 25 Mar 2020 20:20:02 GMT
+   * ```
+   */
+  renderHeader?: (renderInfo: PackageChangelogRenderInfo) => string;
+
+  /**
+   * Custom renderer for the section about `changeType` changes for a particular package version.
+   *
+   * Default is like this:
+   * ```txt
+   * ### Minor changes
+   *
+   * - ChangeLog: add empty options interface (xgao@microsoft.com)
+   * ```
+   */
+  renderChangeTypeSection?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+
+  /**
+   * Custom renderer for the section header about `changeType` changes for a particular package version.
+   *
+   * Default is like this:
+   * ```txt
+   * ### Minor changes
+   * ```
+   */
+  renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+
+  /**
+   * Custom renderer for an individual change entry.
+   *
+   * Default is like this:
+   * ```txt
+   * - ChangeLog: add empty options interface (xgao@microsoft.com)
+   * ```
+   */
+  renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => string;
+}

--- a/packages/beachball/src/types/ChangelogOptions.ts
+++ b/packages/beachball/src/types/ChangelogOptions.ts
@@ -17,7 +17,7 @@ export interface ChangelogOptions {
    * Default renderers (and `customRenderers` if provided) will be available in `renderInfo.renderers`
    * but will not be called automatically.
    */
-  renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => string;
+  renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 
   /**
    * Fine-grained custom renderers for individual parts of the changelog.
@@ -76,7 +76,7 @@ export interface ChangelogRenderers {
    * Wed, 25 Mar 2020 20:20:02 GMT
    * ```
    */
-  renderHeader?: (renderInfo: PackageChangelogRenderInfo) => string;
+  renderHeader?: (renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 
   /**
    * Custom renderer for the section about `changeType` changes for a particular package version.
@@ -88,7 +88,7 @@ export interface ChangelogRenderers {
    * - Really interesting change (user1@microsoft.com)
    * ```
    */
-  renderChangeTypeSection?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+  renderChangeTypeSection?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 
   /**
    * Custom renderer for the section header about `changeType` changes for a particular package version.
@@ -98,7 +98,7 @@ export interface ChangelogRenderers {
    * ### Minor changes
    * ```
    */
-  renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+  renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 
   /**
    * Custom renderer for the list of `changeType` changes (not including the change type header)
@@ -118,7 +118,7 @@ export interface ChangelogRenderers {
    *   - Boring change (user2@microsoft.com)
    * ```
    */
-  renderEntries?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string;
+  renderEntries?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 
   /**
    * Custom renderer for an individual change entry.
@@ -128,5 +128,5 @@ export interface ChangelogRenderers {
    * - Really interesting change (user1@microsoft.com)
    * ```
    */
-  renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => string;
+  renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
 }

--- a/packages/beachball/src/validation/isValidChangelogOptions.ts
+++ b/packages/beachball/src/validation/isValidChangelogOptions.ts
@@ -1,4 +1,4 @@
-import { ChangelogOptions, ChangelogGroupOptions } from '../types/BeachballOptions';
+import { ChangelogOptions, ChangelogGroupOptions } from '../types/ChangelogOptions';
 
 export function isValidChangelogOptions(options: ChangelogOptions): boolean {
   if (options.groups) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13086,11 +13086,6 @@ normalize.css@^8.0.1:
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
 
-not@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/not/-/not-0.1.0.tgz#c9691c1746c55dcfbe54cbd8bd4ff041bc2b519d"
-  integrity sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0=
-
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
@@ -15789,27 +15784,6 @@ remark-parse@^7.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
-remark-parse@~7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-7.0.1.tgz#0c13d67e0d7b82c2ad2d8b6604ec5fae6c333c2b"
-  integrity sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==
-  dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
-
 remark-preset-lint-recommended@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/remark-preset-lint-recommended/-/remark-preset-lint-recommended-3.0.3.tgz#1322af0e49801278057f8f275ed1b6ed60328b40"
@@ -18470,17 +18444,6 @@ unified@^8.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-8.3.2.tgz#aed69d0e577d6ef27268431c63a10faef60e63ab"
-  integrity sha512-NDtUAXcd4c+mKppCbsZHzmhkKEQuhveZNBrFYmNgMIMk2K9bc8hmG3mLEGVtRmSNodobwyMePAnvIGVWZfPdzQ==
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^2.0.0"
-    trough "^1.0.0"
-    vfile "^4.0.0"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -18590,17 +18553,6 @@ unist-util-select@^1.5.0:
     css-selector-parser "^1.1.0"
     debug "^2.2.0"
     nth-check "^1.0.1"
-
-unist-util-select@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-2.0.2.tgz#cb2774b599695172e7b60a8b5f50793e418f7ea6"
-  integrity sha512-Yv5Z5ShMxv7Z9Dw175tKvOiRVXV4FrMHG778DSD9Z0jALgb3wAx9DoeInr3200QlYp71rYUXzzJdCb76xKdrCw==
-  dependencies:
-    css-selector-parser "^1.1.0"
-    not "^0.1.0"
-    nth-check "^1.0.1"
-    unist-util-is "^3.0.0"
-    zwitch "^1.0.3"
 
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.2"
@@ -19916,7 +19868,7 @@ yurnalist@^1.1.1:
     strip-ansi "^5.2.0"
     strip-bom "^4.0.0"
 
-zwitch@^1.0.0, zwitch@^1.0.3:
+zwitch@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.4.tgz#93b1b993b13c8926753a41afaf8f27bbfac6be8b"
   integrity sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg==


### PR DESCRIPTION
Add fine-grained custom render functions for the changelog markdown. This way if someone wants to just modify one little part, they don't have to re-create the entire rendering logic. 

Variant of @xugao's PR #289.

Example:
```js
module.exports = {
  // ...
  changelogOptions: {
    customRenderers: {
      renderHeader: (renderInfo) => {
        return [
          `## ${renderInfo.newPackageVersion.version}`, 
          renderInfo.newPackageVersion.date.toUTCString(),
          `[Compare changes](${/*get compare link*/})`
        ].join('\n');
      },
      renderEntry: (entry, renderInfo) =>
        `- ${entry.comment} (${entry.author}, PR #${/*get PR number*/})`
    }
  }
};
```

Also add the git tag to CHANGELOG.json, which was part of Xu's change.