### PR TITLE
publish: log errors for each retry attempt

### DIFF
--- a/change/beachball-2020-06-03-09-54-09-publish-error-log.json
+++ b/change/beachball-2020-06-03-09-54-09-publish-error-log.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "publish: log errors for each retry attempt",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-03T16:54:09.658Z"
+}

--- a/packages/beachball/src/__e2e__/publishRegistry.test.ts
+++ b/packages/beachball/src/__e2e__/publishRegistry.test.ts
@@ -84,7 +84,7 @@ describe('publish command (registry)', () => {
     });
 
     await expect(publishPromise).rejects.toThrow();
-    expect(spy).toHaveBeenCalledWith('Published failed, retrying... (3/3)');
+    expect(spy).toHaveBeenCalledWith('\nRetrying... (3/3)');
 
     spy.mockRestore();
 

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -75,8 +75,11 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       } else {
         retries++;
 
+        console.log('Publish failed:');
+        console.log(result.stderr);
+
         if (retries <= options.retries) {
-          console.log(`Published failed, retrying... (${retries}/${options.retries})`);
+          console.log(`\nRetrying... (${retries}/${options.retries})`);
         }
       }
     } while (retries <= options.retries);


### PR DESCRIPTION
If a publish attempt fails, log errors for every attempt, not just the last one.