### PR TITLE
Allow Individual Packages to Opt Out of Git Tags

### DIFF
--- a/change/beachball-2020-06-23-03-29-15-package-git-tags.json
+++ b/change/beachball-2020-06-23-03-29-15-package-git-tags.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Allow Individual Packages to Opt Out of Git Tags",
+  "packageName": "beachball",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T10:29:15.562Z"
+}

--- a/packages/beachball/src/__e2e__/packageManager.test.ts
+++ b/packages/beachball/src/__e2e__/packageManager.test.ts
@@ -59,7 +59,7 @@ describe('packageManager', () => {
     it('publish package with defaultNpmTag publishes as defaultNpmTag', () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
-        options: { defaultNpmTag: testTag, disallowedChangeTypes: null },
+        options: { gitTags: true, defaultNpmTag: testTag, disallowedChangeTypes: null },
       };
       const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', undefined, '');
       expect(publishResult.success).toBeTruthy();
@@ -83,7 +83,7 @@ describe('packageManager', () => {
     it('publish with specified tag overrides defaultNpmTag', () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
-        options: { defaultNpmTag: 'thisShouldNotBeUsed', disallowedChangeTypes: null },
+        options: { gitTags: true, defaultNpmTag: 'thisShouldNotBeUsed', disallowedChangeTypes: null },
       };
       const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', testTag, '');
       expect(publishResult.success).toBeTruthy();

--- a/packages/beachball/src/__tests__/publish/tagPackages.test.ts
+++ b/packages/beachball/src/__tests__/publish/tagPackages.test.ts
@@ -1,4 +1,4 @@
-import { tagPackages } from '../../publish/tagPackages';
+import { tagPackages, tagDistTag } from '../../publish/tagPackages';
 import { generateTag } from '../../tag';
 import { BumpInfo } from '../../types/BumpInfo';
 import { gitFailFast } from '../../git';
@@ -11,7 +11,7 @@ const createTagParameters = (tag: string, cwd: string) => {
   return [['tag', '-a', '-f', tag, '-m', tag], { cwd }];
 };
 
-const bumpInfo = ({
+const noTagBumpInfo = ({
   packageChangeTypes: {
     foo: 'minor',
     bar: 'major',
@@ -20,47 +20,76 @@ const bumpInfo = ({
     foo: {
       name: 'foo',
       version: '1.0.0',
+      options: {
+        gitTags: false,
+      }
     },
     bar: {
       name: 'bar',
       version: '1.0.1',
+      options: {
+        gitTags: false,
+      }
     },
   },
   modifiedPackages: new Set(['foo', 'bar']),
   newPackages: new Set(),
 } as unknown) as BumpInfo;
 
+const oneTagBumpInfo = ({
+  packageChangeTypes: {
+    foo: 'minor',
+    bar: 'major',
+  },
+  packageInfos: {
+    foo: {
+      name: 'foo',
+      version: '1.0.0',
+      options: {
+        gitTags: true,
+      }
+    },
+    bar: {
+      name: 'bar',
+      version: '1.0.1',
+      options: {
+        gitTags: false,
+      }
+    },
+  },
+  modifiedPackages: new Set(['foo', 'bar']),
+  newPackages: new Set(),
+} as unknown) as BumpInfo;
+
+beforeEach(() => {
+  (gitFailFast as jest.Mock).mockReset();
+});
+
 describe('tagPackages', () => {
-  beforeEach(() => {
-    (gitFailFast as jest.Mock).mockReset();
+  it('createTag is not called for packages without gitTags', () => {
+    tagPackages(noTagBumpInfo, /* cwd*/ '');
+    expect(gitFailFast).not.toHaveBeenCalled();
   });
 
-  it('createTag is not called when gitTags is false', () => {
-    tagPackages(bumpInfo, /* gitTag */ false, /* tag */ 'abc', /* cwd*/ '');
-    expect(gitFailFast).not.toBeCalled();
+  it('createTag is called for packages with gitTags', () => {
+    tagPackages(oneTagBumpInfo, /* cwd*/ '');
+    expect(gitFailFast).toHaveBeenCalledTimes(1);
 
-    tagPackages(bumpInfo, /* gitTag */ false, /* tag */ 'latest', /* cwd*/ '');
-    expect(gitFailFast).not.toBeCalled();
-  });
-
-  it('createTag is called when gitTags is true', () => {
-    tagPackages(bumpInfo, /* gitTags */ true, /* tag */ '', /* cwd*/ '');
     // verify git is being called to create new auto tag for foo and bar
-    const newFooTag = generateTag('foo', bumpInfo.packageInfos['foo'].version);
-    const newBarTag = generateTag('bar', bumpInfo.packageInfos['bar'].version);
-    expect(gitFailFast).toBeCalledTimes(2);
-    expect(gitFailFast).toHaveBeenNthCalledWith(1, ...createTagParameters(newFooTag, ''));
-    expect(gitFailFast).toHaveBeenNthCalledWith(2, ...createTagParameters(newBarTag, ''));
+    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos['foo'].version);
+    expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters(newFooTag, ''));
+  });
+});
+
+describe('tagDistTag', () => {
+  it('createTag is not called for an empty dist tag', () => {
+    tagDistTag(/* tag */ '', /* cwd*/ '');
+    expect(gitFailFast).not.toHaveBeenCalled();
   });
 
-  it('createTag is called when gitTags is true and a tag is passed', () => {
-    tagPackages(bumpInfo, /* gitTags */ true, /* tag */ 'abc', /* cwd*/ '');
-    // verify git is being called to create new auto tag for foo and bar
-    const newFooTag = generateTag('foo', bumpInfo.packageInfos['foo'].version);
-    const newBarTag = generateTag('bar', bumpInfo.packageInfos['bar'].version);
-    expect(gitFailFast).toBeCalledTimes(3);
-    expect(gitFailFast).toHaveBeenNthCalledWith(1, ...createTagParameters(newFooTag, ''));
-    expect(gitFailFast).toHaveBeenNthCalledWith(2, ...createTagParameters(newBarTag, ''));
-    expect(gitFailFast).toHaveBeenNthCalledWith(3, ...createTagParameters('abc', ''));
+  it('createTag is called for unique dist tags', () => {
+    tagDistTag(/* tag */ 'abc', /* cwd*/ '');
+    expect(gitFailFast).toBeCalledTimes(1);
+    expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters('abc', ''));
   });
 });

--- a/packages/beachball/src/fixtures/package.ts
+++ b/packages/beachball/src/fixtures/package.ts
@@ -21,6 +21,7 @@ export const testPackageInfo: PackageInfo = {
   version: testPackage.version,
   private: false,
   options: {
+    gitTags: true,
     defaultNpmTag: 'latest',
     disallowedChangeTypes: [],
   },

--- a/packages/beachball/src/publish/bumpAndPush.ts
+++ b/packages/beachball/src/publish/bumpAndPush.ts
@@ -2,7 +2,7 @@ import { performBump } from '../bump/performBump';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { git, gitFailFast, revertLocalChanges, parseRemoteBranch } from '../git';
-import { tagPackages } from './tagPackages';
+import { tagDistTag, tagPackages } from './tagPackages';
 import { mergePublishBranch } from './mergePublishBranch';
 import { displayManualRecovery } from './displayManualRecovery';
 
@@ -36,7 +36,10 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
   }
 
   // Tag & Push to remote
-  tagPackages(bumpInfo, options.gitTags, tag, cwd);
+  if (options.gitTags) {
+    tagPackages(bumpInfo, cwd);
+    tagDistTag(tag, cwd);
+  }
 
   console.log(`pushing to ${branch}, running the following command for git push:`);
   const pushArgs = ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`];

--- a/packages/beachball/src/publish/bumpAndPush.ts
+++ b/packages/beachball/src/publish/bumpAndPush.ts
@@ -36,8 +36,8 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
   }
 
   // Tag & Push to remote
+  tagPackages(bumpInfo, cwd);
   if (options.gitTags) {
-    tagPackages(bumpInfo, cwd);
     tagDistTag(tag, cwd);
   }
 

--- a/packages/beachball/src/publish/tagPackages.ts
+++ b/packages/beachball/src/publish/tagPackages.ts
@@ -6,24 +6,24 @@ function createTag(tag: string, cwd: string) {
   gitFailFast(['tag', '-a', '-f', tag, '-m', tag], { cwd });
 }
 
-export function tagPackages(bumpInfo: BumpInfo, gitTags: boolean, tag: string, cwd: string) {
+export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
   const { modifiedPackages, newPackages } = bumpInfo;
 
-  if (gitTags) {
-    [...modifiedPackages, ...newPackages].forEach(pkg => {
-      const packageInfo = bumpInfo.packageInfos[pkg];
-      const changeType = bumpInfo.packageChangeTypes[pkg];
-      // Do not tag change type of "none" or private packages
-      if (changeType === 'none' || packageInfo.private) {
-        return;
-      }
-      console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
-      const generatedTag = generateTag(packageInfo.name, packageInfo.version);
-      createTag(generatedTag, cwd);
-    });
-    // Adds a special dist-tag based tag in git
-    if (tag && tag !== 'latest') {
-      createTag(tag, cwd);
+  [...modifiedPackages, ...newPackages].forEach(pkg => {
+    const packageInfo = bumpInfo.packageInfos[pkg];
+    const changeType = bumpInfo.packageChangeTypes[pkg];
+    // Do not tag change type of "none", private packages, or packages opting out of tagging
+    if (changeType === 'none' || packageInfo.private || !packageInfo.options.gitTags) {
+      return;
     }
+    console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
+    const generatedTag = generateTag(packageInfo.name, packageInfo.version);
+    createTag(generatedTag, cwd);
+  });
+}
+
+export function tagDistTag(tag: string, cwd: string) {
+  if (tag && tag !== 'latest') {
+    createTag(tag, cwd);
   }
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -65,6 +65,7 @@ export interface RepoOptions {
 }
 
 export interface PackageOptions {
+  gitTags: boolean;
   disallowedChangeTypes: ChangeType[] | null;
   defaultNpmTag: string;
   changeFilePrompt?: ChangeFilePromptOptions;


### PR DESCRIPTION
This builds upon #346 and exposes gitTags as an option in package.json. This is useful for monorepos which only want one package to show up in their release view.

This is populated according to the existing rules of `getPackageOptions`, meaning the option we will see precedence of:
1. Cli options
2. Local package
3. Root package
4. Default options (tag)