### PR TITLE
Expose disallowed-change-types as a CLI option

### DIFF
--- a/change/beachball-d030ff29-357f-4404-be5b-0b800e7582da.json
+++ b/change/beachball-d030ff29-357f-4404-be5b-0b800e7582da.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose 'disallowed-change-types' as a CLI option",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -14,7 +14,7 @@ export function getCliOptions(): CliOptions {
   const argv = process.argv.splice(2);
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package', 'since'],
-    array: ['scope'],
+    array: ['scope', 'disallowed-change-types'],
     boolean: ['git-tags', 'keep-change-files', 'force'],
     alias: {
       branch: ['b'],
@@ -38,6 +38,7 @@ export function getCliOptions(): CliOptions {
     fromRef: args.since,
     keepChangeFiles: args['keep-change-files'],
     forceVersions: args['force'],
+    disallowedChangeTypes: args['disallowed-change-types'],
   } as CliOptions;
   if (args.branch) {
     cliOptions.branch = args.branch.indexOf('/') > -1 ? args.branch : getDefaultRemoteBranch(args.branch, cwd);

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -33,6 +33,7 @@ export interface CliOptions {
   bump: boolean;
   canaryName?: string | undefined;
   forceVersions?: boolean;
+  disallowedChangeTypes: ChangeType[] | null;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
The `disallowed-change-types` option allows the user to specify the `disallowedChangeTypes` as CLI args without adding the `beachball` config. It is especially useful on CI, where different policies can specify `disallowedChangeTypes` without changing the beachball config on the disk.