### PR TITLE
adding a sync command to help recover

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ bumps versions as well as generating changelogs
 
 bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
 
+### sync
+
+synchronizes published versions of packages from a registry, makes local package.json changes to match what is published
+
 ## Options
 
 ### --registry, -r

--- a/change/beachball-2020-03-30-14-47-30-sync.json
+++ b/change/beachball-2020-03-30-14-47-30-sync.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding a sync command to help recover",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-30T21:47:30.808Z"
+}

--- a/packages/beachball/README.md
+++ b/packages/beachball/README.md
@@ -38,6 +38,10 @@ bumps versions as well as generating changelogs
 
 bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
 
+### sync
+
+synchronizes published versions of packages from a registry, makes local package.json changes to match what is published
+
 ## Options
 
 ### --registry, -r

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -1,6 +1,7 @@
 import { bump } from './commands/bump';
 import { change } from './commands/change';
 import { publish } from './commands/publish';
+import { sync } from './commands/sync';
 
 import { showVersion, showHelp } from './help';
 import { getOptions } from './options/getOptions';
@@ -36,6 +37,11 @@ import { validate } from './validation/validate';
     case 'bump':
       validate(options);
       bump(options);
+      break;
+
+
+    case 'sync':
+      sync(options);
       break;
 
     default:

--- a/packages/beachball/src/commands/sync.ts
+++ b/packages/beachball/src/commands/sync.ts
@@ -1,0 +1,27 @@
+import { BeachballOptions } from '../types/BeachballOptions';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { npm } from '../packageManager/npm';
+import semver from 'semver';
+import fs from 'fs-extra';
+
+export async function sync(options: BeachballOptions) {
+  const packageInfos = getPackageInfos(options.path);
+
+  for (const [pkg, info] of Object.entries(packageInfos)) {
+    const npmArgs = ['view', pkg, 'version'];
+    if (options.registry) {
+      npmArgs.push('--registry');
+      npmArgs.push(options.registry);
+    }
+    const result = npm(npmArgs);
+    const publishedVersion = result.stdout;
+
+    if (semver.lt(info.version, publishedVersion)) {
+      console.log(`There is a newer version of "${pkg}@${info.version}". Syncing to the published version ${publishedVersion}`)
+
+      const packageJson = fs.readJsonSync(info.packageJsonPath);
+      packageJson.version = publishedVersion;
+      fs.writeJsonSync(info.packageJsonPath, packageJson, { spaces: 2 });
+    }
+  }
+}

--- a/packages/beachball/src/help.ts
+++ b/packages/beachball/src/help.ts
@@ -21,13 +21,14 @@ Commands:
   changelog           - based on change files, create changelogs and then unlinks the change files
   bump                - bumps versions as well as generating changelogs
   publish             - bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
+  sync                - synchronizes published versions of packages from a registry, makes local package.json changes to match what is published
 
 Options:
 
   --registry, -r      - registry, defaults to https://registry.npmjs.org
   --tag, -t           - dist-tag for npm publishes
   --branch, -b        - target branch from origin (default: master)
-  --message, -m       - for publish command: custom publish message for the checkin (default: applying package updates); 
+  --message, -m       - for publish command: custom publish message for the checkin (default: applying package updates);
                         for change command: description of the change
   --no-push           - skip pushing changes back to git remote origin
   --no-publish        - skip publishing to the npm registry

--- a/packages/beachball/src/publish/displayManualRecovery.ts
+++ b/packages/beachball/src/publish/displayManualRecovery.ts
@@ -17,8 +17,14 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
   if (succeededLines.length) {
     console.warn(
       'These packages and versions were successfully published, but may be invalid due to depending on ' +
-        'package versions for which publishing failed:'
+      'package versions for which publishing failed:'
     );
+
     succeededLines.forEach(console.warn);
+
+    console.warn('To recover from this, you should run "beachball sync" to update local package.json ' +
+      'files to synchronize package.json version. If necessary, unpublish any invalid packages from the above ' +
+      'list after "beachball sync".'
+    )
   }
 }


### PR DESCRIPTION
Fixes a long standing feature request: #29 

In the event of a partial publish failure, it is tedious to have to find out which package versions to sync. This automates the procedure. This script does NOT unpublish old partially published versions, however.