### PR TITLE
Fix setting response.type in promptForChange

### DIFF
--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -101,6 +101,9 @@ export async function promptForChange(options: BeachballOptions) {
       //    but we didn't display it due to showChangeTypePrompt === false;
       //    so set the type to 'none'
       if (!response.type) {
+        if (!options.type) {
+          console.log("WARN: change type 'none' assumed by default");
+        }
         response = { ...response, type: options.type || 'none' };
       }
 

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -93,9 +93,15 @@ export async function promptForChange(options: BeachballOptions) {
         return;
       }
 
-      // fallback to the options.type if type is absent in the user input
-      if (!response.type && options.type) {
-        response = { ...response, type: options.type };
+      // if type is absent in the user input, there are two possiblities for
+      // proceeding next:
+      // 1) if options.type is defined, use that
+      // 2) otherwise, we hit the edge case when options.type is undefined
+      //    and there was only one possible ChangeType to display, 'none'
+      //    but we didn't display it due to showChangeTypePrompt === false;
+      //    so set the type to 'none'
+      if (!response.type) {
+        response = { ...response, type: options.type || 'none' };
       }
 
       // fallback to the options.message if message is absent in the user input


### PR DESCRIPTION
This commit handles edge case for properly setting `response.type` in `promptForChange` in a situation when `options.type` is `undefined` or `null` **and** there is only one viable default `ChangeType` option (`'none'`) in which case the type prompt won't be shown, and we fall back to `'none'` by default.

Prior to this change, since `options.type` would be left `undefined` and the type prompt not shown, the CLI would incorrectly exit with "Prompt response contains invalid change type" without any other hint to the user.

For more context, this problem emerged when we were adding a new package to the [microsoft/fluentui](https://github.com/microsoft/fluentui) repo: microsoft/fluentui#16458.

---
EDIT:

After offline discussion with @ecraig12345, we agreed it would make sense to emit a warning if the user selects `none` as the change type, or ask for confirmation. I went a step further and figure it would make sense to actually confirm with the user their choices regardless. Therefore, this PR also adds a snippet which prints out a confirmation dialog to confirm their choices. Example output after this change looks like:

```
Checking for changes against "origin/master"
fetching latest from remotes "origin/master"
Found changes in the following packages:
  @fluentui/cra-template
fetching latest from remotes "origin/master"

Please describe the changes for: @fluentui/cra-template
✔ Describe changes (type or choose one) › feat(cra-template): boot up CRA template
Your response:
{
  changeType: "none",
  comment:    "feat(cra-template): boot up CRA template",
}
✔ Do you want to continue? … no
Aborting...
```

Hopefully, this should shield the user a little bit better from making unwanted decision, for instance, like in the snippet above, selecting `'none'` as the change type which is undesired and should be investigated and fixed before running `beachball` against the changes.