### PR TITLE
Change file prompt: support customizing prompt questions

### DIFF
--- a/change/beachball-2020-03-30-13-44-57-xgao-custom-change-type-prompt.json
+++ b/change/beachball-2020-03-30-13-44-57-xgao-custom-change-type-prompt.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Change file prompt: support customizing prompt questions",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-30T20:44:57.439Z"
+}

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -1,12 +1,14 @@
 import { ChangeFileInfo, ChangeType } from '../types/ChangeInfo';
 import { getChangedPackages } from './getChangedPackages';
-import { getRecentCommitMessages, getUserEmail, getCurrentHash } from '../git';
+import { getRecentCommitMessages, getUserEmail } from '../git';
 import prompts from 'prompts';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { prerelease } from 'semver';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 import { PackageGroups, PackageInfos } from '../types/PackageInfo';
+import { isValidChangeType } from '../validation/isValidChangeType';
+import { DefaultPrompt } from '../types/ChangeFilePrompt';
 
 /**
  * Uses `prompts` package to prompt for change type and description, fills in git user.email, scope, and the commit hash
@@ -26,8 +28,8 @@ export async function promptForChange(options: BeachballOptions) {
     console.log(`Please describe the changes for: ${pkg}`);
 
     const disallowedChangeTypes = getDisallowedChangeTypes(pkg, packageInfos, packageGroups);
-
-    const showPrereleaseOption = prerelease(packageInfos[pkg].version);
+    const packageInfo = packageInfos[pkg];
+    const showPrereleaseOption = prerelease(packageInfo.version);
     const changeTypePrompt: prompts.PromptObject<string> = {
       type: 'select',
       name: 'type',
@@ -62,10 +64,18 @@ export async function promptForChange(options: BeachballOptions) {
 
     const showChangeTypePrompt = !options.type && changeTypePrompt.choices!.length > 1;
 
-    const questions = [
-      ...(showChangeTypePrompt ? [changeTypePrompt] : []),
-      ...(!options.message ? [descriptionPrompt] : []),
-    ];
+    const defaultPrompt: DefaultPrompt = {
+      changeType: showChangeTypePrompt ? changeTypePrompt : undefined,
+      description: !options.message ? descriptionPrompt : undefined,
+    };
+
+    let questions = [defaultPrompt.changeType, defaultPrompt.description].filter(q => !!q) as prompts.PromptObject<
+      string
+    >[];
+
+    if (packageInfo.options.changeFilePrompt?.changePrompt) {
+      questions = packageInfo.options.changeFilePrompt?.changePrompt(defaultPrompt);
+    }
 
     let response: { comment: string; type: ChangeType } = {
       type: options.type || 'none',
@@ -77,6 +87,11 @@ export async function promptForChange(options: BeachballOptions) {
 
       if (Object.keys(response).length === 0) {
         console.log('Cancelled, no change files are written');
+        return;
+      }
+
+      if (!isValidChangeType(response.type)) {
+        console.error('Prompt response contains invalid change type.');
         return;
       }
     }

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -69,13 +69,13 @@ export async function promptForChange(options: BeachballOptions) {
       description: !options.message ? descriptionPrompt : undefined,
     };
 
-    let questions = [defaultPrompt.changeType, defaultPrompt.description].filter(q => !!q) as prompts.PromptObject<
-      string
-    >[];
+    let questions = [defaultPrompt.changeType, defaultPrompt.description];
 
     if (packageInfo.options.changeFilePrompt?.changePrompt) {
       questions = packageInfo.options.changeFilePrompt?.changePrompt(defaultPrompt);
     }
+
+    questions = questions.filter(q => !!q);
 
     let response: { comment: string; type: ChangeType } = {
       type: options.type || 'none',
@@ -83,7 +83,7 @@ export async function promptForChange(options: BeachballOptions) {
     };
 
     if (questions.length > 0) {
-      response = (await prompts(questions)) as { comment: string; type: ChangeType };
+      response = (await prompts(questions as prompts.PromptObject[])) as { comment: string; type: ChangeType };
 
       if (Object.keys(response).length === 0) {
         console.log('Cancelled, no change files are written');

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -1,4 +1,5 @@
 import { ChangeType } from './ChangeInfo';
+import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -46,11 +47,13 @@ export interface RepoOptions {
   retries: number;
   groups?: VersionGroupOptions[];
   changelog?: ChangelogOptions;
+  changeFilePrompt?: ChangeFilePromptOptions;
 }
 
 export interface PackageOptions {
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
+  changeFilePrompt?: ChangeFilePromptOptions;
 }
 
 export interface VersionGroupOptions {

--- a/packages/beachball/src/types/ChangeFilePrompt.ts
+++ b/packages/beachball/src/types/ChangeFilePrompt.ts
@@ -1,0 +1,13 @@
+import prompts from 'prompts';
+
+export interface DefaultPrompt {
+  changeType: prompts.PromptObject<string> | undefined;
+  description: prompts.PromptObject<string> | undefined;
+}
+
+/**
+ * Options for customizing change file prompt.
+ */
+export interface ChangeFilePromptOptions {
+  changePrompt?(defaultPrompt: DefaultPrompt): prompts.PromptObject[];
+}


### PR DESCRIPTION
Enable customizing the prompt with the following:
1. description for each change type 
2. add change area prompt

For instance:
Beachball options:
```

  changeFilePrompt: {
    changePrompt: prompt => {
      const { changeType } = prompt;
      changeType.choices &&
        changeType.choices.forEach(choice => {
          if (choice.value === 'patch') {
            choice.title = ' [1mPatch[22m      - Changes that bumps packge with patch version.';
          } else if (choice.value === 'minor') {
            choice.title = ' [1mMinor[22m      - Changes that bumps packge with minor version.';
          }
        });

      const changeAreaPrompt = {
        type: 'select',
        name: 'area',
        message: 'Change area',
        choices: [
          { value: 'fix', title: 'Bug fix' },
          { value: 'perf', title: 'Performance' },
          { value: 'doc', title: 'Documentation' },
        ],
      };
      return [prompt.changeType, changeAreaPrompt, prompt.description];
    },
  },
```
Will lead to prompt:
![image](https://user-images.githubusercontent.com/1207059/77951368-cf71aa00-727e-11ea-8b84-488163a8e7b0.png)
![image](https://user-images.githubusercontent.com/1207059/77951487-0051df00-727f-11ea-86ee-ba717d4ace69.png)

No change to existing description prompt

Addresses #275