### PR TITLE
Parameterise dependentChangeType and fix a bug of the --type arg being ineffective

### DIFF
--- a/change/beachball-b0d9adf7-3d09-4bf0-92b4-9a1d6b5a55fc.json
+++ b/change/beachball-b0d9adf7-3d09-4bf0-92b4-9a1d6b5a55fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose dependent-change-type as CLI argument",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -76,6 +76,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -141,6 +142,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -228,6 +230,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -318,6 +321,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -388,6 +392,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: false,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -464,6 +469,7 @@ describe('publish command (e2e)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const fooNpmResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -544,6 +550,7 @@ describe('publish command (e2e)', () => {
           }
         },
       },
+      dependentChangeType: null,
     });
 
     // Query the information from package.json from the registry to see if it was successfully patched

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -67,6 +67,7 @@ describe('publish command (git)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const newRepo = await repositoryFactory.cloneRepository();
@@ -125,6 +126,7 @@ describe('publish command (git)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     };
 
     const bumpInfo = gatherBumpInfo(options);

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -83,6 +83,7 @@ describe('publish command (registry)', () => {
       timeout: 100,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     await expect(publishPromise).rejects.toThrow();
@@ -137,6 +138,7 @@ describe('publish command (registry)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -218,6 +220,7 @@ describe('publish command (registry)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
@@ -295,6 +298,7 @@ describe('publish command (registry)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResultFoo = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
@@ -377,6 +381,7 @@ describe('publish command (registry)', () => {
       retries: 3,
       bump: true,
       generateChangelog: true,
+      dependentChangeType: null,
     });
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'badname', '--json']);

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -95,6 +95,7 @@ describe('sync command (e2e)', () => {
       retries: 3,
       bump: false,
       generateChangelog: false,
+      dependentChangeType: null,
     });
 
     const packageInfosAfterSync = getPackageInfos(repo.rootPath);
@@ -146,6 +147,7 @@ describe('sync command (e2e)', () => {
       retries: 3,
       bump: false,
       generateChangelog: false,
+      dependentChangeType: null,
     });
 
     const packageInfosAfterSync = getPackageInfos(repo.rootPath);
@@ -207,6 +209,7 @@ describe('sync command (e2e)', () => {
       bump: false,
       generateChangelog: false,
       forceVersions: true,
+      dependentChangeType: null,
     });
 
     const packageInfosAfterSync = getPackageInfos(repo.rootPath);

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -11,7 +11,7 @@ import { DefaultPrompt } from '../types/ChangeFilePrompt';
 import { getDisallowedChangeTypes } from './getDisallowedChangeTypes';
 
 /**
- * Uses `prompts` package to prompt for change type and description, fills in git user.email, scope, and the commit hash
+ * Uses `prompts` package to prompt for change type and description, fills in git user.email and scope
  */
 export async function promptForChange(options: BeachballOptions) {
   const { branch, path: cwd, package: specificPackage } = options;
@@ -93,6 +93,11 @@ export async function promptForChange(options: BeachballOptions) {
         return;
       }
 
+      // fallback to the options.type if type is absent in the user input
+      if (!response.type && options.type) {
+        response = { ...response, type: options.type };
+      }
+
       if (!isValidChangeType(response.type)) {
         console.error('Prompt response contains invalid change type.');
         return;
@@ -103,7 +108,7 @@ export async function promptForChange(options: BeachballOptions) {
       ...response,
       packageName: pkg,
       email: getUserEmail(cwd) || 'email not defined',
-      dependentChangeType: response.type === 'none' ? 'none' : 'patch',
+      dependentChangeType: options.dependentChangeType || (response.type === 'none' ? 'none' : 'patch'),
     };
   }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -25,23 +25,24 @@ Commands:
 
 Options:
 
-  --registry, -r      - registry, defaults to https://registry.npmjs.org
-  --tag, -t           - for the publish command: dist-tag for npm publishes
-                      - for the sync command: will use specified tag to set the version
-  --branch, -b        - target branch from origin (default: master)
-  --message, -m       - for the publish command: custom publish message for the checkin (default: applying package updates);
-                        for the change command: description of the change
-  --no-push           - skip pushing changes back to git remote origin
-  --no-publish        - skip publishing to the npm registry
-  --no-bump           - skip both bumping versions and pushing changes back to git remote origin when publishing;
-  --help, -?, -h      - this very help message
-  --yes, -y           - skips the prompts for publish
-  --package, -p       - manually specify a package to create a change file; creates a change file regardless of diffs
-  --changehint        - give your developers a customized hint message when they forget to add a change file
-  --since             - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
+  --registry, -r          - registry, defaults to https://registry.npmjs.org
+  --tag, -t               - for the publish command: dist-tag for npm publishes
+                          - for the sync command: will use specified tag to set the version
+  --branch, -b            - target branch from origin (default: master)
+  --message, -m           - for the publish command: custom publish message for the checkin (default: applying package updates);
+                            for the change command: description of the change
+  --no-push               - skip pushing changes back to git remote origin
+  --no-publish            - skip publishing to the npm registry
+  --no-bump               - skip both bumping versions and pushing changes back to git remote origin when publishing;
+  --help, -?, -h          - this very help message
+  --yes, -y               - skips the prompts for publish
+  --package, -p           - manually specify a package to create a change file; creates a change file regardless of diffs
+  --changehint            - give your developers a customized hint message when they forget to add a change file
+  --since                 - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
                         for the publish command: bumps and publishes packages based on the specified range of the change files.
-  --keep-change-files - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
-  --force             - force the sync command to skip the version comparison and use the version in the registry as is.
+  --keep-change-files     - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
+  --force                 - force the sync command to skip the version comparison and use the version in the registry as is.
+  --dependent-change-type - for the change command: override the default dependent-change-type that will end-up in the change file.
 
 Examples:
 

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -13,7 +13,7 @@ export function getCliOptions(): CliOptions {
 
   const argv = process.argv.splice(2);
   const args = parser(argv, {
-    string: ['branch', 'tag', 'message', 'package', 'since'],
+    string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type'],
     array: ['scope', 'disallowed-change-types'],
     boolean: ['git-tags', 'keep-change-files', 'force'],
     alias: {

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -34,6 +34,7 @@ export interface CliOptions {
   canaryName?: string | undefined;
   forceVersions?: boolean;
   disallowedChangeTypes: ChangeType[] | null;
+  dependentChangeType: ChangeType | null;
 }
 
 export interface RepoOptions {

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -27,6 +27,12 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     process.exit(1);
   }
 
+  const dependentChangeType = options.dependentChangeType;
+  if (dependentChangeType && !isValidChangeType(dependentChangeType)) {
+    console.error(`ERROR: Invalid dependent change type: ${dependentChangeType}`);
+    process.exit(1);
+  }
+
   const untracked = getUntrackedChanges(options.path);
 
   if (untracked && untracked.length > 0) {

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -27,12 +27,6 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     process.exit(1);
   }
 
-  const dependentChangeType = options.dependentChangeType;
-  if (dependentChangeType && !isValidChangeType(dependentChangeType)) {
-    console.error(`ERROR: Invalid dependent change type: ${dependentChangeType}`);
-    process.exit(1);
-  }
-
   const untracked = getUntrackedChanges(options.path);
 
   if (untracked && untracked.length > 0) {
@@ -43,6 +37,11 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
 
   if (options.package && !isValidPackageName(options.package, options.path)) {
     console.error('ERROR: Specified package name is not valid');
+    process.exit(1);
+  }
+
+  if (options.dependentChangeType && !isValidChangeType(options.dependentChangeType)) {
+    console.error(`ERROR: dependent change type ${options.dependentChangeType} is not valid`);
     process.exit(1);
   }
 


### PR DESCRIPTION
This PR:
 * Fixes a bug: when the `--type` argument is passed without `--message`, the `response.type` always ends-up being `undefined`. This happens because the list of questions does not include the change type prompt, anticipating the value to be available from `options.type`, but the `response.type` receives undefined as the message prompt overrides it. 
 * Adds a new CLI argument `--dependent-change-type` that allows overriding the default change type calculated for change files. This flag is handy when the PR author knows what kind of change (other than `none` or `patch`) is anticipated for dependent packages. For example, if package C in graph A <- B <- C receives a new pre-release version 1.0.0-2, I would want B and C also to receive a pre-release bump.