### PR TITLE
Add postpublish hook

### DIFF
--- a/change/beachball-e50c5d70-a427-41d3-9181-a65cbb99530e.json
+++ b/change/beachball-e50c5d70-a427-41d3-9181-a65cbb99530e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add postpublish hook",
+  "packageName": "beachball",
+  "email": "mmaclachlan@ccri.com",
+  "dependentChangeType": "patch"
+}

--- a/src/fixtures/monorepo.ts
+++ b/src/fixtures/monorepo.ts
@@ -18,6 +18,9 @@ export const packageJsonFixtures: { [path: string]: PackageJson } = {
     onPublish: {
       main: 'lib/index.js',
     },
+    afterPublish: {
+      notify: 'message'
+    },
   } as PackageJson,
 
   'packages/bar': {

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -43,11 +43,15 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     return publish;
   });
 
-  // if there is a prepublish hook perform a prepublish pass, calling the routine on each package
-  const prepublishHook = options.hooks?.prepublish;
-  if (prepublishHook) {
-    for (const pkg of packagesToPublish) {
-      const packageInfo = bumpInfo.packageInfos[pkg];
+
+  // finally pass through doing the actual npm publish command
+  for (const pkg of packagesToPublish) {
+    const packageInfo = packageInfos[pkg];
+    console.log(`Publishing - ${packageInfo.name}@${packageInfo.version} with tag ${packageInfo.combinedOptions.tag}.`);
+
+    // if there is a prepublish hook perform a prepublish
+    const prepublishHook = options.hooks?.prepublish;
+    if (prepublishHook) {
       const maybeAwait = prepublishHook(
         path.dirname(packageInfo.packageJsonPath),
         packageInfo.name,
@@ -57,12 +61,6 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
         await maybeAwait;
       }
     }
-  }
-
-  // finally pass through doing the actual npm publish command
-  for (const pkg of packagesToPublish) {
-    const packageInfo = bumpInfo.packageInfos[pkg];
-    console.log(`Publishing - ${packageInfo.name}@${packageInfo.version} with tag ${packageInfo.combinedOptions.tag}.`);
 
     let result;
     let retries = 0;
@@ -73,6 +71,20 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       if (result.success) {
         console.log('Published!');
         succeededPackages.add(pkg);
+
+        // if there is a postpublish hook perform a postpublish
+        const postpublishHook = options.hooks?.postpublish;
+        if (postpublishHook) {
+          const maybeAwait = postpublishHook(
+            path.dirname(packageInfo.packageJsonPath),
+            packageInfo.name,
+            packageInfo.version
+          );
+          if (maybeAwait instanceof Promise) {
+            await maybeAwait;
+          }
+        }
+
         break;
       } else {
         retries++;
@@ -90,22 +102,6 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       displayManualRecovery(bumpInfo, succeededPackages);
       console.error(result.stderr);
       throw new Error('Error publishing, refer to the previous error messages for recovery instructions');
-    }
-  }
-
-  // if there is a postpublish hook perform a postpublish pass, calling the routine on each package
-  const postpublishHook = options.hooks?.postpublish;
-  if (postpublishHook) {
-    for (const pkg of packagesToPublish) {
-      const packageInfo = bumpInfo.packageInfos[pkg];
-      const maybeAwait = postpublishHook(
-        path.dirname(packageInfo.packageJsonPath),
-        packageInfo.name,
-        packageInfo.version
-      );
-      if (maybeAwait instanceof Promise) {
-        await maybeAwait;
-      }
     }
   }
 }

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -92,4 +92,20 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       throw new Error('Error publishing, refer to the previous error messages for recovery instructions');
     }
   }
+
+  // if there is a postpublish hook perform a postpublish pass, calling the routine on each package
+  const postpublishHook = options.hooks?.postpublish;
+  if (postpublishHook) {
+    for (const pkg of packagesToPublish) {
+      const packageInfo = bumpInfo.packageInfos[pkg];
+      const maybeAwait = postpublishHook(
+        path.dirname(packageInfo.packageJsonPath),
+        packageInfo.name,
+        packageInfo.version
+      );
+      if (maybeAwait instanceof Promise) {
+        await maybeAwait;
+      }
+    }
+  }
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -73,6 +73,12 @@ export interface RepoOptions {
      * repository.
      */
     prepublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+
+    /**
+     * Runs for each package after the publish command.
+     *
+     */
+    postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
   };
 }
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -76,6 +76,7 @@ export interface RepoOptions {
 
     /**
      * Runs for each package after the publish command.
+     * Any file changes made in this step will **not** be committed automatically.
      */
     postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
   };

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -76,7 +76,6 @@ export interface RepoOptions {
 
     /**
      * Runs for each package after the publish command.
-     *
      */
     postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
   };


### PR DESCRIPTION
Add postpublish hook used to modify files after publishing, or to kick off other processes. One concrete example is to update lock files, which currently don't get updated (using npm)--see #482.

Fixes #488 
Fixes #482