### PR TITLE
Bump specific dependencies instead of the whole thing

### DIFF
--- a/change/beachball-2020-10-07-15-07-47-bump-specifics.json
+++ b/change/beachball-2020-10-07-15-07-47-bump-specifics.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "bumps very specific deps, don't go overboard with spreading",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T22:07:47.266Z"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -253,6 +253,101 @@ describe('publish command (e2e)', () => {
     expect(fetchCount).toBe(2);
   });
 
+  it('can perform a successful npm publish from a race condition in the dependencies', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    writeChangeFiles(
+      {
+        foo: {
+          type: 'minor',
+          comment: 'test',
+          date: new Date('2019-01-01'),
+          email: 'test@test.com',
+          packageName: 'foo',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    // Adds a step that injects a race condition
+    let fetchCount = 0;
+
+    addGitObserver((args, output) => {
+      if (args[0] === 'fetch') {
+        if (fetchCount === 0) {
+          const anotherRepo = repositoryFactory!.cloneRepository();
+          // inject a checkin
+          const packageJsonFile = path.join(anotherRepo.rootPath, 'package.json');
+          const contents = JSON.parse(fs.readFileSync(packageJsonFile, 'utf-8'));
+
+          delete contents.dependencies.baz;
+
+          fs.writeFileSync(packageJsonFile, JSON.stringify(contents, null, 2));
+
+          git(['add', packageJsonFile], { cwd: anotherRepo.rootPath });
+          git(['commit', '-m', 'test'], { cwd: anotherRepo.rootPath });
+          git(['push', 'origin', 'HEAD:master'], { cwd: anotherRepo.rootPath });
+        }
+
+        fetchCount++;
+      }
+    });
+
+    await publish({
+      branch: 'origin/master',
+      command: 'publish',
+      message: 'apply package updates',
+      path: repo.rootPath,
+      publish: true,
+      bumpDeps: true,
+      push: true,
+      registry: registry.getUrl(),
+      gitTags: true,
+      tag: 'latest',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: '',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      bump: true,
+      generateChangelog: true,
+    });
+
+    const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
+
+    expect(showResult.success).toBeTruthy();
+
+    const show = JSON.parse(showResult.stdout);
+    expect(show.name).toEqual('foo');
+    expect(show.versions.length).toEqual(1);
+    expect(show['dist-tags'].latest).toEqual('1.1.0');
+
+    git(['checkout', 'master'], { cwd: repo.rootPath });
+    git(['pull'], { cwd: repo.rootPath });
+    const gitResults = git(['describe', '--abbrev=0'], { cwd: repo.rootPath });
+
+    expect(gitResults.success).toBeTruthy();
+    expect(gitResults.stdout).toBe('foo_v1.1.0');
+
+    // this indicates 2 tries
+    expect(fetchCount).toBe(2);
+
+    const packageJsonFile = path.join(repo.rootPath, 'package.json');
+    const contents = JSON.parse(fs.readFileSync(packageJsonFile, 'utf-8'));
+    expect(contents.dependencies.baz).toBeUndefined();
+  });
+
   it('can perform a successful npm publish without bump', async () => {
     repositoryFactory = new RepositoryFactory();
     await repositoryFactory.create();

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -22,7 +22,9 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
         const modifiedDeps = Object.keys(updatedDepsVersions).filter(dep => modifiedPackages.has(dep));
 
         for (const dep of modifiedDeps) {
-          packageJson[depKind] = updatedDepsVersions[dep];
+          if (packageJson[depKind] && packageJson[depKind][dep]) {
+            packageJson[depKind][dep] = updatedDepsVersions[dep];
+          }
         }
       }
     });

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -13,9 +13,17 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
     packageJson.version = info.version;
 
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depKind => {
-      const deps: PackageDeps | undefined = (info as any)[depKind];
-      if (deps) {
-        packageJson[depKind] = { ...packageJson[depKind], ...deps };
+      // updatedDeps contains all of the dependencies in the bump info since the beginning of a build job
+      const updatedDepsVersions: PackageDeps | undefined = (info as any)[depKind];
+      if (updatedDepsVersions) {
+        // to be cautious, only update internal && modifiedPackages, since some other dependency
+        // changes could have occurred since the beginning of the build job and the next merge step
+        // would overwrite those incorrectly!
+        const modifiedDeps = Object.keys(updatedDepsVersions).filter(dep => modifiedPackages.has(dep));
+
+        for (const dep of modifiedDeps) {
+          packageJson[depKind] = updatedDepsVersions[dep];
+        }
       }
     });
 

--- a/src/fixtures/repository.ts
+++ b/src/fixtures/repository.ts
@@ -7,6 +7,10 @@ import { git } from '../git';
 export const packageJsonFixture = {
   name: 'foo',
   version: '1.0.0',
+  dependencies: {
+    bar: '1.0.0',
+    baz: '1.0.0',
+  },
 };
 
 export class RepositoryFactory {


### PR DESCRIPTION
In the past, the "writePackageJson" overzealously writes over ALL dependencies entries, assuming that the deps entries did not change since the beginning of the build job. This is often not the case. In fact, the most often changed part of a package.json IS the versions of those deps. This, combined with the "merge -X ours" strategy end up with the undesired effect of OVERRIDING the incoming fetched changes. This means that any bumps of unrelated deps (external ones) end up having their bumps reverted.