### PR TITLE
reduce npm publish log by set loglevel to warn

### DIFF
--- a/change/beachball-2020-04-17-14-27-42-xgao-reduce-log.json
+++ b/change/beachball-2020-04-17-14-27-42-xgao-reduce-log.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "reduce npm publish log by set loglevel to warn",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-17T21:27:42.607Z"
+}

--- a/packages/beachball/src/packageManager/packagePublish.ts
+++ b/packages/beachball/src/packageManager/packagePublish.ts
@@ -11,7 +11,7 @@ export function packagePublish(
 ) {
   const packageOptions = packageInfo.options;
   const packagePath = path.dirname(packageInfo.packageJsonPath);
-  const args = ['publish', '--registry', registry, '--tag', tag || packageOptions.defaultNpmTag];
+  const args = ['publish', '--registry', registry, '--tag', tag || packageOptions.defaultNpmTag, '--loglevel', 'warn'];
   if (token) {
     const shorthand = registry.substring(registry.indexOf('//'));
     args.push(`--${shorthand}:_authToken=${token}`);


### PR DESCRIPTION
Along the lines of fixing #293 and increasing max buffer size