### PR TITLE
Update sync command to respect the --tag value

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ registry, defaults to https://registry.npmjs.org
 
 ### --tag, -t
 
-dist-tag for npm publishes
+- for the publish command: dist-tag for npm publishes
+- for the sync command: will use specified tag to set the version
 
 ### --branch, -b
 

--- a/change/beachball-2020-10-19-13-52-16-arabisho-sync-by-tag.json
+++ b/change/beachball-2020-10-19-13-52-16-arabisho-sync-by-tag.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update sync command to respect the --tag value",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T11:52:16.112Z"
+}

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs-extra';
+import path from 'path';
+import * as tmp from 'tmp';
+import { sync } from '../commands/sync';
+import { Registry } from '../fixtures/registry';
+import { Repository, RepositoryFactory } from '../fixtures/repository';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { infoFromPackageJson } from '../monorepo/infoFromPackageJson';
+import { packagePublish } from '../packageManager/packagePublish';
+
+async function createRepoPackage(repo: Repository, name: string, version: string) {
+  const packageJson = {
+    name: name,
+    version: version,
+  };
+
+  await repo.commitChange(`packages/${name}/package.json`, JSON.stringify(packageJson));
+}
+
+async function createTempPackage(name: string, version: string) {
+  const packageJsonFile = path.join(tmp.dirSync().name, 'package.json');
+  const packageJson = {
+    name: name,
+    version: version,
+  };
+
+  fs.writeJSONSync(packageJsonFile, packageJson, { spaces: 2 });
+  return infoFromPackageJson(packageJson, packageJsonFile);
+}
+
+describe('sync command (e2e)', () => {
+  const repositoryFactory = new RepositoryFactory();
+  let registry: Registry;
+
+  beforeAll(() => {
+    registry = new Registry();
+    jest.setTimeout(30000);
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  beforeEach(async () => {
+    await registry.reset();
+    await repositoryFactory.create();
+  });
+
+  afterEach(async () => {
+    await repositoryFactory.cleanUp();
+  });
+
+  it('can perform a successful sync', async () => {
+    const repo = await repositoryFactory.cloneRepository();
+
+    await createRepoPackage(repo, 'foopkg', '1.0.0');
+    await createRepoPackage(repo, 'barpkg', '2.2.0');
+    await createRepoPackage(repo, 'bazpkg', '3.0.0');
+
+    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+
+    expect(packagePublish(packageInfosBeforeSync['foopkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+    expect(packagePublish(packageInfosBeforeSync['barpkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    const newFooInfo = await createTempPackage('foopkg', '1.2.0');
+    const newBarInfo = await createTempPackage('barpkg', '3.0.0');
+
+    expect(packagePublish(newFooInfo, registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+    expect(packagePublish(newBarInfo, registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    await sync({
+      branch: 'origin/master',
+      command: 'sync',
+      message: '',
+      path: repo.rootPath,
+      publish: false,
+      bumpDeps: false,
+      push: false,
+      registry: registry.getUrl(),
+      gitTags: false,
+      tag: '',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: '',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      bump: false,
+      generateChangelog: false,
+    });
+
+    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+
+    expect(packageInfosAfterSync['foopkg'].version).toEqual('1.2.0');
+    expect(packageInfosAfterSync['barpkg'].version).toEqual('3.0.0');
+    expect(packageInfosAfterSync['bazpkg'].version).toEqual('3.0.0');
+  });
+
+  it('can perform a successful sync using dist tag', async () => {
+    const repo = await repositoryFactory.cloneRepository();
+
+    await createRepoPackage(repo, 'apkg', '1.0.0');
+    await createRepoPackage(repo, 'bpkg', '2.2.0');
+    await createRepoPackage(repo, 'cpkg', '3.0.0');
+
+    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+
+    expect(packagePublish(packageInfosBeforeSync['apkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+    expect(packagePublish(packageInfosBeforeSync['bpkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    const newFooInfo = await createTempPackage('apkg', '2.0.0');
+    const newBarInfo = await createTempPackage('bpkg', '3.0.0');
+
+    expect(packagePublish(newFooInfo, registry.getUrl(), '', 'beta', '').success).toBeTruthy();
+    expect(packagePublish(newBarInfo, registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    await sync({
+      branch: 'origin/master',
+      command: 'sync',
+      message: '',
+      path: repo.rootPath,
+      publish: false,
+      bumpDeps: false,
+      push: false,
+      registry: registry.getUrl(),
+      gitTags: false,
+      tag: 'beta',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: '',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      bump: false,
+      generateChangelog: false,
+    });
+
+    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+
+    expect(packageInfosAfterSync['apkg'].version).toEqual('2.0.0');
+    expect(packageInfosAfterSync['bpkg'].version).toEqual('2.2.0');
+    expect(packageInfosAfterSync['cpkg'].version).toEqual('3.0.0');
+  });
+});

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,7 +1,7 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-import { listLatestPackageVersions } from '../packageManager/listPackageVersions';
+import { listPackageVersionsByTag } from '../packageManager/listPackageVersions';
 import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
 import { writePackageJson } from '../bump/performBump';
@@ -11,7 +11,11 @@ export async function sync(options: BeachballOptions) {
   const scopedPackages = new Set(getScopedPackages(options));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));
-  const publishedVersions = await listLatestPackageVersions([...infos.keys()], options.registry);
+  const publishedVersions = await listPackageVersionsByTag(
+    [...infos.keys()],
+    options.registry,
+    options.tag ? options.tag : 'latest'
+  );
 
   const modifiedPackages = new Set<string>();
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -26,10 +26,11 @@ Commands:
 Options:
 
   --registry, -r      - registry, defaults to https://registry.npmjs.org
-  --tag, -t           - dist-tag for npm publishes
+  --tag, -t           - for the publish command: dist-tag for npm publishes
+                      - for the sync command: will use specified tag to set the version
   --branch, -b        - target branch from origin (default: master)
-  --message, -m       - for publish command: custom publish message for the checkin (default: applying package updates);
-                        for change command: description of the change
+  --message, -m       - for the publish command: custom publish message for the checkin (default: applying package updates);
+                        for the change command: description of the change
   --no-push           - skip pushing changes back to git remote origin
   --no-publish        - skip publishing to the npm registry
   --no-bump           - skip both bumping versions and pushing changes back to git remote origin when publishing;
@@ -37,9 +38,9 @@ Options:
   --yes, -y           - skips the prompts for publish
   --package, -p       - manually specify a package to create a change file; creates a change file regardless of diffs
   --changehint        - give your developers a customized hint message when they forget to add a change file
-  --since             - for bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
-                        for publish command: bumps and publishes packages based on the specified range of the change files.
-  --keep-change-files - for bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
+  --since             - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
+                        for the publish command: bumps and publishes packages based on the specified range of the change files.
+  --keep-change-files - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
 
 Examples:
 

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -19,7 +19,7 @@ export async function getNpmPackageInfo(packageName: string, registry: string) {
   return packageVersions[packageName];
 }
 
-export async function listLatestPackageVersions(packageList: string[], registry: string) {
+export async function listPackageVersionsByTag(packageList: string[], registry: string, tag: string) {
   const limit = pLimit(NPM_CONCURRENCY);
   const all: Promise<void>[] = [];
   const versions: { [pkg: string]: string } = {};
@@ -28,7 +28,7 @@ export async function listLatestPackageVersions(packageList: string[], registry:
     all.push(
       limit(async () => {
         const info = await getNpmPackageInfo(pkg, registry);
-        versions[pkg] = info['dist-tags'] && info['dist-tags'].latest ? info['dist-tags'].latest : undefined;
+        versions[pkg] = info['dist-tags'] && info['dist-tags'][tag] ? info['dist-tags'][tag] : undefined;
       })
     );
   }


### PR DESCRIPTION
Some scenarios require an ability to choose a version tag for syncing packages. By default, beachball uses `latest` and does not allow to choose the distribution tag. This PR adds support for `--tag` in the sync command, as well as adds a couple of E2E tests :)

**cc:** @VincentBailly, @bweggersen