### PR TITLE
Fix multi-package publishing regression (#327).

### DIFF
--- a/change/beachball-2020-04-20-01-01-13-reli-fix-multiple-package-publishing.json
+++ b/change/beachball-2020-04-20-01-01-13-reli-fix-multiple-package-publishing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix multi-package publishing regression (#327).",
+  "packageName": "beachball",
+  "email": "reli@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T08:01:13.833Z"
+}

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -169,7 +169,7 @@ describe('publish command (e2e)', () => {
 
     git(['checkout', 'master'], { cwd: repo.rootPath });
     git(['pull'], { cwd: repo.rootPath });
-    const barGitResults = git(['describe', '--abbrev=0'], { cwd: repo.rootPath });
+    const barGitResults = git(['describe', '--abbrev=0', 'bar_v1.4.0'], { cwd: repo.rootPath });
 
     expect(barGitResults.success).toBeTruthy();
     expect(barGitResults.stdout).toBe('bar_v1.4.0');

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -68,7 +68,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       if (result.success) {
         console.log('Published!');
         succeededPackages.add(pkg);
-        return;
+        break;
       } else {
         retries++;
 
@@ -78,8 +78,10 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       }
     } while (retries <= options.retries);
 
-    displayManualRecovery(bumpInfo, succeededPackages);
-    console.error(result.stderr);
-    throw new Error('Error publishing, refer to the previous error messages for recovery instructions');
+    if (!result.success) {
+      displayManualRecovery(bumpInfo, succeededPackages);
+      console.error(result.stderr);
+      throw new Error('Error publishing, refer to the previous error messages for recovery instructions');
+    }
   }
 }


### PR DESCRIPTION
Fixes #327 .

The current `return` when after package is successfully published will stop Beachball to publish other packages if multiple packages needs to publish to the registry. This change fixes this regression introduced by #299 .