### PR TITLE
--since flag implementation for bump and publish commands

### DIFF
--- a/change/beachball-2020-08-03-21-50-54-arabisho-adding-since-flag-for-change-file-deltas.json
+++ b/change/beachball-2020-08-03-21-50-54-arabisho-adding-since-flag-for-change-file-deltas.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "The `--since` flag implementation is added for filtering change files using git refs.",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T19:50:54.676Z"
+}

--- a/packages/beachball/src/changefile/readChangeFiles.ts
+++ b/packages/beachball/src/changefile/readChangeFiles.ts
@@ -4,21 +4,43 @@ import fs from 'fs-extra';
 import path from 'path';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
-import { getFileAddedHash } from '../git';
+import { getFileAddedHash, getChangesBetweenRefs } from '../git';
 
 export function readChangeFiles(options: BeachballOptions): ChangeSet {
   const { path: cwd } = options;
   const scopedPackages = getScopedPackages(options);
   const changeSet: ChangeSet = new Map();
   const changePath = getChangePath(cwd);
+  const fromRef = options.fromRef;
 
   if (!changePath || !fs.existsSync(changePath)) {
     return changeSet;
   }
-  const changeFiles = fs.readdirSync(changePath);
+
+  const allChangeFiles = fs.readdirSync(changePath);
+  const filteredChangeFiles: string[] = [];
+
+  if (fromRef) {
+    const changeFilesSinceFromRef = getChangesBetweenRefs(
+      fromRef,
+      'HEAD',
+      [
+        '--diff-filter=d', // excluding deleted files from the diff.
+        '--relative', // results will include path relative to the cwd, i.e. only file names.
+      ],
+      changePath
+    );
+
+    allChangeFiles
+      .filter(fileName => changeFilesSinceFromRef?.includes(fileName))
+      .forEach(fileName => filteredChangeFiles.push(fileName));
+  } else {
+    filteredChangeFiles.push(...allChangeFiles);
+  }
+
   try {
     // sort the change files by modified time. Most recent modified file comes first.
-    changeFiles.sort(function(f1, f2) {
+    filteredChangeFiles.sort(function(f1, f2) {
       return (
         fs.statSync(path.join(changePath, f2)).mtime.getTime() - fs.statSync(path.join(changePath, f1)).mtime.getTime()
       );
@@ -27,7 +49,7 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
     console.warn('Failed to sort change files', err);
   }
 
-  changeFiles.forEach(changeFile => {
+  filteredChangeFiles.forEach(changeFile => {
     try {
       const changeFilePath = path.join(changePath, changeFile);
       const changeInfo: ChangeInfo = {

--- a/packages/beachball/src/git/index.ts
+++ b/packages/beachball/src/git/index.ts
@@ -106,8 +106,8 @@ function processGitOutput(output: ProcessOutput) {
     return [];
   }
 
-  let changes = output.stdout;
-  let lines = changes.split(/\n/) || [];
+  let stdout = output.stdout;
+  let lines = stdout.split(/\n/) || [];
 
   return lines
     .filter(line => line.trim() !== '')

--- a/packages/beachball/src/git/index.ts
+++ b/packages/beachball/src/git/index.ts
@@ -101,6 +101,14 @@ export function getChangesBetweenRefs(fromRef: string, toRef: string, options: s
   }
 }
 
+export function getStagedChanges(branch: string, cwd: string) {
+  try {
+    return processGitOutput(git(['--no-pager', 'diff', '--staged', '--name-only'], { cwd }));
+  } catch (e) {
+    console.error('Cannot gather information about changes: ', e.message);
+  }
+}
+
 function processGitOutput(output: ProcessOutput) {
   if (!output.success) {
     return [];
@@ -113,27 +121,6 @@ function processGitOutput(output: ProcessOutput) {
     .filter(line => line.trim() !== '')
     .map(line => line.trim())
     .filter(line => !line.includes('node_modules'));
-}
-
-export function getStagedChanges(branch: string, cwd: string) {
-  try {
-    const results = git(['--no-pager', 'diff', '--staged', '--name-only'], { cwd });
-
-    if (!results.success) {
-      return [];
-    }
-
-    let changes = results.stdout;
-
-    let lines = changes.split(/\n/) || [];
-
-    return lines
-      .filter(line => line.trim() !== '')
-      .map(line => line.trim())
-      .filter(line => !line.includes('node_modules'));
-  } catch (e) {
-    console.error('Cannot gather information about changes: ', e.message);
-  }
 }
 
 export function getRecentCommitMessages(branch: string, cwd: string) {

--- a/packages/beachball/src/help.ts
+++ b/packages/beachball/src/help.ts
@@ -36,6 +36,8 @@ Options:
   --yes, -y           - skips the prompts for publish
   --package, -p       - manually specify a package to create a change file; creates a change file regardless of diffs
   --changehint        - give your developers a customized hint message when they forget to add a change file
+  --since             - for bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
+                        for publish command: bumps and publishes packages based on the specified range of the change files.
 
 Examples:
 

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -13,7 +13,7 @@ export function getCliOptions(): CliOptions {
 
   const argv = process.argv.splice(2);
   const args = parser(argv, {
-    string: ['branch', 'tag', 'message', 'package'],
+    string: ['branch', 'tag', 'message', 'package', 'since'],
     array: ['scope'],
     boolean: ['git-tags'],
     alias: {
@@ -35,6 +35,7 @@ export function getCliOptions(): CliOptions {
     ...(_.length > 0 && { command: _[0] }),
     ...(restArgs as any),
     path: cwd,
+    fromRef: args.since,
     branch: args.branch && args.branch.indexOf('/') > -1 ? args.branch : getDefaultRemoteBranch(args.branch, cwd),
   } as CliOptions;
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -28,6 +28,7 @@ export interface CliOptions {
   version?: boolean;
   scope?: string[] | null;
   timeout?: number;
+  fromRef?: string;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
This PR includes implementation of the `--since` flag that allows users to specify a range of change files used by the `bump` and `publish` commands. The value passed to the `--since` flag can be any git ref, i.e. commit SHA, branch name or tag. 

**Behaviour of `bump --since <ref>`:** with `bump --since C1` executed for the repo containing `C1 <- C2 <- C3` commits, `bump` is going to pick-up change files introduced in commits C2 and C3. Once versions are bumped, corresponding change files will be deleted.

**Behaviour of `publish --since <ref>`:** similar to `bump --since <ref`, with the difference that publish is going to upload affected packages to an npm registry.

The flag does not affect the behaviour of `check`, `change` or `sync` commands. This PR implements part of a
solution for the issue https://github.com/microsoft/beachball/issues/361.