### PR TITLE
Add a CLI argument that allows to specify a prerelease prefix

### DIFF
--- a/change/beachball-e88a3f18-8aca-4ca2-a348-d8f0c2a9ff71.json
+++ b/change/beachball-e88a3f18-8aca-4ca2-a348-d8f0c2a9ff71.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding a new option that allows to specify a pre-release prefix",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -43,3 +43,7 @@ show help message
 ###### `--yes, -y`
 
 skips the prompts for publish
+
+###### `--prerelease-prefix`
+
+sets a prerelease prefix for packages that are expected to receive a prerelease bump (for example, --prerelease-prefix "beta" will produce the "x.y.z-beta.prerelease" version)

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -587,4 +587,277 @@ describe('version bumping', () => {
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles.length).toBe(1);
   });
+
+  it('bumps all packages and uses prefix in the version', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-2/package.json',
+      JSON.stringify({
+        name: 'pkg-2',
+        version: '1.0.0',
+        dependencies: {
+          'pkg-1': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-3/package.json',
+      JSON.stringify({
+        name: 'pkg-3',
+        version: '1.0.0',
+        devDependencies: {
+          'pkg-2': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-4/package.json',
+      JSON.stringify({
+        name: 'pkg-4',
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-3': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'foo-repo',
+        version: '1.0.0',
+        private: true,
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'prerelease',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: true,
+      keepChangeFiles: false,
+      prereleasePrefix: 'beta',
+    } as BeachballOptions);
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+
+    expect(packageInfos['pkg-1'].version).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1');
+    expect(packageInfos['pkg-3'].version).toBe('1.0.1');
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.1');
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.1');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(0);
+  });
+
+  it('bumps all packages and uses prefixed versions in dependents', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-2/package.json',
+      JSON.stringify({
+        name: 'pkg-2',
+        version: '1.0.0',
+        dependencies: {
+          'pkg-1': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-3/package.json',
+      JSON.stringify({
+        name: 'pkg-3',
+        version: '1.0.0',
+        devDependencies: {
+          'pkg-2': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-4/package.json',
+      JSON.stringify({
+        name: 'pkg-4',
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-3': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'foo-repo',
+        version: '1.0.0',
+        private: true,
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'prerelease',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'prerelease',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: true,
+      keepChangeFiles: false,
+      prereleasePrefix: 'beta',
+    } as BeachballOptions);
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+
+    expect(packageInfos['pkg-1'].version).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-3'].version).toBe('1.0.1-beta.0');
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.1-beta.0');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(0);
+  });
+
+  it('bumps all packages and increments prefixed versions in dependents', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.1-beta.0',
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-2/package.json',
+      JSON.stringify({
+        name: 'pkg-2',
+        version: '1.0.0',
+        dependencies: {
+          'pkg-1': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-3/package.json',
+      JSON.stringify({
+        name: 'pkg-3',
+        version: '1.0.0',
+        devDependencies: {
+          'pkg-2': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'packages/pkg-4/package.json',
+      JSON.stringify({
+        name: 'pkg-4',
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-3': '1.0.0',
+        },
+      })
+    );
+
+    await repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'foo-repo',
+        version: '1.0.0',
+        private: true,
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'prerelease',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'prerelease',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: true,
+      keepChangeFiles: false,
+      prereleasePrefix: 'beta',
+    } as BeachballOptions);
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+
+    expect(packageInfos['pkg-1'].version).toBe('1.0.1-beta.1');
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-3'].version).toBe('1.0.1-beta.0');
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe('1.0.1-beta.1');
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.1-beta.0');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(0);
+  });
 });

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -28,7 +28,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(packageChangeTypes).forEach(pkgName => {
-    bumpPackageInfoVersion(pkgName, bumpInfo);
+    bumpPackageInfoVersion(pkgName, bumpInfo, options);
   });
 
   // pass 3: Bump all the dependencies packages

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -1,10 +1,11 @@
 import { BumpInfo } from '../types/BumpInfo';
 import semver from 'semver';
+import { BeachballOptions } from '../types/BeachballOptions';
 
 /**
  * Bumps an individual package version based on the change type
  */
-export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo) {
+export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
   const { packageChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
   const changeType = packageChangeTypes[pkgName];
@@ -21,7 +22,7 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo) {
     return;
   }
   if (!info.private) {
-    info.version = semver.inc(info.version, changeType) as string;
+    info.version = semver.inc(info.version, changeType, options.prereleasePrefix) as string;
     modifiedPackages.add(pkgName);
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -44,6 +44,7 @@ Options:
   --force                         - force the sync command to skip the version comparison and use the version in the registry as is.
   --dependent-change-type         - for the change command: override the default dependent-change-type that will end-up in the change file.
   --disallow-deleted-change-files - for the check command: verifies that no change files were deleted between head and target branch.
+  --prerelease-prefix             - for the bump and publish commands: specify a prerelease prefix for packages that will receive a prerelease bump.
 
 Examples:
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -36,6 +36,7 @@ export interface CliOptions {
   disallowedChangeTypes: ChangeType[] | null;
   dependentChangeType: ChangeType | null;
   disallowDeletedChangeFiles?: boolean;
+  prereleasePrefix?: string | null;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
SemVer specification allows `prerelease` version to be a string/number combination. For example: `1.0.0-beta.5`, where `beta.5` is a prerelease version. Unfortunately, beachball does not give a user control over the prerelease prefix. This PR addresses this at the level of the `bump` command. 

This is extremely useful if you want to scope versions to avoid conflicts. For example, `1.0.0-beta.2` and `1.0.0-alpha.2` are two different versions. Without `--prerelease-prefix` option, beachball will be calculating the same version (`1.0.0-2` and `1.0.0-2`) for two packages that have different contents.