### PR TITLE
Fix: update canary cli command to respect --no-publish flag 

### DIFF
--- a/change/beachball-226ed93e-ad37-4475-8be5-5a684c13c8a4.json
+++ b/change/beachball-226ed93e-ad37-4475-8be5-5a684c13c8a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update canary command to respect --no-publish flag",
+  "packageName": "beachball",
+  "email": "mail@jamesburnside.com",
+  "dependentChangeType": "patch"
+}

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -38,5 +38,9 @@ export async function canary(options: BeachballOptions) {
 
   await performBump(bumpInfo, options);
 
-  await publishToRegistry(bumpInfo, options);
+  if (options.publish) {
+    await publishToRegistry(bumpInfo, options);
+  } else {
+    console.log('Skipping publish');
+  }
 }


### PR DESCRIPTION
## What
This change updates the canary cli command to respect --no-publish

**Behavior before**
```
D:\repos\beachball [jaburnsi/fixNoPublishCanary ≡ +0 ~1 -0 !]> node ./lib/cli.js canary --canary-name canaryname --tag canarytag --no-publish
Validating no private package among package dependencies OK!
Validating package version - beachball@1.53.2-canaryname.0 OK!
Validating no private package among package dependencies OK!
Publishing - beachball@1.53.2-canaryname.0 with tag canarytag.
publish command: publish --registry https://registry.npmjs.org/ --tag canarytag --loglevel warn
```

**Behavior after**
```
D:\repos\beachball [jaburnsi/fixNoPublishCanary]> node ./lib/cli.js canary --canary-name canaryname --tag canarytag --no-publish
Validating no private package among package dependencies OK!
Skipping publish
```