### PR TITLE
e2e tests should clean up properly

### DIFF
--- a/change/beachball-2020-04-01-20-18-37-e2e-cleanup.json
+++ b/change/beachball-2020-04-01-20-18-37-e2e-cleanup.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "e2e tests should clean up properly",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "date": "2020-04-02T03:18:37.100Z"
+}

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -9,14 +9,23 @@ import { getChangePath } from '../paths';
 import { MonoRepoFactory } from '../fixtures/monorepo';
 
 describe('version bumping', () => {
+  let repositoryFactory: RepositoryFactory | undefined;
+
   function getChangeFiles(cwd: string): string[] {
     const changePath = getChangePath(cwd);
     const changeFiles = changePath && fs.existsSync(changePath) ? fs.readdirSync(changePath) : [];
     return changeFiles;
   }
 
+  afterEach(async () => {
+    if (repositoryFactory) {
+      repositoryFactory.cleanUp();
+      repositoryFactory = undefined;
+    }
+  });
+
   it('bumps only packages with change files', async () => {
-    const repositoryFactory = new RepositoryFactory();
+    repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -103,7 +112,7 @@ describe('version bumping', () => {
   });
 
   it('bumps all dependent packages with `bumpDeps` flag', async () => {
-    const repositoryFactory = new RepositoryFactory();
+    repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -190,7 +199,7 @@ describe('version bumping', () => {
   });
 
   it('bumps all grouped packages', async () => {
-    const repositoryFactory = new RepositoryFactory();
+    repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -256,7 +265,7 @@ describe('version bumping', () => {
   });
 
   it('bumps all grouped AND dependent packages', async () => {
-    const repositoryFactory = new RepositoryFactory();
+    repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -350,7 +359,7 @@ describe('version bumping', () => {
   });
 
   it('should not bump out-of-scope package even if package has change', async () => {
-    const repositoryFactory = new MonoRepoFactory();
+    repositoryFactory = new MonoRepoFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -381,7 +390,7 @@ describe('version bumping', () => {
   });
 
   it('should not bump out-of-scope package even if dependency of the package has change', async () => {
-    const repositoryFactory = new MonoRepoFactory();
+    repositoryFactory = new MonoRepoFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 

--- a/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
+++ b/packages/beachball/src/__e2e__/monorepo/getScopedPackages.test.ts
@@ -4,12 +4,16 @@ import { MonoRepoFactory } from '../../fixtures/monorepo';
 import { Repository } from '../../fixtures/repository';
 
 describe('getScopedPackages', () => {
+  let repoFactory: MonoRepoFactory;
   let repo: Repository;
 
   beforeAll(async () => {
-    const repoFactory = new MonoRepoFactory();
+    repoFactory = new MonoRepoFactory();
     await repoFactory.create();
     repo = await repoFactory.cloneRepository();
+  });
+  afterAll(async () => {
+    await repoFactory.cleanUp();
   });
 
   it('can scope packages', async () => {

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -8,6 +8,7 @@ import { MonoRepoFactory } from '../fixtures/monorepo';
 
 describe('publish command (e2e)', () => {
   let registry: Registry;
+  let repositoryFactory: RepositoryFactory | undefined;
 
   beforeAll(() => {
     registry = new Registry();
@@ -22,8 +23,15 @@ describe('publish command (e2e)', () => {
     await registry.reset();
   });
 
+  afterEach(async () => {
+    if (repositoryFactory) {
+      await repositoryFactory.cleanUp();
+      repositoryFactory = undefined;
+    }
+  });
+
   it('can perform a successful npm publish', async () => {
-    const repositoryFactory = new RepositoryFactory();
+    repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 
@@ -84,7 +92,7 @@ describe('publish command (e2e)', () => {
   });
 
   it('should not perform npm publish on out-of-scope package', async () => {
-    const repositoryFactory = new MonoRepoFactory();
+    repositoryFactory = new MonoRepoFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();
 

--- a/packages/beachball/src/__e2e__/publishGit.test.ts
+++ b/packages/beachball/src/__e2e__/publishGit.test.ts
@@ -1,4 +1,4 @@
-import { RepositoryFactory } from '../fixtures/repository';
+import { RepositoryFactory, Repository } from '../fixtures/repository';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publish } from '../commands/publish';
 import path from 'path';
@@ -19,6 +19,10 @@ describe('publish command (git)', () => {
   beforeEach(async () => {
     repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();
+  });
+
+  afterEach(async () => {
+    await repositoryFactory.cleanUp();
   });
 
   it('can perform a successful git push', async () => {

--- a/packages/beachball/src/__e2e__/validation.test.ts
+++ b/packages/beachball/src/__e2e__/validation.test.ts
@@ -9,6 +9,10 @@ describe('validation', () => {
     await repositoryFactory.create();
   });
 
+  afterAll(async () => {
+    await repositoryFactory.cleanUp();
+  });
+
   describe('isChangeFileNeeded', () => {
     let repository: Repository;
 

--- a/packages/beachball/src/fixtures/exec.ts
+++ b/packages/beachball/src/fixtures/exec.ts
@@ -2,19 +2,19 @@ import { exec as nativeExec } from 'child_process';
 
 export interface PsResult {
   stderr: string;
-  status: Error | null;
+  error: Error | null;
   stdout: string;
 }
 
 export function exec(command: string): Promise<PsResult> {
   return new Promise(function(resolve, reject) {
-    nativeExec(command, (status, stdout, stderr) => {
+    nativeExec(command, (error, stdout, stderr) => {
       const result = {
         stderr,
         stdout,
-        status,
+        error,
       };
-      if (status) {
+      if (error) {
         reject(result);
       } else {
         resolve(result);
@@ -29,11 +29,7 @@ export async function runCommands(commands: string[]): Promise<PsResult[]> {
     try {
       results.push(await exec(commands[i]));
     } catch (e) {
-      console.error('runCommands failed:');
-      console.error(e.stdout);
-      console.error(e.stderr);
-      console.error(e);
-      console.error(e.message);
+      console.error('runCommands failed:', e);
       throw e;
     }
   }

--- a/packages/beachball/src/fixtures/tmpdir.ts
+++ b/packages/beachball/src/fixtures/tmpdir.ts
@@ -1,17 +1,19 @@
 import * as tmp from 'tmp';
 
-// Clean up created directories when the program exits
+// tmp is supposed to be able to clean up automatically, but this doesn't always work within jest.
+// So we attempt to use its built-in cleanup mechanisms, but tests should ideally do their own cleanup too.
+
+// Clean up created directories when the program exits (even on uncaught exception)
 tmp.setGracefulCleanup();
 
-export type DirResult = tmp.DirResult;
-
-export async function tmpdir(options: tmp.DirOptions): Promise<tmp.DirResult> {
+export async function tmpdir(options: tmp.DirOptions): Promise<string> {
   return new Promise((resolve, reject) => {
-    tmp.dir(options, (err, name, removeCallback) => {
+    // "unsafe" means delete on exit even if it still contains files...which actually is safe
+    tmp.dir({ ...options, unsafeCleanup: true }, (err, name) => {
       if (err) {
         reject(err);
       } else {
-        resolve({ name, removeCallback });
+        resolve(name);
       }
     });
   });


### PR DESCRIPTION
For some reason `tmp` isn't cleaning up its files when run within jest, even with the (needlessly obscure) cleanup options enabled. So all the e2e tests should do manual cleanup instead.

Easiest way to do this is add a cleanup method on RepositoryFactory which deletes all repos created by that factory, and call it in each test (usually in afterAll).