### PR TITLE
chore: Fix a typo in the status message

### DIFF
--- a/src/changefile/writeChangeFiles.ts
+++ b/src/changefile/writeChangeFiles.ts
@@ -46,7 +46,7 @@ export function writeChangeFiles(
     }
 
     console.log(
-      `git ${commitChangeFiles ? 'commited' : 'staged'} these change files: ${changeFiles
+      `git ${commitChangeFiles ? 'committed' : 'staged'} these change files: ${changeFiles
         .map(f => ` - ${f}`)
         .join('\n')}`
     );


### PR DESCRIPTION
The status message says:
> git commited these change files: <list>

In fact, it should say "committed".