### PR TITLE
Use a common ancestor as the base for comparing two refs

### DIFF
--- a/change/beachball-8632abdd-2de8-43f1-8c36-d1003bc46ac8.json
+++ b/change/beachball-8632abdd-2de8-43f1-8c36-d1003bc46ac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use merge base for comparing two refs",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -126,7 +126,7 @@ export function getChanges(branch: string, cwd: string) {
 export function getChangesBetweenRefs(fromRef: string, toRef: string, options: string[], pattern: string, cwd: string) {
   try {
     return processGitOutput(
-      git(['--no-pager', 'diff', '--name-only', ...options, fromRef, toRef, '--', pattern], { cwd })
+      git(['--no-pager', 'diff', '--name-only', ...options, `${fromRef}...${toRef}`, '--', pattern], { cwd })
     );
   } catch (e) {
     console.error('Cannot gather information about changes: ', e.message);


### PR DESCRIPTION
`getChangesBetweenRefs` performs diff by comparing two refs directly: `git diff A B`. When executed in the context of `check`, files that were added in A, after B has branched out, look like they were deleted. To prevent this from happening, we need to diff A to B using the common ancestor as a base: `git diff $(git-merge-base A B) B`. The equivalent syntax for doing that in git is: `git diff A...B`