### PR TITLE
Make sure fetch is NOT called during validation for publish.

### DIFF
--- a/change/beachball-2020-08-20-16-04-11-nochange.json
+++ b/change/beachball-2020-08-20-16-04-11-nochange.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "do not fetch before npm publish",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T23:04:11.044Z"
+}

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -28,7 +28,8 @@ import { validate } from './validation/validate';
       break;
 
     case 'publish':
-      validate(options);
+      validate(options, { allowFetching: false });
+
       // set a default publish message
       options.message = options.message || 'applying package updates';
       await publish(options);

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -13,7 +13,10 @@ import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes
 
 export function validate(
   options: BeachballOptions,
-  validateOptions: { allowMissingChangeFiles: boolean } = { allowMissingChangeFiles: false }
+  validateOptions: { allowMissingChangeFiles?: boolean; allowFetching?: boolean } = {
+    allowMissingChangeFiles: false,
+    allowFetching: true,
+  }
 ) {
   // Validation Steps
   if (!isGitAvailable(options.path)) {
@@ -39,12 +42,14 @@ export function validate(
     process.exit(1);
   }
 
-  const isChangeNeeded = isChangeFileNeeded(options);
+  if (validateOptions.allowFetching) {
+    const isChangeNeeded = isChangeFileNeeded(options);
 
-  if (isChangeNeeded && !validateOptions.allowMissingChangeFiles) {
-    console.error('ERROR: Change files are needed!');
-    console.log(options.changehint);
-    process.exit(1);
+    if (isChangeNeeded && !validateOptions.allowMissingChangeFiles) {
+      console.error('ERROR: Change files are needed!');
+      console.log(options.changehint);
+      process.exit(1);
+    }
   }
 
   if (options.groups && !isValidGroupOptions(options.path, options.groups)) {

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -78,8 +78,4 @@ export function validate(
       process.exit(1);
     }
   }
-
-  return {
-    isChangeNeeded,
-  };
 }


### PR DESCRIPTION
We need to guarantee that the published bits are the same as when the source was checked out. Therefore no fetches should happen before npm publish.