### PR TITLE
Use getWorkspaces() rather than listAllTrackedFiles() to get packages.

### DIFF
--- a/change/beachball-9ec2303e-6777-4b37-9a83-a17fe56954a1.json
+++ b/change/beachball-9ec2303e-6777-4b37-9a83-a17fe56954a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "more workspace-tools integration: getPackageInfos",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -1,30 +1,36 @@
 import { findPackageRoot, findProjectRoot } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
-import { listAllTrackedFiles } from 'workspace-tools';
+import { getWorkspaces } from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 
 export function getPackageInfos(cwd: string) {
   const root = findProjectRoot(cwd)!;
-  const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], root);
   const packageInfos: PackageInfos = {};
 
-  if (packageJsonFiles && packageJsonFiles.length > 0) {
-    packageJsonFiles.forEach(packageJsonPath => {
-      try {
-        const packageJsonFullPath = path.join(root, packageJsonPath);
-        const packageJson = fs.readJSONSync(packageJsonFullPath);
-        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
-      } catch (e) {
-        // Pass, the package.json is invalid
-        console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
-      }
-    });
-  } else {
-    const packageJsonFullPath = path.join(root, findPackageRoot(cwd)!, 'package.json');
+  try {
+    const workspaceInfo = getWorkspaces(root);
+
+    if (workspaceInfo && workspaceInfo.length > 0) {
+      workspaceInfo.forEach(info => {
+        const { path: packagePath, packageJson } = info;
+        const packageJsonPath = path.join(packagePath, 'package.json');
+
+        try {
+          packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
+        } catch (e) {
+          // Pass, the package.json is invalid
+          console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
+        }
+      });
+    }
+
+    return packageInfos;
+  } catch (e) {
+    const packageJsonFullPath = path.resolve(findPackageRoot(cwd)!, 'package.json');
     const packageJson = fs.readJSONSync(packageJsonFullPath);
     packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
+    return packageInfos;
   }
-  return packageInfos;
 }

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -1,16 +1,28 @@
 import { findPackageRoot, findProjectRoot } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
-import { getWorkspaces } from 'workspace-tools';
+import { getWorkspaces, listAllTrackedFiles } from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 
 export function getPackageInfos(cwd: string) {
-  const root = findProjectRoot(cwd)!;
-  const packageInfos: PackageInfos = {};
+  const projectRoot = findProjectRoot(cwd);
+  const packageRoot = findPackageRoot(cwd);
 
+  return (
+    (projectRoot && getPackageInfosFromWorkspace(projectRoot)) ||
+    (projectRoot && getPackageInfosFromNonWorkspaceMonorepo(projectRoot)) ||
+    (packageRoot && getPackageInfosFromSingleRepo(packageRoot)) ||
+    {}
+  );
+}
+
+function getPackageInfosFromWorkspace(projectRoot: string) {
   try {
-    const workspaceInfo = getWorkspaces(root);
+    const packageInfos: PackageInfos = {};
+
+    // first try using the workspace provided packages (if available)
+    const workspaceInfo = getWorkspaces(projectRoot);
 
     if (workspaceInfo && workspaceInfo.length > 0) {
       workspaceInfo.forEach(info => {
@@ -24,13 +36,39 @@ export function getPackageInfos(cwd: string) {
           console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
         }
       });
+
+      return packageInfos;
     }
+  } catch (e) {
+    // not a recognized workspace from workspace-tools
+  }
+}
+
+function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string) {
+  const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], projectRoot);
+
+  const packageInfos: PackageInfos = {};
+
+  if (packageJsonFiles && packageJsonFiles.length > 0) {
+    packageJsonFiles.forEach(packageJsonPath => {
+      try {
+        const packageJsonFullPath = path.join(projectRoot, packageJsonPath);
+        const packageJson = fs.readJSONSync(packageJsonFullPath);
+        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
+      } catch (e) {
+        // Pass, the package.json is invalid
+        console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
+      }
+    });
 
     return packageInfos;
-  } catch (e) {
-    const packageJsonFullPath = path.resolve(findPackageRoot(cwd)!, 'package.json');
-    const packageJson = fs.readJSONSync(packageJsonFullPath);
-    packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
-    return packageInfos;
   }
+}
+
+function getPackageInfosFromSingleRepo(packageRoot: string) {
+  const packageInfos: PackageInfos = {};
+  const packageJsonFullPath = path.resolve(packageRoot, 'package.json');
+  const packageJson = fs.readJSONSync(packageJsonFullPath);
+  packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
+  return packageInfos;
 }


### PR DESCRIPTION
Using the workspace-tools getWorkspaces() to get packageInfo rather than the listAllTrackedFiles which could be error prone if there are package.json checked in but not in a workspace.