### PR TITLE
Add star command and enable syncing from changelogs

### DIFF
--- a/change/beachball-ece8a98e-a729-4032-9708-93e71741c292.json
+++ b/change/beachball-ece8a98e-a729-4032-9708-93e71741c292.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add star command and enable syncing from changelogs",
+  "packageName": "beachball",
+  "email": "zh3zh3@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -30,7 +30,7 @@ module.exports = {
         title: 'Command Line Args', // required
         collapsable: false, // optional, defaults to true
         sidebarDepth: 1, // optional, defaults to 1
-        children: ['/cli/options', '/cli/bump', '/cli/change', '/cli/check', '/cli/publish', '/cli/sync'],
+        children: ['/cli/options', '/cli/bump', '/cli/change', '/cli/check', '/cli/publish', '/cli/sync', '/cli/star'],
       },
     ],
   },

--- a/docs/cli/star.md
+++ b/docs/cli/star.md
@@ -1,0 +1,10 @@
+---
+tags: cli
+category: doc
+---
+
+# `star`
+
+Depending on how CI is set up in a repo, it's possible that when beachball is in the process of bumping versions against main branch that is also used by developers, beachball could tag an incorrect commit and/or developers could get merge conflicts due to changed package.json.
+
+One possible solution is to set up separate branches so that developers work against a "dev" branch and CI would run beachball against a "main" branch. On "dev" branch, use `star` command to update all workspace dependencies in package.json files and reference them by `*` instead of an actual version. When CI runs, use `sync` command with `--replace-stars` to ensure dependencies versions are restored from "dev" branch.

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -20,3 +20,11 @@ Force the sync command to skip the version comparison and use the version in the
 ##### `--tag, -t`
 
 Sync with the version this `dist-tag` points to. Defaults to the tag from repo, group, or package level beachball configs if present.
+
+##### `--use-changelog-versions`
+
+Sync package versions from changelogs (CHANGELOG.json) instead of registry.
+
+##### `--replace-stars`
+
+For dependencies that have `*` as versions in package.json, replace them with actual versions. See [star](./star) command for a typical flow.

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -27,4 +27,6 @@ Sync package versions from changelogs (CHANGELOG.json) instead of registry.
 
 ##### `--replace-stars`
 
-For dependencies that have `*` as versions in package.json, replace them with actual versions. See [star](./star) command for a typical flow.
+For dependencies that have `*` as versions in package.json, replace them with actual versions. Valid values are `exact` (replaces `*` with `x.x.x`), `tilde` (replaces `*` with `~x.x.x`), and `caret` (replaces `*` with `^x.x.x`).
+
+See [star](./star) command for a typical flow.

--- a/src/__e2e__/star.test.ts
+++ b/src/__e2e__/star.test.ts
@@ -1,0 +1,28 @@
+import { star } from '../commands/star';
+import { MonoRepoFactory } from '../fixtures/monorepo';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { BeachballOptions } from '../types/BeachballOptions';
+
+describe('star command', () => {
+  let repositoryFactory: MonoRepoFactory | undefined;
+
+  afterEach(async () => {
+    if (repositoryFactory) {
+      repositoryFactory.cleanUp();
+      repositoryFactory = undefined;
+    }
+  });
+
+  it('applies * to workspace dependencies', async () => {
+    repositoryFactory = new MonoRepoFactory();
+    await repositoryFactory.create();
+    const repo = await repositoryFactory.cloneRepository();
+
+    star({
+      path: repo.rootPath,
+    } as BeachballOptions);
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+    expect(packageInfos['foo'].dependencies?.['bar']).toBe('*');
+  });
+});

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -281,15 +281,15 @@ describe('sync command (e2e)', () => {
       bump: false,
       generateChangelog: false,
       dependentChangeType: null,
-      replaceStars: true,
+      replaceStars: 'caret',
       useChangelogVersions: true
     });
 
     const packageInfosAfterSync = getPackageInfos(repo.rootPath);
 
     expect(packageInfosAfterSync['foopkg'].version).toEqual('1.2.0');
-    expect(packageInfosAfterSync['foopkg'].dependencies?.['barpkg']).toEqual('2.2.0');
-    expect(packageInfosAfterSync['foopkg'].dependencies?.['bazpkg']).toEqual('3.0.0');
+    expect(packageInfosAfterSync['foopkg'].dependencies?.['barpkg']).toEqual('^2.2.0');
+    expect(packageInfosAfterSync['foopkg'].dependencies?.['bazpkg']).toEqual('^3.0.0');
     expect(packageInfosAfterSync['barpkg'].version).toEqual('2.2.0');
     expect(packageInfosAfterSync['bazpkg'].version).toEqual('3.0.0');
   });

--- a/src/__tests__/bump/applySemverRange.test.ts
+++ b/src/__tests__/bump/applySemverRange.test.ts
@@ -1,0 +1,25 @@
+import { applySemverRange } from '../../bump/applySemverRange';
+
+describe('applySemverRange', () => {
+  it('applies ^ to semver range', () => {
+    const result = applySemverRange('caret', '1.0.0');
+    expect(result).toBe('^1.0.0');
+  });
+
+  it('applies ~ to semver range', () => {
+    const result = applySemverRange('tilde', '1.3.0');
+    expect(result).toBe('~1.3.0');
+  });
+
+  describe('no-op', () => {
+    it('does nothing if range is exact', () => {
+      const result = applySemverRange('exact', '0.1.0');
+      expect(result).toBe('0.1.0');
+    });
+
+    it('does nothing if tilde range is already applied', () => {
+      const result = applySemverRange('tilde', '~0.2.0');
+      expect(result).toBe('~0.2.0');
+    });
+  });
+});

--- a/src/bump/applySemverRange.ts
+++ b/src/bump/applySemverRange.ts
@@ -1,0 +1,11 @@
+import { CliOptions } from '../types/BeachballOptions';
+
+export function applySemverRange(range: CliOptions['replaceStars'], versionString: string): string {
+  if (!versionString.startsWith('^') && range === 'caret') {
+    return `^${versionString}`;
+  } else if (!versionString.startsWith('~') && range === 'tilde') {
+    return `~${versionString}`;
+  }
+
+  return versionString;
+}

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -1,7 +1,7 @@
 import { PackageInfos, PackageDeps } from '../types/PackageInfo';
 import { bumpMinSemverRange } from './bumpMinSemverRange';
 
-export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>) {
+export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>, replaceStars: boolean = false) {
   const modifiedPackages = new Set<string>();
   Object.keys(packageInfos).forEach(pkgName => {
     if (!scopedPackages.has(pkgName)) {
@@ -16,7 +16,7 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
           const packageInfo = packageInfos[dep];
           if (packageInfo) {
             const existingVersionRange = deps[dep];
-            const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, existingVersionRange);
+            const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, replaceStars ? packageInfo.version : existingVersionRange);
             if (existingVersionRange !== bumpedVersionRange) {
               deps[dep] = bumpedVersionRange;
               modifiedPackages.add(pkgName);

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -1,7 +1,9 @@
+import { CliOptions } from '../types/BeachballOptions';
 import { PackageInfos, PackageDeps } from '../types/PackageInfo';
+import { applySemverRange } from './applySemverRange';
 import { bumpMinSemverRange } from './bumpMinSemverRange';
 
-export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>, replaceStars: boolean = false) {
+export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>, replaceStars?: CliOptions['replaceStars']) {
   const modifiedPackages = new Set<string>();
   Object.keys(packageInfos).forEach(pkgName => {
     if (!scopedPackages.has(pkgName)) {
@@ -16,7 +18,8 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
           const packageInfo = packageInfos[dep];
           if (packageInfo) {
             const existingVersionRange = deps[dep];
-            const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, replaceStars ? packageInfo.version : existingVersionRange);
+            const semverRange = replaceStars ? applySemverRange(replaceStars, packageInfo.version) : existingVersionRange;
+            const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, semverRange);
             if (existingVersionRange !== bumpedVersionRange) {
               deps[dep] = bumpedVersionRange;
               modifiedPackages.add(pkgName);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { canary } from './commands/canary';
 import { change } from './commands/change';
 import { init } from './commands/init';
 import { publish } from './commands/publish';
+import { star } from './commands/star';
 import { sync } from './commands/sync';
 
 import { showVersion, showHelp } from './help';
@@ -53,6 +54,10 @@ import { validate } from './validation/validate';
 
     case 'sync':
       sync(options);
+      break;
+
+    case 'star':
+      star(options);
       break;
 
     default:

--- a/src/commands/star.ts
+++ b/src/commands/star.ts
@@ -1,0 +1,33 @@
+import fs from 'fs-extra';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { PackageDeps, PackageInfo } from '../types/PackageInfo';
+
+export async function star(options: BeachballOptions) {
+  const packageInfos = getPackageInfos(options.path);
+  const packageInfoKeys = Object.keys(packageInfos);
+  const packageKeysSet = new Set<string>(packageInfoKeys);
+  packageInfoKeys.forEach(pkgName => {
+    const info = packageInfos[pkgName];
+    const packageJson: PackageInfo = fs.readJSONSync(info.packageJsonPath);
+    let writePackageJson = false;
+
+    ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depKind => {
+      const deps: PackageDeps | undefined = (info as any)[depKind];
+
+      if (deps) {
+        const workspaceDeps = Object.keys(deps).filter(dep => packageKeysSet.has(dep));
+        if (workspaceDeps.length > 0) {
+          workspaceDeps.forEach(dep => {
+            packageJson[depKind][dep] = '*';
+          });
+          writePackageJson = true;
+        }
+      }
+    });
+
+    if (writePackageJson) {
+      fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
+    }
+  });
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -42,5 +42,5 @@ export async function sync(options: BeachballOptions) {
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages, options.replaceStars);
   dependentModifiedPackages.forEach(pkg => modifiedPackages.add(pkg));
 
-  writePackageJson(modifiedPackages, packageInfos);
+  writePackageJson(modifiedPackages, packageInfos, !options.replaceStars);
 }

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -24,7 +24,7 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
   const args = parser(trimmedArgv, {
     string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type', 'config'],
     array: ['scope', 'disallowed-change-types'],
-    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit'],
+    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit', 'replace-stars', 'use-changelog-versions'],
     alias: {
       authType: ['a'],
       branch: ['b'],
@@ -51,6 +51,8 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
     disallowDeletedChangeFiles: args['disallow-deleted-change-files'],
     forceVersions: args.force,
     configPath: args.config,
+    replaceStars: args['replace-stars'],
+    useChangelogVersions: args['use-changelog-versions']
   } as CliOptions;
 
   const disallowedChangeTypesArgs = args['disallowed-change-types'];

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -22,9 +22,9 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
   const trimmedArgv = [...argv].splice(2);
 
   const args = parser(trimmedArgv, {
-    string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type', 'config'],
+    string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type', 'config', 'replace-stars'],
     array: ['scope', 'disallowed-change-types'],
-    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit', 'replace-stars', 'use-changelog-versions'],
+    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit', 'use-changelog-versions'],
     alias: {
       authType: ['a'],
       branch: ['b'],

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -42,6 +42,8 @@ export interface CliOptions {
   prereleasePrefix?: string | null;
   configPath?: string;
   commit?: boolean;
+  replaceStars?: boolean;
+  useChangelogVersions?: boolean;
 }
 
 export interface RepoOptions {

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -42,7 +42,7 @@ export interface CliOptions {
   prereleasePrefix?: string | null;
   configPath?: string;
   commit?: boolean;
-  replaceStars?: boolean;
+  replaceStars?: 'exact' | 'caret' | 'tilde';
   useChangelogVersions?: boolean;
 }
 


### PR DESCRIPTION
- Adds a `star` command that allows referencing workspace packages as a `*` dependency. This is not applicable to yarn 2 where `workspace:` notation exists.
- Adds ability for `sync` command to pull versions from changelogs