### PR TITLE
Change files that point to a private package is affecting dependent changes

### DIFF
--- a/change/beachball-2020-09-28-13-54-01-no-loop.json
+++ b/change/beachball-2020-09-28-13-54-01-no-loop.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "avoid bump loop by being more selective about what gets bumped",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T20:54:01.927Z"
+}

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -17,7 +17,7 @@ export function unlinkChangeFiles(
   cwd: string
 ) {
   const changePath = getChangePath(cwd);
-  if (!changePath || !changeSet) {
+  if (!changePath || !changeSet || changeSet.size === 0) {
     return;
   }
   console.log('Removing change files:');


### PR DESCRIPTION
In those cases, we should not even consider the dependent changes. In other words, we need to be selective about the "entry" change files. It should also give warning to the users about which files are causing troubles