### PR TITLE
Rolling-up the changelogs to dependents

### DIFF
--- a/change/beachball-28c0f2c4-6394-4dfc-94d5-0c8854742e09.json
+++ b/change/beachball-28c0f2c4-6394-4dfc-94d5-0c8854742e09.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Roll-up the changelogs to dependents",
+  "packageName": "beachball",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -15,6 +15,8 @@ This log was last generated on (date) and should not be manually modified.
 
 - comment 2 (test@testtestme.com)
 - comment 1 (test@testtestme.com)
+- additional comment 1 (test@testtestme.com)
+- additional comment 2 (test@testtestme.com)
 "
 `;
 
@@ -33,6 +35,18 @@ Object {
           Object {
             "author": "test@testtestme.com",
             "comment": "comment 1",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "additional comment 1",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "additional comment 2",
             "commit": "(sha1)",
             "package": "foo",
           },

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -110,7 +110,11 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
 
-      await writeChangelog(beachballOptions, changes, new Array<ChangeInfo>(), packageInfos);
+      const dependentChangeInfos = new Array<ChangeInfo>();
+      dependentChangeInfos.push({ ...getChange({ comment: 'additional comment 1' }), commit: '' });
+      dependentChangeInfos.push({ ...getChange({ comment: 'additional comment 2' }), commit: '' });
+
+      await writeChangelog(beachballOptions, changes, dependentChangeInfos, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -11,7 +11,7 @@ import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { SortedChangeTypes } from '../changefile/getPackageChangeTypes';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { ChangeFileInfo } from '../types/ChangeInfo';
+import { ChangeFileInfo, ChangeInfo } from '../types/ChangeInfo';
 import { MonoRepoFactory } from '../fixtures/monorepo';
 import { ChangelogJson } from '../types/ChangeLog';
 
@@ -110,7 +110,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
 
-      await writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, new Array<ChangeInfo>(), packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });
@@ -150,7 +150,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, new Array<ChangeInfo>(), packageInfos);
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
@@ -194,7 +194,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, changes, packageInfos);
+      await writeChangelog(beachballOptions, changes, new Array<ChangeInfo>(), packageInfos);
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -1,6 +1,7 @@
 import { updateRelatedChangeType } from '../../bump/updateRelatedChangeType';
 import { BumpInfo } from '../../types/BumpInfo';
 import _ from 'lodash';
+import { ChangeInfo } from '../../types/ChangeInfo';
 
 describe('updateRelatedChangeType', () => {
   const bumpInfoFixture: BumpInfo = ({
@@ -26,13 +27,24 @@ describe('updateRelatedChangeType', () => {
     groupOptions: {},
   } as unknown) as BumpInfo;
 
+  const changeInfoFixture: ChangeInfo = {
+    dependentChangeType: 'none',
+    packageName: '',
+    comment: '',
+    commit: '',
+    email: '',
+    type: 'none',
+  };
+
   it('should bump dependent packages with "patch" change type by default', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       dependents: {
         foo: ['bar'],
       },
       packageChangeTypes: {
-        foo: 'minor',
+        foo: {
+          type: 'minor',
+        },
       },
       dependentChangeTypes: {
         foo: 'patch',
@@ -46,10 +58,16 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', 'minor', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'minor' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
   });
 
   it('should bump dependent packages according to the bumpInfo.dependentChangeTypes', () => {
@@ -58,7 +76,7 @@ describe('updateRelatedChangeType', () => {
         foo: ['bar'],
       },
       packageChangeTypes: {
-        foo: 'patch',
+        foo: { type: 'patch' },
       },
       dependentChangeTypes: {
         foo: 'minor',
@@ -72,10 +90,16 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', 'patch', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
   });
 
   it('should bump all packages in a group together as minor', () => {
@@ -95,10 +119,16 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('foo', 'minor', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'minor' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 
@@ -119,10 +149,16 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('foo', 'patch', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 
@@ -143,10 +179,16 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('foo', 'none', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'none' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('none');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('none');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 
@@ -170,10 +212,16 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('foo', 'none', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'none' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('none');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('none');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 
@@ -207,11 +255,17 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('dep', 'patch', bumpInfo, true);
+    updateRelatedChangeType(
+      'dep',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['dep']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
   });
 
@@ -249,12 +303,18 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('dep', 'patch', bumpInfo, true);
+    updateRelatedChangeType(
+      'dep',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['dep']).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['app']).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['app'].type).toBe('minor');
   });
 
   it('should propagate dependent change type across group', () => {
@@ -306,14 +366,26 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType('mergeStyles', 'patch', bumpInfo, true);
-    updateRelatedChangeType('datetimeUtils', 'patch', bumpInfo, true);
+    updateRelatedChangeType(
+      'mergeStyles',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
+    updateRelatedChangeType(
+      'datetimeUtils',
+      { ...changeInfoFixture, type: 'patch' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['mergeStyles']).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['datetime']).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['datetimeUtils']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['mergeStyles'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['datetime'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['datetimeUtils'].type).toBe('patch');
   });
 
   it('should respect disallowed change type', () => {
@@ -325,8 +397,14 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', 'major', bumpInfo, true);
+    updateRelatedChangeType(
+      'foo',
+      { ...changeInfoFixture, type: 'major' },
+      bumpInfo,
+      new Map<string, Array<ChangeInfo>>(),
+      true
+    );
 
-    expect(bumpInfo.packageChangeTypes['foo']).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
   });
 });

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -20,6 +20,10 @@ describe('updateRelatedChangeType', () => {
         name: 'bar',
         combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
       },
+      baz: {
+        name: 'baz',
+        combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
+      },
     },
     modifiedPackages: new Set(),
     newPackages: new Set(),
@@ -29,10 +33,10 @@ describe('updateRelatedChangeType', () => {
 
   const changeInfoFixture: ChangeInfo = {
     dependentChangeType: 'none',
-    packageName: '',
-    comment: '',
-    commit: '',
-    email: '',
+    packageName: 'foo',
+    comment: 'test comment',
+    commit: '0xdeadbeef',
+    email: 'test@dev.com',
     type: 'none',
   };
 
@@ -46,9 +50,6 @@ describe('updateRelatedChangeType', () => {
           type: 'minor',
         },
       },
-      dependentChangeTypes: {
-        foo: 'patch',
-      },
       packageInfos: {
         bar: {
           dependencies: {
@@ -58,16 +59,23 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'minor' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'minor' }, bumpInfo, dependentChangeInfos, true);
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
+    expect(dependentChangeInfos.size).toBe(1);
+
+    const fooChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooChangeInfos).toBeDefined();
+    expect(fooChangeInfos?.size).toBe(1);
+
+    const fooChangeInfo = fooChangeInfos?.get('bar');
+    expect(fooChangeInfo?.type).toBe('patch');
+    expect(fooChangeInfo?.packageName).toBe('bar');
+    expect(fooChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(fooChangeInfo?.email).toBe('test@dev.com');
+    expect(fooChangeInfo?.comment).toBe('');
   });
 
   it('should bump dependent packages according to the bumpInfo.dependentChangeTypes', () => {
@@ -90,16 +98,268 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
+    expect(dependentChangeInfos.size).toBe(1);
+
+    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooDependentChangeInfos).toBeDefined();
+    expect(fooDependentChangeInfos?.size).toBe(1);
+
+    const barDependentChangeInfo = fooDependentChangeInfos?.get('bar');
+
+    expect(barDependentChangeInfo?.type).toBe('minor');
+    expect(barDependentChangeInfo?.packageName).toBe('bar');
+    expect(barDependentChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(barDependentChangeInfo?.email).toBe('test@dev.com');
+    expect(barDependentChangeInfo?.comment).toBe('');
+  });
+
+  it("should bump dependent packages according to the bumpInfo.dependentChangeTypes and respect package's own change type", () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependents: {
+        foo: ['bar'],
+        bar: ['app'],
+      },
+      packageChangeTypes: {
+        foo: { type: 'patch' },
+        bar: { type: 'major' },
+      },
+      dependentChangeTypes: {
+        foo: 'patch',
+        bar: 'minor',
+      },
+      packageInfos: {
+        app: {
+          dependencies: {
+            bar: '1.0.0',
+          },
+        },
+        bar: {
+          dependencies: {
+            foo: '1.0.0',
+          },
+        },
+      },
+    });
+
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('bar', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('major');
+    expect(bumpInfo.packageChangeTypes['app'].type).toBe('patch');
+    expect(dependentChangeInfos.size).toBe(2);
+
+    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooDependentChangeInfos?.size).toBe(1);
+
+    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
+    expect(barChangeInfoForFoo?.type).toBe('patch');
+    expect(barChangeInfoForFoo?.packageName).toBe('bar');
+    expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
+    expect(barChangeInfoForFoo?.comment).toBe('');
+
+    const barDependentChangeInfos = dependentChangeInfos.get('bar');
+    expect(barDependentChangeInfos?.size).toBe(1);
+
+    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
+    expect(appChangeInfoForBar?.type).toBe('patch');
+    expect(appChangeInfoForBar?.packageName).toBe('app');
+    expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
+    expect(appChangeInfoForBar?.email).toBe('test@dev.com');
+    expect(appChangeInfoForBar?.comment).toBe('');
+  });
+
+  it('should bump dependent packages according to the bumpInfo.dependentChangeTypes and dependentChangeInfos must stay up to date', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependents: {
+        foo: ['bar'],
+        baz: ['bar'],
+        bar: ['app'],
+      },
+      packageChangeTypes: {
+        foo: { type: 'patch' },
+        baz: { type: 'minor' },
+      },
+      dependentChangeTypes: {
+        foo: 'patch',
+        baz: 'minor',
+      },
+      packageInfos: {
+        app: {
+          dependencies: {
+            bar: '1.0.0',
+          },
+        },
+        bar: {
+          dependencies: {
+            foo: '1.0.0',
+            baz: '2.0.0',
+          },
+        },
+      },
+    });
+
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['app'].type).toBe('patch');
+    expect(dependentChangeInfos.size).toBe(2);
+
+    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooDependentChangeInfos?.size).toBe(1);
+
+    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
+    expect(barChangeInfoForFoo?.type).toBe('patch');
+    expect(barChangeInfoForFoo?.packageName).toBe('bar');
+    expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
+    expect(barChangeInfoForFoo?.comment).toBe('');
+
+    const barDependentChangeInfos = dependentChangeInfos.get('bar');
+    expect(barDependentChangeInfos?.size).toBe(1);
+
+    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
+    expect(appChangeInfoForBar?.type).toBe('patch');
+    expect(appChangeInfoForBar?.packageName).toBe('app');
+    expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
+    expect(appChangeInfoForBar?.email).toBe('test@dev.com');
+    expect(appChangeInfoForBar?.comment).toBe('');
+
     updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'patch' },
+      'baz',
+      { ...changeInfoFixture, type: 'patch', email: 'dev@test.com', commit: '0xfeef' },
       bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
+      dependentChangeInfos,
       true
     );
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
+    expect(bumpInfo.packageChangeTypes['app'].type).toBe('minor');
+    expect(dependentChangeInfos.size).toBe(3);
+
+    const fooDependentChangeInfos2 = dependentChangeInfos.get('foo');
+    expect(fooDependentChangeInfos2?.size).toBe(1);
+
+    const barChangeInfoForFoo2 = fooDependentChangeInfos?.get('bar');
+    expect(barChangeInfoForFoo2?.type).toBe('patch');
+    expect(barChangeInfoForFoo2?.packageName).toBe('bar');
+    expect(barChangeInfoForFoo2?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfoForFoo2?.email).toBe('test@dev.com');
+    expect(barChangeInfoForFoo2?.comment).toBe('');
+
+    const bazDependentChangeInfos = dependentChangeInfos.get('baz');
+    expect(bazDependentChangeInfos?.size).toBe(1);
+
+    const bazChangeInfoForBar = bazDependentChangeInfos?.get('bar');
+    expect(bazChangeInfoForBar?.type).toBe('minor');
+    expect(bazChangeInfoForBar?.packageName).toBe('bar');
+    expect(bazChangeInfoForBar?.commit).toBe('0xfeef');
+    expect(bazChangeInfoForBar?.email).toBe('dev@test.com');
+    expect(bazChangeInfoForBar?.comment).toBe('');
+
+    const barDependentChangeInfos2 = dependentChangeInfos.get('bar');
+    expect(barDependentChangeInfos2?.size).toBe(1);
+
+    const appChangeInfoForBar2 = barDependentChangeInfos2?.get('app');
+    expect(appChangeInfoForBar2?.type).toBe('minor');
+    expect(appChangeInfoForBar2?.packageName).toBe('app');
+    expect(appChangeInfoForBar2?.commit).toBe('0xfeef');
+    expect(appChangeInfoForBar2?.email).toBe('dev@test.com');
+    expect(appChangeInfoForBar2?.comment).toBe('');
+  });
+
+  it('should bump dependent packages according to the bumpInfo.dependentChangeTypes and roll-up multiple change infos', () => {
+    const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      dependents: {
+        foo: ['bar'],
+        bar: ['app'],
+        baz: ['bar', 'app'],
+      },
+      packageChangeTypes: {
+        foo: { type: 'patch' },
+        baz: { type: 'patch' },
+      },
+      dependentChangeTypes: {
+        foo: 'major',
+        baz: 'minor',
+      },
+      packageInfos: {
+        app: {
+          dependencies: {
+            bar: '1.0.0',
+            baz: '2.0.0',
+          },
+        },
+        bar: {
+          dependencies: {
+            foo: '1.0.0',
+            baz: '2.0.0',
+          },
+        },
+      },
+    });
+
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('baz', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+
+    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('patch');
+    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('major');
+    expect(bumpInfo.packageChangeTypes['app'].type).toBe('major');
+
+    expect(dependentChangeInfos.size).toBe(3);
+
+    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooDependentChangeInfos?.size).toBe(1);
+
+    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
+    expect(barChangeInfoForFoo?.type).toBe('major');
+    expect(barChangeInfoForFoo?.packageName).toBe('bar');
+    expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
+    expect(barChangeInfoForFoo?.comment).toBe('');
+
+    const barDependentChangeInfos = dependentChangeInfos.get('bar');
+    expect(barDependentChangeInfos?.size).toBe(1);
+
+    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
+    expect(appChangeInfoForBar?.type).toBe('major');
+    expect(appChangeInfoForBar?.packageName).toBe('app');
+    expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
+    expect(appChangeInfoForBar?.email).toBe('test@dev.com');
+    expect(appChangeInfoForBar?.comment).toBe('');
+
+    const bazDependentChangeInfos = dependentChangeInfos.get('baz');
+    expect(bazDependentChangeInfos?.size).toBe(2);
+
+    const barChangeInfoForBaz = bazDependentChangeInfos?.get('bar');
+    expect(barChangeInfoForBaz?.type).toBe('minor');
+    expect(barChangeInfoForBaz?.packageName).toBe('bar');
+    expect(barChangeInfoForBaz?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfoForBaz?.email).toBe('test@dev.com');
+    expect(barChangeInfoForBaz?.comment).toBe('');
+
+    const appChangeInfoForBaz = bazDependentChangeInfos?.get('app');
+    expect(appChangeInfoForBaz?.type).toBe('minor');
+    expect(appChangeInfoForBaz?.packageName).toBe('app');
+    expect(appChangeInfoForBaz?.commit).toBe('0xdeadbeef');
+    expect(appChangeInfoForBaz?.email).toBe('test@dev.com');
+    expect(appChangeInfoForBaz?.comment).toBe('');
   });
 
   it('should bump all packages in a group together as minor', () => {
@@ -119,14 +379,10 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'minor' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'minor' }, bumpInfo, dependentChangeInfos, true);
 
+    expect(dependentChangeInfos.size).toBe(0);
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
@@ -149,14 +405,10 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'patch' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
 
+    expect(dependentChangeInfos.size).toBe(0);
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
@@ -179,14 +431,10 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'none' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'none' }, bumpInfo, dependentChangeInfos, true);
 
+    expect(dependentChangeInfos.size).toBe(0);
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
@@ -212,17 +460,13 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'none' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'none' }, bumpInfo, dependentChangeInfos, true);
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+    expect(dependentChangeInfos.size).toBe(0);
   });
 
   it('should bump all grouped packages, if a dependency was bumped', () => {
@@ -255,18 +499,26 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'dep',
-      { ...changeInfoFixture, type: 'patch' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('dep', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+
+    expect(dependentChangeInfos.size).toBe(1);
+
+    const depChangeInfos = dependentChangeInfos.get('dep');
+    expect(depChangeInfos).toBeDefined();
+    expect(depChangeInfos?.size).toBe(1);
+
+    const depChangeInfo = depChangeInfos?.get('bar');
+    expect(depChangeInfo?.type).toBe('minor');
+    expect(depChangeInfo?.packageName).toBe('bar');
+    expect(depChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(depChangeInfo?.email).toBe('test@dev.com');
+    expect(depChangeInfo?.comment).toBe('');
   });
 
   it('should bump dependent package, if a dependency was in a group', () => {
@@ -303,24 +555,44 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType(
-      'dep',
-      { ...changeInfoFixture, type: 'patch' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('dep', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['app'].type).toBe('minor');
+
+    expect(dependentChangeInfos.size).toBe(2);
+
+    const depChangeInfos = dependentChangeInfos.get('dep');
+    expect(depChangeInfos).toBeDefined();
+    expect(depChangeInfos?.size).toBe(1);
+
+    const depChangeInfo = depChangeInfos?.get('bar');
+    expect(depChangeInfo?.type).toBe('minor');
+    expect(depChangeInfo?.packageName).toBe('bar');
+    expect(depChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(depChangeInfo?.email).toBe('test@dev.com');
+    expect(depChangeInfo?.comment).toBe('');
+
+    const fooChangeInfos = dependentChangeInfos.get('foo');
+    expect(fooChangeInfos).toBeDefined();
+    expect(fooChangeInfos?.size).toBe(1);
+
+    const fooChangeInfo = fooChangeInfos?.get('app');
+    expect(fooChangeInfo?.type).toBe('minor');
+    expect(fooChangeInfo?.packageName).toBe('app');
+    expect(fooChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(fooChangeInfo?.email).toBe('test@dev.com');
+    expect(fooChangeInfo?.comment).toBe('');
   });
 
   it('should propagate dependent change type across group', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       dependentChangeTypes: {
         mergeStyles: 'minor',
+        datetimeUtils: 'patch',
       },
       dependents: {
         mergeStyles: ['styling'],
@@ -360,32 +632,80 @@ describe('updateRelatedChangeType', () => {
           },
         },
         datetimeUtils: {
-          name: 'app',
+          name: 'datetimeUtils',
         },
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
     updateRelatedChangeType(
       'mergeStyles',
       { ...changeInfoFixture, type: 'patch' },
       bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
+      dependentChangeInfos,
       true
     );
+
     updateRelatedChangeType(
       'datetimeUtils',
       { ...changeInfoFixture, type: 'patch' },
       bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
+      dependentChangeInfos,
       true
     );
+
+    expect(dependentChangeInfos.size).toBe(4);
 
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['mergeStyles'].type).toBe('patch');
     expect(bumpInfo.packageChangeTypes['datetime'].type).toBe('minor');
     expect(bumpInfo.packageChangeTypes['datetimeUtils'].type).toBe('patch');
+
+    const mergeStylesChangeInfos = dependentChangeInfos.get('mergeStyles');
+    expect(mergeStylesChangeInfos).toBeDefined();
+    expect(mergeStylesChangeInfos?.size).toBe(1);
+
+    const mergeStyleChangeInfo = mergeStylesChangeInfos?.get('styling');
+    expect(mergeStyleChangeInfo?.type).toBe('minor');
+    expect(mergeStyleChangeInfo?.packageName).toBe('styling');
+    expect(mergeStyleChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(mergeStyleChangeInfo?.email).toBe('test@dev.com');
+    expect(mergeStyleChangeInfo?.comment).toBe('');
+
+    const stylingChangeInfos = dependentChangeInfos.get('styling');
+    expect(stylingChangeInfos).toBeDefined();
+    expect(stylingChangeInfos?.size).toBe(1);
+
+    const stylingChangeInfo = stylingChangeInfos?.get('bar');
+    expect(stylingChangeInfo?.type).toBe('minor');
+    expect(stylingChangeInfo?.packageName).toBe('bar');
+    expect(stylingChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(stylingChangeInfo?.email).toBe('test@dev.com');
+    expect(stylingChangeInfo?.comment).toBe('');
+
+    const barChangeInfos = dependentChangeInfos.get('bar');
+    expect(barChangeInfos).toBeDefined();
+    expect(barChangeInfos?.size).toBe(1);
+
+    const barChangeInfo = barChangeInfos?.get('datetime');
+    expect(barChangeInfo?.type).toBe('minor');
+    expect(barChangeInfo?.packageName).toBe('datetime');
+    expect(barChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfo?.email).toBe('test@dev.com');
+    expect(barChangeInfo?.comment).toBe('');
+
+    const datetimeUtilsChangeInfos = dependentChangeInfos.get('datetimeUtils');
+    expect(datetimeUtilsChangeInfos).toBeDefined();
+    expect(datetimeUtilsChangeInfos?.size).toBe(1);
+
+    const datetimeUtilsChangeInfo = datetimeUtilsChangeInfos?.get('datetime');
+    expect(datetimeUtilsChangeInfo?.type).toBe('patch');
+    expect(datetimeUtilsChangeInfo?.packageName).toBe('datetime');
+    expect(datetimeUtilsChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(datetimeUtilsChangeInfo?.email).toBe('test@dev.com');
+    expect(datetimeUtilsChangeInfo?.comment).toBe('');
   });
 
   it('should respect disallowed change type', () => {
@@ -397,14 +717,10 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType(
-      'foo',
-      { ...changeInfoFixture, type: 'major' },
-      bumpInfo,
-      new Map<string, Array<ChangeInfo>>(),
-      true
-    );
+    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'major' }, bumpInfo, dependentChangeInfos, true);
 
+    expect(dependentChangeInfos.size).toBe(0);
     expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
   });
 });

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -23,9 +23,8 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   setGroupsInBumpInfo(bumpInfo, options);
 
-  const dependentChangeInfos = new Map<string, Array<ChangeInfo>>();
+  const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
   Object.keys(changes).forEach(pkgName => {
-    // that's where you need to identify the email and commit SHAs of the underlying change file
     updateRelatedChangeType(pkgName, changes[pkgName], bumpInfo, dependentChangeInfos, bumpDeps);
   });
 
@@ -36,10 +35,10 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   // pass 3: update the dependentChangeInfos with relevant comments
   dependentChangeInfos.forEach((changeInfos, dependencyName) => {
-    changeInfos.forEach(changeInfo => {
+    for (let changeInfo of changeInfos.values()) {
       changeInfo.comment = `Bump ${dependencyName} to v${packageInfos[dependencyName].version}`;
       bumpInfo.dependentChangeInfos.push(changeInfo);
-    });
+    }
   });
 
   // pass 4: Bump all the dependencies packages

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -8,7 +8,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
   const { packageChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
-  const changeType = packageChangeTypes[pkgName].type;
+  const changeType = packageChangeTypes[pkgName]?.type;
   if (!info) {
     console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
     return;

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -8,7 +8,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
   const { packageChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
-  const changeType = packageChangeTypes[pkgName];
+  const changeType = packageChangeTypes[pkgName].type;
   if (!info) {
     console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
     return;

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -1,7 +1,7 @@
 import { getPackageChangeTypes } from '../changefile/getPackageChangeTypes';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-import { ChangeSet } from '../types/ChangeInfo';
+import { ChangeInfo, ChangeSet } from '../types/ChangeInfo';
 import { BumpInfo } from '../types/BumpInfo';
 import { bumpInPlace } from './bumpInPlace';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -56,6 +56,7 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
     dependentChangeTypes,
     groupOptions,
     dependents: {},
+    dependentChangeInfos: new Array<ChangeInfo>(),
   };
 }
 

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -39,13 +39,13 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
  * deletes change files, update package.json, and changelogs
  */
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { modifiedPackages, packageInfos, changes } = bumpInfo;
+  const { modifiedPackages, packageInfos, changes, dependentChangeInfos } = bumpInfo;
 
   writePackageJson(modifiedPackages, packageInfos);
 
   if (options.generateChangelog) {
     // Generate changelog
-    await writeChangelog(options, changes, packageInfos);
+    await writeChangelog(options, changes, dependentChangeInfos, packageInfos);
   }
 
   if (!options.keepChangeFiles) {

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -1,6 +1,6 @@
 import { getMaxChangeType, MinChangeType } from '../changefile/getPackageChangeTypes';
-import { ChangeType } from '../types/ChangeInfo';
 import { BumpInfo } from '../types/BumpInfo';
+import { ChangeInfo } from '../types/ChangeInfo';
 
 /**
  * Updates package change types based on dependents (e.g given A -> B, if B has a minor change, A should also have minor change)
@@ -9,50 +9,80 @@ import { BumpInfo } from '../types/BumpInfo';
  */
 export function updateRelatedChangeType(
   pkgName: string,
-  changeType: ChangeType,
+  changeType: ChangeInfo,
   bumpInfo: BumpInfo,
+  dependentChangeInfos: Map<string, Array<ChangeInfo>>,
   bumpDeps: boolean
 ) {
   const { packageChangeTypes, packageGroups, dependents, packageInfos, dependentChangeTypes, groupOptions } = bumpInfo;
 
-  const disallowedChangeTypes = packageInfos[pkgName].combinedOptions?.disallowedChangeTypes ?? [];
+  const packageInfo = packageInfos[pkgName];
+  const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
 
-  let depChangeType = getMaxChangeType(MinChangeType, dependentChangeTypes[pkgName], disallowedChangeTypes);
+  let depChangeType = {
+    ...changeType,
+    type: getMaxChangeType(MinChangeType, dependentChangeTypes[pkgName], disallowedChangeTypes),
+  };
+
   let dependentPackages = dependents[pkgName];
 
   // Handle groups
-  packageChangeTypes[pkgName] = getMaxChangeType(changeType, packageChangeTypes[pkgName], disallowedChangeTypes);
+  packageChangeTypes[pkgName] = {
+    ...packageChangeTypes[pkgName],
+    type: getMaxChangeType(changeType.type, packageChangeTypes[pkgName]?.type, disallowedChangeTypes),
+  };
 
   const groupName = packageInfos[pkgName].group;
   if (groupName) {
-    let maxGroupChangeType: ChangeType = MinChangeType;
+    let maxGroupChangeType: ChangeInfo = {
+      ...changeType,
+      type: MinChangeType,
+    };
 
     // calculate maxChangeType
     packageGroups[groupName].packageNames.forEach(groupPkgName => {
-      maxGroupChangeType = getMaxChangeType(
-        maxGroupChangeType,
-        packageChangeTypes[groupPkgName],
-        groupOptions[groupName]?.disallowedChangeTypes
-      );
+      maxGroupChangeType = {
+        ...maxGroupChangeType,
+        type: getMaxChangeType(
+          maxGroupChangeType.type,
+          packageChangeTypes[groupPkgName]?.type,
+          groupOptions[groupName]?.disallowedChangeTypes
+        ),
+      };
 
       // disregard the target disallowed types for now and will be culled at the subsequent update steps
-      dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeType, dependentChangeTypes[groupPkgName], []);
+      dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeType.type, dependentChangeTypes[groupPkgName], []);
     });
 
     packageGroups[groupName].packageNames.forEach(groupPkgName => {
-      if (packageChangeTypes[groupPkgName] !== maxGroupChangeType) {
-        updateRelatedChangeType(groupPkgName, maxGroupChangeType, bumpInfo, bumpDeps);
+      if (packageChangeTypes[groupPkgName]?.type !== maxGroupChangeType.type) {
+        updateRelatedChangeType(groupPkgName, maxGroupChangeType, bumpInfo, dependentChangeInfos, bumpDeps);
       }
     });
   }
 
   if (bumpDeps && dependentPackages) {
     new Set(dependentPackages).forEach(parent => {
-      if (packageChangeTypes[parent] !== depChangeType) {
+      if (packageChangeTypes[parent]?.type !== depChangeType.type) {
         // propagate the dependentChangeType of the current package to the subsequent related packages
-        dependentChangeTypes[parent] = depChangeType;
+        dependentChangeTypes[parent] = depChangeType.type;
 
-        updateRelatedChangeType(parent, depChangeType, bumpInfo, bumpDeps);
+        let changeInfos = dependentChangeInfos.get(pkgName);
+        if (!changeInfos) {
+          changeInfos = new Array<ChangeInfo>();
+          dependentChangeInfos.set(pkgName, changeInfos);
+        }
+
+        changeInfos.push({
+          type: depChangeType.type,
+          packageName: parent,
+          email: depChangeType.email,
+          dependentChangeType: depChangeType.type,
+          commit: depChangeType.commit,
+          comment: '', // comment will be populated at later stages when new versions are computed
+        });
+
+        updateRelatedChangeType(parent, depChangeType, bumpInfo, dependentChangeInfos, bumpDeps);
       }
     });
   }

--- a/src/changefile/getPackageChangeTypes.ts
+++ b/src/changefile/getPackageChangeTypes.ts
@@ -1,4 +1,4 @@
-import { ChangeFileInfo, ChangeSet, ChangeType } from '../types/ChangeInfo';
+import { ChangeInfo, ChangeSet, ChangeType } from '../types/ChangeInfo';
 
 /**
  * List of all change types from least to most significant.
@@ -21,13 +21,13 @@ const ChangeTypeWeights: { [t in ChangeType]: number } = SortedChangeTypes.reduc
 
 export function getPackageChangeTypes(changeSet: ChangeSet) {
   const changePerPackage: {
-    [pkgName: string]: ChangeFileInfo['type'];
+    [pkgName: string]: ChangeInfo;
   } = {};
 
   for (let change of changeSet.values()) {
     const { packageName } = change;
-    if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName])) {
-      changePerPackage[packageName] = change.type;
+    if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName].type)) {
+      changePerPackage[packageName] = change;
     }
   }
   return changePerPackage;

--- a/src/changefile/getPackageChangeTypes.ts
+++ b/src/changefile/getPackageChangeTypes.ts
@@ -58,6 +58,18 @@ export function getAllowedChangeType(changeType: ChangeType, disallowedChangeTyp
   return changeType;
 }
 
+export function updateChangeInfoWithMaxType(
+  changeInfo: ChangeInfo,
+  inputA: ChangeType,
+  inputB: ChangeType,
+  disallowedChangeTypes: ChangeType[] | null
+): ChangeInfo {
+  return {
+    ...changeInfo,
+    type: getMaxChangeType(inputA, inputB, disallowedChangeTypes),
+  };
+}
+
 export function getMaxChangeType(inputA: ChangeType, inputB: ChangeType, disallowedChangeTypes: ChangeType[] | null) {
   const a = getAllowedChangeType(inputA, disallowedChangeTypes);
   const b = getAllowedChangeType(inputB, disallowedChangeTypes);

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -1,18 +1,20 @@
-import { ChangeSet } from '../types/ChangeInfo';
+import { ChangeInfo, ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
 import { generateTag } from '../tag';
 
 export function getPackageChangelogs(
   changeSet: ChangeSet,
+  dependentChangeInfos: Array<ChangeInfo>,
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
 ) {
+  const changeInfos = Array.from(changeSet.values()).concat(dependentChangeInfos);
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};
-  for (let change of changeSet.values()) {
+  for (let change of changeInfos) {
     const { packageName } = change;
     if (!changelogs[packageName]) {
       const version = packageInfos[packageName].version;

--- a/src/publish/shouldPublishPackage.ts
+++ b/src/publish/shouldPublishPackage.ts
@@ -8,7 +8,7 @@ export function shouldPublishPackage(
   reasonToSkip?: string;
 } {
   const packageInfo = bumpInfo.packageInfos[pkgName];
-  const changeType = bumpInfo.packageChangeTypes[pkgName];
+  const changeType = bumpInfo.packageChangeTypes[pkgName]?.type;
 
   if (changeType === 'none') {
     return {

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -11,7 +11,7 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
 
   [...modifiedPackages, ...newPackages].forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    const changeType = bumpInfo.packageChangeTypes[pkg].type;
+    const changeType = bumpInfo.packageChangeTypes[pkg]?.type;
     // Do not tag change type of "none", private packages, or packages opting out of tagging
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       return;

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -11,7 +11,7 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
 
   [...modifiedPackages, ...newPackages].forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    const changeType = bumpInfo.packageChangeTypes[pkg];
+    const changeType = bumpInfo.packageChangeTypes[pkg].type;
     // Do not tag change type of "none", private packages, or packages opting out of tagging
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       return;

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -1,15 +1,16 @@
-import { ChangeSet, ChangeType } from './ChangeInfo';
+import { ChangeInfo, ChangeSet, ChangeType } from './ChangeInfo';
 import { PackageInfo, PackageGroups } from './PackageInfo';
 import { VersionGroupOptions } from './BeachballOptions';
 
 export type BumpInfo = {
   changes: ChangeSet;
   packageInfos: { [pkgName: string]: PackageInfo };
-  packageChangeTypes: { [pkgName: string]: ChangeType };
+  packageChangeTypes: { [pkgName: string]: ChangeInfo };
   packageGroups: PackageGroups;
   groupOptions: { [grp: string]: VersionGroupOptions };
   dependents: { [pkgName: string]: string[] };
   dependentChangeTypes: { [pkgName: string]: ChangeType };
+  dependentChangeInfos: Array<ChangeInfo>;
   modifiedPackages: Set<string>;
   newPackages: Set<string>;
   scopedPackages: Set<string>;


### PR DESCRIPTION
Currently, beachball generates changelogs only for packages that are described in change files. Dependent packages, however, do not receive new changelog entries, even though their versions get bumped. 

This PR enables beachball to rollup a changelog entry to dependents, such as: `Bump ${package} to v${version}` making it obvious what has caused the version bump.