### PR TITLE
feat(change): add --no-commit flag to CLI

### DIFF
--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs-extra';
+import { RepositoryFactory } from '../fixtures/repository';
+import { git } from '../git';
+import { change } from '../commands/change';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { getChangePath } from '../paths';
+
+describe('change command', () => {
+  let repositoryFactory: RepositoryFactory | undefined;
+
+  function getChangeFiles(cwd: string): string[] {
+    const changePath = getChangePath(cwd);
+    const changeFiles = changePath && fs.existsSync(changePath) ? fs.readdirSync(changePath) : [];
+    return changeFiles;
+  }
+
+  afterEach(async () => {
+    if (repositoryFactory) {
+      repositoryFactory.cleanUp();
+      repositoryFactory = undefined;
+    }
+  });
+
+  it('create change file but git stage only', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    await change({
+      type: 'minor',
+      dependentChangeType: 'patch',
+      package: 'pkg-1',
+      message: 'stage me please',
+      path: repo.rootPath,
+      commit: false,
+    } as BeachballOptions);
+
+    const output = git(['status', '-s'], { cwd: repo.rootPath });
+    expect(output.success).toBeTruthy();
+    expect(output.stdout.startsWith('A')).toBeTruthy();
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(1);
+  });
+
+  it('create change file and commit', async () => {
+    repositoryFactory = new RepositoryFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    await repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    await change({
+      type: 'minor',
+      dependentChangeType: 'patch',
+      package: 'pkg-1',
+      message: 'commit me please',
+      path: repo.rootPath,
+    } as BeachballOptions);
+
+    const output = git(['status', '-s'], { cwd: repo.rootPath });
+    expect(output.success).toBeTruthy();
+    expect(output.stdout.length).toBe(0);
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(1);
+  });
+});

--- a/src/changefile/writeChangeFiles.ts
+++ b/src/changefile/writeChangeFiles.ts
@@ -1,6 +1,6 @@
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
-import { getBranchName, stageAndCommit } from '../git';
+import { getBranchName, stage, commit } from '../git';
 import fs from 'fs-extra';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,7 +13,8 @@ export function writeChangeFiles(
   changes: {
     [pkgname: string]: ChangeFileInfo;
   },
-  cwd: string
+  cwd: string,
+  commitChangeFiles = true
 ): string[] {
   if (Object.keys(changes).length === 0) {
     return [];
@@ -37,11 +38,16 @@ export function writeChangeFiles(
       return changeFile;
     });
 
-    stageAndCommit(changeFiles, 'Change files', cwd);
+    stage(changeFiles, cwd);
+    if (commitChangeFiles) {
+      commit('Change files', cwd);
+    }
 
-    console.log(`git committed these change files:
-${changeFiles.map(f => ` - ${f}`).join('\n')}
-`);
+    console.log(
+      `git ${commitChangeFiles ? 'commited' : 'staged'} these change files: ${changeFiles
+        .map(f => ` - ${f}`)
+        .join('\n')}`
+    );
     return changeFiles;
   }
 

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -6,6 +6,6 @@ export async function change(options: BeachballOptions) {
   const changes = await promptForChange(options);
 
   if (changes) {
-    writeChangeFiles(changes, options.path);
+    writeChangeFiles(changes, options.path, options.commit);
   }
 }

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -250,12 +250,18 @@ export function getFileAddedHash(filename: string, cwd: string) {
   return undefined;
 }
 
-export function stageAndCommit(patterns: string[], message: string, cwd: string) {
+export function stage(patterns: string[], cwd: string) {
   try {
     patterns.forEach(pattern => {
       git(['add', pattern], { cwd });
     });
+  } catch (e) {
+    console.error('Cannot stage changes', e.message);
+  }
+}
 
+export function commit(message: string, cwd: string) {
+  try {
     const commitResults = git(['commit', '-m', message], { cwd });
 
     if (!commitResults.success) {
@@ -264,7 +270,7 @@ export function stageAndCommit(patterns: string[], message: string, cwd: string)
       console.error(commitResults.stderr);
     }
   } catch (e) {
-    console.error('Cannot stage and commit changes', e.message);
+    console.error('Cannot commit changes', e.message);
   }
 }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -34,6 +34,7 @@ Options:
   --no-push                       - skip pushing changes back to git remote origin
   --no-publish                    - skip publishing to the npm registry
   --no-bump                       - skip both bumping versions and pushing changes back to git remote origin when publishing;
+  --no-commit                     - for the change command: stage change files only without autocommitting them
   --help, -?, -h                  - this very help message
   --yes, -y                       - skips the prompts for publish
   --package, -p                   - manually specify a package to create a change file; creates a change file regardless of diffs

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -5,7 +5,7 @@ import { getDefaultRemoteBranch } from '../git';
 
 let cachedCliOptions: CliOptions;
 
-export function getCliOptions(argv: string[]) : CliOptions {
+export function getCliOptions(argv: string[]): CliOptions {
   // Special case caching to process.argv which should be immutable
   if (argv === process.argv) {
     if (!cachedCliOptions) {
@@ -24,7 +24,7 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
   const args = parser(trimmedArgv, {
     string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type', 'config'],
     array: ['scope', 'disallowed-change-types'],
-    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files'],
+    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit'],
     alias: {
       branch: ['b'],
       config: ['c'],

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -38,6 +38,7 @@ export interface CliOptions {
   disallowDeletedChangeFiles?: boolean;
   prereleasePrefix?: string | null;
   configPath?: string;
+  commit?: boolean;
 }
 
 export interface RepoOptions {


### PR DESCRIPTION
This commit adds `--no-commit` flag which only affects `beachball change` command. With this flag set, the change files generated with `beachball change` will only be staged for commit in git, but the commit will have to be done manually by the caller of `beachball`. The defaults stay the same, i.e., by default we still stage and autocommit the generated change files for the user with message 'Change file'.

Suggested usage for only staging change files:

```
beachball change --no-commit
```

This addition is motivated by a few of us working on [microsoft/fluentui](https://github.com/microsoft/fluentui) constantly finding ourselves uncommitting the change files and then squashing them with the actual changes to the codebase.