### PR TITLE
Hooks: adding support for prepublish steps

### DIFF
--- a/change/beachball-2020-04-15-14-48-23-hooks.json
+++ b/change/beachball-2020-04-15-14-48-23-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding a hooks option for prepublish foolery",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T21:48:23.323Z"
+}

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -176,7 +176,7 @@ describe('publish command (e2e)', () => {
     expect(barGitResults.stdout).toBe('bar_v1.4.0');
   });
 
-  fit('should respect prepublish hooks', async () => {
+  it('should respect prepublish hooks', async () => {
     repositoryFactory = new MonoRepoFactory();
     await repositoryFactory.create();
     const repo = await repositoryFactory.cloneRepository();

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -4,9 +4,11 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { packagePublish } from '../packageManager/packagePublish';
 import { validatePackageVersions } from './validatePackageVersions';
 import { displayManualRecovery } from './displayManualRecovery';
+import _ from 'lodash';
 
-export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOptions) {
+export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions) {
   const { registry, tag, token, access, timeout } = options;
+  const bumpInfo = _.cloneDeep(originalBumpInfo);
   const { modifiedPackages, newPackages } = bumpInfo;
 
   // Execute prepublish hook if available
@@ -70,5 +72,6 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
       );
     }
   });
+
   return;
 }

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -15,7 +15,9 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
   if (options.hooks?.prepublish) {
     const results = options.hooks.prepublish(bumpInfo);
     if (results instanceof Promise) {
-      await results;
+      bumpInfo = await results;
+    } else {
+      bumpInfo = results;
     }
   }
 

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -9,17 +9,16 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
   const { registry, tag, token, access, timeout } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
-  await performBump(bumpInfo, options);
-
   // Execute prepublish hook if available
   if (options.hooks?.prepublish) {
-    const results = options.hooks.prepublish(bumpInfo);
-    if (results instanceof Promise) {
-      bumpInfo = await results;
-    } else {
-      bumpInfo = results;
+    const maybePromise = options.hooks.prepublish(bumpInfo);
+
+    if (maybePromise instanceof Promise) {
+      await maybePromise;
     }
   }
+
+  await performBump(bumpInfo, options);
 
   const succeededPackages = new Set<string>();
 

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -11,6 +11,14 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
 
   await performBump(bumpInfo, options);
 
+  // Execute prepublish hook if available
+  if (options.hooks?.prepublish) {
+    const results = options.hooks.prepublish(bumpInfo);
+    if (results instanceof Promise) {
+      await results;
+    }
+  }
+
   const succeededPackages = new Set<string>();
 
   if (!validatePackageVersions(bumpInfo, registry)) {

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -53,7 +53,7 @@ export interface RepoOptions {
 
   hooks?: {
     /** Prepublish hook gets run right before npm publish, the changes will be reverted before pushing */
-    prepublish?: (bumpInfo: BumpInfo) => void | Promise<void>;
+    prepublish?: (bumpInfo: BumpInfo) => BumpInfo | Promise<BumpInfo>;
   };
 }
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -1,6 +1,7 @@
 import { ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
+import { BumpInfo } from './BumpInfo';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -49,6 +50,11 @@ export interface RepoOptions {
   groups?: VersionGroupOptions[];
   changelog?: ChangelogOptions;
   changeFilePrompt?: ChangeFilePromptOptions;
+
+  hooks?: {
+    /** Prepublish hook gets run right before npm publish, the changes will be reverted before pushing */
+    prepublish?: (bumpInfo: BumpInfo) => void | Promise<void>;
+  };
 }
 
 export interface PackageOptions {

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -52,8 +52,13 @@ export interface RepoOptions {
   changeFilePrompt?: ChangeFilePromptOptions;
 
   hooks?: {
-    /** Prepublish hook gets run right before npm publish, the changes will be reverted before pushing */
-    prepublish?: (bumpInfo: BumpInfo) => BumpInfo | Promise<BumpInfo>;
+    /**
+     * Prepublish hook gets run right before npm publish (during performBump)
+     * the changes will be reverted before pushing
+     *
+     * This hook expects manipulation to the bumpInfo object (side effects)
+     */
+    prepublish?: (bumpInfo: BumpInfo) => void | Promise<void>;
   };
 }
 


### PR DESCRIPTION
In this PR, we add the ability to have hooks specifically from beachball.config.js.

1. These hooks are repo wide right now
2. There is only one prepublish hook right now
3. The hook is expected to be side effects heavy, being passed in a bumpInfo
4. if bumpInfo is modified, the bumpInfo is used during npm publish only
5. git push happens against original gather bump info process without prepublish