### PR TITLE
--keep-change-files flag implementation to prevent removing change files

### DIFF
--- a/change/beachball-2020-08-05-21-57-19-arabisho-adding-keep-change-files-flag.json
+++ b/change/beachball-2020-08-05-21-57-19-arabisho-adding-keep-change-files-flag.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Implements the `--keep-change-files` flag to prevent change files from being deleted by bump and publish commands",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T19:57:19.938Z"
+}

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -509,4 +509,91 @@ describe('version bumping', () => {
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles.length).toBe(0);
   });
+
+  it('bumps all packages and keeps change files with `keep-change-files` flag', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-2/package.json',
+      JSON.stringify({
+        name: 'pkg-2',
+        version: '1.0.0',
+        dependencies: {
+          'pkg-1': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-3/package.json',
+      JSON.stringify({
+        name: 'pkg-3',
+        version: '1.0.0',
+        devDependencies: {
+          'pkg-2': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-4/package.json',
+      JSON.stringify({
+        name: 'pkg-4',
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-3': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'foo-repo',
+        version: '1.0.0',
+        private: true,
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'minor',
+          comment: 'test',
+          date: new Date('2019-01-01'),
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await bump({ path: repo.rootPath, bumpDeps: false, keepChangeFiles: true } as BeachballOptions);
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+
+    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
+    expect(packageInfos['pkg-2'].version).toBe('1.0.0');
+    expect(packageInfos['pkg-3'].version).toBe('1.0.0');
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe('1.1.0');
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.0');
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.0');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(1);
+  });
 });

--- a/packages/beachball/src/bump/performBump.ts
+++ b/packages/beachball/src/bump/performBump.ts
@@ -36,6 +36,8 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
   // Generate changelog
   await writeChangelog(options, changes, packageInfos);
 
-  // Unlink changelogs
-  unlinkChangeFiles(changes, packageInfos, options.path);
+  if (!options.keepChangeFiles) {
+    // Unlink changelogs
+    unlinkChangeFiles(changes, packageInfos, options.path);
+  }
 }

--- a/packages/beachball/src/help.ts
+++ b/packages/beachball/src/help.ts
@@ -38,6 +38,7 @@ Options:
   --changehint        - give your developers a customized hint message when they forget to add a change file
   --since             - for bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
                         for publish command: bumps and publishes packages based on the specified range of the change files.
+  --keep-change-files - for bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
 
 Examples:
 

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -15,7 +15,7 @@ export function getCliOptions(): CliOptions {
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package', 'since'],
     array: ['scope'],
-    boolean: ['git-tags'],
+    boolean: ['git-tags', 'keep-change-files'],
     alias: {
       branch: ['b'],
       tag: ['t'],
@@ -36,6 +36,7 @@ export function getCliOptions(): CliOptions {
     ...(restArgs as any),
     path: cwd,
     fromRef: args.since,
+    keepChangeFiles: args['keep-change-files'],
     branch: args.branch && args.branch.indexOf('/') > -1 ? args.branch : getDefaultRemoteBranch(args.branch, cwd),
   } as CliOptions;
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -29,6 +29,7 @@ export interface CliOptions {
   scope?: string[] | null;
   timeout?: number;
   fromRef?: string;
+  keepChangeFiles?: boolean;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
The current behaviour of `bump` and `publish` implies removal of the change files. This is needed to avoid bumping the same packages multiple times. With the introduction of the [`--since` flag](https://github.com/microsoft/beachball/pull/373) users can select a subset of relevant change files without relying on clean-up. 

Additionally, the rolling release branch flow described in https://github.com/microsoft/beachball/issues/361 implies that master / release branches need to stay as close as possible to each other with the only differences being versions in package.json files and change logs. 

Hence, this PR introduces a new flag to disable the change file removal in `bump` and `publish`. 

Please note, this PR depends on https://github.com/microsoft/beachball/pull/373 :) 