### PR TITLE
Prevent git process from crashing with enobufs when collecting git messages

### DIFF
--- a/change/beachball-5d642d94-42cc-4a0b-8404-359bfb1dfe40.json
+++ b/change/beachball-5d642d94-42cc-4a0b-8404-359bfb1dfe40.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cap the output from git to avoid process crashing with enobufs",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -157,7 +157,7 @@ function processGitOutput(output: ProcessOutput) {
 
 export function getRecentCommitMessages(branch: string, cwd: string) {
   try {
-    const results = git(['log', '--decorate', '--pretty=format:%s', branch, 'HEAD'], { cwd });
+    const results = git(['log', '--decorate', '--pretty=format:%s', '--max-count=100', branch, 'HEAD'], { cwd });
 
     if (!results.success) {
       return [];


### PR DESCRIPTION
In repositories with massive git history, a call to `git log` without capping the commit count leads to a process crash. This PR caps the git log output by 100 commits.