### PR TITLE
Scale - use the ls-files command to search a pattern in git rather than filter with node

### DIFF
--- a/change/beachball-2020-04-13-15-18-11-scale.json
+++ b/change/beachball-2020-04-13-15-18-11-scale.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Making beachball getPackageInfos scale much better with a different git command",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T22:18:11.489Z"
+}

--- a/packages/beachball/src/git/index.ts
+++ b/packages/beachball/src/git/index.ts
@@ -364,11 +364,12 @@ export function getDefaultRemote(cwd: string) {
   return 'origin';
 }
 
-export function listAllTrackedFiles(cwd: string) {
-  const results = git(['ls-tree', '-r', '--name-only', '--full-tree', 'HEAD'], { cwd });
-
-  if (results.success) {
-    return results.stdout.split(/\n/);
+export function listAllTrackedFiles(patterns: string[], cwd: string) {
+  if (patterns) {
+    const results = git(['ls-files', ...patterns], { cwd });
+    if (results.success) {
+      return results.stdout.split(/\n/);
+    }
   }
 
   return [];

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -6,8 +6,7 @@ import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 export function getPackageInfos(cwd: string) {
   const gitRoot = findGitRoot(cwd)!;
-  const trackedFiles = listAllTrackedFiles(gitRoot);
-  const packageJsonFiles = trackedFiles.filter(file => path.basename(file) === 'package.json');
+  const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], gitRoot);
   const packageInfos: PackageInfos = {};
   if (packageJsonFiles && packageJsonFiles.length > 0) {
     packageJsonFiles.forEach(packageJsonPath => {


### PR DESCRIPTION
We are hitting scale issues if the total # of files goes above a threshold - SIGTERM is applied to a ls-tree