### PR TITLE
Option to specify Custom changelog at the package level

### DIFF
--- a/change/beachball-3d0b6a3d-44a8-4046-aaa3-7e338d0ec7e6.json
+++ b/change/beachball-3d0b6a3d-44a8-4046-aaa3-7e338d0ec7e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding option to specify custom changelog at the package level",
+  "packageName": "beachball",
+  "email": "pravcha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -75,7 +75,11 @@ export async function promptForChange(options: BeachballOptions) {
     let questions = [defaultPrompt.changeType, defaultPrompt.description];
 
     if (packageInfo.combinedOptions.changeFilePrompt?.changePrompt) {
-      questions = packageInfo.combinedOptions.changeFilePrompt?.changePrompt(defaultPrompt);
+      /**
+       * We are providing the package name also as the parameter so
+       * that the custom changelog can be specified at the package level
+       */
+      questions = packageInfo.combinedOptions.changeFilePrompt?.changePrompt(defaultPrompt, pkg);
     }
 
     questions = questions.filter(q => !!q);

--- a/src/types/ChangeFilePrompt.ts
+++ b/src/types/ChangeFilePrompt.ts
@@ -9,5 +9,5 @@ export interface DefaultPrompt {
  * Options for customizing change file prompt.
  */
 export interface ChangeFilePromptOptions {
-  changePrompt?(defaultPrompt: DefaultPrompt): prompts.PromptObject[];
+  changePrompt?(defaultPrompt: DefaultPrompt, pkg: string): prompts.PromptObject[];
 }


### PR DESCRIPTION
Currently the beachball allows to specify a custom schema for the changelog(s) at the repository level. So, we cannot have a custom schema at the package level.

This PR introduces more flexibility in terms of defining a custom schema for the changelog, by allowing developers to specify a custom schema at the package level.

For example - 

Currently in the beachball config file we can have - 

`
changeFilePrompt: {
    changePrompt: prompt => {}
}
`

will be now like - 

`
changeFilePrompt: {
    changePrompt: (prompt, packageName) => {
        // logic to return the schema based on the packageName
    }
}
`
