### PR TITLE
Update error logic for disallowedChangeTypes in groups option

### DIFF
--- a/change/beachball-2020-09-10-13-23-15-xgao-fix-disallowedTypes.json
+++ b/change/beachball-2020-09-10-13-23-15-xgao-fix-disallowedTypes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Only throw error when disallowedChangeType is defined in package option and not defined in groups option ",
+  "packageName": "beachball",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T20:23:15.670Z"
+}

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -20,7 +20,7 @@ export function isValidGroupOptions(root: string, groups: VersionGroupOptions[])
   for (const grp of Object.keys(packageGroups)) {
     const pkgs = packageGroups[grp].packageNames;
     for (const pkgName of pkgs) {
-      if (packageInfos[pkgName].options.disallowedChangeTypes) {
+      if (packageInfos[pkgName].options.disallowedChangeTypes && !packageGroups[grp].disallowedChangeTypes) {
         console.error(
           `Cannot have a disallowedChangeType inside a package config (${pkgName}) when there is a group defined; use the groups.disallowedChangeTypes instead.`
         );


### PR DESCRIPTION
Only throw error when disallowedChangeType is defined in package option and not defined in groups option