### PR TITLE
`--no-bump` flag implementation

### DIFF
--- a/change/beachball-2020-08-06-17-39-17-arabisho-no-bump-flag-implementation.json
+++ b/change/beachball-2020-08-06-17-39-17-arabisho-no-bump-flag-implementation.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "--no-bump flag implementation",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T15:39:17.525Z"
+}

--- a/packages/beachball/src/__e2e__/publishGit.test.ts
+++ b/packages/beachball/src/__e2e__/publishGit.test.ts
@@ -66,6 +66,7 @@ describe('publish command (git)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     });
 
     const newRepo = await repositoryFactory.cloneRepository();
@@ -123,6 +124,7 @@ describe('publish command (git)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     };
 
     const bumpInfo = gatherBumpInfo(options);

--- a/packages/beachball/src/__e2e__/publishRegistry.test.ts
+++ b/packages/beachball/src/__e2e__/publishRegistry.test.ts
@@ -82,6 +82,7 @@ describe('publish command (registry)', () => {
       defaultNpmTag: 'latest',
       retries: 3,
       timeout: 100,
+      bump: true,
     });
 
     await expect(publishPromise).rejects.toThrow();
@@ -135,6 +136,7 @@ describe('publish command (registry)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -215,6 +217,7 @@ describe('publish command (registry)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
@@ -292,6 +295,7 @@ describe('publish command (registry)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     });
 
     const showResultFoo = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
@@ -373,6 +377,7 @@ describe('publish command (registry)', () => {
       disallowedChangeTypes: null,
       defaultNpmTag: 'latest',
       retries: 3,
+      bump: true,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'badname', '--json']);

--- a/packages/beachball/src/commands/publish.ts
+++ b/packages/beachball/src/commands/publish.ts
@@ -27,8 +27,9 @@ export async function publish(options: BeachballOptions) {
   target branch: ${branch}
   tag: ${tag}
 
+  bumps versions: ${options.bump ? 'yes' : 'no'}
   publishes to npm registry: ${options.publish ? 'yes' : 'no'}
-  pushes to remote git repo: ${options.push && options.branch ? 'yes' : 'no'}
+  pushes to remote git repo: ${options.bump && options.push && options.branch ? 'yes' : 'no'}
 
 `);
   if (!options.yes) {
@@ -44,7 +45,11 @@ export async function publish(options: BeachballOptions) {
   // checkout publish branch
   const publishBranch = 'publish_' + String(new Date().getTime());
   gitFailFast(['checkout', '-b', publishBranch], { cwd });
-  console.log('Bumping version for npm publish');
+
+  if (options.bump) {
+    console.log('Bumping version for npm publish');
+  }
+
   const bumpInfo = gatherBumpInfo(options);
 
   if (options.new) {
@@ -60,7 +65,7 @@ export async function publish(options: BeachballOptions) {
   }
   // Step 2.
   // - reset, fetch latest from origin/master (to ensure less chance of conflict), then bump again + commit
-  if (branch && options.push) {
+  if (options.bump && branch && options.push) {
     await bumpAndPush(bumpInfo, publishBranch, options);
   } else {
     console.log('Skipping git push and tagging');

--- a/packages/beachball/src/help.ts
+++ b/packages/beachball/src/help.ts
@@ -32,6 +32,7 @@ Options:
                         for change command: description of the change
   --no-push           - skip pushing changes back to git remote origin
   --no-publish        - skip publishing to the npm registry
+  --no-bump           - skip both bumping versions and pushing changes back to git remote origin when publishing;
   --help, -?, -h      - this very help message
   --yes, -y           - skips the prompts for publish
   --package, -p       - manually specify a package to create a change file; creates a change file regardless of diffs

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -24,5 +24,6 @@ export function getDefaultOptions() {
     scope: null,
     retries: 3,
     timeout: undefined,
+    bump: true,
   } as BeachballOptions;
 }

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -15,7 +15,9 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
   const bumpInfo = _.cloneDeep(originalBumpInfo);
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
-  await performBump(bumpInfo, options);
+  if (options.bump) {
+    await performBump(bumpInfo, options);
+  }
 
   const succeededPackages = new Set<string>();
 

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -30,6 +30,7 @@ export interface CliOptions {
   timeout?: number;
   fromRef?: string;
   keepChangeFiles?: boolean;
+  bump: boolean;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
`--no-bump` allows to skip the bump step when invoking the `publish` command. As a side effect, it also implies that publish is not going to have anything to commit or push to the remote repo. Hence, when using `--no-bump` you also get the `--no-push` behaviour. The PR makes necessary changes to the console output and documentation to make that clear to the user.