### PR TITLE
Remove timestamp from change files

### DIFF
--- a/change/beachball-2020-10-21-14-27-46-arabisho-infer-timestamps.json
+++ b/change/beachball-2020-10-21-14-27-46-arabisho-infer-timestamps.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove timestamp from change files",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -84,7 +84,6 @@ describe('version bumping', () => {
         'pkg-1': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
@@ -157,7 +156,6 @@ describe('version bumping', () => {
         'pkg-1': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
@@ -176,7 +174,6 @@ describe('version bumping', () => {
         'pkg-3': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-02'),
           email: 'test@test.com',
           packageName: 'pkg-3',
           dependentChangeType: 'patch',
@@ -260,7 +257,6 @@ describe('version bumping', () => {
         'pkg-1': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
@@ -329,7 +325,6 @@ describe('version bumping', () => {
         'pkg-1': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
@@ -417,7 +412,6 @@ describe('version bumping', () => {
         commonlib: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'commonlib',
           dependentChangeType: 'minor',
@@ -457,7 +451,6 @@ describe('version bumping', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -488,7 +481,6 @@ describe('version bumping', () => {
         bar: {
           type: 'patch',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'bar',
           dependentChangeType: 'patch',
@@ -570,7 +562,6 @@ describe('version bumping', () => {
         'pkg-1': {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -18,7 +18,6 @@ import { ChangelogJson } from '../types/ChangeLog';
 function getChange(partialChange: Partial<ChangeFileInfo> = {}): ChangeFileInfo {
   return {
     comment: 'comment 1',
-    date: new Date('Thu Aug 22 2019 14:20:40 GMT-0700 (Pacific Daylight Time)'),
     email: 'test@testtestme.com',
     packageName: 'foo',
     type: 'patch',

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -42,7 +42,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -106,7 +105,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -165,7 +163,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -263,7 +260,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -358,7 +354,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -421,7 +416,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -435,7 +429,6 @@ describe('publish command (e2e)', () => {
         bar: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'bar',
           dependentChangeType: 'patch',
@@ -506,7 +499,6 @@ describe('publish command (e2e)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -33,7 +33,6 @@ describe('publish command (git)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -86,7 +85,6 @@ describe('publish command (git)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -139,7 +137,6 @@ describe('publish command (git)', () => {
         foo2: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo2',
           dependentChangeType: 'patch',

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -46,7 +46,6 @@ describe('publish command (registry)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -104,7 +103,6 @@ describe('publish command (registry)', () => {
         foo: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foo',
           dependentChangeType: 'patch',
@@ -186,7 +184,6 @@ describe('publish command (registry)', () => {
         foopkg: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foopkg',
           dependentChangeType: 'patch',
@@ -257,7 +254,6 @@ describe('publish command (registry)', () => {
         foopkg: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'foopkg',
           dependentChangeType: 'patch',
@@ -265,7 +261,6 @@ describe('publish command (registry)', () => {
         barpkg: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'barpkg',
           dependentChangeType: 'patch',
@@ -348,7 +343,6 @@ describe('publish command (registry)', () => {
         badname: {
           type: 'minor',
           comment: 'test',
-          date: new Date('2019-01-01'),
           email: 'test@test.com',
           packageName: 'badname',
           dependentChangeType: 'patch',

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -104,7 +104,6 @@ export async function promptForChange(options: BeachballOptions) {
       packageName: pkg,
       email: getUserEmail(cwd) || 'email not defined',
       dependentChangeType: response.type === 'none' ? 'none' : 'patch',
-      date: new Date(),
     };
   }
 

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -8,7 +8,6 @@ export interface ChangeFileInfo {
   comment: string;
   packageName: string;
   email: string;
-  date: Date;
   dependentChangeType?: ChangeType;
 }
 


### PR DESCRIPTION
Based on my findings, it seems that beachball doesn't use dates from change files for anything (I might be missing something here). However, timestamps in change files come at a cognitive cost. For example, when working in the long-living branches, the date quickly gets out of sync with the actual changes. The same applies to cherrypicked commits that might include the change files or rebasing the branch.

My initial thoughts were that the date was used to order changelog entries, but `PackageChangeLog` apparently generates its date during the bump and doesn't use the change file date in any way.

This PR removes the date from a changefile. Running tests has not revealed any breaking changes :) 