### PR TITLE
Allow the "type" CLI arg to accept multiple types

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ target branch from origin (default: master)
 
 ### --message, -m
 
-custom message for the checkin (default: applying package updates)
+- for the publish command: custom message for the checkin (default: applying package updates)
+- for the change command: uses the given changelog msessage instead of prompting
 
 ### --no-push
 
@@ -76,6 +77,10 @@ show help message
 ### --yes, -y
 
 skips the prompts for publish
+
+### --type
+Allows specifying a default type for the "change" command to avoid prompting. Multiple types may be
+specified in order of preference, where the first allowed by a package is picked.
 
 ## Examples
 

--- a/change/beachball-671dcab4-39d8-4310-b61d-98e8ddb412fc.json
+++ b/change/beachball-671dcab4-39d8-4310-b61d-98e8ddb412fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow the \"type\" CLI arg to accept multiple types",
+  "packageName": "beachball",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -51,8 +51,14 @@ export async function promptForChange(options: BeachballOptions) {
       return;
     }
 
-    if (options.type && disallowedChangeTypes?.includes(options.type as ChangeType)) {
-      console.log(`${options.type} type is not allowed, aborting`);
+    const bestOptionType = bestSpecifiedType(options, disallowedChangeTypes);
+
+    if (options.type && bestOptionType === null) {
+      if (options.type.length === 1) {
+        console.log(`${options.type} type is not allowed, aborting`);
+      } else {
+        console.log(`None of "${options.type}" are allowed change types, aborting`)
+      }
       return;
     }
 
@@ -81,7 +87,7 @@ export async function promptForChange(options: BeachballOptions) {
     questions = questions.filter(q => !!q);
 
     let response: { comment: string; type: ChangeType } = {
-      type: options.type || 'none',
+      type: bestOptionType || 'none',
       comment: options.message || '',
     };
 
@@ -94,8 +100,8 @@ export async function promptForChange(options: BeachballOptions) {
       }
 
       // fallback to the options.type if type is absent in the user input
-      if (!response.type && options.type) {
-        response = { ...response, type: options.type };
+      if (!response.type && bestOptionType) {
+        response = { ...response, type: bestOptionType };
       }
 
       // fallback to the options.message if message is absent in the user input
@@ -118,4 +124,17 @@ export async function promptForChange(options: BeachballOptions) {
   }
 
   return packageChangeInfo;
+}
+
+/**
+ * Pick the most preferable default type specified in options given a list of disallowed types
+ */
+function bestSpecifiedType(options: BeachballOptions, disallowedChangeTypes: ChangeType[] | null): ChangeType | null {
+  for (const optionType of options.type || []) {
+    if (!disallowedChangeTypes?.includes(optionType)) {
+      return optionType;
+    }
+  }
+
+  return null;
 }

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -14,7 +14,7 @@ export function getCliOptions(): CliOptions {
   const argv = process.argv.splice(2);
   const args = parser(argv, {
     string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type'],
-    array: ['scope', 'disallowed-change-types'],
+    array: ['scope', 'disallowed-change-types', 'type'],
     boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files'],
     alias: {
       branch: ['b'],

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -23,7 +23,8 @@ export interface CliOptions {
   package: string;
   changehint: string;
   retries: number;
-  type?: ChangeType | null;
+  /** Type/types to choose as default when creating a changefile, ordered by precedence of choice */
+  type?: ChangeType[] | null;
   help?: boolean;
   version?: boolean;
   scope?: string[] | null;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -46,9 +46,11 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     process.exit(1);
   }
 
-  if (options.type && !isValidChangeType(options.type)) {
-    console.error(`ERROR: change type ${options.type} is not valid`);
-    process.exit(1);
+  for (const type of options.type || []) {
+    if (!isValidChangeType(type)) {
+      console.error(`ERROR: change type ${type} is not valid`);
+      process.exit(1);
+    }
   }
 
   let isChangeNeeded = false;


### PR DESCRIPTION
The "type" arg is useful when scripting Beachball to avoid prompting. There are sometimes cases where react-native-windows wants to generate changefiles of different types dependent on what the package allows. E.g. where one package only allows prerelease types, but others prefer patch.

This change allows the "type" argument to accept a list of types in order of preference, where the first allowed type is picked. This maintains compatibility with previous usage, since a single argument will be treated by `yargs-parser` as a single element array.

There is not great infrastructure present to test the change prompt, so validation was manual. I linked the development beachball bits to a separate repo and tested the cases of no type arg, one type arg, multiple type args (with 1 vs 2 winning).