### PR TITLE
Validate the dependentChangeType field

### DIFF
--- a/change/beachball-b9f81072-b73d-4dae-8e88-092f9f64654e.json
+++ b/change/beachball-b9f81072-b73d-4dae-8e88-092f9f64654e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add validation for the dependentChangeType field in changefiles",
+  "packageName": "beachball",
+  "email": "nickykalu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -84,6 +84,7 @@ export function updateRelatedChangeType(
           email: depChangeInfo.email,
           commit: depChangeInfo.commit,
           comment: '', // comment will be populated at later stages when new versions are computed
+          dependentChangeType: depChangeInfo.type,
         };
 
         if (prevChangeInfo) {

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -8,7 +8,7 @@ export interface ChangeFileInfo {
   comment: string;
   packageName: string;
   email: string;
-  dependentChangeType?: ChangeType;
+  dependentChangeType: ChangeType;
 }
 
 /**

--- a/src/validation/isValidDependantChangeType.ts
+++ b/src/validation/isValidDependantChangeType.ts
@@ -1,3 +1,11 @@
-export function isValidDependentChangeType(dependentChangeType: string) {
-  return ['patch', 'major', 'minor', 'prerelease', 'none'].includes(dependentChangeType);
+import { ChangeType } from '../types/ChangeInfo';
+
+export function isValidDependentChangeType(
+  dependentChangeType: ChangeType,
+  disallwedDependentChangeTypes: ChangeType[] | null
+) {
+  return (
+    ['patch', 'major', 'minor', 'prerelease', 'none'].includes(dependentChangeType) &&
+    !disallwedDependentChangeTypes?.includes(dependentChangeType)
+  );
 }

--- a/src/validation/isValidDependantChangeType.ts
+++ b/src/validation/isValidDependantChangeType.ts
@@ -1,0 +1,3 @@
+export function isValidDependentChangeType(dependentChangeType: string) {
+  return ['patch', 'major', 'minor', 'prerelease', 'none'].includes(dependentChangeType);
+}

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -96,7 +96,7 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
       );
       process.exit(1);
     }
-    if (!change.dependentChangeType && !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
+    if (!change.dependentChangeType || !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
       console.error(
         `ERROR: there is an invalid dependentChangeType detected ${changeFile}: "${change.dependentChangeType}" is not a valid dependentChangeType`
       );

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -13,6 +13,7 @@ import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes
 import { areChangeFilesDeleted } from './areChangeFilesDeleted';
 import { validatePackageDependencies } from '../publish/validatePackageDependencies';
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
+import { isValidDependentChangeType } from './isValidDependantChangeType';
 
 type ValidationOptions = { allowMissingChangeFiles: boolean; allowFetching: boolean };
 type PartialValidateOptions = Partial<ValidationOptions>;
@@ -92,6 +93,16 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     if (!change.type || !isValidChangeType(change.type) || disallowedChangeTypes?.includes(change.type)) {
       console.error(
         `ERROR: there is an invalid change type detected ${changeFile}: "${change.type}" is not a valid change type`
+      );
+      process.exit(1);
+    }
+    if (
+      !change.dependentChangeType ||
+      !isValidDependentChangeType(change.dependentChangeType) ||
+      disallowedChangeTypes?.includes(change.dependentChangeType)
+    ) {
+      console.error(
+        `ERROR: there is an invalid dependentChangeType detected ${changeFile}: "${change.dependentChangeType}" is not a valid dependentChangeType`
       );
       process.exit(1);
     }

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -96,11 +96,7 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
       );
       process.exit(1);
     }
-    if (
-      !change.dependentChangeType ||
-      !isValidDependentChangeType(change.dependentChangeType) ||
-      disallowedChangeTypes?.includes(change.dependentChangeType)
-    ) {
+    if (!change.dependentChangeType || !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
       console.error(
         `ERROR: there is an invalid dependentChangeType detected ${changeFile}: "${change.dependentChangeType}" is not a valid dependentChangeType`
       );

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -96,7 +96,7 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
       );
       process.exit(1);
     }
-    if (!change.dependentChangeType || !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
+    if (!change.dependentChangeType && !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
       console.error(
         `ERROR: there is an invalid dependentChangeType detected ${changeFile}: "${change.dependentChangeType}" is not a valid dependentChangeType`
       );


### PR DESCRIPTION
Validate the dependentChangeType field in the changefile.
Validations include: 

- Check if it is a valid change type.
- Check if it is not a disallowed change type (if specified)