### PR TITLE
Respect --token argument in the sync command

### DIFF
--- a/change/beachball-c8f63b87-9c78-426d-84b9-3fa7182653c2.json
+++ b/change/beachball-c8f63b87-9c78-426d-84b9-3fa7182653c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Respect --token argument in the sync command",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -14,7 +14,8 @@ export async function sync(options: BeachballOptions) {
   const publishedVersions = await listPackageVersionsByTag(
     [...infos.values()],
     options.registry,
-    options.tag
+    options.tag,
+    options.token
   );
 
   const modifiedPackages = new Set<string>();


### PR DESCRIPTION
This PR enables the sync command to use the `--token` argument for authentication against the registry.