### PR TITLE
Fix a bug with inferring the commit hash

### DIFF
--- a/change/beachball-2020-04-08-16-33-06-fix-infer-commit.json
+++ b/change/beachball-2020-04-08-16-33-06-fix-infer-commit.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix a bug with inferring the commit hash",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-08T23:33:06.690Z"
+}

--- a/packages/beachball/src/changefile/readChangeFiles.ts
+++ b/packages/beachball/src/changefile/readChangeFiles.ts
@@ -28,10 +28,11 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
 
   changeFiles.forEach(changeFile => {
     try {
+      const changeFilePath = path.join(changePath, changeFile);
       const changeInfo: ChangeInfo = {
-        ...fs.readJSONSync(path.join(changePath, changeFile)),
+        ...fs.readJSONSync(changeFilePath),
         // Add the commit hash where the file was actually first introduced
-        commit: getFileAddedHash(changePath, cwd) || '',
+        commit: getFileAddedHash(changeFilePath, cwd) || '',
       };
 
       const packageName = changeInfo.packageName;


### PR DESCRIPTION
The git log command to get the hash was running on the `change` folder, not the changefile itself.