### PR TITLE
Change prepublish hook to be file based and happen per-package

### DIFF
--- a/change/beachball-2020-04-17-16-33-59-pre-publish.json
+++ b/change/beachball-2020-04-17-16-33-59-pre-publish.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "update prepublish hook to work on files rather than bumpInfo",
+  "packageName": "beachball",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-17T23:33:59.224Z"
+}

--- a/packages/beachball/src/fixtures/monorepo.ts
+++ b/packages/beachball/src/fixtures/monorepo.ts
@@ -13,6 +13,10 @@ export const packageJsonFixtures = {
     dependencies: {
       bar: '^1.3.4',
     },
+    main: 'src/index.ts',
+    onPublish: {
+      main: 'lib/index.js',
+    },
   },
 
   'packages/bar': {

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -35,7 +35,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
 
   const packagesToPublish = toposortPackages([...modifiedPackages, ...newPackages], packageInfos);
 
-  packagesToPublish.forEach(pkg => {
+  for (const pkg of packagesToPublish) {
     const { publish, reasonToSkip } = shouldPublishPackage(bumpInfo, pkg);
     if (!publish) {
       console.log(`Skipping publish - ${reasonToSkip}`);
@@ -47,7 +47,10 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
 
     // run the prepublish hook once, after version bumping but before actually executing npm publish (with retries)
     if (prepublishHook) {
-      prepublishHook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
+      const maybeAwait = prepublishHook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
+      if (maybeAwait instanceof Promise) {
+        await maybeAwait;
+      }
     }
 
     let result;
@@ -72,5 +75,5 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     displayManualRecovery(bumpInfo, succeededPackages);
     console.error(result.stderr);
     throw new Error('Error publishing, refer to the previous error messages for recovery instructions');
-  });
+  }
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -58,7 +58,7 @@ export interface RepoOptions {
      * This allows for file modifications which will be reflected in the published package but not be reflected in the
      * repository.
      */
-    prepublish?: (packagePath: string, name: string, version: string) => void;
+    prepublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
   };
 }
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -1,7 +1,6 @@
 import { ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
-import { BumpInfo } from './BumpInfo';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -53,12 +52,13 @@ export interface RepoOptions {
 
   hooks?: {
     /**
-     * Prepublish hook gets run right before npm publish (during performBump)
-     * the changes will be reverted before pushing
+     * Runs for each package after version bumps have been processed and committed to git, but before the actual
+     * publish command.
      *
-     * This hook expects manipulation to the bumpInfo object (side effects)
+     * This allows for file modifications which will be reflected in the published package but not be reflected in the
+     * repository.
      */
-    prepublish?: (bumpInfo: BumpInfo) => void | Promise<void>;
+    prepublish?: (packagePath: string, name: string, version: string) => void;
   };
 }
 


### PR DESCRIPTION
## Removal of old prepublish hook

The first iteration on the prepublish hook allowed for modifying bumpInfo.  This happened during publish before packages were bumped.  While it allowed for modifying versions the implementation comes with some issues:

- it only worked for certain fields like version, changes to other information wouldn't be reflected in the files
- it happens before the last batch of changes are committed to the package.json files, this means that modification in bumpInfo, were they to be respected, might conflict
- it leaks too much in the way of internal implementation details
- it doesn't address the desire to make modifications to package.json that only apply to published files

Eventually the old prepublish hook could reappear as a prebump hook with a more deterministic API such as one that has a specific set of actions which can be taken on the packages.

## New prepublish hook

The new hook happens:

- after bumps have been done
- after updated package.json files have been committed to git
- after we have determined which packages should be published
- before each actual publish command is executed

This allows for modifications to the files before they are published to the registry.  This could be used for:

- modifying package.json files
- cleaning up internal only files
- copying data from elsewhere that should be published together but doesn't need to be in the internal environment.

This also removes the capability for returning a promise.  Because the publish routine is happening immediately after all async operations related to this call should be resolved before it returns.