### PR TITLE
Check changetype beyond the command line

### DIFF
--- a/change/beachball-2020-04-30-12-25-25-check-changetype.json
+++ b/change/beachball-2020-04-30-12-25-25-check-changetype.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "checks for invalid beachball change file on check and all operations",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T19:25:25.085Z"
+}

--- a/packages/beachball/src/changefile/readChangeFiles.ts
+++ b/packages/beachball/src/changefile/readChangeFiles.ts
@@ -11,6 +11,7 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
   const scopedPackages = getScopedPackages(options);
   const changeSet: ChangeSet = new Map();
   const changePath = getChangePath(cwd);
+
   if (!changePath || !fs.existsSync(changePath)) {
     return changeSet;
   }

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -6,6 +6,7 @@ import { isChangeFileNeeded } from './isChangeFileNeeded';
 import { isValidGroupOptions } from './isValidGroupOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { isValidChangelogOptions } from './isValidChangelogOptions';
+import { readChangeFiles } from '../changefile/readChangeFiles';
 
 export function validate(
   options: BeachballOptions,
@@ -53,6 +54,16 @@ export function validate(
     console.error('ERROR: Changelog defined inside the configuration is invalid');
     console.log(options.changelog);
     process.exit(1);
+  }
+
+  const changeSet = readChangeFiles(options);
+  for (const [changeFile, change] of changeSet) {
+    if (!change.type || !isValidChangeType(change.type)) {
+      console.error(
+        `ERROR: there is an invalid change type detected ${changeFile}: "${change.type}" is not a valid change type`
+      );
+      process.exit(1);
+    }
   }
 
   return {


### PR DESCRIPTION
`beachball check` needs to validate all change files that have been created inside the repo. Change can occur where someone manually made a typo in the change type.