### PR TITLE
MAJOR BUMP to 2.0: breaking change is to move to node 12.0+

### DIFF
--- a/change/beachball-bfdc4803-018a-4049-8780-3efffac42b81.json
+++ b/change/beachball-bfdc4803-018a-4049-8780-3efffac42b81.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "MAJOR BUMP! Adding a requirement of node engine 12+",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beachball",
-  "version": "1.53.2",
+  "version": "2.0.0",
   "description": "The Sunniest Semantic Version Bumper",
   "repository": {
     "type": "git",
@@ -11,6 +11,9 @@
   "types": "lib/index.d.ts",
   "bin": {
     "beachball": "./bin/beachball.js"
+  },
+  "engines": {
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc",
@@ -54,7 +57,7 @@
     "@types/jest": "^24.0.17",
     "@types/lodash": "^4.14.149",
     "@types/minimatch": "^3.0.3",
-    "@types/node": "^8.10.51",
+    "@types/node": "^12.0.0",
     "@types/p-limit": "^2.2.0",
     "@types/prompts": "~2.0.0",
     "@types/tmp": "^0.1.0",

--- a/src/fixtures/registry.ts
+++ b/src/fixtures/registry.ts
@@ -49,9 +49,13 @@ export class Registry {
     return new Promise((resolve, reject) => {
       this.server = spawn(process.execPath, [verdaccioApi, port.toString()]);
 
+      if (!this.server || !this.server.stdout || !this.server.stderr) {
+        return reject();
+      }
+
       this.server.stdout.on('data', data => {
         if (data.includes('verdaccio running')) {
-          resolve();
+          resolve(port);
         }
       });
 

--- a/src/packageManager/npm.ts
+++ b/src/packageManager/npm.ts
@@ -1,7 +1,6 @@
-import { SpawnSyncOptions } from 'child_process';
 import execa from 'execa';
 
-export function npm(args: string[], options: SpawnSyncOptions = {}) {
+export function npm(args: string[], options: execa.SyncOptions = {}) {
   try {
     const result = execa.sync('npm', args, { ...options });
     return {
@@ -16,7 +15,7 @@ export function npm(args: string[], options: SpawnSyncOptions = {}) {
   }
 }
 
-export async function npmAsync(args: string[], options: SpawnSyncOptions = {}) {
+export async function npmAsync(args: string[], options: execa.Options = {}) {
   try {
     const result = await execa('npm', args, { ...options });
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,10 +1478,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
-"@types/node@^8.10.51":
-  version "8.10.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.51.tgz#80600857c0a47a8e8bafc2dae6daed6db58e3627"
-  integrity sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==
+"@types/node@^12.0.0":
+  version "12.20.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
+  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
 
 "@types/p-limit@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
Dependency up now that node 10 is almost EOL'ed.

* node engine is now at 12.0.0+
* added @types/node@^12.0.0
* fixed typing errors (execa.Options not compatible?)