### PR TITLE
Warning if package.json config is empty

### DIFF
--- a/src/__tests__/options/getPackageOptions.test.ts
+++ b/src/__tests__/options/getPackageOptions.test.ts
@@ -1,0 +1,53 @@
+import { cosmiconfigSync } from 'cosmiconfig';
+import { getPackageOptions } from '../../options/getPackageOptions';
+import { PackageOptions } from '../../types/BeachballOptions';
+
+jest.mock('cosmiconfig');
+
+describe('getPackageOptions', () => {
+  const defaultConfig: PackageOptions = {
+    gitTags: true,
+    defaultNpmTag: 'latest',
+    disallowedChangeTypes: ['major'],
+    tag: null,
+  };
+  const mockCosmiconfig = (options: Partial<PackageOptions> = {}, result: any = {}) => {
+    (cosmiconfigSync as jest.Mock).mockReturnValue({
+      load: (): any => ({
+        filepath: '',
+        config: {
+          ...defaultConfig,
+          ...options,
+        },
+        ...result,
+      }),
+    });
+  };
+
+  it('should return config if defined', () => {
+    // Arrange
+    mockCosmiconfig();
+
+    // Act
+    const res = getPackageOptions('/path/test');
+
+    // Assert
+    expect(res).toEqual(defaultConfig);
+  });
+
+  it.each([null, undefined])('should return empty object if config is %s', config => {
+    // Arrange
+    mockCosmiconfig({}, { config });
+
+    // Act & Assert
+    expect(getPackageOptions('/path/test')).toEqual({});
+  });
+
+  it.each([null, undefined])('should return empty object if config is %s', returnValue => {
+    // Arrange
+    (cosmiconfigSync as jest.Mock).mockReturnValue({ load: () => returnValue });
+
+    // Act & Assert
+    expect(getPackageOptions('/path/test')).toEqual({});
+  });
+});

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -13,6 +13,7 @@ export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageO
   const defaultOptions = getDefaultOptions();
   const cliOptions = getCliOptions(process.argv);
   const rootOptions = getRootOptions(cliOptions);
+
   return {
     ...defaultOptions,
     ...rootOptions,
@@ -26,11 +27,17 @@ export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageO
  */
 export function getPackageOptions(packagePath: string): Partial<PackageOptions> {
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
+  console.log(configExplorer);
   try {
     const results = configExplorer.load(path.join(packagePath, 'package.json'));
-    return (results && results.config) || {};
+    if (results && results.config) {
+      return results.config;
+    }
+
+    throw new Error('Config is undefined or empty');
   } catch (e) {
     // File does not exist, returns the default packageOptions
+    console.warn(`${packagePath} has no beachball config`);
     return {};
   }
 }

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -27,7 +27,6 @@ export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageO
  */
 export function getPackageOptions(packagePath: string): Partial<PackageOptions> {
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
-  console.log(configExplorer);
   try {
     const results = configExplorer.load(path.join(packagePath, 'package.json'));
     if (results && results.config) {


### PR DESCRIPTION
This PR adds a warning if beachball config is not set in package.json,
which could help future debug attempts for errors. i.e. root config
might not be behaving as you would expect

Co-authored-by: Jakub Konka <jakubkonka@microsoft.com>