### PR TITLE
Export public-facing types from root

### DIFF
--- a/change/beachball-2020-04-02-18-05-18-export-types.json
+++ b/change/beachball-2020-04-02-18-05-18-export-types.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export public-facing types from root",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-03T01:05:18.113Z"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/microsoft/beachball"
   },
   "license": "MIT",
-  "main": "index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "beachball": "./bin/beachball.js"
   },

--- a/packages/beachball/src/index.ts
+++ b/packages/beachball/src/index.ts
@@ -1,6 +1,10 @@
 // Public types of Beachball used in config files
 // (the package does not have a callable public API since it's meant to be invoked via command line)
-export { RepoOptions, PackageOptions, VersionGroupOptions } from './types/BeachballOptions';
+import { RepoOptions, PackageOptions } from './types/BeachballOptions';
+
+export type BeachballConfig = Partial<RepoOptions> & Partial<PackageOptions>;
+
+export { VersionGroupOptions } from './types/BeachballOptions';
 export { ChangeFilePromptOptions } from './types/ChangeFilePrompt';
 export { ChangeType } from './types/ChangeInfo';
 export {

--- a/packages/beachball/src/index.ts
+++ b/packages/beachball/src/index.ts
@@ -1,0 +1,10 @@
+// Public API of Beachball
+export { RepoOptions, PackageOptions, VersionGroupOptions } from './types/BeachballOptions';
+export { ChangeFilePromptOptions } from './types/ChangeFilePrompt';
+export { ChangeType } from './types/ChangeInfo';
+export {
+  ChangelogOptions,
+  ChangelogGroupOptions,
+  PackageChangelogRenderInfo,
+  ChangelogRenderers,
+} from './types/ChangelogOptions';

--- a/packages/beachball/src/index.ts
+++ b/packages/beachball/src/index.ts
@@ -1,4 +1,5 @@
-// Public API of Beachball
+// Public types of Beachball used in config files
+// (the package does not have a callable public API since it's meant to be invoked via command line)
 export { RepoOptions, PackageOptions, VersionGroupOptions } from './types/BeachballOptions';
 export { ChangeFilePromptOptions } from './types/ChangeFilePrompt';
 export { ChangeType } from './types/ChangeInfo';


### PR DESCRIPTION
Export types which might be used in a config file or custom renderers from a new file `src/index.ts`.