### PR TITLE
Publish packages in the right order based on dependency graph

### DIFF
--- a/change/beachball-2020-04-17-10-47-58-xgao-sort-publish.json
+++ b/change/beachball-2020-04-17-10-47-58-xgao-sort-publish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Publish packages in the right order based on their dependency graph",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-17T17:47:58.662Z"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -31,7 +31,8 @@
     "minimatch": "^3.0.4",
     "prompts": "~2.1.0",
     "semver": "^6.1.1",
-    "yargs-parser": "^13.1.0"
+    "yargs-parser": "^13.1.0",
+    "toposort": "^2.0.2"
   },
   "devDependencies": {
     "@types/cosmiconfig": "6.0.0",

--- a/packages/beachball/src/__tests__/publish/toposortPackages.test.ts
+++ b/packages/beachball/src/__tests__/publish/toposortPackages.test.ts
@@ -1,0 +1,108 @@
+import { toposortPackages } from '../../publish/toposortPackages';
+import { PackageInfos, PackageInfo } from '../../types/PackageInfo';
+
+describe('toposortPackages', () => {
+  it('sort packages which none of them has dependency', () => {
+    const packageInfos: PackageInfos = {
+      foo: {} as PackageInfo,
+      bar: {} as PackageInfo,
+    };
+
+    expect(toposortPackages(['foo', 'bar'], packageInfos)).toEqual(['foo', 'bar']);
+  });
+
+  it('sort packages with dependencies', () => {
+    const packageInfos = ({
+      foo: {
+        dependencies: {
+          bar: '1.0.0',
+          bar2: '1.0.0',
+        },
+      },
+      bar: {
+        dependencies: {
+          foo2: '1.0.0',
+        },
+      },
+      foo2: {},
+    } as any) as PackageInfos;
+
+    expect(toposortPackages(['foo', 'bar', 'foo2'], packageInfos)).toEqual(['foo2', 'bar', 'foo']);
+  });
+
+  it('sort packages with different kinds of dependencies', () => {
+    const packageInfos = ({
+      foo: {
+        dependencies: {
+          foo3: '1.0.0',
+        },
+        peerDependencies: {
+          foo4: '1.0.0',
+          bar: '1.0.0',
+        },
+      },
+      foo2: {
+        dependencies: {},
+      },
+      foo3: {
+        dependencies: {
+          foo2: '1.0.0',
+        },
+      },
+      foo4: {
+        devDependencies: {
+          foo2: '1.0.0',
+        },
+      },
+    } as any) as PackageInfos;
+
+    expect(toposortPackages(['foo', 'foo2', 'foo3', 'foo4'], packageInfos)).toEqual(['foo2', 'foo3', 'foo4', 'foo']);
+  });
+
+  it('do not sort packages if it is not included', () => {
+    const packageInfos = ({
+      foo: {
+        dependencies: {
+          bar: '1.0.0',
+          bar2: '1.0.0',
+        },
+      },
+      bar: {
+        dependencies: {
+          foo2: '1.0.0',
+        },
+      },
+      foo2: {},
+    } as any) as PackageInfos;
+
+    expect(toposortPackages(['foo', 'bar'], packageInfos)).toEqual(['bar', 'foo']);
+  });
+
+  it('throws if contains circular dependencies', () => {
+    const packageInfos = ({
+      foo: {
+        dependencies: {
+          bar: '1.0.0',
+          bar2: '1.0.0',
+        },
+      },
+      bar: {
+        dependencies: {
+          foo: '1.0.0',
+        },
+      },
+    } as any) as PackageInfos;
+
+    expect(() => {
+      toposortPackages(['foo', 'bar'], packageInfos);
+    }).toThrow();
+  });
+
+  it('throws if package info is missing', () => {
+    const packageInfos = ({} as any) as PackageInfos;
+
+    expect(() => {
+      toposortPackages(['foo'], packageInfos);
+    }).toThrow();
+  });
+});

--- a/packages/beachball/src/__tests__/publish/toposortPackages.test.ts
+++ b/packages/beachball/src/__tests__/publish/toposortPackages.test.ts
@@ -15,11 +15,11 @@ describe('toposortPackages', () => {
     const packageInfos = ({
       foo: {
         dependencies: {
-          bar: '1.0.0',
+          foo3: '1.0.0',
           bar2: '1.0.0',
         },
       },
-      bar: {
+      foo3: {
         dependencies: {
           foo2: '1.0.0',
         },
@@ -27,7 +27,7 @@ describe('toposortPackages', () => {
       foo2: {},
     } as any) as PackageInfos;
 
-    expect(toposortPackages(['foo', 'bar', 'foo2'], packageInfos)).toEqual(['foo2', 'bar', 'foo']);
+    expect(toposortPackages(['foo', 'foo2', 'foo3'], packageInfos)).toEqual(['foo2', 'foo3', 'foo']);
   });
 
   it('sort packages with different kinds of dependencies', () => {
@@ -63,19 +63,19 @@ describe('toposortPackages', () => {
     const packageInfos = ({
       foo: {
         dependencies: {
+          foo3: '1.0.0',
           bar: '1.0.0',
-          bar2: '1.0.0',
         },
       },
-      bar: {
+      foo2: {},
+      foo3: {
         dependencies: {
           foo2: '1.0.0',
         },
       },
-      foo2: {},
     } as any) as PackageInfos;
 
-    expect(toposortPackages(['foo', 'bar'], packageInfos)).toEqual(['bar', 'foo']);
+    expect(toposortPackages(['foo', 'foo3'], packageInfos)).toEqual(['foo3', 'foo']);
   });
 
   it('throws if contains circular dependencies', () => {

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -1,17 +1,18 @@
+import _ from 'lodash';
 import { performBump } from '../bump/performBump';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { packagePublish } from '../packageManager/packagePublish';
 import { validatePackageVersions } from './validatePackageVersions';
 import { displayManualRecovery } from './displayManualRecovery';
-import _ from 'lodash';
+import { toposortPackages } from './toposortPackages';
 import { shouldPublishPackage } from './shouldPublishPackage';
 import { validatePackageDependencies } from './validatePackageDependencies';
 
 export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions) {
   const { registry, tag, token, access, timeout } = options;
   const bumpInfo = _.cloneDeep(originalBumpInfo);
-  const { modifiedPackages, newPackages } = bumpInfo;
+  const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
   // Execute prepublish hook if available
   if (options.hooks?.prepublish) {
@@ -39,7 +40,9 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     process.exit(1);
   }
 
-  [...modifiedPackages, ...newPackages].forEach(pkg => {
+  const packagesToPublish = toposortPackages([...modifiedPackages, ...newPackages], packageInfos);
+
+  packagesToPublish.forEach(pkg => {
     const { publish, reasonToSkip } = shouldPublishPackage(bumpInfo, pkg);
     if (!publish) {
       console.log(`Skipping publish - ${reasonToSkip}`);

--- a/packages/beachball/src/publish/toposortPackages.ts
+++ b/packages/beachball/src/publish/toposortPackages.ts
@@ -1,10 +1,12 @@
-import { PackageInfos } from '../types/PackageInfo';
-import toposort from 'toposort';
 import * as _ from 'lodash';
+import toposort from 'toposort';
+import { PackageInfos } from '../types/PackageInfo';
 
 /**
  * Topological sort the packages based on its dependency graph.
  * Dependency comes first before dependent.
+ * @param packages Packages to be sorted.
+ * @param packageInfos PackagesInfos for the sorted packages.
  */
 export function toposortPackages(packages: string[], packageInfos: PackageInfos): string[] {
   const packageSet = new Set(packages);
@@ -37,9 +39,8 @@ export function toposortPackages(packages: string[], packageInfos: PackageInfos)
   });
 
   try {
-    const sortedPackages = toposort(dependencyGraph).filter(pkg => !!pkg);
-    return sortedPackages;
+    return toposort(dependencyGraph).filter(pkg => !!pkg);
   } catch (err) {
-    throw new Error('Failed to do toposort for packages: ' + err.message);
+    throw new Error(`Failed to do toposort for packages: ${err?.message}`);
   }
 }

--- a/packages/beachball/src/publish/toposortPackages.ts
+++ b/packages/beachball/src/publish/toposortPackages.ts
@@ -1,0 +1,45 @@
+import { PackageInfos } from '../types/PackageInfo';
+import toposort from 'toposort';
+import * as _ from 'lodash';
+
+/**
+ * Topological sort the packages based on its dependency graph.
+ * Dependency comes first before dependent.
+ */
+export function toposortPackages(packages: string[], packageInfos: PackageInfos): string[] {
+  const packageSet = new Set(packages);
+  const dependencyGraph: [string | undefined, string][] = [];
+
+  packages.forEach(pkgName => {
+    let allDeps: string[] = [];
+
+    ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depKind => {
+      const info = packageInfos[pkgName];
+      if (!info) {
+        throw new Error(`Package info is missing for ${pkgName}.`);
+      }
+
+      const deps = packageInfos[pkgName][depKind];
+      if (deps) {
+        const depPkgNames = Object.keys(deps);
+        allDeps = allDeps.concat(depPkgNames);
+      }
+    });
+
+    allDeps = _.uniq(allDeps).filter(pkg => packageSet.has(pkg));
+    if (allDeps.length > 0) {
+      allDeps.forEach(depPkgName => {
+        dependencyGraph.push([depPkgName, pkgName]);
+      });
+    } else {
+      dependencyGraph.push([undefined, pkgName]);
+    }
+  });
+
+  try {
+    const sortedPackages = toposort(dependencyGraph).filter(pkg => !!pkg);
+    return sortedPackages;
+  } catch (err) {
+    throw new Error('Failed to do toposort for packages: ' + err.message);
+  }
+}

--- a/packages/beachball/src/publish/toposortPackages.ts
+++ b/packages/beachball/src/publish/toposortPackages.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import toposort from 'toposort';
 import { PackageInfos } from '../types/PackageInfo';
 
@@ -28,7 +27,7 @@ export function toposortPackages(packages: string[], packageInfos: PackageInfos)
       }
     });
 
-    allDeps = _.uniq(allDeps).filter(pkg => packageSet.has(pkg));
+    allDeps = [...new Set(allDeps)].filter(pkg => packageSet.has(pkg));
     if (allDeps.length > 0) {
       allDeps.forEach(depPkgName => {
         dependencyGraph.push([depPkgName, pkgName]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -18055,6 +18055,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"


### PR DESCRIPTION
Fixes #322

## Problem
if dependent publishes first and dependencies failed to publish, we ended up publishing packages which are not installable for users.

## Solution
Do a topological sort on the packages before publishing them to guarantee dependencies are published before dependent.
