### PR TITLE
Fixes changelog comments being overridden by the auto-generated dependent bump comments

### DIFF
--- a/change/beachball-701b536a-cdf6-499c-b60b-36c6dfb7545b.json
+++ b/change/beachball-701b536a-cdf6-499c-b60b-36c6dfb7545b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes changelogs comment count to be overridden by dependent bumps",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -17,6 +17,7 @@ This log was last generated on (date) and should not be manually modified.
 - comment 1 (test@testtestme.com)
 - additional comment 1 (test@testtestme.com)
 - additional comment 2 (test@testtestme.com)
+- bump foo to v1.0.1 (test@testtestme.com)
 "
 `;
 
@@ -47,6 +48,12 @@ Object {
           Object {
             "author": "test@testtestme.com",
             "comment": "additional comment 2",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "bump foo to v1.0.1",
             "commit": "(sha1)",
             "package": "foo",
           },

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -100,7 +100,7 @@ describe('changelog generation', () => {
       const packageInfos = getPackageInfos(repository.rootPath);
       const calculated = calculateChangeInfos(changes);
 
-      await writeChangelog(beachballOptions, calculated, packageInfos);
+      await writeChangelog(beachballOptions, changes, calculated, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });
@@ -142,7 +142,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, calculateChangeInfos(changes), packageInfos);
+      await writeChangelog(beachballOptions, changes, calculateChangeInfos(changes), packageInfos);
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
@@ -186,7 +186,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, calculateChangeInfos(changes), packageInfos);
+      await writeChangelog(beachballOptions, changes, calculateChangeInfos(changes), packageInfos);
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -91,7 +91,12 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
 
-      await writeChangelog(beachballOptions, changes, {}, packageInfos);
+      await writeChangelog(
+        beachballOptions,
+        changes,
+        { foo: { ...getChange({ comment: 'bump foo to v1.0.1' }), commit: 'bogus' } },
+        packageInfos
+      );
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -11,7 +11,7 @@ import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { SortedChangeTypes } from '../changefile/getPackageChangeTypes';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { ChangeFileInfo, ChangeSet } from '../types/ChangeInfo';
+import { ChangeFileInfo } from '../types/ChangeInfo';
 import { MonoRepoFactory } from '../fixtures/monorepo';
 import { ChangelogJson } from '../types/ChangeLog';
 
@@ -43,14 +43,6 @@ function cleanJsonForSnapshot(changelog: ChangelogJson) {
     }
   }
   return changelog;
-}
-
-function calculateChangeInfos(changes: ChangeSet) {
-  const calculated = {};
-  for (const [pkg, info] of changes.entries()) {
-    calculated[pkg] = info;
-  }
-  return calculated;
 }
 
 describe('changelog generation', () => {
@@ -98,9 +90,8 @@ describe('changelog generation', () => {
 
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
-      const calculated = calculateChangeInfos(changes);
 
-      await writeChangelog(beachballOptions, changes, calculated, packageInfos);
+      await writeChangelog(beachballOptions, changes, {}, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = await fs.readFile(changelogFile, { encoding: 'utf-8' });
@@ -142,7 +133,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, changes, calculateChangeInfos(changes), packageInfos);
+      await writeChangelog(beachballOptions, changes, {}, packageInfos);
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
@@ -186,7 +177,7 @@ describe('changelog generation', () => {
       // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
 
-      await writeChangelog(beachballOptions, changes, calculateChangeInfos(changes), packageInfos);
+      await writeChangelog(beachballOptions, changes, {}, packageInfos);
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -46,7 +46,9 @@ describe('updateRelatedChangeType', () => {
       dependents: {
         foo: ['bar'],
       },
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'minor', dependentChangeType: 'patch' }]]),
+      changeFileChangeInfos: new Map([
+        ['foo.json', { ...changeInfoFixture, type: 'minor', dependentChangeType: 'patch' }],
+      ]),
       calculatedChangeInfos: {
         foo: {
           type: 'minor',
@@ -62,7 +64,7 @@ describe('updateRelatedChangeType', () => {
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('patch');
@@ -85,7 +87,7 @@ describe('updateRelatedChangeType', () => {
       dependents: {
         foo: ['bar'],
       },
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'patch' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'patch' }]]),
       calculatedChangeInfos: {
         foo: { type: 'patch' },
       },
@@ -102,7 +104,7 @@ describe('updateRelatedChangeType', () => {
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
@@ -124,8 +126,8 @@ describe('updateRelatedChangeType', () => {
         bar: ['app'],
       },
       changeFileChangeInfos: new Map([
-        ['foo', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
-        ['bar', { ...changeInfoFixture, type: 'patch', packageName: 'bar' }],
+        ['foo.json', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
+        ['bar.json', { ...changeInfoFixture, type: 'patch', packageName: 'bar' }],
       ]),
       calculatedChangeInfos: {
         foo: { type: 'patch' },
@@ -150,8 +152,8 @@ describe('updateRelatedChangeType', () => {
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
-    updateRelatedChangeType('bar', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
+    updateRelatedChangeType('bar.json', 'bar', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('major');
@@ -181,8 +183,8 @@ describe('updateRelatedChangeType', () => {
         bar: ['app'],
       },
       changeFileChangeInfos: new Map([
-        ['foo', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
-        ['baz', { ...changeInfoFixture, type: 'patch', email: 'dev@test.com', commit: '0xfeef' }],
+        ['foo.json', { ...changeInfoFixture, type: 'patch', packageName: 'foo' }],
+        ['baz.json', { ...changeInfoFixture, type: 'patch', email: 'dev@test.com', commit: '0xfeef' }],
       ]),
       calculatedChangeInfos: {
         foo: { type: 'patch' },
@@ -207,7 +209,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
     expect(bumpInfo.calculatedChangeInfos['baz'].type).toBe('minor');
@@ -232,7 +234,7 @@ describe('updateRelatedChangeType', () => {
     expect(appChangeInfoForBar?.email).toBe('test@dev.com');
     expect(appChangeInfoForBar?.comment).toBe('');
 
-    updateRelatedChangeType('baz', bumpInfo, true);
+    updateRelatedChangeType('baz.json', 'baz', bumpInfo, true);
 
     expect(bumpInfo.dependentChangeInfos['baz']).toBeUndefined();
     expect(bumpInfo.dependentChangeInfos['bar'].commit).toBe('0xfeef');
@@ -246,8 +248,8 @@ describe('updateRelatedChangeType', () => {
         baz: ['bar', 'app'],
       },
       changeFileChangeInfos: new Map([
-        ['foo', { ...changeInfoFixture, type: 'patch' }],
-        ['baz', { ...changeInfoFixture, type: 'patch' }],
+        ['foo.json', { ...changeInfoFixture, type: 'patch' }],
+        ['baz.json', { ...changeInfoFixture, type: 'patch' }],
       ]),
       calculatedChangeInfos: {
         foo: { type: 'patch' },
@@ -274,8 +276,8 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
-    updateRelatedChangeType('baz', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
+    updateRelatedChangeType('baz.json', 'baz', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('patch');
     expect(bumpInfo.calculatedChangeInfos['baz'].type).toBe('patch');
@@ -318,11 +320,11 @@ describe('updateRelatedChangeType', () => {
         unrelated: {},
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'minor' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'minor' }]]),
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
@@ -349,7 +351,7 @@ describe('updateRelatedChangeType', () => {
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('patch');
@@ -362,7 +364,7 @@ describe('updateRelatedChangeType', () => {
         foo: 'none',
       },
       calculatedChangeInfos: {},
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'none' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'none' }]]),
       packageInfos: {
         foo: {
           group: 'grp',
@@ -376,7 +378,7 @@ describe('updateRelatedChangeType', () => {
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('none');
@@ -400,12 +402,12 @@ describe('updateRelatedChangeType', () => {
         },
         unrelated: {},
       },
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'none' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'none' }]]),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(1);
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('none');
@@ -439,12 +441,12 @@ describe('updateRelatedChangeType', () => {
           combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
       },
-      changeFileChangeInfos: new Map([['dep', { ...changeInfoFixture, type: 'patch' }]]),
+      changeFileChangeInfos: new Map([['dep.json', { ...changeInfoFixture, type: 'patch' }]]),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('dep', bumpInfo, true);
+    updateRelatedChangeType('dep.json', 'dep', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
@@ -486,10 +488,10 @@ describe('updateRelatedChangeType', () => {
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
       dependentChangeInfos: {},
-      changeFileChangeInfos: new Map([['dep', { ...changeInfoFixture, type: 'patch' }]]),
+      changeFileChangeInfos: new Map([['dep.json', { ...changeInfoFixture, type: 'patch' }]]),
     });
 
-    updateRelatedChangeType('dep', bumpInfo, true);
+    updateRelatedChangeType('dep.json', 'dep', bumpInfo, true);
 
     expect(bumpInfo.calculatedChangeInfos['foo'].type).toBe('minor');
     expect(bumpInfo.calculatedChangeInfos['bar'].type).toBe('minor');
@@ -554,14 +556,14 @@ describe('updateRelatedChangeType', () => {
       },
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
       changeFileChangeInfos: new Map([
-        ['mergeStyles', { ...changeInfoFixture, type: 'patch' }],
-        ['datetimeUtils', { ...changeInfoFixture, type: 'patch' }],
+        ['mergeStyles.json', { ...changeInfoFixture, type: 'patch' }],
+        ['datetimeUtils.json', { ...changeInfoFixture, type: 'patch' }],
       ]),
       dependentChangeInfos: {},
     });
 
-    updateRelatedChangeType('mergeStyles', bumpInfo, true);
-    updateRelatedChangeType('datetimeUtils', bumpInfo, true);
+    updateRelatedChangeType('mergeStyles.json', 'mergeStyles', bumpInfo, true);
+    updateRelatedChangeType('datetimeUtils.json', 'datetimeUtils', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(4);
 
@@ -573,7 +575,7 @@ describe('updateRelatedChangeType', () => {
 
   it('should respect disallowed change type', () => {
     const bumpInfo = _.merge(_.cloneDeep(bumpInfoFixture), {
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'major' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'major' }]]),
       packageInfos: {
         foo: {
           combinedOptions: { disallowedChangeTypes: ['minor', 'major'], defaultNpmTag: 'latest' },
@@ -581,7 +583,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType('foo', bumpInfo, true);
+    updateRelatedChangeType('foo.json', 'foo', bumpInfo, true);
 
     expect(Object.keys(bumpInfo.dependentChangeInfos).length).toBe(0);
     expect(bumpInfo.calculatedChangeInfos['foo']).toBeUndefined();

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -337,7 +337,7 @@ describe('updateRelatedChangeType', () => {
         foo: 'patch',
       },
       calculatedChangeInfos: {},
-      changeFileChangeInfos: new Map([['foo', { ...changeInfoFixture, type: 'patch' }]]),
+      changeFileChangeInfos: new Map([['foo.json', { ...changeInfoFixture, type: 'patch' }]]),
       packageInfos: {
         foo: {
           group: 'grp',

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -1,0 +1,71 @@
+import { getPackageChangelogs } from '../../changelog/getPackageChangelogs';
+import { BumpInfo } from '../../types/BumpInfo';
+import { ChangeSet } from '../../types/ChangeInfo';
+import { PackageInfos } from '../../types/PackageInfo';
+
+describe('getPackageChangelogs', () => {
+  it('should have multiple comment entries when a package has a changefile AND was part of a dependent bump', () => {
+    const changeFileChangeInfos: ChangeSet = new Map([
+      [
+        'foo.json',
+        {
+          comment: 'comment for foo',
+          commit: 'deadbeef',
+          dependentChangeType: 'patch',
+          email: 'something@something.com',
+          packageName: 'foo',
+          type: 'patch',
+        },
+      ],
+      [
+        'bar.json',
+        {
+          comment: 'comment for foo',
+          commit: 'deadbeef',
+          dependentChangeType: 'patch',
+          email: 'something@something.com',
+          packageName: 'bar',
+          type: 'patch',
+        },
+      ],
+    ]);
+
+    const dependentChangeInfos: BumpInfo['dependentChangeInfos'] = {
+      bar: {
+        comment: 'bumped due to foo',
+        commit: 'deadbeef',
+        dependentChangeType: 'patch',
+        email: 'something@something.com',
+        packageName: 'bar',
+        type: 'patch',
+      },
+    };
+
+    const packageInfos: PackageInfos = {
+      foo: {
+        combinedOptions: {} as any,
+        name: 'foo',
+        packageJsonPath: 'packages/foo/package.json',
+        packageOptions: {},
+        private: false,
+        version: '1.0.0',
+        dependencies: {
+          bar: '^1.0.0',
+        },
+      },
+      bar: {
+        combinedOptions: {} as any,
+        name: 'foo',
+        packageJsonPath: 'packages/foo/package.json',
+        packageOptions: {},
+        private: false,
+        version: '1.0.0',
+      },
+    };
+
+    const changelogs = getPackageChangelogs(changeFileChangeInfos, dependentChangeInfos, packageInfos, '.');
+
+    expect(Object.keys(changelogs.bar.comments.patch!).length).toBe(2);
+    expect(Object.keys(changelogs.foo.comments.patch!).length).toBe(1);
+  });
+});

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -13,7 +13,14 @@ import { setDependentVersions } from './setDependentVersions';
  */
 export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { bumpDeps } = options;
-  const { packageInfos, scopedPackages, calculatedChangeInfos, changeFileChangeInfos, modifiedPackages } = bumpInfo;
+  const {
+    packageInfos,
+    scopedPackages,
+    calculatedChangeInfos,
+    dependentChangeInfos,
+    changeFileChangeInfos,
+    modifiedPackages,
+  } = bumpInfo;
 
   // pass 1: figure out all the change types for all the packages taking into account the bumpDeps option and version groups
   if (bumpDeps) {
@@ -22,8 +29,8 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   setGroupsInBumpInfo(bumpInfo, options);
 
-  for (const changeInfo of changeFileChangeInfos.values()) {
-    updateRelatedChangeType(changeInfo.packageName, bumpInfo, bumpDeps);
+  for (const [changeFile, changeInfo] of changeFileChangeInfos.entries()) {
+    updateRelatedChangeType(changeFile, changeInfo.packageName, bumpInfo, bumpDeps);
   }
   // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(calculatedChangeInfos).forEach(pkgName => {
@@ -31,9 +38,9 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   });
 
   // pass 3: update the dependentChangeInfos with relevant comments
-  for (const changeInfo of Object.values(bumpInfo.dependentChangeInfos)) {
+  for (const changeInfo of Object.values(dependentChangeInfos)) {
     const pkg = changeInfo.packageName;
-    calculatedChangeInfos[pkg]!.comment = `Bump ${pkg} to v${packageInfos[pkg].version}`;
+    dependentChangeInfos[pkg]!.comment = `Bump ${pkg} to v${packageInfos[pkg].version}`;
   }
 
   // pass 4: Bump all the dependencies packages

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -32,6 +32,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   for (const [changeFile, changeInfo] of changeFileChangeInfos.entries()) {
     updateRelatedChangeType(changeFile, changeInfo.packageName, bumpInfo, bumpDeps);
   }
+
   // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(calculatedChangeInfos).forEach(pkgName => {
     bumpPackageInfoVersion(pkgName, bumpInfo, options);

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -39,13 +39,13 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
  * deletes change files, update package.json, and changelogs
  */
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { modifiedPackages, packageInfos, changeFileChangeInfos, calculatedChangeInfos } = bumpInfo;
+  const { modifiedPackages, packageInfos, changeFileChangeInfos, dependentChangeInfos } = bumpInfo;
 
   writePackageJson(modifiedPackages, packageInfos);
 
   if (options.generateChangelog) {
     // Generate changelog
-    await writeChangelog(options, calculatedChangeInfos, packageInfos);
+    await writeChangelog(options, changeFileChangeInfos, dependentChangeInfos, packageInfos);
   }
 
   if (!options.keepChangeFiles) {

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -29,7 +29,12 @@ import { ChangeInfo, ChangeType } from '../types/ChangeInfo';
  * @param bumpDeps
  * @returns
  */
-export function updateRelatedChangeType(entryPointPackageName: string, bumpInfo: BumpInfo, bumpDeps: boolean) {
+export function updateRelatedChangeType(
+  changeFile: string,
+  entryPointPackageName: string,
+  bumpInfo: BumpInfo,
+  bumpDeps: boolean
+) {
   /** [^1]: all the information needed from `bumpInfo` */
   const {
     calculatedChangeInfos,
@@ -50,7 +55,7 @@ export function updateRelatedChangeType(entryPointPackageName: string, bumpInfo:
   const dependentChangeType = dependentChangeTypes[entryPointPackageName];
 
   let baseChangeInfo = {
-    ...changeFileChangeInfos.get(entryPointPackageName),
+    ...changeFileChangeInfos.get(changeFile),
     ...dependentChangeInfos[entryPointPackageName],
     ...calculatedChangeInfos[entryPointPackageName],
   };

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -3,15 +3,17 @@ import { PackageChangelog } from '../types/ChangeLog';
 import { generateTag } from '../tag';
 import { BumpInfo } from '../types/BumpInfo';
 import { getCurrentHash } from 'workspace-tools';
+import { ChangeSet } from '../types/ChangeInfo';
 
 export function getPackageChangelogs(
-  calculatedChangeInfo: BumpInfo['calculatedChangeInfos'],
+  changeFileChangeInfos: ChangeSet,
+  dependentChangeInfos: BumpInfo['dependentChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   },
   cwd: string
 ) {
-  const changeInfos = Object.values(calculatedChangeInfo);
+  const changeInfos = Array.from(changeFileChangeInfos.values()).concat(Object.values(dependentChangeInfos));
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -14,6 +14,7 @@ export function getPackageChangelogs(
   cwd: string
 ) {
   const changeInfos = Array.from(changeFileChangeInfos.values()).concat(Object.values(dependentChangeInfos));
+
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -10,18 +10,25 @@ import { BumpInfo } from '../types/BumpInfo';
 import { isPathIncluded } from '../monorepo/utils';
 import { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
+import { ChangeSet } from '../types/ChangeInfo';
 
 export async function writeChangelog(
   options: BeachballOptions,
-  calculatedChangeInfos: BumpInfo['calculatedChangeInfos'],
+  changeFileChangeInfos: ChangeSet,
+  dependentChangeInfos: BumpInfo['dependentChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
 ): Promise<void> {
-  const groupedChangelogPaths = await writeGroupedChangelog(options, calculatedChangeInfos, packageInfos);
+  const groupedChangelogPaths = await writeGroupedChangelog(
+    options,
+    changeFileChangeInfos,
+    dependentChangeInfos,
+    packageInfos
+  );
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
 
-  const changelogs = getPackageChangelogs(calculatedChangeInfos, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(changeFileChangeInfos, dependentChangeInfos, packageInfos, options.path);
   // Use a standard for loop here to prevent potentially firing off multiple network requests at once
   // (in case any custom renderers have network requests)
   for (const pkg of Object.keys(changelogs)) {
@@ -36,7 +43,8 @@ export async function writeChangelog(
 
 async function writeGroupedChangelog(
   options: BeachballOptions,
-  calculatedChangeInfo: BumpInfo['calculatedChangeInfos'],
+  changeFileChangeInfos: ChangeSet,
+  dependentChangeInfos: BumpInfo['dependentChangeInfos'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
@@ -50,7 +58,7 @@ async function writeGroupedChangelog(
     return [];
   }
 
-  const changelogs = getPackageChangelogs(calculatedChangeInfo, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(changeFileChangeInfos, dependentChangeInfos, packageInfos, options.path);
   const groupedChangelogs: {
     [path: string]: { changelogs: PackageChangelog[]; masterPackage: PackageInfo };
   } = {};


### PR DESCRIPTION
Fixes #553 

1. getPackageChangelogs was taking in the incorrect changeinfo for its job - changed back to dependentChangeInfos + the changeFileChangeInfos
2. fixes the updateRelatedChangeTypes to create  baseChangeInfo based on changeFileChangeInfos.get(changeFile) rather than package name
3. added some test cases for the updated code
