### PR TITLE
Distinguish between combinedOptions vs packageOptions so disallowChangeType check can be done

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 120
 }

--- a/change/beachball-2020-09-11-10-57-53-group-disallow.json
+++ b/change/beachball-2020-09-11-10-57-53-group-disallow.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "making a distinction between packageOptions and combinedOptions",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T17:57:53.017Z"
+}

--- a/src/__e2e__/packageManager.test.ts
+++ b/src/__e2e__/packageManager.test.ts
@@ -59,7 +59,7 @@ describe('packageManager', () => {
     it('publish package with defaultNpmTag publishes as defaultNpmTag', () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
-        options: { gitTags: true, defaultNpmTag: testTag, disallowedChangeTypes: null },
+        combinedOptions: { gitTags: true, defaultNpmTag: testTag, disallowedChangeTypes: null },
       };
       const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', undefined, '');
       expect(publishResult.success).toBeTruthy();
@@ -83,7 +83,7 @@ describe('packageManager', () => {
     it('publish with specified tag overrides defaultNpmTag', () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
-        options: { gitTags: true, defaultNpmTag: 'thisShouldNotBeUsed', disallowedChangeTypes: null },
+        combinedOptions: { gitTags: true, defaultNpmTag: 'thisShouldNotBeUsed', disallowedChangeTypes: null },
       };
       const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', testTag, '');
       expect(publishResult.success).toBeTruthy();

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -13,11 +13,11 @@ describe('updateRelatedChangeType', () => {
     packageInfos: {
       foo: {
         name: 'foo',
-        options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+        combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
       },
       bar: {
         name: 'bar',
-        options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+        combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
       },
     },
     modifiedPackages: new Set(),
@@ -197,11 +197,11 @@ describe('updateRelatedChangeType', () => {
         },
         dep: {
           name: 'dep',
-          options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
         unrelated: {
           name: 'unrelated',
-          options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
@@ -236,14 +236,14 @@ describe('updateRelatedChangeType', () => {
         },
         dep: {
           name: 'dep',
-          options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
         app: {
           name: 'app',
           dependencies: {
             foo: '1.0.0',
           },
-          options: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
@@ -320,7 +320,7 @@ describe('updateRelatedChangeType', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       packageInfos: {
         foo: {
-          options: { disallowedChangeTypes: ['minor', 'major'], defaultNpmTag: 'latest' },
+          combinedOptions: { disallowedChangeTypes: ['minor', 'major'], defaultNpmTag: 'latest' },
         },
       },
     });

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -20,16 +20,16 @@ const noTagBumpInfo = ({
     foo: {
       name: 'foo',
       version: '1.0.0',
-      options: {
+      combinedOptions: {
         gitTags: false,
-      }
+      },
     },
     bar: {
       name: 'bar',
       version: '1.0.1',
-      options: {
+      combinedOptions: {
         gitTags: false,
-      }
+      },
     },
   },
   modifiedPackages: new Set(['foo', 'bar']),
@@ -45,16 +45,16 @@ const oneTagBumpInfo = ({
     foo: {
       name: 'foo',
       version: '1.0.0',
-      options: {
+      combinedOptions: {
         gitTags: true,
-      }
+      },
     },
     bar: {
       name: 'bar',
       version: '1.0.1',
-      options: {
+      combinedOptions: {
         gitTags: false,
-      }
+      },
     },
   },
   modifiedPackages: new Set(['foo', 'bar']),

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -15,7 +15,7 @@ export function updateRelatedChangeType(
 ) {
   const { packageChangeTypes, packageGroups, dependents, packageInfos, dependentChangeTypes, groupOptions } = bumpInfo;
 
-  const disallowedChangeTypes = packageInfos[pkgName].options?.disallowedChangeTypes ?? [];
+  const disallowedChangeTypes = packageInfos[pkgName].combinedOptions?.disallowedChangeTypes ?? [];
 
   let depChangeType = getMaxChangeType(MinChangeType, dependentChangeTypes[pkgName], disallowedChangeTypes);
   let dependentPackages = dependents[pkgName];

--- a/src/changefile/getDisallowedChangeTypes.ts
+++ b/src/changefile/getDisallowedChangeTypes.ts
@@ -11,5 +11,5 @@ export function getDisallowedChangeTypes(
       return groupsInfo.disallowedChangeTypes;
     }
   }
-  return packageInfos[packageName].options.disallowedChangeTypes;
+  return packageInfos[packageName].combinedOptions.disallowedChangeTypes;
 }

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -38,7 +38,10 @@ export async function promptForChange(options: BeachballOptions) {
         ...(showPrereleaseOption ? [{ value: 'prerelease', title: ' [1mPrerelease[22m - bump prerelease version' }] : []),
         { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no backwards incompatible changes.' },
         { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible changes.' },
-        { value: 'none', title: ' [1mNone[22m       - this change does not affect the published package in any way.' },
+        {
+          value: 'none',
+          title: ' [1mNone[22m       - this change does not affect the published package in any way.',
+        },
         { value: 'major', title: ' [1mMajor[22m      - major feature; breaking changes.' },
       ].filter(choice => !disallowedChangeTypes?.includes(choice.value as ChangeType)),
     };
@@ -71,8 +74,8 @@ export async function promptForChange(options: BeachballOptions) {
 
     let questions = [defaultPrompt.changeType, defaultPrompt.description];
 
-    if (packageInfo.options.changeFilePrompt?.changePrompt) {
-      questions = packageInfo.options.changeFilePrompt?.changePrompt(defaultPrompt);
+    if (packageInfo.combinedOptions.changeFilePrompt?.changePrompt) {
+      questions = packageInfo.combinedOptions.changeFilePrompt?.changePrompt(defaultPrompt);
     }
 
     questions = questions.filter(q => !!q);

--- a/src/fixtures/package.ts
+++ b/src/fixtures/package.ts
@@ -20,7 +20,12 @@ export const testPackageInfo: PackageInfo = {
   packageJsonPath: tmpPackageFile,
   version: testPackage.version,
   private: false,
-  options: {
+  combinedOptions: {
+    gitTags: true,
+    defaultNpmTag: 'latest',
+    disallowedChangeTypes: [],
+  },
+  packageOptions: {
     gitTags: true,
     defaultNpmTag: 'latest',
     disallowedChangeTypes: [],

--- a/src/monorepo/infoFromPackageJson.ts
+++ b/src/monorepo/infoFromPackageJson.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { PackageInfo, PackageJson } from '../types/PackageInfo';
-import { getPackageOptions } from '../options/getPackageOptions';
+import { getActualPackageOptions, getPackageOptions } from '../options/getPackageOptions';
 
 export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: string): PackageInfo {
+  const actualOptions = getActualPackageOptions(path.dirname(packageJsonPath));
   return {
     name: packageJson.name!,
     version: packageJson.version,
@@ -11,6 +12,7 @@ export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: s
     devDependencies: packageJson.devDependencies,
     peerDependencies: packageJson.peerDependencies,
     private: packageJson.private !== undefined ? packageJson.private : false,
-    options: getPackageOptions(path.dirname(packageJsonPath)),
+    combinedOptions: getPackageOptions(actualOptions),
+    packageOptions: getActualPackageOptions(path.dirname(packageJsonPath)),
   };
 }

--- a/src/monorepo/infoFromPackageJson.ts
+++ b/src/monorepo/infoFromPackageJson.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 import { PackageInfo, PackageJson } from '../types/PackageInfo';
-import { getActualPackageOptions, getPackageOptions } from '../options/getPackageOptions';
+import { getPackageOptions, getCombinedPackageOptions } from '../options/getPackageOptions';
 
 export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: string): PackageInfo {
-  const actualOptions = getActualPackageOptions(path.dirname(packageJsonPath));
+  const actualOptions = getPackageOptions(path.dirname(packageJsonPath));
   return {
     name: packageJson.name!,
     version: packageJson.version,
@@ -12,7 +12,7 @@ export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: s
     devDependencies: packageJson.devDependencies,
     peerDependencies: packageJson.peerDependencies,
     private: packageJson.private !== undefined ? packageJson.private : false,
-    combinedOptions: getPackageOptions(actualOptions),
-    packageOptions: getActualPackageOptions(path.dirname(packageJsonPath)),
+    combinedOptions: getCombinedPackageOptions(actualOptions),
+    packageOptions: getPackageOptions(path.dirname(packageJsonPath)),
   };
 }

--- a/src/monorepo/infoFromPackageJson.ts
+++ b/src/monorepo/infoFromPackageJson.ts
@@ -3,7 +3,7 @@ import { PackageInfo, PackageJson } from '../types/PackageInfo';
 import { getPackageOptions, getCombinedPackageOptions } from '../options/getPackageOptions';
 
 export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: string): PackageInfo {
-  const actualOptions = getPackageOptions(path.dirname(packageJsonPath));
+  const packageOptions = getPackageOptions(path.dirname(packageJsonPath));
   return {
     name: packageJson.name!,
     version: packageJson.version,
@@ -12,7 +12,7 @@ export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: s
     devDependencies: packageJson.devDependencies,
     peerDependencies: packageJson.peerDependencies,
     private: packageJson.private !== undefined ? packageJson.private : false,
-    combinedOptions: getCombinedPackageOptions(actualOptions),
-    packageOptions: getPackageOptions(path.dirname(packageJsonPath)),
+    combinedOptions: getCombinedPackageOptions(packageOptions),
+    packageOptions,
   };
 }

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -8,7 +8,7 @@ import { getDefaultOptions } from './getDefaultOptions';
  * Gets all package level options (default + root options + package options + cli options)
  * This function inherits packageOptions from the rootOptions
  */
-export function getPackageOptions(actualPackageOptions: PackageOptions): PackageOptions {
+export function getCombinedPackageOptions(actualPackageOptions: PackageOptions): PackageOptions {
   const defaultOptions = getDefaultOptions();
   const rootOptions = getRootOptions();
   return {
@@ -22,7 +22,7 @@ export function getPackageOptions(actualPackageOptions: PackageOptions): Package
 /**
  * Gets all the package options from the configuration file of the package itself without inheritance
  */
-export function getActualPackageOptions(packagePath: string): PackageOptions {
+export function getPackageOptions(packagePath: string): PackageOptions {
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
   const searchResults = configExplorer.search(packagePath);
   return searchResults && searchResults.config;

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -3,6 +3,7 @@ import { PackageOptions } from '../types/BeachballOptions';
 import { getCliOptions } from './getCliOptions';
 import { getRootOptions } from './getRootOptions';
 import { getDefaultOptions } from './getDefaultOptions';
+import path from 'path';
 
 /**
  * Gets all package level options (default + root options + package options + cli options)

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -6,16 +6,24 @@ import { getDefaultOptions } from './getDefaultOptions';
 
 /**
  * Gets all package level options (default + root options + package options + cli options)
+ * This function inherits packageOptions from the rootOptions
  */
-export function getPackageOptions(packagePath: string): PackageOptions {
-  const configExplorer = cosmiconfigSync('beachball', { cache: false });
-  const searchResults = configExplorer.search(packagePath);
+export function getPackageOptions(actualPackageOptions: PackageOptions): PackageOptions {
   const defaultOptions = getDefaultOptions();
   const rootOptions = getRootOptions();
   return {
     ...defaultOptions,
     ...rootOptions,
-    ...(searchResults && searchResults.config),
+    ...actualPackageOptions,
     ...getCliOptions(),
   };
+}
+
+/**
+ * Gets all the package options from the configuration file of the package itself without inheritance
+ */
+export function getActualPackageOptions(packagePath: string): PackageOptions {
+  const configExplorer = cosmiconfigSync('beachball', { cache: false });
+  const searchResults = configExplorer.search(packagePath);
+  return searchResults && searchResults.config;
 }

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -23,7 +23,17 @@ export function getCombinedPackageOptions(actualPackageOptions: PackageOptions):
  * Gets all the package options from the configuration file of the package itself without inheritance
  */
 export function getPackageOptions(packagePath: string): PackageOptions {
+  const defaultOptions = getDefaultOptions();
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
-  const searchResults = configExplorer.search(packagePath);
-  return searchResults && searchResults.config;
+  try {
+    const results = configExplorer.load(packagePath);
+    return results && results.config;
+  } catch (e) {
+    // File does not exist, returns the default packageOptions
+    return {
+      gitTags: defaultOptions.gitTags,
+      disallowedChangeTypes: defaultOptions.disallowedChangeTypes,
+      defaultNpmTag: defaultOptions.defaultNpmTag,
+    };
+  }
 }

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -8,7 +8,7 @@ import { getDefaultOptions } from './getDefaultOptions';
  * Gets all package level options (default + root options + package options + cli options)
  * This function inherits packageOptions from the rootOptions
  */
-export function getCombinedPackageOptions(actualPackageOptions: PackageOptions): PackageOptions {
+export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageOptions>): PackageOptions {
   const defaultOptions = getDefaultOptions();
   const rootOptions = getRootOptions();
   return {
@@ -22,18 +22,13 @@ export function getCombinedPackageOptions(actualPackageOptions: PackageOptions):
 /**
  * Gets all the package options from the configuration file of the package itself without inheritance
  */
-export function getPackageOptions(packagePath: string): PackageOptions {
-  const defaultOptions = getDefaultOptions();
+export function getPackageOptions(packagePath: string): Partial<PackageOptions> {
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
   try {
     const results = configExplorer.load(packagePath);
     return results && results.config;
   } catch (e) {
     // File does not exist, returns the default packageOptions
-    return {
-      gitTags: defaultOptions.gitTags,
-      disallowedChangeTypes: defaultOptions.disallowedChangeTypes,
-      defaultNpmTag: defaultOptions.defaultNpmTag,
-    };
+    return {};
   }
 }

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -10,9 +10,17 @@ export function packagePublish(
   access: string,
   timeout?: number | undefined
 ) {
-  const packageOptions = packageInfo.options;
+  const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);
-  const args = ['publish', '--registry', registry, '--tag', tag || packageOptions.defaultNpmTag, '--loglevel', 'warn'];
+  const args = [
+    'publish',
+    '--registry',
+    registry,
+    '--tag',
+    tag || packageOptions.defaultNpmTag,
+    '--loglevel',
+    'warn',
+  ];
   if (token) {
     const shorthand = registry.substring(registry.indexOf('//'));
     args.push(`--${shorthand}:_authToken=${token}`);

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -13,7 +13,7 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
     const packageInfo = bumpInfo.packageInfos[pkg];
     const changeType = bumpInfo.packageChangeTypes[pkg];
     // Do not tag change type of "none", private packages, or packages opting out of tagging
-    if (changeType === 'none' || packageInfo.private || !packageInfo.options.gitTags) {
+    if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       return;
     }
     console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -24,7 +24,8 @@ export interface PackageInfo {
   devDependencies?: PackageDeps;
   peerDependencies?: PackageDeps;
   private: boolean;
-  options: PackageOptions;
+  combinedOptions: PackageOptions;
+  packageOptions: PackageOptions;
   group?: string;
 }
 

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -25,7 +25,7 @@ export interface PackageInfo {
   peerDependencies?: PackageDeps;
   private: boolean;
   combinedOptions: PackageOptions;
-  packageOptions: PackageOptions;
+  packageOptions: Partial<PackageOptions>;
   group?: string;
 }
 

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -24,7 +24,11 @@ export interface PackageInfo {
   devDependencies?: PackageDeps;
   peerDependencies?: PackageDeps;
   private: boolean;
+
+  /** options that are combined from the root configuration */
   combinedOptions: PackageOptions;
+
+  /** options that are SPECIFIC to the package from its configuration file (might be nothing) */
   packageOptions: Partial<PackageOptions>;
   group?: string;
 }

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -20,7 +20,7 @@ export function isValidGroupOptions(root: string, groups: VersionGroupOptions[])
   for (const grp of Object.keys(packageGroups)) {
     const pkgs = packageGroups[grp].packageNames;
     for (const pkgName of pkgs) {
-      if (packageInfos[pkgName].options.disallowedChangeTypes) {
+      if (packageInfos[pkgName].packageOptions.disallowedChangeTypes) {
         console.error(
           `Cannot have a disallowedChangeType inside a package config (${pkgName}) when there is a group defined; use the groups.disallowedChangeTypes instead.`
         );


### PR DESCRIPTION
In a version group, the disallowChangeType must not be specified at the package level. However, the packageInfo options has root options mixed into it. This made the validation of the option to be overly strict. This change preserves which options were set by the package itself. This will allow validations to be more precise.