### PR TITLE
No hash in change & rewritten updateRelatedChangeTypes

### DIFF
--- a/change/beachball-a9607dc7-0c16-4883-a0d1-77911df68c28.json
+++ b/change/beachball-a9607dc7-0c16-4883-a0d1-77911df68c28.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Beachball check is going to be much faster",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -86,6 +86,8 @@ describe('changelog generation', () => {
     it('generates correct changelog', async () => {
       const repository = await repositoryFactory.cloneRepository();
       await repository.commitChange('foo');
+      writeChangeFiles({ foo: getChange({ comment: 'additional comment 2' }) }, repository.rootPath);
+      writeChangeFiles({ foo: getChange({ comment: 'additional comment 1' }) }, repository.rootPath);
       writeChangeFiles({ foo: getChange() }, repository.rootPath);
 
       await repository.commitChange('bar');

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -5,9 +5,9 @@ import { ChangeInfo } from '../../types/ChangeInfo';
 
 describe('updateRelatedChangeType', () => {
   const bumpInfoFixture: BumpInfo = ({
-    changes: new Map(),
+    changeFileChangeInfos: new Map(),
     dependents: {},
-    packageChangeTypes: {},
+    calculatedChangeInfos: {},
     dependentChangeTypes: {
       foo: 'patch',
     },
@@ -25,6 +25,7 @@ describe('updateRelatedChangeType', () => {
         combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
       },
     },
+    dependentChangeInfos: {},
     modifiedPackages: new Set(),
     newPackages: new Set(),
     packageGroups: {},
@@ -45,7 +46,8 @@ describe('updateRelatedChangeType', () => {
       dependents: {
         foo: ['bar'],
       },
-      packageChangeTypes: {
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'minor', dependentChangeType: 'patch' }]]),
+      calculatedChangeInfos: {
         foo: {
           type: 'minor',
         },
@@ -57,25 +59,25 @@ describe('updateRelatedChangeType', () => {
           },
         },
       },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'minor' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
-    expect(dependentChangeInfos.size).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('patch');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
 
-    const fooChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooChangeInfos).toBeDefined();
-    expect(fooChangeInfos?.size).toBe(1);
+    const fooChangeInfo = bumpInfo.dependentChangeInfos['foo'];
+    expect(fooChangeInfo).toBeUndefined();
 
-    const fooChangeInfo = fooChangeInfos?.get('bar');
-    expect(fooChangeInfo?.type).toBe('patch');
-    expect(fooChangeInfo?.packageName).toBe('bar');
-    expect(fooChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(fooChangeInfo?.email).toBe('test@dev.com');
-    expect(fooChangeInfo?.comment).toBe('');
+    const barChangeInfo = bumpInfo.dependentChangeInfos['bar'];
+    expect(barChangeInfo).toBeDefined();
+    expect(barChangeInfo?.type).toBe('patch');
+    expect(barChangeInfo?.packageName).toBe('bar');
+    expect(barChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(barChangeInfo?.email).toBe('test@dev.com');
+    expect(barChangeInfo?.comment).toBe('');
   });
 
   it('should bump dependent packages according to the bumpInfo.dependentChangeTypes', () => {
@@ -83,7 +85,8 @@ describe('updateRelatedChangeType', () => {
       dependents: {
         foo: ['bar'],
       },
-      packageChangeTypes: {
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'patch' }]]),
+      calculatedChangeInfos: {
         foo: { type: 'patch' },
       },
       dependentChangeTypes: {
@@ -96,21 +99,17 @@ describe('updateRelatedChangeType', () => {
           },
         },
       },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(dependentChangeInfos.size).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
 
-    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooDependentChangeInfos).toBeDefined();
-    expect(fooDependentChangeInfos?.size).toBe(1);
-
-    const barDependentChangeInfo = fooDependentChangeInfos?.get('bar');
-
+    const barDependentChangeInfo = bumpInfo.dependentChangeInfos['bar'];
+    expect(barDependentChangeInfo).toBeDefined();
     expect(barDependentChangeInfo?.type).toBe('minor');
     expect(barDependentChangeInfo?.packageName).toBe('bar');
     expect(barDependentChangeInfo?.commit).toBe('0xdeadbeef');
@@ -124,7 +123,11 @@ describe('updateRelatedChangeType', () => {
         foo: ['bar'],
         bar: ['app'],
       },
-      packageChangeTypes: {
+      changeFileChangeInfos: new Map([
+        ['foo', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
+        ['bar', { ...changeInfoFixture, type: 'patch', packageName: 'bar' }],
+      ]),
+      calculatedChangeInfos: {
         foo: { type: 'patch' },
         bar: { type: 'major' },
       },
@@ -144,33 +147,26 @@ describe('updateRelatedChangeType', () => {
           },
         },
       },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('bar', bumpInfo, true);
 
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
-    updateRelatedChangeType('bar', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('major');
+    expect(bumpInfo.calculatedChangeInfos['app'].type).toBe('minor');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(2);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('major');
-    expect(bumpInfo.packageChangeTypes['app'].type).toBe('patch');
-    expect(dependentChangeInfos.size).toBe(2);
+    const barDependentChangeInfo = bumpInfo.dependentChangeInfos['bar'];
+    expect(barDependentChangeInfo).toBeDefined();
+    expect(barDependentChangeInfo?.type).toBe('major');
+    expect(barDependentChangeInfo?.commit).toBe('0xdeadbeef');
+    expect(barDependentChangeInfo?.email).toBe('test@dev.com');
+    expect(barDependentChangeInfo?.comment).toBe('');
 
-    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooDependentChangeInfos?.size).toBe(1);
-
-    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
-    expect(barChangeInfoForFoo?.type).toBe('patch');
-    expect(barChangeInfoForFoo?.packageName).toBe('bar');
-    expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
-    expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
-    expect(barChangeInfoForFoo?.comment).toBe('');
-
-    const barDependentChangeInfos = dependentChangeInfos.get('bar');
-    expect(barDependentChangeInfos?.size).toBe(1);
-
-    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
-    expect(appChangeInfoForBar?.type).toBe('patch');
+    const appChangeInfoForBar = bumpInfo.dependentChangeInfos['app'];
+    expect(appChangeInfoForBar?.type).toBe('minor');
     expect(appChangeInfoForBar?.packageName).toBe('app');
     expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
     expect(appChangeInfoForBar?.email).toBe('test@dev.com');
@@ -184,7 +180,11 @@ describe('updateRelatedChangeType', () => {
         baz: ['bar'],
         bar: ['app'],
       },
-      packageChangeTypes: {
+      changeFileChangeInfos: new Map([
+        ['foo', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
+        ['baz', { ...changeInfoFixture, type: 'patch', email: 'dev@test.com', commit: '0xfeef' }],
+      ]),
+      calculatedChangeInfos: {
         foo: { type: 'patch' },
         baz: { type: 'minor' },
       },
@@ -207,79 +207,35 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['baz'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['app'].type).toBe('patch');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(2);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['app'].type).toBe('patch');
-    expect(dependentChangeInfos.size).toBe(2);
+    const fooDependentChangeInfos = bumpInfo.dependentChangeInfos['foo'];
+    expect(fooDependentChangeInfos).toBeUndefined();
 
-    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooDependentChangeInfos?.size).toBe(1);
-
-    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
+    const barChangeInfoForFoo = bumpInfo.dependentChangeInfos['bar'];
     expect(barChangeInfoForFoo?.type).toBe('patch');
     expect(barChangeInfoForFoo?.packageName).toBe('bar');
     expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
     expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
     expect(barChangeInfoForFoo?.comment).toBe('');
 
-    const barDependentChangeInfos = dependentChangeInfos.get('bar');
-    expect(barDependentChangeInfos?.size).toBe(1);
-
-    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
+    const appChangeInfoForBar = bumpInfo.dependentChangeInfos['app'];
     expect(appChangeInfoForBar?.type).toBe('patch');
     expect(appChangeInfoForBar?.packageName).toBe('app');
     expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
     expect(appChangeInfoForBar?.email).toBe('test@dev.com');
     expect(appChangeInfoForBar?.comment).toBe('');
 
-    updateRelatedChangeType(
-      'baz',
-      { ...changeInfoFixture, type: 'patch', email: 'dev@test.com', commit: '0xfeef' },
-      bumpInfo,
-      dependentChangeInfos,
-      true
-    );
+    updateRelatedChangeType('baz', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['app'].type).toBe('minor');
-    expect(dependentChangeInfos.size).toBe(3);
-
-    const fooDependentChangeInfos2 = dependentChangeInfos.get('foo');
-    expect(fooDependentChangeInfos2?.size).toBe(1);
-
-    const barChangeInfoForFoo2 = fooDependentChangeInfos?.get('bar');
-    expect(barChangeInfoForFoo2?.type).toBe('patch');
-    expect(barChangeInfoForFoo2?.packageName).toBe('bar');
-    expect(barChangeInfoForFoo2?.commit).toBe('0xdeadbeef');
-    expect(barChangeInfoForFoo2?.email).toBe('test@dev.com');
-    expect(barChangeInfoForFoo2?.comment).toBe('');
-
-    const bazDependentChangeInfos = dependentChangeInfos.get('baz');
-    expect(bazDependentChangeInfos?.size).toBe(1);
-
-    const bazChangeInfoForBar = bazDependentChangeInfos?.get('bar');
-    expect(bazChangeInfoForBar?.type).toBe('minor');
-    expect(bazChangeInfoForBar?.packageName).toBe('bar');
-    expect(bazChangeInfoForBar?.commit).toBe('0xfeef');
-    expect(bazChangeInfoForBar?.email).toBe('dev@test.com');
-    expect(bazChangeInfoForBar?.comment).toBe('');
-
-    const barDependentChangeInfos2 = dependentChangeInfos.get('bar');
-    expect(barDependentChangeInfos2?.size).toBe(1);
-
-    const appChangeInfoForBar2 = barDependentChangeInfos2?.get('app');
-    expect(appChangeInfoForBar2?.type).toBe('minor');
-    expect(appChangeInfoForBar2?.packageName).toBe('app');
-    expect(appChangeInfoForBar2?.commit).toBe('0xfeef');
-    expect(appChangeInfoForBar2?.email).toBe('dev@test.com');
-    expect(appChangeInfoForBar2?.comment).toBe('');
+    expect(bumpInfo.dependentChangeInfos['baz']).toBeUndefined();
+    expect(bumpInfo.dependentChangeInfos['bar'].commit).toBe('0xfeef');
   });
 
   it('should bump dependent packages according to the bumpInfo.dependentChangeTypes and roll-up multiple change infos', () => {
@@ -289,7 +245,11 @@ describe('updateRelatedChangeType', () => {
         bar: ['app'],
         baz: ['bar', 'app'],
       },
-      packageChangeTypes: {
+      changeFileChangeInfos: new Map([
+        ['foo', { ...changeInfoFixture, type: 'patch' }],
+        ['baz', { ...changeInfoFixture, type: 'patch' }],
+      ]),
+      calculatedChangeInfos: {
         foo: { type: 'patch' },
         baz: { type: 'patch' },
       },
@@ -297,6 +257,7 @@ describe('updateRelatedChangeType', () => {
         foo: 'major',
         baz: 'minor',
       },
+      dependentChangeInfos: {},
       packageInfos: {
         app: {
           dependencies: {
@@ -313,53 +274,32 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
-    updateRelatedChangeType('baz', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('baz', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['baz'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('major');
-    expect(bumpInfo.packageChangeTypes['app'].type).toBe('major');
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['baz'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('major');
+    expect(bumpInfo.calculatedChangeInfos['app'].type).toBe('major');
 
-    expect(dependentChangeInfos.size).toBe(3);
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(2);
 
-    const fooDependentChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooDependentChangeInfos?.size).toBe(1);
+    const fooDependentChangeInfos = bumpInfo.dependentChangeInfos['foo'];
+    expect(fooDependentChangeInfos).toBeUndefined();
 
-    const barChangeInfoForFoo = fooDependentChangeInfos?.get('bar');
+    const barChangeInfoForFoo = bumpInfo.dependentChangeInfos['bar'];
     expect(barChangeInfoForFoo?.type).toBe('major');
     expect(barChangeInfoForFoo?.packageName).toBe('bar');
     expect(barChangeInfoForFoo?.commit).toBe('0xdeadbeef');
     expect(barChangeInfoForFoo?.email).toBe('test@dev.com');
     expect(barChangeInfoForFoo?.comment).toBe('');
 
-    const barDependentChangeInfos = dependentChangeInfos.get('bar');
-    expect(barDependentChangeInfos?.size).toBe(1);
-
-    const appChangeInfoForBar = barDependentChangeInfos?.get('app');
+    const appChangeInfoForBar = bumpInfo.dependentChangeInfos['app'];
     expect(appChangeInfoForBar?.type).toBe('major');
     expect(appChangeInfoForBar?.packageName).toBe('app');
     expect(appChangeInfoForBar?.commit).toBe('0xdeadbeef');
     expect(appChangeInfoForBar?.email).toBe('test@dev.com');
     expect(appChangeInfoForBar?.comment).toBe('');
-
-    const bazDependentChangeInfos = dependentChangeInfos.get('baz');
-    expect(bazDependentChangeInfos?.size).toBe(2);
-
-    const barChangeInfoForBaz = bazDependentChangeInfos?.get('bar');
-    expect(barChangeInfoForBaz?.type).toBe('minor');
-    expect(barChangeInfoForBaz?.packageName).toBe('bar');
-    expect(barChangeInfoForBaz?.commit).toBe('0xdeadbeef');
-    expect(barChangeInfoForBaz?.email).toBe('test@dev.com');
-    expect(barChangeInfoForBaz?.comment).toBe('');
-
-    const appChangeInfoForBaz = bazDependentChangeInfos?.get('app');
-    expect(appChangeInfoForBaz?.type).toBe('minor');
-    expect(appChangeInfoForBaz?.packageName).toBe('app');
-    expect(appChangeInfoForBaz?.commit).toBe('0xdeadbeef');
-    expect(appChangeInfoForBaz?.email).toBe('test@dev.com');
-    expect(appChangeInfoForBaz?.comment).toBe('');
   });
 
   it('should bump all packages in a group together as minor', () => {
@@ -367,6 +307,7 @@ describe('updateRelatedChangeType', () => {
       dependentChangeTypes: {
         foo: 'minor',
       },
+      calculatedChangeInfos: {},
       packageInfos: {
         foo: {
           group: 'grp',
@@ -377,15 +318,15 @@ describe('updateRelatedChangeType', () => {
         unrelated: {},
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'minor' }]]),
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'minor' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(dependentChangeInfos.size).toBe(0);
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['unrelated']).toBeUndefined();
   });
 
   it('should bump all packages in a group together as patch', () => {
@@ -393,6 +334,8 @@ describe('updateRelatedChangeType', () => {
       dependentChangeTypes: {
         foo: 'patch',
       },
+      calculatedChangeInfos: {},
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'patch' }]]),
       packageInfos: {
         foo: {
           group: 'grp',
@@ -403,22 +346,23 @@ describe('updateRelatedChangeType', () => {
         unrelated: {},
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(dependentChangeInfos.size).toBe(0);
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('patch');
+    expect(bumpInfo.calculatedChangeInfos['unrelated']).toBeUndefined();
   });
 
   it('should bump all packages in a group together as none', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
       dependentChangeTypes: {
-        foo: 'patch',
+        foo: 'none',
       },
+      calculatedChangeInfos: {},
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'none' }]]),
       packageInfos: {
         foo: {
           group: 'grp',
@@ -429,15 +373,14 @@ describe('updateRelatedChangeType', () => {
         unrelated: {},
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'none' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(dependentChangeInfos.size).toBe(0);
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
-    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('none');
+    expect(bumpInfo.calculatedChangeInfos['unrelated']).toBeUndefined();
   });
 
   it('should bump all packages in a group together as none with dependents', () => {
@@ -457,16 +400,16 @@ describe('updateRelatedChangeType', () => {
         },
         unrelated: {},
       },
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'none' }]]),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'none' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('none');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('none');
-    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
-    expect(dependentChangeInfos.size).toBe(0);
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('none');
+    expect(bumpInfo.calculatedChangeInfos['unrelated']).toBeUndefined();
   });
 
   it('should bump all grouped packages, if a dependency was bumped', () => {
@@ -496,29 +439,18 @@ describe('updateRelatedChangeType', () => {
           combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
+      changeFileChangeInfos: new Map([['dep', { ...changeInfoFixture, type: 'patch' }]]),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('dep', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('dep', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['unrelated']).toBeUndefined();
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['unrelated']).toBeUndefined();
 
-    expect(dependentChangeInfos.size).toBe(1);
-
-    const depChangeInfos = dependentChangeInfos.get('dep');
-    expect(depChangeInfos).toBeDefined();
-    expect(depChangeInfos?.size).toBe(1);
-
-    const depChangeInfo = depChangeInfos?.get('bar');
-    expect(depChangeInfo?.type).toBe('minor');
-    expect(depChangeInfo?.packageName).toBe('bar');
-    expect(depChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(depChangeInfo?.email).toBe('test@dev.com');
-    expect(depChangeInfo?.comment).toBe('');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(2);
   });
 
   it('should bump dependent package, if a dependency was in a group', () => {
@@ -553,34 +485,19 @@ describe('updateRelatedChangeType', () => {
         },
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      dependentChangeInfos: {},
+      changeFileChangeInfos: new Map([['dep', { ...changeInfoFixture, type: 'patch' }]]),
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('dep', { ...changeInfoFixture, type: 'patch' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('dep', bumpInfo, true);
 
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['dep'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['app'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['app'].type).toBe('minor');
 
-    expect(dependentChangeInfos.size).toBe(2);
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(3);
 
-    const depChangeInfos = dependentChangeInfos.get('dep');
-    expect(depChangeInfos).toBeDefined();
-    expect(depChangeInfos?.size).toBe(1);
-
-    const depChangeInfo = depChangeInfos?.get('bar');
-    expect(depChangeInfo?.type).toBe('minor');
-    expect(depChangeInfo?.packageName).toBe('bar');
-    expect(depChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(depChangeInfo?.email).toBe('test@dev.com');
-    expect(depChangeInfo?.comment).toBe('');
-
-    const fooChangeInfos = dependentChangeInfos.get('foo');
-    expect(fooChangeInfos).toBeDefined();
-    expect(fooChangeInfos?.size).toBe(1);
-
-    const fooChangeInfo = fooChangeInfos?.get('app');
+    const fooChangeInfo = bumpInfo.dependentChangeInfos['app'];
     expect(fooChangeInfo?.type).toBe('minor');
     expect(fooChangeInfo?.packageName).toBe('app');
     expect(fooChangeInfo?.commit).toBe('0xdeadbeef');
@@ -636,80 +553,27 @@ describe('updateRelatedChangeType', () => {
         },
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
+      changeFileChangeInfos: new Map([
+        ['mergeStyles', { ...changeInfoFixture, type: 'patch' }],
+        ['datetimeUtils', { ...changeInfoFixture, type: 'patch' }],
+      ]),
+      dependentChangeInfos: {},
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType(
-      'mergeStyles',
-      { ...changeInfoFixture, type: 'patch' },
-      bumpInfo,
-      dependentChangeInfos,
-      true
-    );
+    updateRelatedChangeType('mergeStyles', bumpInfo, true);
+    updateRelatedChangeType('datetimeUtils', bumpInfo, true);
 
-    updateRelatedChangeType(
-      'datetimeUtils',
-      { ...changeInfoFixture, type: 'patch' },
-      bumpInfo,
-      dependentChangeInfos,
-      true
-    );
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(4);
 
-    expect(dependentChangeInfos.size).toBe(4);
-
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['bar'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['mergeStyles'].type).toBe('patch');
-    expect(bumpInfo.packageChangeTypes['datetime'].type).toBe('minor');
-    expect(bumpInfo.packageChangeTypes['datetimeUtils'].type).toBe('patch');
-
-    const mergeStylesChangeInfos = dependentChangeInfos.get('mergeStyles');
-    expect(mergeStylesChangeInfos).toBeDefined();
-    expect(mergeStylesChangeInfos?.size).toBe(1);
-
-    const mergeStyleChangeInfo = mergeStylesChangeInfos?.get('styling');
-    expect(mergeStyleChangeInfo?.type).toBe('minor');
-    expect(mergeStyleChangeInfo?.packageName).toBe('styling');
-    expect(mergeStyleChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(mergeStyleChangeInfo?.email).toBe('test@dev.com');
-    expect(mergeStyleChangeInfo?.comment).toBe('');
-
-    const stylingChangeInfos = dependentChangeInfos.get('styling');
-    expect(stylingChangeInfos).toBeDefined();
-    expect(stylingChangeInfos?.size).toBe(1);
-
-    const stylingChangeInfo = stylingChangeInfos?.get('bar');
-    expect(stylingChangeInfo?.type).toBe('minor');
-    expect(stylingChangeInfo?.packageName).toBe('bar');
-    expect(stylingChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(stylingChangeInfo?.email).toBe('test@dev.com');
-    expect(stylingChangeInfo?.comment).toBe('');
-
-    const barChangeInfos = dependentChangeInfos.get('bar');
-    expect(barChangeInfos).toBeDefined();
-    expect(barChangeInfos?.size).toBe(1);
-
-    const barChangeInfo = barChangeInfos?.get('datetime');
-    expect(barChangeInfo?.type).toBe('minor');
-    expect(barChangeInfo?.packageName).toBe('datetime');
-    expect(barChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(barChangeInfo?.email).toBe('test@dev.com');
-    expect(barChangeInfo?.comment).toBe('');
-
-    const datetimeUtilsChangeInfos = dependentChangeInfos.get('datetimeUtils');
-    expect(datetimeUtilsChangeInfos).toBeDefined();
-    expect(datetimeUtilsChangeInfos?.size).toBe(1);
-
-    const datetimeUtilsChangeInfo = datetimeUtilsChangeInfos?.get('datetime');
-    expect(datetimeUtilsChangeInfo?.type).toBe('patch');
-    expect(datetimeUtilsChangeInfo?.packageName).toBe('datetime');
-    expect(datetimeUtilsChangeInfo?.commit).toBe('0xdeadbeef');
-    expect(datetimeUtilsChangeInfo?.email).toBe('test@dev.com');
-    expect(datetimeUtilsChangeInfo?.comment).toBe('');
+    expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['datetime'].type).toBe('minor');
+    expect(bumpInfo.calculatedChangeInfos['styling'].type).toBe('minor');
   });
 
   it('should respect disallowed change type', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
+      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'major' }]]),
       packageInfos: {
         foo: {
           combinedOptions: { disallowedChangeTypes: ['minor', 'major'], defaultNpmTag: 'latest' },
@@ -717,10 +581,9 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-    updateRelatedChangeType('foo', { ...changeInfoFixture, type: 'major' }, bumpInfo, dependentChangeInfos, true);
+    updateRelatedChangeType('foo', bumpInfo, true);
 
-    expect(dependentChangeInfos.size).toBe(0);
-    expect(bumpInfo.packageChangeTypes['foo'].type).toBe('patch');
+    expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(0);
+    expect(bumpInfo.calculatedChangeInfos['foo']).toBeUndefined();
   });
 });

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -12,7 +12,7 @@ const createTagParameters = (tag: string, cwd: string) => {
 };
 
 const noTagBumpInfo = ({
-  packageChangeTypes: {
+  calculatedChangeInfos: {
     foo: 'minor',
     bar: 'major',
   },
@@ -37,7 +37,7 @@ const noTagBumpInfo = ({
 } as unknown) as BumpInfo;
 
 const oneTagBumpInfo = ({
-  packageChangeTypes: {
+  calculatedChangeInfos: {
     foo: 'minor',
     bar: 'major',
   },

--- a/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -6,7 +6,7 @@ describe('validatePackageDependencies', () => {
   const bumpInfoFixture = ({
     changes: new Map(),
     dependents: {},
-    packageChangeTypes: {},
+    calculatedChangeInfos: {},
     dependentChangeTypes: {
       foo: 'patch',
     },

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -5,7 +5,6 @@ import { bumpPackageInfoVersion } from './bumpPackageInfoVersion';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { setGroupsInBumpInfo } from './setGroupsInBumpInfo';
 import { setDependentVersions } from './setDependentVersions';
-import { ChangeInfo } from '../types/ChangeInfo';
 
 /**
  * Updates BumpInfo according to change types, bump deps, and version groups
@@ -14,8 +13,8 @@ import { ChangeInfo } from '../types/ChangeInfo';
  */
 export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { bumpDeps } = options;
-  const { packageInfos, scopedPackages, packageChangeTypes, modifiedPackages } = bumpInfo;
-  const changes = { ...packageChangeTypes };
+  const { packageInfos, scopedPackages, calculatedChangeInfos, changeFileChangeInfos, modifiedPackages } = bumpInfo;
+
   // pass 1: figure out all the change types for all the packages taking into account the bumpDeps option and version groups
   if (bumpDeps) {
     setDependentsInBumpInfo(bumpInfo);
@@ -23,23 +22,19 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   setGroupsInBumpInfo(bumpInfo, options);
 
-  const dependentChangeInfos = new Map<string, Map<string, ChangeInfo>>();
-  Object.keys(changes).forEach(pkgName => {
-    updateRelatedChangeType(pkgName, changes[pkgName], bumpInfo, dependentChangeInfos, bumpDeps);
-  });
-
+  for (const pkgName of changeFileChangeInfos.keys()) {
+    updateRelatedChangeType(pkgName, bumpInfo, bumpDeps);
+  }
   // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
-  Object.keys(packageChangeTypes).forEach(pkgName => {
+  Object.keys(calculatedChangeInfos).forEach(pkgName => {
     bumpPackageInfoVersion(pkgName, bumpInfo, options);
   });
 
   // pass 3: update the dependentChangeInfos with relevant comments
-  dependentChangeInfos.forEach((changeInfos, dependencyName) => {
-    for (let changeInfo of changeInfos.values()) {
-      changeInfo.comment = `Bump ${dependencyName} to v${packageInfos[dependencyName].version}`;
-      bumpInfo.dependentChangeInfos.push(changeInfo);
-    }
-  });
+  for (const changeInfo of Object.values(bumpInfo.dependentChangeInfos)) {
+    const pkg = changeInfo.packageName;
+    calculatedChangeInfos[pkg]!.comment = `Bump ${pkg} to v${packageInfos[pkg].version}`;
+  }
 
   // pass 4: Bump all the dependencies packages
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages);

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -22,8 +22,8 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   setGroupsInBumpInfo(bumpInfo, options);
 
-  for (const pkgName of changeFileChangeInfos.keys()) {
-    updateRelatedChangeType(pkgName, bumpInfo, bumpDeps);
+  for (const changeInfo of changeFileChangeInfos.values()) {
+    updateRelatedChangeType(changeInfo.packageName, bumpInfo, bumpDeps);
   }
   // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(calculatedChangeInfos).forEach(pkgName => {

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -6,9 +6,9 @@ import { BeachballOptions } from '../types/BeachballOptions';
  * Bumps an individual package version based on the change type
  */
 export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { packageChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
+  const { calculatedChangeInfos, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
-  const changeType = packageChangeTypes[pkgName]?.type;
+  const changeType = calculatedChangeInfos[pkgName]?.type;
   if (!info) {
     console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
     return;

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -8,7 +8,6 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getChangePath } from '../paths';
 import path from 'path';
-import { getCurrentHash } from 'workspace-tools';
 
 function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
   const { path: cwd } = options;
@@ -16,11 +15,6 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
   const packageInfos = getPackageInfos(cwd);
   const changes = readChangeFiles(options);
   const changePath = getChangePath(cwd);
-  const currentHash = getCurrentHash(cwd);
-
-  if (!currentHash) {
-    throw new Error('bump: cannot determine current hash');
-  }
 
   const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
   const groupOptions = {};
@@ -38,8 +32,6 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
       );
       continue;
     }
-
-    change.commit = currentHash;
 
     filteredChanges.set(changeFile, change);
     dependentChangeTypes[change.packageName] = change.dependentChangeType || 'patch';

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -39,17 +39,17 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
  * deletes change files, update package.json, and changelogs
  */
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { modifiedPackages, packageInfos, changes, dependentChangeInfos } = bumpInfo;
+  const { modifiedPackages, packageInfos, changeFileChangeInfos, calculatedChangeInfos } = bumpInfo;
 
   writePackageJson(modifiedPackages, packageInfos);
 
   if (options.generateChangelog) {
     // Generate changelog
-    await writeChangelog(options, changes, dependentChangeInfos, packageInfos);
+    await writeChangelog(options, calculatedChangeInfos, packageInfos);
   }
 
   if (!options.keepChangeFiles) {
     // Unlink changelogs
-    unlinkChangeFiles(changes, packageInfos, options.path);
+    unlinkChangeFiles(changeFileChangeInfos, packageInfos, options.path);
   }
 }

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -1,102 +1,205 @@
-import { getMaxChangeType, MinChangeType, updateChangeInfoWithMaxType } from '../changefile/getPackageChangeTypes';
+import { MinChangeType, updateChangeInfoWithMaxType } from '../changefile/getPackageChangeTypes';
 import { BumpInfo } from '../types/BumpInfo';
-import { ChangeInfo } from '../types/ChangeInfo';
+import { ChangeInfo, ChangeType } from '../types/ChangeInfo';
 
-/**
- * Updates package change types based on dependents (e.g given A -> B, if B has a minor change, A should also have minor change)
- *
- * This function is recursive and will futher call itself to update related dependent packages noting groups and bumpDeps flag
- */
-export function updateRelatedChangeType(
-  pkgName: string,
-  changeInfo: ChangeInfo,
-  bumpInfo: BumpInfo,
-  dependentChangeInfos: Map<string, Map<string, ChangeInfo>>,
-  bumpDeps: boolean
-) {
-  const { packageChangeTypes, packageGroups, dependents, packageInfos, dependentChangeTypes, groupOptions } = bumpInfo;
+export function updateRelatedChangeType(pkgName: string, bumpInfo: BumpInfo, bumpDeps: boolean) {
+  if (!bumpDeps) {
+    return;
+  }
+
+  const {
+    calculatedChangeInfos,
+    changeFileChangeInfos,
+    packageGroups,
+    dependents,
+    packageInfos,
+    dependentChangeInfos,
+    dependentChangeTypes,
+    groupOptions,
+  } = bumpInfo;
 
   const packageInfo = packageInfos[pkgName];
+  const dependentChangeType = dependentChangeTypes[pkgName];
   const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
+  let baseChangeInfo = {
+    ...changeFileChangeInfos.get(pkgName),
+    ...dependentChangeInfos[pkgName],
+    ...calculatedChangeInfos[pkgName],
+  };
+  const queue = [{ subjectPackage: pkgName, baseChangeInfo }];
 
-  let depChangeInfo = updateChangeInfoWithMaxType(
-    changeInfo,
-    MinChangeType,
-    dependentChangeTypes[pkgName],
-    disallowedChangeTypes
-  );
+  // visited is a set of package names
+  const visited = new Set<string>();
 
-  let dependentPackages = dependents[pkgName];
+  while (queue.length > 0) {
+    let { subjectPackage, baseChangeInfo } = queue.shift()!;
 
-  // Handle groups
-  packageChangeTypes[pkgName] = updateChangeInfoWithMaxType(
-    packageChangeTypes[pkgName],
-    changeInfo.type,
-    packageChangeTypes[pkgName]?.type,
-    disallowedChangeTypes
-  );
+    if (!visited.has(subjectPackage)) {
+      visited.add(subjectPackage);
 
-  const groupName = packageInfos[pkgName].group;
-  if (groupName) {
-    let groupChangeInfo: ChangeInfo = {
-      ...changeInfo,
+      if (subjectPackage !== pkgName) {
+        baseChangeInfo = createOrUpdateChangeInfo(subjectPackage, dependentChangeType, baseChangeInfo);
+      }
+
+      const dependentPackages = dependents[subjectPackage];
+
+      if (dependentPackages && dependentPackages.length > 0) {
+        for (const dependentPackage of dependentPackages) {
+          queue.push({ subjectPackage: dependentPackage, baseChangeInfo });
+        }
+      }
+
+      // handle the group dependent updates
+      const groupName = packageInfos[subjectPackage].group;
+
+      if (groupName) {
+        for (const packageNameInGroup of packageGroups[groupName].packageNames) {
+          if (
+            !groupOptions[groupName] ||
+            !groupOptions[groupName]?.disallowedChangeTypes?.includes(dependentChangeType)
+          ) {
+            queue.push({ subjectPackage: packageNameInGroup, baseChangeInfo });
+          }
+        }
+      }
+    }
+  }
+
+  function createOrUpdateChangeInfo(pkg: string, dependentChangeType: ChangeType, changeInfo: ChangeInfo) {
+    const newChangeInfo = {
       type: MinChangeType,
+      packageName: pkg,
+      email: changeInfo.email,
+      commit: changeInfo.commit,
+      comment: '', // comment will be populated at later stages when new versions are computed
+      dependentChangeType: MinChangeType,
     };
 
-    // calculate maxChangeType
-    packageGroups[groupName].packageNames.forEach(groupPkgName => {
-      groupChangeInfo = {
-        ...groupChangeInfo,
-        type: getMaxChangeType(
-          groupChangeInfo.type,
-          packageChangeTypes[groupPkgName]?.type,
-          groupOptions[groupName]?.disallowedChangeTypes
-        ),
-      };
+    if (!calculatedChangeInfos[pkg]) {
+      // for packages previously unseen, initialize with the dependentChangeType unless it is disallowed
+      calculatedChangeInfos[pkg] = updateChangeInfoWithMaxType(
+        newChangeInfo,
+        newChangeInfo.dependentChangeType,
+        dependentChangeType,
+        disallowedChangeTypes
+      );
+    } else {
+      // for packages already in calculatedChangeInfos, do max type calculation between existing type with dependentChangeType
+      calculatedChangeInfos[pkg] = updateChangeInfoWithMaxType(
+        newChangeInfo,
+        calculatedChangeInfos[pkg].type,
+        dependentChangeType,
+        disallowedChangeTypes
+      );
+    }
 
-      // disregard the target disallowed types for now and will be culled at the subsequent update steps
-      dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeInfo.type, dependentChangeTypes[groupPkgName], []);
-    });
-
-    packageGroups[groupName].packageNames.forEach(groupPkgName => {
-      if (packageChangeTypes[groupPkgName]?.type !== groupChangeInfo.type) {
-        updateRelatedChangeType(groupPkgName, groupChangeInfo, bumpInfo, dependentChangeInfos, bumpDeps);
-      }
-    });
-  }
-
-  if (bumpDeps && dependentPackages) {
-    new Set(dependentPackages).forEach(parent => {
-      if (packageChangeTypes[parent]?.type !== depChangeInfo.type) {
-        // propagate the dependentChangeType of the current package to the subsequent related packages
-        dependentChangeTypes[parent] = depChangeInfo.type;
-
-        let changeInfos = dependentChangeInfos.get(pkgName);
-        if (!changeInfos) {
-          changeInfos = new Map<string, ChangeInfo>();
-          dependentChangeInfos.set(pkgName, changeInfos);
-        }
-
-        let prevChangeInfo = changeInfos.get(parent);
-        let nextChangeInfo: ChangeInfo = {
-          type: depChangeInfo.type,
-          packageName: parent,
-          email: depChangeInfo.email,
-          commit: depChangeInfo.commit,
-          comment: '', // comment will be populated at later stages when new versions are computed
-          dependentChangeType: depChangeInfo.type,
-        };
-
-        if (prevChangeInfo) {
-          nextChangeInfo = {
-            ...nextChangeInfo,
-            type: getMaxChangeType(prevChangeInfo.type, nextChangeInfo.type, disallowedChangeTypes),
-          };
-        }
-
-        changeInfos.set(parent, nextChangeInfo);
-        updateRelatedChangeType(parent, depChangeInfo, bumpInfo, dependentChangeInfos, bumpDeps);
-      }
-    });
+    dependentChangeInfos[pkg] = calculatedChangeInfos[pkg];
+    return calculatedChangeInfos[pkg];
   }
 }
+
+// /**
+//  * Updates package change types based on dependents (e.g given A -> B, if B has a minor change, A should also have minor change)
+//  *
+//  * This function is recursive and will futher call itself to update related dependent packages noting groups and bumpDeps flag
+//  */
+// export function updateRelatedChangeType2(
+//   pkgName: string,
+//   changeInfo: ChangeInfo,
+//   bumpInfo: BumpInfo,
+//   dependentChangeInfos: Map<string, Map<string, ChangeInfo>>,
+//   bumpDeps: boolean
+// ) {
+//   const {
+//     calculatedChangeInfo: packageChangeTypes,
+//     packageGroups,
+//     dependents,
+//     packageInfos,
+//     dependentChangeTypes,
+//     groupOptions,
+//   } = bumpInfo;
+
+//   const packageInfo = packageInfos[pkgName];
+//   const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
+
+//   let depChangeInfo = updateChangeInfoWithMaxType(
+//     changeInfo,
+//     MinChangeType,
+//     dependentChangeTypes[pkgName],
+//     disallowedChangeTypes
+//   );
+
+//   let dependentPackages = dependents[pkgName];
+
+//   // Handle groups
+//   packageChangeTypes[pkgName] = updateChangeInfoWithMaxType(
+//     packageChangeTypes[pkgName],
+//     changeInfo.type,
+//     packageChangeTypes[pkgName]?.type,
+//     disallowedChangeTypes
+//   );
+
+//   const groupName = packageInfos[pkgName].group;
+//   if (groupName) {
+//     let groupChangeInfo: ChangeInfo = {
+//       ...changeInfo,
+//       type: MinChangeType,
+//     };
+
+//     // calculate maxChangeType
+//     packageGroups[groupName].packageNames.forEach(groupPkgName => {
+//       groupChangeInfo = {
+//         ...groupChangeInfo,
+//         type: getMaxChangeType(
+//           groupChangeInfo.type,
+//           packageChangeTypes[groupPkgName]?.type,
+//           groupOptions[groupName]?.disallowedChangeTypes
+//         ),
+//       };
+
+//       // disregard the target disallowed types for now and will be culled at the subsequent update steps
+//       dependentChangeTypes[groupPkgName] = getMaxChangeType(depChangeInfo.type, dependentChangeTypes[groupPkgName], []);
+//     });
+
+//     packageGroups[groupName].packageNames.forEach(groupPkgName => {
+//       if (packageChangeTypes[groupPkgName]?.type !== groupChangeInfo.type) {
+//         updateRelatedChangeType2(groupPkgName, groupChangeInfo, bumpInfo, dependentChangeInfos, bumpDeps);
+//       }
+//     });
+//   }
+
+//   if (bumpDeps && dependentPackages) {
+//     new Set(dependentPackages).forEach(parent => {
+//       if (packageChangeTypes[parent]?.type !== depChangeInfo.type) {
+//         // propagate the dependentChangeType of the current package to the subsequent related packages
+//         dependentChangeTypes[parent] = depChangeInfo.type;
+
+//         let changeInfos = dependentChangeInfos.get(pkgName);
+//         if (!changeInfos) {
+//           changeInfos = new Map<string, ChangeInfo>();
+//           dependentChangeInfos.set(pkgName, changeInfos);
+//         }
+
+//         let prevChangeInfo = changeInfos.get(parent);
+//         let nextChangeInfo: ChangeInfo = {
+//           type: depChangeInfo.type,
+//           packageName: parent,
+//           email: depChangeInfo.email,
+//           commit: depChangeInfo.commit,
+//           comment: '', // comment will be populated at later stages when new versions are computed
+//           dependentChangeType: depChangeInfo.type,
+//         };
+
+//         if (prevChangeInfo) {
+//           nextChangeInfo = {
+//             ...nextChangeInfo,
+//             type: getMaxChangeType(prevChangeInfo.type, nextChangeInfo.type, disallowedChangeTypes),
+//           };
+//         }
+
+//         changeInfos.set(parent, nextChangeInfo);
+//         updateRelatedChangeType2(parent, depChangeInfo, bumpInfo, dependentChangeInfos, bumpDeps);
+//       }
+//     });
+//   }
+// }

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -20,6 +20,11 @@ export function updateRelatedChangeType(pkgName: string, bumpInfo: BumpInfo, bum
 
   const packageInfo = packageInfos[pkgName];
   const dependentChangeType = dependentChangeTypes[pkgName];
+
+  if (!packageInfo) {
+    return;
+  }
+
   const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
   let baseChangeInfo = {
     ...changeFileChangeInfos.get(pkgName),

--- a/src/changefile/getPackageChangeTypes.ts
+++ b/src/changefile/getPackageChangeTypes.ts
@@ -19,7 +19,7 @@ const ChangeTypeWeights: { [t in ChangeType]: number } = SortedChangeTypes.reduc
   return weights;
 }, {} as { [t in ChangeType]: number });
 
-export function getPackageChangeTypes(changeSet: ChangeSet) {
+export function initializePackageChangeInfo(changeSet: ChangeSet) {
   const changePerPackage: {
     [pkgName: string]: ChangeInfo;
   } = {};

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -58,8 +58,6 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
       const packageName = changeInfo.packageName;
       if (scopedPackages.includes(packageName)) {
         changeSet.set(changeFile, changeInfo);
-      } else {
-        console.log(`Skipping reading change file for out-of-scope package ${packageName}`);
       }
     } catch (e) {
       console.warn(`Invalid change file detected: ${changeFile}`);

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
-import { getFileAddedHash, getChangesBetweenRefs } from 'workspace-tools';
+import { getChangesBetweenRefs } from 'workspace-tools';
 
 export function readChangeFiles(options: BeachballOptions): ChangeSet {
   const { path: cwd } = options;
@@ -53,11 +53,7 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
   filteredChangeFiles.forEach(changeFile => {
     try {
       const changeFilePath = path.join(changePath, changeFile);
-      const changeInfo: ChangeInfo = {
-        ...fs.readJSONSync(changeFilePath),
-        // Add the commit hash where the file was actually first introduced
-        commit: getFileAddedHash(changeFilePath, cwd) || '',
-      };
+      const changeInfo: ChangeInfo = { ...fs.readJSONSync(changeFilePath), reason: 'changefile' };
 
       const packageName = changeInfo.packageName;
       if (scopedPackages.includes(packageName)) {

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -53,7 +53,7 @@ export function readChangeFiles(options: BeachballOptions): ChangeSet {
   filteredChangeFiles.forEach(changeFile => {
     try {
       const changeFilePath = path.join(changePath, changeFile);
-      const changeInfo: ChangeInfo = { ...fs.readJSONSync(changeFilePath), reason: 'changefile' };
+      const changeInfo: ChangeInfo = fs.readJSONSync(changeFilePath);
 
       const packageName = changeInfo.packageName;
       if (scopedPackages.includes(packageName)) {

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -1,16 +1,15 @@
-import { ChangeInfo, ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
 import { generateTag } from '../tag';
+import { BumpInfo } from '../types/BumpInfo';
 
 export function getPackageChangelogs(
-  changeSet: ChangeSet,
-  dependentChangeInfos: Array<ChangeInfo>,
+  calculatedChangeInfo: BumpInfo['calculatedChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
 ) {
-  const changeInfos = Array.from(changeSet.values()).concat(dependentChangeInfos);
+  const changeInfos = Object.values(calculatedChangeInfo);
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -2,17 +2,22 @@ import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
 import { generateTag } from '../tag';
 import { BumpInfo } from '../types/BumpInfo';
+import { getCurrentHash } from 'workspace-tools';
 
 export function getPackageChangelogs(
   calculatedChangeInfo: BumpInfo['calculatedChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
-  }
+  },
+  cwd: string
 ) {
   const changeInfos = Object.values(calculatedChangeInfo);
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};
+
+  const commit = getCurrentHash(cwd) || 'not available';
+
   for (let change of changeInfos) {
     const { packageName } = change;
     if (!changelogs[packageName]) {
@@ -31,7 +36,7 @@ export function getPackageChangelogs(
     changelogs[packageName].comments[change.type]!.push({
       comment: change.comment,
       author: change.email,
-      commit: change.commit,
+      commit,
       package: packageName,
     });
   }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -21,7 +21,7 @@ export async function writeChangelog(
   const groupedChangelogPaths = await writeGroupedChangelog(options, calculatedChangeInfos, packageInfos);
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
 
-  const changelogs = getPackageChangelogs(calculatedChangeInfos, packageInfos);
+  const changelogs = getPackageChangelogs(calculatedChangeInfos, packageInfos, options.path);
   // Use a standard for loop here to prevent potentially firing off multiple network requests at once
   // (in case any custom renderers have network requests)
   for (const pkg of Object.keys(changelogs)) {
@@ -50,7 +50,7 @@ async function writeGroupedChangelog(
     return [];
   }
 
-  const changelogs = getPackageChangelogs(calculatedChangeInfo, packageInfos);
+  const changelogs = getPackageChangelogs(calculatedChangeInfo, packageInfos, options.path);
   const groupedChangelogs: {
     [path: string]: { changelogs: PackageChangelog[]; masterPackage: PackageInfo };
   } = {};

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -1,28 +1,27 @@
 import path from 'path';
 import fs from 'fs-extra';
 import _ from 'lodash';
-import { ChangeInfo, ChangeSet } from '../types/ChangeInfo';
 import { PackageInfo } from '../types/PackageInfo';
 import { getPackageChangelogs } from './getPackageChangelogs';
 import { renderChangelog } from './renderChangelog';
 import { renderJsonChangelog } from './renderJsonChangelog';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { BumpInfo } from '../types/BumpInfo';
 import { isPathIncluded } from '../monorepo/utils';
 import { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
 
 export async function writeChangelog(
   options: BeachballOptions,
-  changeSet: ChangeSet,
-  dependentChangeInfos: Array<ChangeInfo>,
+  calculatedChangeInfos: BumpInfo['calculatedChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
 ): Promise<void> {
-  const groupedChangelogPaths = await writeGroupedChangelog(options, changeSet, dependentChangeInfos, packageInfos);
+  const groupedChangelogPaths = await writeGroupedChangelog(options, calculatedChangeInfos, packageInfos);
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
 
-  const changelogs = getPackageChangelogs(changeSet, dependentChangeInfos, packageInfos);
+  const changelogs = getPackageChangelogs(calculatedChangeInfos, packageInfos);
   // Use a standard for loop here to prevent potentially firing off multiple network requests at once
   // (in case any custom renderers have network requests)
   for (const pkg of Object.keys(changelogs)) {
@@ -37,8 +36,7 @@ export async function writeChangelog(
 
 async function writeGroupedChangelog(
   options: BeachballOptions,
-  changeSet: ChangeSet,
-  dependentChangeInfos: Array<ChangeInfo>,
+  calculatedChangeInfo: BumpInfo['calculatedChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
@@ -52,7 +50,7 @@ async function writeGroupedChangelog(
     return [];
   }
 
-  const changelogs = getPackageChangelogs(changeSet, dependentChangeInfos, packageInfos);
+  const changelogs = getPackageChangelogs(calculatedChangeInfo, packageInfos);
   const groupedChangelogs: {
     [path: string]: { changelogs: PackageChangelog[]; masterPackage: PackageInfo };
   } = {};

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,7 +2,7 @@ import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { gitFailFast, getBranchName, getCurrentHash } from 'workspace-tools';
 import prompts from 'prompts';
-import { getPackageChangeTypes } from '../changefile/getPackageChangeTypes';
+import { initializePackageChangeInfo } from '../changefile/getPackageChangeTypes';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publishToRegistry } from '../publish/publishToRegistry';
@@ -12,7 +12,7 @@ export async function publish(options: BeachballOptions) {
   const { path: cwd, branch, registry, tag } = options;
   // First, validate that we have changes to publish
   const changes = readChangeFiles(options);
-  const packageChangeTypes = getPackageChangeTypes(changes);
+  const packageChangeTypes = initializePackageChangeInfo(changes);
   if (Object.keys(packageChangeTypes).length === 0) {
     console.log('Nothing to bump, skipping publish!');
     return;

--- a/src/publish/shouldPublishPackage.ts
+++ b/src/publish/shouldPublishPackage.ts
@@ -8,7 +8,7 @@ export function shouldPublishPackage(
   reasonToSkip?: string;
 } {
   const packageInfo = bumpInfo.packageInfos[pkgName];
-  const changeType = bumpInfo.packageChangeTypes[pkgName]?.type;
+  const changeType = bumpInfo.calculatedChangeInfos[pkgName]?.type;
 
   if (changeType === 'none') {
     return {

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -11,7 +11,7 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
 
   [...modifiedPackages, ...newPackages].forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    const changeType = bumpInfo.packageChangeTypes[pkg]?.type;
+    const changeType = bumpInfo.calculatedChangeInfos[pkg]?.type;
     // Do not tag change type of "none", private packages, or packages opting out of tagging
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       return;

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -3,15 +3,36 @@ import { PackageInfo, PackageGroups } from './PackageInfo';
 import { VersionGroupOptions } from './BeachballOptions';
 
 export type BumpInfo = {
-  changes: ChangeSet;
+  /** Changes coming from the change files */
+  changeFileChangeInfos: ChangeSet;
+
+  /** Cached version of package info (e.g. package.json, package path) */
   packageInfos: { [pkgName: string]: PackageInfo };
-  packageChangeTypes: { [pkgName: string]: ChangeInfo };
+
+  /** Change info collated by the package names */
+  calculatedChangeInfos: { [pkgName: string]: ChangeInfo };
+
+  /** Package grouping */
   packageGroups: PackageGroups;
+
+  /** Package group options */
   groupOptions: { [grp: string]: VersionGroupOptions };
+
+  /** Dependents cache (if A depends on B, then {B: [A]}) - child points to parents */
   dependents: { [pkgName: string]: string[] };
+
+  /** Dependent change types (if A depends on B & B has a change, B would specify what its dependents would be change to - i.e. A would be changed to this type) */
   dependentChangeTypes: { [pkgName: string]: ChangeType };
-  dependentChangeInfos: Array<ChangeInfo>;
+
+  /** A Cache of the ChangeInfo for all the dependents in this bump session */
+  dependentChangeInfos: { [pkgName: string]: ChangeInfo };
+
+  /** Set of packages that had been modified */
   modifiedPackages: Set<string>;
+
+  /** Set of new packages detected in this info */
   newPackages: Set<string>;
+
+  /** Set of packages that are in scope for this bump */
   scopedPackages: Set<string>;
 };


### PR DESCRIPTION
Included are two major changes to speed up beachball tremendously:

1. rewrites the beachball update related change types internal algorithm to be a lot faster
2. no hash calculation per change file

I've used the e2e tests as well as hand tested to validate the change. I'm reasonably confident the results are the same as before. There's no behavior changes except for the fact that it is faster.