### PR TITLE
Add fallback logic for publishConfig values

### DIFF
--- a/change/beachball-08413465-8d24-4f5a-aeba-7ec04112dc1c.json
+++ b/change/beachball-08413465-8d24-4f5a-aeba-7ec04112dc1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fallback logic for publishConfig values",
+  "packageName": "beachball",
+  "email": "scott.schmalz@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/publish/performPublishConfigOverrides.test.ts
+++ b/src/__tests__/publish/performPublishConfigOverrides.test.ts
@@ -60,6 +60,31 @@ describe('perform publishConfig overrides', () => {
     cleanUp(tmpDir);
   });
 
+  it('uses values on packageJson root as fallback values when present', () => {
+    const { packageInfos, tmpDir } = createFixture({
+      main: 'lib/index.js',
+    });
+
+    const original = JSON.parse(fs.readFileSync(packageInfos['foo'].packageJsonPath, 'utf-8'));
+
+    expect(original.main).toBe('src/index.ts');
+    expect(original.bin).toStrictEqual({ 'foo-bin': 'src/foo-bin.js' });
+    expect(original.files).toBeUndefined();
+
+    performPublishConfigOverrides(['foo'], packageInfos);
+
+    const modified = JSON.parse(fs.readFileSync(packageInfos['foo'].packageJsonPath, 'utf-8'));
+
+    expect(modified.main).toBe('lib/index.js');
+    expect(modified.bin).toStrictEqual({ 'foo-bin': 'src/foo-bin.js' });
+    expect(modified.files).toBeUndefined();
+    expect(modified.publishConfig.main).toBeUndefined();
+    expect(modified.publishConfig.bin).toBeUndefined();
+    expect(modified.publishConfig.files).toBeUndefined();
+
+    cleanUp(tmpDir);
+  });
+
   it('should always at least accept types, main, and module', () => {
     expect(acceptedKeys).toContain('main');
     expect(acceptedKeys).toContain('module');

--- a/src/publish/performPublishConfigOverrides.ts
+++ b/src/publish/performPublishConfigOverrides.ts
@@ -12,7 +12,7 @@ export function performPublishConfigOverrides(packagesToPublish: string[], packa
 
     if (packageJson.publishConfig) {
       for (const key of acceptedKeys) {
-        const value = packageJson.publishConfig[key];
+        const value = packageJson.publishConfig[key] || packageJson[key];
         packageJson[key] = value;
         delete packageJson.publishConfig[key];
       }


### PR DESCRIPTION
# TLDR

This adds logic to fallback to values defined on the root of `package.json` when they are not defined within `publishConfigs`. 

---

# Details

I ran into a situation where I need a `publishConfig` to specify a private registry we are publishing to. We have our `main` and `files` options specified on the root of the `package.json`. Our `package.json` looked something like this:

```json
{
  "name": "@my-scope/my-package",
  "version": "1.0.0",
  "description": "",
  "main": "dist/index.js",
  "files": ["dist"],
  "publishConfig": {
    "registry": "https://registry.my-private-npm.com"
  },
  "scripts": {},
  "dependencies": {},
  "devDependencies": {},
}
```

Using `beachball` in its current form, my published package was missing `main` and `files` from the `package.json` file. This caused upstream dependencies to fail when pulling in the latest version. To make things a bit more confusing, when I looked at the updates pushed to the repo after running `beachball`, the `package.json` still looked good.

I discovered in the `beachball` code where/why this was happening. My first instinct was to just move the `main` and `files` entries underneath `publishConfig` and call it a day. That would result in my `package.json` looking something like this:

```json
{
  "name": "@my-scope/my-package",
  "version": "1.0.0",
  "description": "",
  "publishConfig": {
    "registry": "https://registry.my-private-npm.com",
    "main": "dist/index.js",
    "files": ["dist"]
  },
  "scripts": {},
  "dependencies": {},
  "devDependencies": {},
}
```

Unfortunately, we use `yarn link` quite a bit in our local development. Moving `main` and `files` underneath `publishConfig` breaks `yarn link`.

This means our only remaining option would be to define our `package.json` like this:

```json
{
  "name": "@my-scope/my-package",
  "version": "1.0.0",
  "description": "",
  "main": "dist/index.js",
  "files": ["dist"],
  "publishConfig": {
    "registry": "https://registry.my-private-npm.com",
    "main": "dist/index.js",
    "files": ["dist"]
  },
  "scripts": {},
  "dependencies": {},
  "devDependencies": {},
}
```

Having the duplicative `main` and `files` entries on both the root and under `publishConfig` doesn't feel right to me.

That led me to open this PR. With this change, when a `publishConfig` is present on the `package.json`, any accepted keys defined within the `publishConfig` will take priority. If a key is not defined within `publishConfig` and is defined on the root `package.json`, that will be used instead.