### PR TITLE
sync: fix precedence of tag options

### DIFF
--- a/change/beachball-321fb1a2-d8d9-431d-94e1-fa0b7408664f.json
+++ b/change/beachball-321fb1a2-d8d9-431d-94e1-fa0b7408664f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sync: fix precedence of tag options",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -14,7 +14,6 @@ export async function sync(options: BeachballOptions) {
   const publishedVersions = await listPackageVersionsByTag(
     [...infos.values()],
     options.registry,
-    options.tag,
     options.token,
     options.authType
   );

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -23,10 +23,12 @@ export async function getNpmPackageInfo(packageName: string, registry: string, t
   return packageVersions[packageName];
 }
 
+/**
+ * List versions matching the appropriate tag for each package (based on combined CLI, package, and repo options)
+ */
 export async function listPackageVersionsByTag(
   packageInfos: PackageInfo[],
   registry: string,
-  tag: string,
   token?: string,
   authType?: AuthType
 ) {
@@ -38,7 +40,7 @@ export async function listPackageVersionsByTag(
     all.push(
       limit(async () => {
         const info = await getNpmPackageInfo(pkg.name, registry, token, authType);
-        const npmTag = tag || pkg.combinedOptions.tag || pkg.combinedOptions.defaultNpmTag;
+        const npmTag = pkg.combinedOptions.tag || pkg.combinedOptions.defaultNpmTag;
         versions[pkg.name] = info['dist-tags'] && info['dist-tags'][npmTag] ? info['dist-tags'][npmTag] : undefined;
       })
     );


### PR DESCRIPTION
We discovered in Fluent UI that the `sync` command was not respecting per-package `tag` options. Fix is in the helper function which fetches the versions, each package info's `combinedOptions` already contains the `tag` option with the appropriate order of precedence, so use that instead of overriding with the global option.