### PR TITLE
Implements the --force flag for sync

### DIFF
--- a/change/beachball-2020-10-20-15-08-05-arabisho-sync-force.json
+++ b/change/beachball-2020-10-20-15-08-05-arabisho-sync-force.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Implements the --force flag for sync",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T13:08:05.276Z"
+}

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -151,4 +151,56 @@ describe('sync command (e2e)', () => {
     expect(packageInfosAfterSync['bpkg'].version).toEqual('2.2.0');
     expect(packageInfosAfterSync['cpkg'].version).toEqual('3.0.0');
   });
+
+  it('can perform a successful sync by forcing dist tag version', async () => {
+    const repo = await repositoryFactory.cloneRepository();
+
+    await createRepoPackage(repo, 'epkg', '1.0.0');
+    await createRepoPackage(repo, 'fpkg', '2.2.0');
+    await createRepoPackage(repo, 'gpkg', '3.0.0');
+
+    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+
+    expect(packagePublish(packageInfosBeforeSync['epkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+    expect(packagePublish(packageInfosBeforeSync['fpkg'], registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    const newFooInfo = await createTempPackage('epkg', '1.0.0-1');
+    const newBarInfo = await createTempPackage('fpkg', '3.0.0');
+
+    expect(packagePublish(newFooInfo, registry.getUrl(), '', 'prerelease', '').success).toBeTruthy();
+    expect(packagePublish(newBarInfo, registry.getUrl(), '', 'latest', '').success).toBeTruthy();
+
+    await sync({
+      branch: 'origin/master',
+      command: 'sync',
+      message: '',
+      path: repo.rootPath,
+      publish: false,
+      bumpDeps: false,
+      push: false,
+      registry: registry.getUrl(),
+      gitTags: false,
+      tag: 'prerelease',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: '',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      bump: false,
+      generateChangelog: false,
+      forceVersions: true
+    });
+
+    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+
+    expect(packageInfosAfterSync['epkg'].version).toEqual('1.0.0-1');
+    expect(packageInfosAfterSync['fpkg'].version).toEqual('2.2.0');
+    expect(packageInfosAfterSync['gpkg'].version).toEqual('3.0.0');
+  });
 });

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -23,7 +23,7 @@ export async function sync(options: BeachballOptions) {
     if (publishedVersions[pkg]) {
       const publishedVersion = publishedVersions[pkg];
 
-      if (publishedVersion && semver.lt(info.version, publishedVersion)) {
+      if (publishedVersion && (options.forceVersions || semver.lt(info.version, publishedVersion))) {
         console.log(
           `There is a newer version of "${pkg}@${info.version}". Syncing to the published version ${publishedVersion}`
         );

--- a/src/help.ts
+++ b/src/help.ts
@@ -41,6 +41,7 @@ Options:
   --since             - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
                         for the publish command: bumps and publishes packages based on the specified range of the change files.
   --keep-change-files - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
+  --force             - force the sync command to skip the version comparison and use the version in the registry as is.
 
 Examples:
 

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -15,7 +15,7 @@ export function getCliOptions(): CliOptions {
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package', 'since'],
     array: ['scope'],
-    boolean: ['git-tags', 'keep-change-files'],
+    boolean: ['git-tags', 'keep-change-files', 'force'],
     alias: {
       branch: ['b'],
       tag: ['t'],
@@ -37,6 +37,7 @@ export function getCliOptions(): CliOptions {
     path: cwd,
     fromRef: args.since,
     keepChangeFiles: args['keep-change-files'],
+    forceVersions: args['force'],
     branch: args.branch && args.branch.indexOf('/') > -1 ? args.branch : getDefaultRemoteBranch(args.branch, cwd),
   } as CliOptions;
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -32,6 +32,7 @@ export interface CliOptions {
   keepChangeFiles?: boolean;
   bump: boolean;
   canaryName?: string | undefined;
+  forceVersions?: boolean;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
This PR implements the `--force` flag for the sync command, which allows us to skip the version comparison and use the version in the registry as is.

**cc:** @VincentBailly, @bweggersen 