### PR TITLE
Adds an option to allow package publishes to be retried

### DIFF
--- a/change/beachball-2020-03-30-12-36-52-retries.json
+++ b/change/beachball-2020-03-30-12-36-52-retries.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding a retries option",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-30T19:36:52.043Z"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -1,6 +1,7 @@
 {
   "name": "beachball",
   "version": "1.23.3",
+  "description": "The Sunniest Semantic Version Bumper",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/beachball"
@@ -12,12 +13,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
     "jest": "jest",
+    "start": "tsc -w --preserveWatchOutput",
     "test": "yarn test:unit && yarn test:e2e",
-    "test:unit": "jest --config jest.config.js",
+    "test-watch": "jest --watch",
     "test:e2e": "jest --runInBand --config jest.e2e.js",
-    "test-watch": "jest --watch"
+    "test:unit": "jest --config jest.config.js"
   },
   "dependencies": {
     "cosmiconfig": "^6.0.0",

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -63,6 +63,7 @@ describe('publish command (e2e)', () => {
       fetch: true,
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
+      retries: 3,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -138,6 +139,7 @@ describe('publish command (e2e)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       scope: ['!packages/foo'],
+      retries: 3,
     });
 
     const fooNpmResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);

--- a/packages/beachball/src/__e2e__/publishGit.test.ts
+++ b/packages/beachball/src/__e2e__/publishGit.test.ts
@@ -60,6 +60,7 @@ describe('publish command (git)', () => {
       fetch: true,
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
+      retries: 3,
     });
 
     const newRepo = await repositoryFactory.cloneRepository();
@@ -115,6 +116,7 @@ describe('publish command (git)', () => {
       fetch: true,
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
+      retries: 3,
     };
 
     const bumpInfo = gatherBumpInfo(options);

--- a/packages/beachball/src/__e2e__/publishRegistry.test.ts
+++ b/packages/beachball/src/__e2e__/publishRegistry.test.ts
@@ -44,6 +44,8 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
+    const spy = jest.spyOn(console, 'log').mockImplementation();
+
     const publishPromise = publish({
       branch: 'origin/master',
       command: 'publish',
@@ -68,7 +70,11 @@ describe('publish command (registry)', () => {
       timeout: 100
     });
 
+
     await expect(publishPromise).rejects.toThrow();
+    expect(spy).toHaveBeenCalledWith('Published failed, retrying... (3/3)')
+
+    spy.mockRestore();
 
     await registry.start();
   });

--- a/packages/beachball/src/__e2e__/publishRegistry.test.ts
+++ b/packages/beachball/src/__e2e__/publishRegistry.test.ts
@@ -44,30 +44,31 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    expect(async () => {
-      await publish({
-        branch: 'origin/master',
-        command: 'publish',
-        message: 'apply package updates',
-        path: repo.rootPath,
-        publish: true,
-        bumpDeps: false,
-        push: false,
-        registry: registry.getUrl(),
-        tag: 'latest',
-        token: '',
-        yes: true,
-        new: false,
-        access: 'public',
-        package: 'foo',
-        changehint: 'Run "beachball change" to create a change file',
-        type: null,
-        fetch: true,
-        disallowedChangeTypes: null,
-        defaultNpmTag: 'latest',
-        retries: 3,
-      });
-    }).toThrow();
+    const publishPromise = publish({
+      branch: 'origin/master',
+      command: 'publish',
+      message: 'apply package updates',
+      path: repo.rootPath,
+      publish: true,
+      bumpDeps: false,
+      push: false,
+      registry: 'httppppp://somethingwrong',
+      tag: 'latest',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: 'foo',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      timeout: 100
+    });
+
+    await expect(publishPromise).rejects.toThrow();
 
     await registry.start();
   });

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -20,5 +20,6 @@ export function getDefaultOptions() {
     disallowedChangeTypes: null,
     defaultNpmTag: 'latest',
     scope: null,
+    retries: 3,
   } as BeachballOptions;
 }

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -21,5 +21,6 @@ export function getDefaultOptions() {
     defaultNpmTag: 'latest',
     scope: null,
     retries: 3,
+    timeout: undefined
   } as BeachballOptions;
 }

--- a/packages/beachball/src/packageManager/packagePublish.ts
+++ b/packages/beachball/src/packageManager/packagePublish.ts
@@ -6,7 +6,8 @@ export function packagePublish(
   registry: string,
   token: string,
   tag: string | undefined,
-  access: string
+  access: string,
+  timeout?: number | undefined
 ) {
   const packageOptions = packageInfo.options;
   const packagePath = path.dirname(packageInfo.packageJsonPath);
@@ -20,5 +21,5 @@ export function packagePublish(
     args.push(access);
   }
   console.log(`publish command: ${args.join(' ')}`);
-  return npm(args, { cwd: packagePath });
+  return npm(args, { cwd: packagePath, timeout });
 }

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -6,7 +6,7 @@ import { validatePackageVersions } from './validatePackageVersions';
 import { displayManualRecovery } from './displayManualRecovery';
 
 export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { registry, tag, token, access } = options;
+  const { registry, tag, token, access, timeout } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
   performBump(bumpInfo, options);
@@ -37,7 +37,7 @@ export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions)
       let retries = 0;
 
       do {
-        result = packagePublish(packageInfo, registry, token, tag, access);
+        result = packagePublish(packageInfo, registry, token, tag, access, timeout);
 
         if (result.success) {
           console.log('Published!');
@@ -45,7 +45,10 @@ export function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions)
           return;
         } else {
           retries++;
-          console.log(`Published failed, retrying... (${retries}/${options.retries})`);
+
+          if (retries <= options.retries) {
+            console.log(`Published failed, retrying... (${retries}/${options.retries})`);
+          }
         }
       } while (retries <= options.retries);
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -19,11 +19,12 @@ export interface CliOptions {
   access: 'public' | 'restricted';
   package: string;
   changehint: string;
+  retries: number;
   type?: ChangeType | null;
   help?: boolean;
   version?: boolean;
   scope?: string[] | null;
-  retries?: number;
+  timeout?: number;
 }
 
 export interface RepoOptions {

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -23,6 +23,7 @@ export interface CliOptions {
   help?: boolean;
   version?: boolean;
   scope?: string[] | null;
+  retries?: number;
 }
 
 export interface RepoOptions {
@@ -39,6 +40,9 @@ export interface RepoOptions {
   changehint: string;
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
+
+  /** number of retries for a package publish before failing */
+  retries: number;
   groups?: VersionGroupOptions[];
   changelog?: ChangelogOptions;
 }


### PR DESCRIPTION
This fixes #290 - sometimes publishes fail due to network conditions. This retry will add resiliency to the publish process.