### PR TITLE
Formatting and typing cleanup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+*.snap

--- a/change/beachball-2020-04-13-13-35-10-format-cleanup.json
+++ b/change/beachball-2020-04-13-13-35-10-format-cleanup.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Formatting cleanup; use fs-extra everywhere",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T20:35:10.230Z"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -47,6 +47,7 @@
     "@types/prompts": "~2.0.0",
     "@types/semver": "^6.0.0",
     "@types/tmp": "^0.1.0",
+    "@types/toposort": "^2.0.3",
     "@types/yargs-parser": "^13.0.0",
     "find-free-port": "~2.0.0",
     "jest": "^24.8.0",

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc",
     "jest": "jest",
+    "prettier": "prettier --write --config ../../.prettierrc --ignore-path ../../.prettierignore 'src/**/*'",
     "start": "tsc -w --preserveWatchOutput",
     "test": "yarn test:unit && yarn test:e2e",
     "test:watch": "jest --watch",
@@ -49,6 +50,7 @@
     "@types/yargs-parser": "^13.0.0",
     "find-free-port": "~2.0.0",
     "jest": "^24.8.0",
+    "prettier": "^1.19.0",
     "tmp": "^0.1.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.7.3",

--- a/packages/beachball/src/__e2e__/changelog.test.ts
+++ b/packages/beachball/src/__e2e__/changelog.test.ts
@@ -62,7 +62,7 @@ describe('changelog generation', () => {
     await monoRepoFactory.cleanUp();
   });
 
-  describe('readChangelog', () => {
+  describe('readChangeFiles', () => {
     it('adds actual commit hash', async () => {
       const repository = await repositoryFactory.cloneRepository();
       await repository.commitChange('foo');

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -5,7 +5,7 @@ import { git } from '../git';
 import { publish } from '../commands/publish';
 import { RepositoryFactory } from '../fixtures/repository';
 import { MonoRepoFactory } from '../fixtures/monorepo';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 
 describe('publish command (e2e)', () => {
@@ -220,7 +220,7 @@ describe('publish command (e2e)', () => {
       hooks: {
         prepublish: (packagePath: string) => {
           const packageJsonPath = path.join(packagePath, 'package.json');
-          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+          const packageJson = fs.readJSONSync(packageJsonPath);
           if (packageJson.onPublish) {
             Object.assign(packageJson, packageJson.onPublish);
             delete packageJson.onPublish;
@@ -244,7 +244,7 @@ describe('publish command (e2e)', () => {
     // All git results should still have previous information
     const fooGitResults = git(['describe', '--abbrev=0'], { cwd: repo.rootPath });
     expect(fooGitResults.success).toBeTruthy();
-    const fooPackageJson = JSON.parse(fs.readFileSync(path.join(repo.rootPath, 'packages/foo/package.json'), 'utf-8'));
+    const fooPackageJson = fs.readJSONSync(path.join(repo.rootPath, 'packages/foo/package.json'));
     expect(fooPackageJson.main).toBe('src/index.ts');
     expect(fooPackageJson.onPublish.main).toBe('lib/index.js');
   });

--- a/packages/beachball/src/__e2e__/publishGit.test.ts
+++ b/packages/beachball/src/__e2e__/publishGit.test.ts
@@ -1,8 +1,8 @@
-import { RepositoryFactory, Repository } from '../fixtures/repository';
+import { RepositoryFactory } from '../fixtures/repository';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publish } from '../commands/publish';
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs-extra';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { git, gitFailFast } from '../git';
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
@@ -69,7 +69,7 @@ describe('publish command (git)', () => {
 
     const newRepo = await repositoryFactory.cloneRepository();
 
-    const packageJson = JSON.parse(fs.readFileSync(path.join(newRepo.rootPath, 'package.json'), 'utf-8'));
+    const packageJson = fs.readJSONSync(path.join(newRepo.rootPath, 'package.json'));
 
     expect(packageJson.version).toBe('1.1.0');
   });
@@ -153,9 +153,7 @@ describe('publish command (git)', () => {
     expect(fs.existsSync(newChangePath)).toBeTruthy();
     const changeFiles = fs.readdirSync(newChangePath);
     expect(changeFiles.length).toBe(1);
-    const changeFileContent: ChangeFileInfo = JSON.parse(
-      fs.readFileSync(path.join(newChangePath, changeFiles[0]), 'utf-8')
-    );
+    const changeFileContent: ChangeFileInfo = fs.readJSONSync(path.join(newChangePath, changeFiles[0]));
     expect(changeFileContent.packageName).toBe('foo2');
   });
 });

--- a/packages/beachball/src/__e2e__/publishRegistry.test.ts
+++ b/packages/beachball/src/__e2e__/publishRegistry.test.ts
@@ -231,7 +231,7 @@ describe('publish command (registry)', () => {
         version: '1.0.0',
         dependencies: {
           barpkg: '^1.0.0',
-        }
+        },
       })
     );
 

--- a/packages/beachball/src/bump/bumpInPlace.ts
+++ b/packages/beachball/src/bump/bumpInPlace.ts
@@ -5,13 +5,12 @@ import { updateRelatedChangeType } from './updateRelatedChangeType';
 import { bumpPackageInfoVersion } from './bumpPackageInfoVersion';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { setGroupsInBumpInfo } from './setGroupsInBumpInfo';
+import { PackageDeps } from '../types/PackageInfo';
 
 /**
  * Updates BumpInfo according to change types, bump deps, and version groups
  *
  * NOTE: THIS FUNCTION MUTATES STATE!
- * @param bumpInfo
- * @param bumpDeps
  */
 export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { bumpDeps } = options;
@@ -37,14 +36,15 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   Object.keys(packageInfos).forEach(pkgName => {
     const info = packageInfos[pkgName];
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depKind => {
-      if (info[depKind]) {
-        Object.keys(info[depKind]).forEach(dep => {
+      const deps: PackageDeps | undefined = (info as any)[depKind];
+      if (deps) {
+        Object.keys(deps).forEach(dep => {
           const packageInfo = packageInfos[dep];
           if (packageInfo) {
-            const existingVersionRange = info[depKind][dep];
+            const existingVersionRange = deps[dep];
             const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, existingVersionRange);
             if (existingVersionRange !== bumpedVersionRange) {
-              info[depKind][dep] = bumpedVersionRange;
+              deps[dep] = bumpedVersionRange;
               modifiedPackages.add(pkgName);
             }
           }

--- a/packages/beachball/src/bump/bumpPackageInfoVersion.ts
+++ b/packages/beachball/src/bump/bumpPackageInfoVersion.ts
@@ -3,8 +3,6 @@ import semver from 'semver';
 
 /**
  * Bumps an individual package version based on the change type
- * @param pkgName
- * @param bumpInfo
  */
 export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo) {
   const { packageChangeTypes, packageInfos, modifiedPackages } = bumpInfo;

--- a/packages/beachball/src/bump/gatherBumpInfo.ts
+++ b/packages/beachball/src/bump/gatherBumpInfo.ts
@@ -13,7 +13,7 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
   const changes = readChangeFiles(options);
   const packageChangeTypes = getPackageChangeTypes(changes);
   const packageInfos = getPackageInfos(cwd);
-  const dependentChangeTypes = {};
+  const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
   const groupOptions = {};
 
   // Clear non-existent changes

--- a/packages/beachball/src/bump/setDependentsInBumpInfo.ts
+++ b/packages/beachball/src/bump/setDependentsInBumpInfo.ts
@@ -1,15 +1,15 @@
 import { BumpInfo } from '../types/BumpInfo';
+import { PackageDeps } from '../types/PackageInfo';
+
 /**
  * Gets dependents for all packages
  *
  * Example: "BigApp" deps on "SomeUtil", "BigApp" would be the dependent
- *
- * @param bumpInfo
  */
 export function setDependentsInBumpInfo(bumpInfo: BumpInfo): void {
   const { packageInfos, scopedPackages } = bumpInfo;
   const packages = Object.keys(packageInfos);
-  const dependents = {};
+  const dependents: BumpInfo['dependents'] = {};
 
   packages.forEach(pkgName => {
     if (!scopedPackages.has(pkgName)) {
@@ -19,8 +19,9 @@ export function setDependentsInBumpInfo(bumpInfo: BumpInfo): void {
     const info = packageInfos[pkgName];
     const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'];
     depTypes.forEach(depType => {
-      if (info[depType]) {
-        for (let [dep, _] of Object.entries(info[depType])) {
+      const deps: PackageDeps | undefined = (info as any)[depType];
+      if (deps) {
+        for (let dep of Object.keys(deps)) {
           if (packages.includes(dep)) {
             dependents[dep] = dependents[dep] || [];
             if (!dependents[dep].includes(pkgName)) {

--- a/packages/beachball/src/bump/setGroupsInBumpInfo.ts
+++ b/packages/beachball/src/bump/setGroupsInBumpInfo.ts
@@ -1,4 +1,4 @@
-import { BeachballOptions, VersionGroupOptions } from '../types/BeachballOptions';
+import { BeachballOptions } from '../types/BeachballOptions';
 import { BumpInfo } from '../types/BumpInfo';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -6,11 +6,6 @@ import { BumpInfo } from '../types/BumpInfo';
  * Updates package change types based on dependents (e.g given A -> B, if B has a minor change, A should also have minor change)
  *
  * This function is recursive and will futher call itself to update related dependent packages noting groups and bumpDeps flag
- *
- * @param pkgName
- * @param changeType
- * @param bumpInfo
- * @param dependents
  */
 export function updateRelatedChangeType(
   pkgName: string,

--- a/packages/beachball/src/changefile/getChangedPackages.ts
+++ b/packages/beachball/src/changefile/getChangedPackages.ts
@@ -1,14 +1,13 @@
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { findPackageRoot, getChangePath } from '../paths';
 import { getChanges, getStagedChanges, git, fetchRemote, parseRemoteBranch } from '../git';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 /**
  * Gets all the changed packages, regardless of the change files
- * @param cwd
  */
 function getAllChangedPackages(options: BeachballOptions) {
   const { branch, path: cwd } = options;
@@ -26,7 +25,7 @@ function getAllChangedPackages(options: BeachballOptions) {
 
         if (root && !packageRoots[root]) {
           try {
-            const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json')).toString());
+            const packageJson = fs.readJSONSync(path.join(root, 'package.json'));
 
             if (!packageJson.private && (!packageJson.beachball || packageJson.beachball.shouldPublish !== false)) {
               const packageName = packageJson.name;
@@ -47,7 +46,6 @@ function getAllChangedPackages(options: BeachballOptions) {
 
 /**
  * Gets all the changed packages, accounting for change files
- * @param cwd
  */
 export function getChangedPackages(options: BeachballOptions) {
   const { fetch, path: cwd, branch } = options;
@@ -75,7 +73,7 @@ export function getChangedPackages(options: BeachballOptions) {
   // Loop through the change files, building up a set of packages that we can skip
   changeFiles.forEach(file => {
     try {
-      const changeInfo: ChangeFileInfo = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const changeInfo: ChangeFileInfo = fs.readJSONSync(file);
       changeFilePackageSet.add(changeInfo.packageName);
     } catch (e) {
       console.warn(`Invalid change file encountered: ${file}`);

--- a/packages/beachball/src/changefile/getPackageChangeTypes.ts
+++ b/packages/beachball/src/changefile/getPackageChangeTypes.ts
@@ -11,20 +11,20 @@ export const SortedChangeTypes: ChangeType[] = ['none', 'prerelease', 'patch', '
 export const MinChangeType = SortedChangeTypes[0];
 
 /**
- * Change type weights
- * Note: the order in which this is defined is IMPORTANT
+ * Change type weights.
+ * Note: the order in which this is defined is IMPORTANT.
  */
-const ChangeTypeWeights = SortedChangeTypes.reduce((weights, changeType, index) => {
+const ChangeTypeWeights: { [t in ChangeType]: number } = SortedChangeTypes.reduce((weights, changeType, index) => {
   weights[changeType] = index;
   return weights;
-}, {});
+}, {} as { [t in ChangeType]: number });
 
 export function getPackageChangeTypes(changeSet: ChangeSet) {
   const changePerPackage: {
     [pkgName: string]: ChangeFileInfo['type'];
   } = {};
 
-  for (let [_, change] of changeSet) {
+  for (let change of changeSet.values()) {
     const { packageName } = change;
     if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName])) {
       changePerPackage[packageName] = change.type;

--- a/packages/beachball/src/changefile/unlinkChangeFiles.ts
+++ b/packages/beachball/src/changefile/unlinkChangeFiles.ts
@@ -3,11 +3,11 @@ import { getChangePath } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
 import { PackageInfo } from '../types/PackageInfo';
+
 /**
  * Unlink only change files that are specified in the changes param
  *
  * @param changes existing change files to be removed
- * @param cwd
  */
 export function unlinkChangeFiles(
   changeSet: ChangeSet,

--- a/packages/beachball/src/changefile/writeChangeFiles.ts
+++ b/packages/beachball/src/changefile/writeChangeFiles.ts
@@ -40,7 +40,7 @@ export function writeChangeFiles(
       }
 
       const change = changes[pkgName];
-      fs.writeFileSync(changeFile, JSON.stringify(change, null, 2));
+      fs.writeJSONSync(changeFile, change, { spaces: 2 });
       return changeFile;
     });
 

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -12,7 +12,7 @@ export function getPackageChangelogs(
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};
-  for (let [_, change] of changeSet) {
+  for (let change of changeSet.values()) {
     const { packageName } = change;
     if (!changelogs[packageName]) {
       const version = packageInfos[packageName].version;

--- a/packages/beachball/src/changelog/mergeChangelogs.ts
+++ b/packages/beachball/src/changelog/mergeChangelogs.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { PackageChangelog } from '../types/ChangeLog';
 import { PackageInfo } from '../types/PackageInfo';
 import { generateTag } from '../tag';
+import { ChangeType } from '../types/ChangeInfo';
 
 /**
  * Merge multiple PackageChangelog into one.
@@ -24,9 +25,9 @@ export function mergeChangelogs(
   };
 
   changelogs.forEach(changelog => {
-    Object.keys(changelog.comments).forEach(changeType => {
+    (Object.keys(changelog.comments) as ChangeType[]).forEach(changeType => {
       if (changelog.comments[changeType]) {
-        result.comments[changeType] = (result.comments[changeType] || []).concat(changelog.comments[changeType]);
+        result.comments[changeType] = (result.comments[changeType] || []).concat(changelog.comments[changeType]!);
       }
     });
   });

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -39,7 +39,6 @@ import { validate } from './validation/validate';
       await bump(options);
       break;
 
-
     case 'sync':
       sync(options);
       break;

--- a/packages/beachball/src/commands/change.ts
+++ b/packages/beachball/src/commands/change.ts
@@ -1,4 +1,3 @@
-import { validate } from '../validation/validate';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { promptForChange } from '../changefile/promptForChange';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';

--- a/packages/beachball/src/fixtures/monorepo.ts
+++ b/packages/beachball/src/fixtures/monorepo.ts
@@ -69,7 +69,7 @@ export class MonoRepoFactory extends RepositoryFactory {
 
       fs.mkdirpSync(path.join(tmpRepo.rootPath, pkg));
 
-      fs.writeJSONSync(packageJsonFile, packageJsonFixture, { spaces: 2 });
+      fs.writeJSONSync(path.join(tmpRepo.rootPath, packageJsonFile), packageJsonFixture, { spaces: 2 });
       await tmpRepo.commitChange(packageJsonFile);
     }
 

--- a/packages/beachball/src/fixtures/monorepo.ts
+++ b/packages/beachball/src/fixtures/monorepo.ts
@@ -18,7 +18,7 @@ export const packageJsonFixtures: { [path: string]: PackageJson } = {
     onPublish: {
       main: 'lib/index.js',
     },
-  },
+  } as PackageJson,
 
   'packages/bar': {
     name: 'bar',

--- a/packages/beachball/src/fixtures/monorepo.ts
+++ b/packages/beachball/src/fixtures/monorepo.ts
@@ -5,8 +5,9 @@ import { runCommands } from './exec';
 import { tmpdir } from './tmpdir';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { Repository, RepositoryFactory } from './repository';
+import { PackageJson } from '../types/PackageInfo';
 
-export const packageJsonFixtures = {
+export const packageJsonFixtures: { [path: string]: PackageJson } = {
   'packages/foo': {
     name: 'foo',
     version: '1.0.0',
@@ -32,7 +33,7 @@ export const packageJsonFixtures = {
   'packages/grouped/b': {
     name: 'b',
     version: '3.1.2',
-    dependencies: ['bar'],
+    dependencies: ['bar'] as any,
   },
 };
 
@@ -68,7 +69,7 @@ export class MonoRepoFactory extends RepositoryFactory {
 
       fs.mkdirpSync(path.join(tmpRepo.rootPath, pkg));
 
-      await fs.writeFile(path.join(tmpRepo.rootPath, packageJsonFile), JSON.stringify(packageJsonFixture, null, 2));
+      fs.writeJSONSync(packageJsonFile, packageJsonFixture, { spaces: 2 });
       await tmpRepo.commitChange(packageJsonFile);
     }
 

--- a/packages/beachball/src/fixtures/package.ts
+++ b/packages/beachball/src/fixtures/package.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import * as tmp from 'tmp';
 import { PackageInfo } from '../types/PackageInfo';
@@ -13,8 +13,7 @@ const testPackage = {
 // Create a test package.json in a temporary location for use in tests.
 var tmpPackageFile = path.join(tmp.dirSync().name, 'package.json');
 
-var testPackageJson = JSON.stringify(testPackage);
-fs.writeFileSync(tmpPackageFile, testPackageJson, 'utf8');
+fs.writeJSONSync(tmpPackageFile, testPackage, { spaces: 2 });
 
 export const testPackageInfo: PackageInfo = {
   name: testPackage.name,

--- a/packages/beachball/src/fixtures/registry.ts
+++ b/packages/beachball/src/fixtures/registry.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from 'child_process';
+// @ts-ignore
 import fp from 'find-free-port';
 
 const verdaccioApi = require.resolve('./verdaccio.js');

--- a/packages/beachball/src/fixtures/verdaccio.js
+++ b/packages/beachball/src/fixtures/verdaccio.js
@@ -5,7 +5,7 @@ const startServer = require('verdaccio').default;
 const store = require('verdaccio-memory').default;
 
 const arguments = {
-  port: process.argv[2]
+  port: process.argv[2],
 };
 
 const port = arguments.port;
@@ -17,22 +17,22 @@ if (!port) {
     packages: {
       '**': {
         access: '$anonymous',
-        publish: '$anonymous'
-      }
+        publish: '$anonymous',
+      },
     },
     store: {
       memory: {
-        limit: 1000
-      }
-    }
+        limit: 1000,
+      },
+    },
   };
-  
+
   const addr = {
     port: port,
     path: '/',
-    host: 'localhost'
+    host: 'localhost',
   };
-  
+
   startServer(config, port, store, '1.0.0', 'verdaccio', (webServer, addrs, pkgName, pkgVersion) => {
     webServer.listen(addr.port || addr.path, addr.host, () => {
       // This is logged to tell whoever spawns us that we're ready.
@@ -41,4 +41,3 @@ if (!port) {
     });
   });
 }
-

--- a/packages/beachball/src/git/index.ts
+++ b/packages/beachball/src/git/index.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import { findGitRoot } from '../paths';
 import gitUrlParse from 'git-url-parse';
@@ -325,7 +325,7 @@ export function getDefaultRemote(cwd: string) {
   let packageJson: any;
 
   try {
-    packageJson = JSON.parse(fs.readFileSync(path.join(findGitRoot(cwd)!, 'package.json')).toString());
+    packageJson = fs.readJSONSync(path.join(findGitRoot(cwd)!, 'package.json'));
   } catch (e) {
     console.log('failed to read package.json');
     throw new Error('invalid package.json detected');

--- a/packages/beachball/src/monorepo/getAllPackages.ts
+++ b/packages/beachball/src/monorepo/getAllPackages.ts
@@ -1,4 +1,5 @@
-import { getPackageInfos } from "./getPackageInfos";
+import { getPackageInfos } from './getPackageInfos';
+
 export function getAllPackages(cwd: string): string[] {
   const infos = getPackageInfos(cwd);
   return Object.keys(infos);

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -1,18 +1,20 @@
 import { findPackageRoot, findGitRoot } from '../paths';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import { listAllTrackedFiles } from '../git';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
+
 export function getPackageInfos(cwd: string) {
   const gitRoot = findGitRoot(cwd)!;
   const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], gitRoot);
   const packageInfos: PackageInfos = {};
+
   if (packageJsonFiles && packageJsonFiles.length > 0) {
     packageJsonFiles.forEach(packageJsonPath => {
       try {
         const packageJsonFullPath = path.join(gitRoot, packageJsonPath);
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf-8'));
+        const packageJson = fs.readJSONSync(packageJsonFullPath);
         packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
       } catch (e) {
         // Pass, the package.json is invalid
@@ -21,7 +23,7 @@ export function getPackageInfos(cwd: string) {
     });
   } else {
     const packageJsonFullPath = path.join(gitRoot, findPackageRoot(cwd)!, 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf-8'));
+    const packageJson = fs.readJSONSync(packageJsonFullPath);
     packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
   }
   return packageInfos;

--- a/packages/beachball/src/monorepo/infoFromPackageJson.ts
+++ b/packages/beachball/src/monorepo/infoFromPackageJson.ts
@@ -1,22 +1,8 @@
 import path from 'path';
-import { PackageInfo } from '../types/PackageInfo';
-import { getPackageOptions } from "../options/getPackageOptions";
-import { PackageOptions } from '../types/BeachballOptions';
-export function infoFromPackageJson(packageJson: {
-  name: string;
-  version: string;
-  dependencies?: {
-    [dep: string]: string;
-  };
-  devDependencies?: {
-    [dep: string]: string;
-  };
-  peerDependencies?: {
-    [dep: string]: string;
-  };
-  beachball?: PackageOptions;
-  private?: boolean;
-}, packageJsonPath: string): PackageInfo {
+import { PackageInfo, PackageJson } from '../types/PackageInfo';
+import { getPackageOptions } from '../options/getPackageOptions';
+
+export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: string): PackageInfo {
   return {
     name: packageJson.name!,
     version: packageJson.version,

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -1,4 +1,5 @@
 import { BeachballOptions } from '../types/BeachballOptions';
+
 export function getDefaultOptions() {
   return {
     branch: 'origin/master',
@@ -21,6 +22,6 @@ export function getDefaultOptions() {
     defaultNpmTag: 'latest',
     scope: null,
     retries: 3,
-    timeout: undefined
+    timeout: undefined,
   } as BeachballOptions;
 }

--- a/packages/beachball/src/options/getOptions.ts
+++ b/packages/beachball/src/options/getOptions.ts
@@ -2,6 +2,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { getCliOptions } from './getCliOptions';
 import { getRootOptions } from './getRootOptions';
 import { getDefaultOptions } from './getDefaultOptions';
+
 /**
  * Gets all repo level options (default + root options + cli options)
  */

--- a/packages/beachball/src/options/getPackageOptions.ts
+++ b/packages/beachball/src/options/getPackageOptions.ts
@@ -3,6 +3,7 @@ import { PackageOptions } from '../types/BeachballOptions';
 import { getCliOptions } from './getCliOptions';
 import { getRootOptions } from './getRootOptions';
 import { getDefaultOptions } from './getDefaultOptions';
+
 /**
  * Gets all package level options (default + root options + package options + cli options)
  */

--- a/packages/beachball/src/options/getRootOptions.ts
+++ b/packages/beachball/src/options/getRootOptions.ts
@@ -1,5 +1,6 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import { RepoOptions } from '../types/BeachballOptions';
+
 export function getRootOptions(): RepoOptions {
   const configExplorer = cosmiconfigSync('beachball');
   const searchResults = configExplorer.search();

--- a/packages/beachball/src/packageManager/packagePublish.ts
+++ b/packages/beachball/src/packageManager/packagePublish.ts
@@ -1,6 +1,7 @@
 import { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
 import { npm } from './npm';
+
 export function packagePublish(
   packageInfo: PackageInfo,
   registry: string,

--- a/packages/beachball/src/paths.ts
+++ b/packages/beachball/src/paths.ts
@@ -1,10 +1,8 @@
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs-extra';
 
 /**
  * Starting from `cwd`, searches up the directory hierarchy for `pathName`
- * @param pathName
- * @param cwd
  */
 export function searchUp(pathName: string, cwd: string) {
   const root = path.parse(cwd).root;

--- a/packages/beachball/src/publish/bumpAndPush.ts
+++ b/packages/beachball/src/publish/bumpAndPush.ts
@@ -9,6 +9,7 @@ import { displayManualRecovery } from './displayManualRecovery';
 export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
   const { path: cwd, branch, tag, message } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
+
   console.log('Reverting');
   revertLocalChanges(cwd);
 
@@ -34,8 +35,9 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     process.exit(1);
   }
 
-  // Step 3. Tag & Push to remote
+  // Tag & Push to remote
   tagPackages(bumpInfo, tag, cwd);
+
   console.log(`pushing to ${branch}, running the following command for git push:`);
   const pushArgs = ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`];
   console.log('git ' + pushArgs.join(' '));

--- a/packages/beachball/src/publish/displayManualRecovery.ts
+++ b/packages/beachball/src/publish/displayManualRecovery.ts
@@ -17,14 +17,15 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
   if (succeededLines.length) {
     console.warn(
       'These packages and versions were successfully published, but may be invalid due to depending on ' +
-      'package versions for which publishing failed:'
+        'package versions for which publishing failed:'
     );
 
     succeededLines.forEach(console.warn);
 
-    console.warn('To recover from this, you should run "beachball sync" to update local package.json ' +
-      'files to synchronize package.json version. If necessary, unpublish any invalid packages from the above ' +
-      'list after "beachball sync".'
-    )
+    console.warn(
+      'To recover from this, you should run "beachball sync" to update local package.json ' +
+        'files to synchronize package.json version. If necessary, unpublish any invalid packages from the above ' +
+        'list after "beachball sync".'
+    );
   }
 }

--- a/packages/beachball/src/publish/getNewPackages.ts
+++ b/packages/beachball/src/publish/getNewPackages.ts
@@ -1,5 +1,6 @@
 import { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
+
 export function getNewPackages(bumpInfo: BumpInfo, registry: string) {
   const { modifiedPackages, packageInfos } = bumpInfo;
 

--- a/packages/beachball/src/publish/mergePublishBranch.ts
+++ b/packages/beachball/src/publish/mergePublishBranch.ts
@@ -1,4 +1,5 @@
 import { git } from '../git';
+
 export function mergePublishBranch(publishBranch: string, branch: string, message: string, cwd: string) {
   let result: ReturnType<typeof git>;
   let mergeSteps = [
@@ -8,6 +9,7 @@ export function mergePublishBranch(publishBranch: string, branch: string, messag
     ['merge', '-X', 'ours', publishBranch],
     ['branch', '-D', publishBranch],
   ];
+
   for (let index = 0; index < mergeSteps.length; index++) {
     const step = mergeSteps[index];
     result = git(step, { cwd });

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -15,7 +15,6 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
   const bumpInfo = _.cloneDeep(originalBumpInfo);
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
-
   await performBump(bumpInfo, options);
 
   const succeededPackages = new Set<string>();
@@ -47,7 +46,11 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
   if (prepublishHook) {
     for (const pkg of packagesToPublish) {
       const packageInfo = bumpInfo.packageInfos[pkg];
-      const maybeAwait = prepublishHook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
+      const maybeAwait = prepublishHook(
+        path.dirname(packageInfo.packageJsonPath),
+        packageInfo.name,
+        packageInfo.version
+      );
       if (maybeAwait instanceof Promise) {
         await maybeAwait;
       }

--- a/packages/beachball/src/publish/toposortPackages.ts
+++ b/packages/beachball/src/publish/toposortPackages.ts
@@ -1,5 +1,5 @@
 import toposort from 'toposort';
-import { PackageInfos } from '../types/PackageInfo';
+import { PackageInfos, PackageDeps } from '../types/PackageInfo';
 
 /**
  * Topological sort the packages based on its dependency graph.
@@ -20,7 +20,7 @@ export function toposortPackages(packages: string[], packageInfos: PackageInfos)
         throw new Error(`Package info is missing for ${pkgName}.`);
       }
 
-      const deps = packageInfos[pkgName][depKind];
+      const deps: PackageDeps | undefined = (info as any)[depKind];
       if (deps) {
         const depPkgNames = Object.keys(deps);
         allDeps = allDeps.concat(depPkgNames);
@@ -38,7 +38,7 @@ export function toposortPackages(packages: string[], packageInfos: PackageInfos)
   });
 
   try {
-    return toposort(dependencyGraph).filter(pkg => !!pkg);
+    return toposort(dependencyGraph).filter((pkg): pkg is string => !!pkg);
   } catch (err) {
     throw new Error(`Failed to do toposort for packages: ${err?.message}`);
   }

--- a/packages/beachball/src/types/PackageInfo.ts
+++ b/packages/beachball/src/types/PackageInfo.ts
@@ -1,13 +1,27 @@
-import { PackageOptions } from './BeachballOptions';
+import { PackageOptions, BeachballOptions } from './BeachballOptions';
 import { ChangeType } from './ChangeInfo';
+
+export interface PackageDeps {
+  [dep: string]: string;
+}
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  dependencies?: PackageDeps;
+  devDependencies?: PackageDeps;
+  peerDependencies?: PackageDeps;
+  private?: boolean;
+  beachball?: BeachballOptions;
+}
 
 export interface PackageInfo {
   name: string;
   packageJsonPath: string;
   version: string;
-  dependencies?: { [dep: string]: string };
-  devDependencies?: { [dep: string]: string };
-  peerDependencies?: { [dep: string]: string };
+  dependencies?: PackageDeps;
+  devDependencies?: PackageDeps;
+  peerDependencies?: PackageDeps;
   private: boolean;
   options: PackageOptions;
   group?: string;

--- a/packages/beachball/src/types/PackageInfo.ts
+++ b/packages/beachball/src/types/PackageInfo.ts
@@ -8,6 +8,7 @@ export interface PackageDeps {
 export interface PackageJson {
   name: string;
   version: string;
+  main?: string;
   dependencies?: PackageDeps;
   devDependencies?: PackageDeps;
   peerDependencies?: PackageDeps;

--- a/packages/beachball/src/validation/isChangeFileNeeded.ts
+++ b/packages/beachball/src/validation/isChangeFileNeeded.ts
@@ -1,7 +1,8 @@
 import { getChangedPackages } from '../changefile/getChangedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
+
 export function isChangeFileNeeded(options: BeachballOptions) {
-  const { branch, path: cwd, fetch } = options;
+  const { branch } = options;
 
   console.log(`Checking for changes against "${branch}"`);
   const changedPackages = getChangedPackages(options);

--- a/packages/beachball/src/validation/isGitAvailable.ts
+++ b/packages/beachball/src/validation/isGitAvailable.ts
@@ -1,5 +1,6 @@
 import { findGitRoot } from '../paths';
 import { git } from '../git';
+
 export function isGitAvailable(cwd: string) {
   const result = git(['--version']);
   const gitRoot = findGitRoot(cwd);

--- a/packages/beachball/src/validation/isValidPackageName.ts
+++ b/packages/beachball/src/validation/isValidPackageName.ts
@@ -1,4 +1,5 @@
 import { getAllPackages } from '../monorepo/getAllPackages';
+
 export function isValidPackageName(pkg: string, cwd: string) {
   const packages = getAllPackages(cwd);
   return packages.includes(pkg);

--- a/packages/beachball/tsconfig.json
+++ b/packages/beachball/tsconfig.json
@@ -8,7 +8,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
-    "noImplicitAny": false,
+    "noUnusedLocals": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -17,7 +17,7 @@
     "lint": "npm run lint:js && npm run lint:md",
     "lint:js": "eslint --ext .js,.jsx --ignore-pattern public,static . && npm run prettier -- --list-different",
     "lint:md": "remark content/posts/",
-    "prettier": "prettier '{,!(node_modules,.cache)/**/}*.{js,jsx}'",
+    "prettier": "prettier --write '{,!(node_modules,.cache)/**/}*.{js,jsx}'",
     "serve": "gatsby serve",
     "start": "gatsby develop"
   },
@@ -72,7 +72,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.1.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.0",
     "remark-cli": "^7.0.1",
     "remark-preset-lint-recommended": "^3.0.1",
     "stylefmt": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14694,10 +14694,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.0:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^5.1.0, pretty-bytes@^5.3.0:
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,6 +2521,11 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
   integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
+"@types/toposort@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/toposort/-/toposort-2.0.3.tgz#dc490842b77c3e910c8d727ff0bdb2fb124cb41b"
+  integrity sha512-jRtyvEu0Na/sy0oIxBW0f6wPQjidgVqlmCTJVHEGTNEUdL1f0YSvdPzHY7nX7MUWAZS6zcAa0KkqofHjy/xDZQ==
+
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"


### PR DESCRIPTION
Some typing and formatting fixes I noticed would be helpful while doing other work on beachball:
- Enable `noImplicitAny` and `noUnusedLocals` and make related typing fixes
- Update prettier to handle new TS syntax
- Fix prettier commands and run them
- Manual formatting fixes: add blank lines; remove empty param tags
- Use `fs-extra` (and its promise-based async methods) everywhere
