### PR TITLE
Allow passing --config to specify config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ synchronizes published versions of packages from a registry, makes local package
 
 ## Options
 
+### --config, -c
+
+Explicit configuration file to use instead of the configuration automatically detected by cosmicconfig.
+
 ### --registry, -r
 
 registry, defaults to https://registry.npmjs.org

--- a/change/beachball-298836ae-681c-4d08-8bb6-cc76f7759dac.json
+++ b/change/beachball-298836ae-681c-4d08-8bb6-cc76f7759dac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow passing --config to specify config file",
+  "packageName": "beachball",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/config.test.ts
+++ b/src/__e2e__/config.test.ts
@@ -6,6 +6,8 @@ import { getOptions } from '../options/getOptions';
 
 const writeFileAsync = promisify(fs.writeFile);
 
+const baseArgv = ['node.exe', 'bin.js'];
+
 describe('config', () => {
   it('uses the branch name defined in beachball.config.js', async () => {
     const repositoryFactory = new RepositoryFactory();
@@ -13,10 +15,22 @@ describe('config', () => {
     const repo = await repositoryFactory.cloneRepository();
     const config = await inDirectory(repo.root!, async () => {
       await writeConfig('module.exports = { branch: "origin/main" };');
-      return getOptions();
+      return getOptions(baseArgv);
     });
     expect(config.branch).toEqual('origin/main');
   });
+});
+
+it('--config overrides configuration path', async () => {
+  const repositoryFactory = new RepositoryFactory();
+  await repositoryFactory.create();
+  const repo = await repositoryFactory.cloneRepository();
+  const config = await inDirectory(repo.root!, async () => {
+    await writeConfig('module.exports = { branch: "origin/main" };');
+    await writeFileAsync('alternate.config.js', 'module.exports = { branch: "origin/foo" };')
+    return getOptions([...baseArgv, '--config', 'alternate.config.js']);
+  });
+  expect(config.branch).toEqual('origin/foo');
 });
 
 const writeConfig = async (contents: string) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { getOptions } from './options/getOptions';
 import { validate } from './validation/validate';
 
 (async () => {
-  const options = getOptions();
+  const options = getOptions(process.argv);
 
   if (options.help) {
     showHelp();

--- a/src/options/getOptions.ts
+++ b/src/options/getOptions.ts
@@ -6,6 +6,6 @@ import { getDefaultOptions } from './getDefaultOptions';
 /**
  * Gets all repo level options (default + root options + cli options)
  */
-export function getOptions(): BeachballOptions {
-  return { ...getDefaultOptions(), ...getRootOptions(), ...getCliOptions() };
+export function getOptions(argv: string[]): BeachballOptions {
+  return { ...getDefaultOptions(), ...getRootOptions(argv), ...getCliOptions(argv) };
 }

--- a/src/options/getOptions.ts
+++ b/src/options/getOptions.ts
@@ -7,5 +7,6 @@ import { getDefaultOptions } from './getDefaultOptions';
  * Gets all repo level options (default + root options + cli options)
  */
 export function getOptions(argv: string[]): BeachballOptions {
-  return { ...getDefaultOptions(), ...getRootOptions(argv), ...getCliOptions(argv) };
+  const cliOptions = getCliOptions(argv);
+  return { ...getDefaultOptions(), ...getRootOptions(cliOptions), ...cliOptions };
 }

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -11,12 +11,13 @@ import path from 'path';
  */
 export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageOptions>): PackageOptions {
   const defaultOptions = getDefaultOptions();
-  const rootOptions = getRootOptions(process.argv);
+  const cliOptions = getCliOptions(process.argv);
+  const rootOptions = getRootOptions(cliOptions);
   return {
     ...defaultOptions,
     ...rootOptions,
     ...actualPackageOptions,
-    ...getCliOptions(process.argv),
+    ...cliOptions,
   };
 }
 

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -11,12 +11,12 @@ import path from 'path';
  */
 export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageOptions>): PackageOptions {
   const defaultOptions = getDefaultOptions();
-  const rootOptions = getRootOptions();
+  const rootOptions = getRootOptions(process.argv);
   return {
     ...defaultOptions,
     ...rootOptions,
     ...actualPackageOptions,
-    ...getCliOptions(),
+    ...getCliOptions(process.argv),
   };
 }
 

--- a/src/options/getRootOptions.ts
+++ b/src/options/getRootOptions.ts
@@ -1,14 +1,11 @@
 import { cosmiconfigSync } from 'cosmiconfig';
-import { RepoOptions } from '../types/BeachballOptions';
-import { getCliOptions } from './getCliOptions';
+import { RepoOptions, CliOptions } from '../types/BeachballOptions';
 
-export function getRootOptions(argv: string[]): RepoOptions {
-  const {configPath} = getCliOptions(argv);
-
-  if (configPath) {
-    const repoOptions = tryLoadConfig(configPath);
+export function getRootOptions(cliOptions: CliOptions): RepoOptions {
+  if (cliOptions.configPath) {
+    const repoOptions = tryLoadConfig(cliOptions.configPath);
     if (!repoOptions) {
-      console.error(`Config file "${configPath}" could not be loaded`);
+      console.error(`Config file "${cliOptions.configPath}" could not be loaded`);
       process.exit(1);
     }
 

--- a/src/options/getRootOptions.ts
+++ b/src/options/getRootOptions.ts
@@ -1,11 +1,31 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import { RepoOptions } from '../types/BeachballOptions';
+import { getCliOptions } from './getCliOptions';
 
-export function getRootOptions(): RepoOptions {
+export function getRootOptions(argv: string[]): RepoOptions {
+  const {configPath} = getCliOptions(argv);
+
+  if (configPath) {
+    const repoOptions = tryLoadConfig(configPath);
+    if (!repoOptions) {
+      console.error(`Config file "${configPath}" could not be loaded`);
+      process.exit(1);
+    }
+
+    return repoOptions;
+  }
+
+  return trySearchConfig() || {};
+}
+
+function tryLoadConfig(configPath: string): RepoOptions {
+  const configExplorer = cosmiconfigSync('beachball');
+  const loadResults = configExplorer.load(configPath);
+  return (loadResults && loadResults.config) || null;
+}
+
+function trySearchConfig(): RepoOptions {
   const configExplorer = cosmiconfigSync('beachball');
   const searchResults = configExplorer.search();
-  if (searchResults && searchResults.config) {
-    return searchResults.config;
-  }
-  return {} as RepoOptions;
+  return (searchResults && searchResults.config) || null;
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -37,6 +37,7 @@ export interface CliOptions {
   dependentChangeType: ChangeType | null;
   disallowDeletedChangeFiles?: boolean;
   prereleasePrefix?: string | null;
+  configPath?: string;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
Automated testing for this change was a bit tricky. To make options code more testable, we allowing injecting argv instead of grabbing from the process, which we should not mutate, and may have flags we don't want. E.g. E2ETest will run jest with a `--config` flag we don't want in our tests.

This exposed some issues where `getCliOptions` was accidentally trimming bits off of process.argv, and we needed to change the CLI options cache to allow different values of argv to have different results. We do this by special casing the cache to only cache when the input is process.argv, which should be immutable and will be the only option used in production code.