### PR TITLE
A flag for publishing package validation before publishing

### DIFF
--- a/change/beachball-70860b14-1b2f-4408-aa7b-a8f94a4a6516.json
+++ b/change/beachball-70860b14-1b2f-4408-aa7b-a8f94a4a6516.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding a new flag to skip package validation before publishing",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -21,17 +21,20 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
 
   const succeededPackages = new Set<string>();
 
-  let invalid = false;
-  if (!(await validatePackageVersions(bumpInfo, registry))) {
-    displayManualRecovery(bumpInfo, succeededPackages);
-    invalid = true;
-  } else if (!validatePackageDependencies(bumpInfo)) {
-    invalid = true;
-  }
+  if (!options.skipPackageValidationOnPublish) {
+    let invalid = false;
 
-  if (invalid) {
-    console.error('No packages have been published');
-    process.exit(1);
+    if (!(await validatePackageVersions(bumpInfo, registry))) {
+      displayManualRecovery(bumpInfo, succeededPackages);
+      invalid = true;
+    } else if (!validatePackageDependencies(bumpInfo)) {
+      invalid = true;
+    }
+
+    if (invalid) {
+      console.error('No packages have been published');
+      process.exit(1);
+    }
   }
 
   // get the packages to publish, reducing the set by packages that don't need publishing

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -37,6 +37,7 @@ export interface CliOptions {
   dependentChangeType: ChangeType | null;
   disallowDeletedChangeFiles?: boolean;
   prereleasePrefix?: string | null;
+  skipPackageValidationOnPublish?: boolean;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
When dealing with many packages, validating package versions can become very slow, especially if the caller has called `beachball sync` upfront. This flag makes the validation step optional.