### PR TITLE
Implement the 'disallow-deleted-change-files' flag

### DIFF
--- a/change/beachball-fe8092a1-3abd-42fa-84e5-39263d79e0ad.json
+++ b/change/beachball-fe8092a1-3abd-42fa-84e5-39263d79e0ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement the 'disallow-deleted-change-files' flag",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -28,6 +28,7 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
         '--diff-filter=d', // excluding deleted files from the diff.
         '--relative', // results will include path relative to the cwd, i.e. only file names.
       ],
+      '*.json',
       changePath
     );
 

--- a/src/fixtures/repository.ts
+++ b/src/fixtures/repository.ts
@@ -105,6 +105,16 @@ export class Repository {
     git(['commit', '-m', `"${newFilename}"`], { cwd: this.root });
   }
 
+  /** Commits a change, automatically uses root path, do not pass absolute paths here */
+  commitAll() {
+    if (!this.root) {
+      throw new Error('Must initialize before cloning');
+    }
+
+    git(['add', '-A'], { cwd: this.root });
+    git(['commit', '-m', 'Committing everything'], { cwd: this.root });
+  }
+
   getCurrentHash() {
     if (!this.root) {
       throw new Error('Must initialize before getting head');

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -123,15 +123,10 @@ export function getChanges(branch: string, cwd: string) {
   }
 }
 
-export function getChangesBetweenRefs(
-  fromRef: string,
-  toRef: string,
-  options: string[],
-  cwd: string
-) {
+export function getChangesBetweenRefs(fromRef: string, toRef: string, options: string[], pattern: string, cwd: string) {
   try {
     return processGitOutput(
-      git(['--no-pager', 'diff', '--name-only', ...options, fromRef, toRef, '.'], { cwd })
+      git(['--no-pager', 'diff', '--name-only', ...options, fromRef, toRef, '--', pattern], { cwd })
     );
   } catch (e) {
     console.error('Cannot gather information about changes: ', e.message);

--- a/src/help.ts
+++ b/src/help.ts
@@ -25,24 +25,25 @@ Commands:
 
 Options:
 
-  --registry, -r          - registry, defaults to https://registry.npmjs.org
-  --tag, -t               - for the publish command: dist-tag for npm publishes
-                          - for the sync command: will use specified tag to set the version
-  --branch, -b            - target branch from origin (default: master)
-  --message, -m           - for the publish command: custom publish message for the checkin (default: applying package updates);
-                            for the change command: description of the change
-  --no-push               - skip pushing changes back to git remote origin
-  --no-publish            - skip publishing to the npm registry
-  --no-bump               - skip both bumping versions and pushing changes back to git remote origin when publishing;
-  --help, -?, -h          - this very help message
-  --yes, -y               - skips the prompts for publish
-  --package, -p           - manually specify a package to create a change file; creates a change file regardless of diffs
-  --changehint            - give your developers a customized hint message when they forget to add a change file
-  --since                 - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
-                        for the publish command: bumps and publishes packages based on the specified range of the change files.
-  --keep-change-files     - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
-  --force                 - force the sync command to skip the version comparison and use the version in the registry as is.
-  --dependent-change-type - for the change command: override the default dependent-change-type that will end-up in the change file.
+  --registry, -r                  - registry, defaults to https://registry.npmjs.org
+  --tag, -t                       - for the publish command: dist-tag for npm publishes
+                                  - for the sync command: will use specified tag to set the version
+  --branch, -b                    - target branch from origin (default: master)
+  --message, -m                   - for the publish command: custom publish message for the checkin (default: applying package updates);
+                                    for the change command: description of the change
+  --no-push                       - skip pushing changes back to git remote origin
+  --no-publish                    - skip publishing to the npm registry
+  --no-bump                       - skip both bumping versions and pushing changes back to git remote origin when publishing;
+  --help, -?, -h                  - this very help message
+  --yes, -y                       - skips the prompts for publish
+  --package, -p                   - manually specify a package to create a change file; creates a change file regardless of diffs
+  --changehint                    - give your developers a customized hint message when they forget to add a change file
+  --since                         - for the bump command: allows to specify the range of change files used to bump packages by using git refs (branch name, commit SHA, etc);
+                                    for the publish command: bumps and publishes packages based on the specified range of the change files.
+  --keep-change-files             - for the bump and publish commands: when specified, both bump and publish commands do not delete the change files on the disk.
+  --force                         - force the sync command to skip the version comparison and use the version in the registry as is.
+  --dependent-change-type         - for the change command: override the default dependent-change-type that will end-up in the change file.
+  --disallow-deleted-change-files - for the check command: verifies that no change files were deleted between head and target branch.
 
 Examples:
 

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -15,7 +15,7 @@ export function getCliOptions(): CliOptions {
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type'],
     array: ['scope', 'disallowed-change-types'],
-    boolean: ['git-tags', 'keep-change-files', 'force'],
+    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files'],
     alias: {
       branch: ['b'],
       tag: ['t'],
@@ -37,6 +37,7 @@ export function getCliOptions(): CliOptions {
     path: cwd,
     fromRef: args.since,
     keepChangeFiles: args['keep-change-files'],
+    disallowDeletedChangeFiles: args['disallow-deleted-change-files'],
     forceVersions: args['force'],
   } as CliOptions;
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -35,6 +35,7 @@ export interface CliOptions {
   forceVersions?: boolean;
   disallowedChangeTypes: ChangeType[] | null;
   dependentChangeType: ChangeType | null;
+  disallowDeletedChangeFiles?: boolean;
 }
 
 export interface RepoOptions {

--- a/src/validation/areChangeFilesDeleted.ts
+++ b/src/validation/areChangeFilesDeleted.ts
@@ -1,0 +1,46 @@
+import { findGitRoot, getChangePath } from '../paths';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { getChangesBetweenRefs } from '../git';
+
+export function areChangeFilesDeleted(options: BeachballOptions): boolean {
+  const { branch, path: cwd } = options;
+
+  const gitRoot = findGitRoot(cwd);
+  if (!gitRoot) {
+    console.error('Failed to find the root of git repository');
+    process.exit(1);
+  }
+
+  const changePath = getChangePath(cwd);
+  if (!changePath) {
+    console.error('Failed to find a folder with change files');
+    process.exit(1);
+  }
+
+  console.log(`Checking for deleted change files against "${branch}"`);
+  const changeFilesDeletedSinceRef = getChangesBetweenRefs(
+    branch,
+    'HEAD',
+    [
+      '--diff-filter=D', // showing only deleted files from the diff.
+    ],
+    `${changePath}/*.json`,
+    gitRoot
+  );
+
+  // if this value is undefined, git has failed to execute the command above.
+  if (!changeFilesDeletedSinceRef) {
+    process.exit(1);
+  }
+
+  const changeFilesDeleted = changeFilesDeletedSinceRef.length > 0;
+
+  if (changeFilesDeleted) {
+    const changeFiles = changeFilesDeletedSinceRef.map(file => `- ${file}`);
+    const errorMessage = 'The following change files were deleted:';
+
+    console.error(`${errorMessage}\n${changeFiles.join('\n')}\n`);
+  }
+
+  return changeFilesDeleted;
+}

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -10,6 +10,7 @@ import { readChangeFiles } from '../changefile/readChangeFiles';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes';
+import { areChangeFilesDeleted } from './areChangeFilesDeleted';
 
 type ValidationOptions = { allowMissingChangeFiles: boolean; allowFetching: boolean };
 type PartialValidateOptions = Partial<ValidationOptions>;
@@ -58,6 +59,11 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     if (isChangeNeeded && !validateOptions.allowMissingChangeFiles) {
       console.error('ERROR: Change files are needed!');
       console.log(options.changehint);
+      process.exit(1);
+    }
+
+    if (options.disallowDeletedChangeFiles && areChangeFilesDeleted(options)) {
+      console.error('ERROR: Change files must not be deleted!');
       process.exit(1);
     }
   }


### PR DESCRIPTION
When `beachball` is invoked together with the `--disallow-deleted-change-files` flag, beachball will verify that no change files were deleted by inspecting the diff between head and `--branch`.