### PR TITLE
Remove the double negative in patch change hint 

### DIFF
--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -36,7 +36,7 @@ export async function promptForChange(options: BeachballOptions) {
       message: 'Change type',
       choices: [
         ...(showPrereleaseOption ? [{ value: 'prerelease', title: ' [1mPrerelease[22m - bump prerelease version' }] : []),
-        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no backwards incompatible changes.' },
+        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; backwards compatible changes.' },
         { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible changes.' },
         {
           value: 'none',

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -36,8 +36,8 @@ export async function promptForChange(options: BeachballOptions) {
       message: 'Change type',
       choices: [
         ...(showPrereleaseOption ? [{ value: 'prerelease', title: ' [1mPrerelease[22m - bump prerelease version' }] : []),
-        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; backwards compatible changes.' },
-        { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible changes.' },
+        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no API changes.' },
+        { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible API changes.' },
         {
           value: 'none',
           title: ' [1mNone[22m       - this change does not affect the published package in any way.',


### PR DESCRIPTION
The current hints for patch and minor changes use different language to tell users that they should only have backwards compatible changes. This change unifies the language, going for the least complicated phrasing.