### PR TITLE
check: Add validation of published package deps

### DIFF
--- a/change/beachball-8b85a3d0-0204-430c-ae46-b75a6902d9f4.json
+++ b/change/beachball-8b85a3d0-0204-430c-ae46-b75a6902d9f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "check: Add validation of published package deps",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -103,6 +103,7 @@ export async function promptForChange(options: BeachballOptions) {
       if (!response.type) {
         if (!options.type) {
           console.log("WARN: change type 'none' assumed by default");
+          console.log('(Not what you intended? Check the repo-level and package-level beachball configs.)');
         }
         response = { ...response, type: options.type || 'none' };
       }

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -9,7 +9,8 @@ export function validatePackageDependencies(bumpInfo: BumpInfo, quiet?: boolean)
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
   const packagesToValidate = [...modifiedPackages, ...newPackages];
-  const allDeps: { [pkg: string]: string[] } = {};
+  /** Mapping from dep to all validated packages that depend on it */
+  const allDeps: { [dep: string]: string[] } = {};
   for (const pkg of packagesToValidate) {
     const { publish, reasonToSkip } = shouldPublishPackage(bumpInfo, pkg);
     if (!publish) {

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -4,7 +4,7 @@ import { shouldPublishPackage } from './shouldPublishPackage';
 /**
  * Validate no private package is listed as package dependency for packages which will be published.
  */
-export function validatePackageDependencies(bumpInfo: BumpInfo, quiet?: boolean): boolean {
+export function validatePackageDependencies(bumpInfo: BumpInfo): boolean {
   let hasErrors: boolean = false;
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
@@ -14,9 +14,7 @@ export function validatePackageDependencies(bumpInfo: BumpInfo, quiet?: boolean)
   for (const pkg of packagesToValidate) {
     const { publish, reasonToSkip } = shouldPublishPackage(bumpInfo, pkg);
     if (!publish) {
-      if (!quiet) {
-        console.log(`Skipping package dep validation - ${reasonToSkip}`);
-      }
+      console.log(`Skipping package dep validation - ${reasonToSkip}`);
       continue;
     }
 

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -11,6 +11,8 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes';
 import { areChangeFilesDeleted } from './areChangeFilesDeleted';
+import { validatePackageDependencies } from '../publish/validatePackageDependencies';
+import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 
 type ValidationOptions = { allowMissingChangeFiles: boolean; allowFetching: boolean };
 type PartialValidateOptions = Partial<ValidationOptions>;
@@ -91,6 +93,19 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
       console.error(
         `ERROR: there is an invalid change type detected ${changeFile}: "${change.type}" is not a valid change type`
       );
+      process.exit(1);
+    }
+  }
+
+  if (!isChangeNeeded) {
+    const bumpInfo = gatherBumpInfo(options);
+    if (!validatePackageDependencies(bumpInfo, true)) {
+      console.error(`ERROR: one or more published packages depend on an unpublished package!
+
+Consider one of the following solutions:
+- If the unpublished package should be published, remove "private": true from its package.json.
+- If it should NOT be published, verify that it is only listed under devDependencies of published packages.
+`);
       process.exit(1);
     }
   }

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -99,7 +99,7 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
 
   if (!isChangeNeeded) {
     const bumpInfo = gatherBumpInfo(options);
-    if (!validatePackageDependencies(bumpInfo, true)) {
+    if (!validatePackageDependencies(bumpInfo)) {
       console.error(`ERROR: one or more published packages depend on an unpublished package!
 
 Consider one of the following solutions:


### PR DESCRIPTION
In Fluent UI we've repeatedly had issues where someone adds a new package which accidentally has `"private": true` set in its package.json, adds the new package as a dep of a published package, and this isn't detected until publishing fails.

Fix is to update `beachball check` to run the same validation logic that's used before publishing to catch these types of errors.