### PR TITLE
Sync needs to use dist-tags for its latest retrieval rather than simple semver sort

### DIFF
--- a/change/beachball-2020-08-17-15-46-31-sync.json
+++ b/change/beachball-2020-08-17-15-46-31-sync.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "making sync actually just ask for latest dist-tag",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T22:46:31.083Z"
+}

--- a/packages/beachball/src/commands/sync.ts
+++ b/packages/beachball/src/commands/sync.ts
@@ -1,7 +1,7 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-import { listPackageVersions } from '../packageManager/listPackageVersions';
+import { listLatestPackageVersions } from '../packageManager/listPackageVersions';
 import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
 import { writePackageJson } from '../bump/performBump';
@@ -11,13 +11,13 @@ export async function sync(options: BeachballOptions) {
   const scopedPackages = new Set(getScopedPackages(options));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));
-  const publishedVersions = await listPackageVersions([...infos.keys()], options.registry);
+  const publishedVersions = await listLatestPackageVersions([...infos.keys()], options.registry);
 
   const modifiedPackages = new Set<string>();
 
   for (const [pkg, info] of infos.entries()) {
     if (publishedVersions[pkg]) {
-      const publishedVersion = semver.sort(publishedVersions[pkg])[publishedVersions[pkg].length - 1];
+      const publishedVersion = publishedVersions[pkg];
 
       if (publishedVersion && semver.lt(info.version, publishedVersion)) {
         console.log(

--- a/packages/beachball/src/packageManager/listPackageVersions.ts
+++ b/packages/beachball/src/packageManager/listPackageVersions.ts
@@ -28,7 +28,7 @@ export async function listLatestPackageVersions(packageList: string[], registry:
     all.push(
       limit(async () => {
         const info = await getNpmPackageInfo(pkg, registry);
-        versions[pkg] = info['dist-tags'] ? info['dist-tags'].latest : undefined;
+        versions[pkg] = info['dist-tags'] && info['dist-tags'].latest ? info['dist-tags'].latest : undefined;
       })
     );
   }
@@ -47,7 +47,7 @@ export async function listPackageVersions(packageList: string[], registry: strin
     all.push(
       limit(async () => {
         const info = await getNpmPackageInfo(pkg, registry);
-        versions[pkg] = info ? info.versions : [];
+        versions[pkg] = info && info.versions ? info.versions : [];
       })
     );
   }


### PR DESCRIPTION
semver sort of ALL versions might yield prerelease versions being synced down