### PR TITLE
Fix for handling of custom schema while updating the CHANGELOG.json file

### DIFF
--- a/change/beachball-7c2b234c-3dbf-430f-956b-a4bdb4fdacfa.json
+++ b/change/beachball-7c2b234c-3dbf-430f-956b-a4bdb4fdacfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix for handling of custom schema while updating the CHANGELOG.json file",
+  "packageName": "beachball",
+  "email": "pravcha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -43,9 +43,17 @@ export function getPackageChangelogs(
 
     const changeLogKeys = Object.keys(change);
 
+    // The list of keys of "change" which we do not want when updating CHANGELOG.json file
+    const predefinedKeys = [
+      'dependentChangeType',
+      'email',
+      'packageName',
+      'type'
+    ]
+
     // For handling custom schema of the changelog specified in the beachball config file
     for(const key of changeLogKeys){
-      if(!changeLog[key] && key !== 'dependentChangeType'){
+      if(!changeLog[key] && !predefinedKeys.includes(key)){
         changeLog[key] = change[key];
       }
     }

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -33,12 +33,24 @@ export function getPackageChangelogs(
 
     changelogs[packageName].comments = changelogs[packageName].comments || {};
     changelogs[packageName].comments[change.type] = changelogs[packageName].comments[change.type] || [];
-    changelogs[packageName].comments[change.type]!.push({
+
+    const changeLog = {
       comment: change.comment,
       author: change.email,
       commit,
-      package: packageName,
-    });
+      package: packageName
+    }
+
+    const changeLogKeys = Object.keys(change);
+
+    // For handling custom schema of the changelog specified in the beachball config file
+    for(const key of changeLogKeys){
+      if(!changeLog[key] && key !== 'dependentChangeType'){
+        changeLog[key] = change[key];
+      }
+    }
+
+    changelogs[packageName].comments[change.type]!.push(changeLog);
   }
   return changelogs;
 }

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -22,7 +22,7 @@ export function getPackageChangelogs(
   const commit = getCurrentHash(cwd) || 'not available';
 
   for (let change of changeInfos) {
-    const { packageName } = change;
+    const { packageName, type: changeType, dependentChangeType, email, ...rest } = change;
     if (!changelogs[packageName]) {
       const version = packageInfos[packageName].version;
       changelogs[packageName] = {
@@ -35,33 +35,15 @@ export function getPackageChangelogs(
     }
 
     changelogs[packageName].comments = changelogs[packageName].comments || {};
-    changelogs[packageName].comments[change.type] = changelogs[packageName].comments[change.type] || [];
-
-    const changeLog = {
-      comment: change.comment,
+    changelogs[packageName].comments[changeType] = changelogs[packageName].comments[changeType] || [];
+    changelogs[packageName].comments[changeType]!.push({
       author: change.email,
+      package: packageName,
+      // This contains the comment and any extra properties added to the change file by
+      // RepoOptions.changeFilePrompt.changePrompt
+      ...rest,
       commit,
-      package: packageName
-    }
-
-    const changeLogKeys = Object.keys(change);
-
-    // The list of keys of "change" which we do not want when updating CHANGELOG.json file
-    const predefinedKeys = [
-      'dependentChangeType',
-      'email',
-      'packageName',
-      'type'
-    ]
-
-    // For handling custom schema of the changelog specified in the beachball config file
-    for(const key of changeLogKeys){
-      if(!changeLog[key] && !predefinedKeys.includes(key)){
-        changeLog[key] = change[key];
-      }
-    }
-
-    changelogs[packageName].comments[change.type]!.push(changeLog);
+    });
   }
   return changelogs;
 }

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -9,6 +9,8 @@ export interface ChangeFileInfo {
   packageName: string;
   email: string;
   dependentChangeType: ChangeType;
+  /** Extra info added to the change file via custom prompts */
+  [extraInfo: string]: any;
 }
 
 /**


### PR DESCRIPTION
Currently, the consumers can specify a custom schema in the beachball config file (`
changeFilePrompt: {
    changePrompt: prompt => {}
}
`) which gets used for creating the individual change files. But when the CHANGELOG.json files are updated not all the fields of the change file gets included in the update written to the CHANGELOG.json file. Due to this the custom schema fields although being part of the generated change files are not included in the CHANGELOG.json file.

This PR introduces the fix to include all the custom schema fields present in the change file to be written to the CHANGELOG.json file when the CHANGELOG.json file is updated.

Fixes #549