### PR TITLE
Sync should limit to current major version and skip prerelease

### DIFF
--- a/change/beachball-2020-04-22-10-00-36-sync-major.json
+++ b/change/beachball-2020-04-22-10-00-36-sync-major.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Sync should limit to current major version",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-22T17:00:36.549Z"
+}

--- a/change/beachball-2020-04-22-10-00-36-sync-major.json
+++ b/change/beachball-2020-04-22-10-00-36-sync-major.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Sync should limit to current major version",
+  "comment": "Sync should limit to current major version and skip prerelease",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/beachball/src/commands/sync.ts
+++ b/packages/beachball/src/commands/sync.ts
@@ -14,17 +14,28 @@ export async function sync(options: BeachballOptions) {
       continue;
     }
 
-    const npmArgs = ['view', pkg, 'version'];
+    // Get the latest of *this major version* of the package.
+    // To do this we have to get all versions within this major version then take the latest.
+    const npmArgs = ['view', `${pkg}@${semver.major(info.version)}`, 'version', '--json'];
     if (options.registry) {
       npmArgs.push('--registry');
       npmArgs.push(options.registry);
     }
     const result = npm(npmArgs);
-    const publishedVersion = result.stdout;
+    let publishedVersion = '';
+
+    try {
+      // The returned array of versions will already be sorted and not include prerelease because
+      // prerelease versions don't satisfy semver pkg@x.
+      publishedVersion = JSON.parse(result.stdout).slice(-1)[0];
+    } catch (ex) {
+      // Package is not published or possibly some other issue (don't need to warn user)
+    }
 
     if (publishedVersion && semver.lt(info.version, publishedVersion)) {
       console.log(
-        `There is a newer version of "${pkg}@${info.version}". Syncing to the published version ${publishedVersion}`
+        `There is a newer version of "${pkg}" (local version: ${info.version}). ` +
+          `Syncing to the published version ${publishedVersion}.`
       );
 
       const packageJson = fs.readJsonSync(info.packageJsonPath);

--- a/packages/beachball/src/commands/sync.ts
+++ b/packages/beachball/src/commands/sync.ts
@@ -14,6 +14,11 @@ export async function sync(options: BeachballOptions) {
       continue;
     }
 
+    if (semver.prerelease(info.version)) {
+      console.log(`Warning: cannot sync prerelease package "${pkg}@${info.version}"`);
+      continue;
+    }
+
     // Get the latest of *this major version* of the package.
     // To do this we have to get all versions within this major version then take the latest.
     const npmArgs = ['view', `${pkg}@${semver.major(info.version)}`, 'version', '--json'];


### PR DESCRIPTION
When syncing to the latest published version, beachball should only sync to latest of the **same major version** specified in package.json. (Example: Say Fabric 6 publish fails partway through. If I run `beachball sync` before this change, all the packages will be updated to version 7!)

It's probably also best not to try to sync packages which are on a prerelease version, since semver isn't so well-defined in that case and we can't automatically figure out what's next.