### PR TITLE
Reduce number of times getPackageInfos is called

### DIFF
--- a/change/beachball-446b7dbb-7400-46bf-ba2a-f539ef4ccdb6.json
+++ b/change/beachball-446b7dbb-7400-46bf-ba2a-f539ef4ccdb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce number of times `getPackageInfos` is called",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -67,7 +67,8 @@ describe('changelog generation', () => {
       repository.commitChange('foo');
       writeChangeFiles({ foo: getChange() }, repository.rootPath);
 
-      const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions);
+      const packageInfos = getPackageInfos(repository.rootPath);
+      const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions, packageInfos);
       const changes = [...changeSet.values()];
       expect(changes).toHaveLength(1);
       expect(changes[0].commit).toBe(undefined);
@@ -86,10 +87,8 @@ describe('changelog generation', () => {
       writeChangeFiles({ foo: getChange({ comment: 'comment 2' }) }, repository.rootPath);
 
       const beachballOptions = { path: repository.rootPath } as BeachballOptions;
-      const changes = readChangeFiles(beachballOptions);
-
-      // Gather all package info from package.json
       const packageInfos = getPackageInfos(repository.rootPath);
+      const changes = readChangeFiles(beachballOptions, packageInfos);
 
       await writeChangelog(
         beachballOptions,
@@ -133,10 +132,8 @@ describe('changelog generation', () => {
         },
       } as BeachballOptions;
 
-      const changes = readChangeFiles(beachballOptions);
-
-      // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
+      const changes = readChangeFiles(beachballOptions, packageInfos);
 
       await writeChangelog(beachballOptions, changes, {}, packageInfos);
 
@@ -177,10 +174,8 @@ describe('changelog generation', () => {
         },
       } as BeachballOptions;
 
-      const changes = readChangeFiles(beachballOptions);
-
-      // Gather all package info from package.json
       const packageInfos = getPackageInfos(monoRepo.rootPath);
+      const changes = readChangeFiles(beachballOptions, packageInfos);
 
       await writeChangelog(beachballOptions, changes, {}, packageInfos);
 

--- a/src/__e2e__/monorepo/getScopedPackages.test.ts
+++ b/src/__e2e__/monorepo/getScopedPackages.test.ts
@@ -2,25 +2,32 @@ import { getScopedPackages } from '../../monorepo/getScopedPackages';
 import { BeachballOptions } from '../../types/BeachballOptions';
 import { MonoRepoFactory } from '../../fixtures/monorepo';
 import { Repository } from '../../fixtures/repository';
+import { PackageInfos } from '../../types/PackageInfo';
+import { getPackageInfos } from '../../monorepo/getPackageInfos';
 
 describe('getScopedPackages', () => {
   let repoFactory: MonoRepoFactory;
   let repo: Repository;
+  let packageInfos: PackageInfos;
 
   beforeAll(() => {
     repoFactory = new MonoRepoFactory();
     repoFactory.create();
     repo = repoFactory.cloneRepository();
+    packageInfos = getPackageInfos(repo.rootPath);
   });
   afterAll(() => {
     repoFactory.cleanUp();
   });
 
   it('can scope packages', () => {
-    const scopedPackages = getScopedPackages({
-      path: repo.rootPath,
-      scope: ['packages/grouped/*'],
-    } as BeachballOptions);
+    const scopedPackages = getScopedPackages(
+      {
+        path: repo.rootPath,
+        scope: ['packages/grouped/*'],
+      } as BeachballOptions,
+      packageInfos
+    );
 
     expect(scopedPackages.includes('a')).toBeTruthy();
     expect(scopedPackages.includes('b')).toBeTruthy();
@@ -30,10 +37,13 @@ describe('getScopedPackages', () => {
   });
 
   it('can scope with excluded packages', () => {
-    const scopedPackages = getScopedPackages({
-      path: repo.rootPath,
-      scope: ['!packages/grouped/*'],
-    } as BeachballOptions);
+    const scopedPackages = getScopedPackages(
+      {
+        path: repo.rootPath,
+        scope: ['!packages/grouped/*'],
+      } as BeachballOptions,
+      packageInfos
+    );
 
     expect(scopedPackages.includes('a')).toBeFalsy();
     expect(scopedPackages.includes('b')).toBeFalsy();
@@ -43,10 +53,13 @@ describe('getScopedPackages', () => {
   });
 
   it('can mix and match with excluded packages', () => {
-    const scopedPackages = getScopedPackages({
-      path: repo.rootPath,
-      scope: ['packages/b*', '!packages/grouped/*'],
-    } as BeachballOptions);
+    const scopedPackages = getScopedPackages(
+      {
+        path: repo.rootPath,
+        scope: ['packages/b*', '!packages/grouped/*'],
+      } as BeachballOptions,
+      packageInfos
+    );
 
     expect(scopedPackages.includes('a')).toBeFalsy();
     expect(scopedPackages.includes('b')).toBeFalsy();

--- a/src/__e2e__/multiMonorepo.test.ts
+++ b/src/__e2e__/multiMonorepo.test.ts
@@ -32,23 +32,32 @@ describe('changed files', () => {
     fs.writeFileSync(testFilePath, '');
     git(['add', testFilePath], { cwd: repoARoot });
 
-    const changedPackagesA = getChangedPackages({
-      fetch: false,
-      path: repoARoot,
-      branch: 'master',
-    } as BeachballOptions);
+    const changedPackagesA = getChangedPackages(
+      {
+        fetch: false,
+        path: repoARoot,
+        branch: 'master',
+      } as BeachballOptions,
+      getPackageInfos(repoARoot)
+    );
 
-    const changedPackagesB = getChangedPackages({
-      fetch: false,
-      path: repoBRoot,
-      branch: 'master',
-    } as BeachballOptions);
+    const changedPackagesB = getChangedPackages(
+      {
+        fetch: false,
+        path: repoBRoot,
+        branch: 'master',
+      } as BeachballOptions,
+      getPackageInfos(repoBRoot)
+    );
 
-    const changedPackagesRoot = getChangedPackages({
-      fetch: false,
-      path: repo.rootPath,
-      branch: 'master',
-    } as BeachballOptions);
+    const changedPackagesRoot = getChangedPackages(
+      {
+        fetch: false,
+        path: repo.rootPath,
+        branch: 'master',
+      } as BeachballOptions,
+      getPackageInfos(repo.rootPath)
+    );
 
     expect(changedPackagesA).toStrictEqual(['foo']);
     expect(changedPackagesB).toStrictEqual([]);

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -8,6 +8,7 @@ import { git, gitFailFast } from 'workspace-tools';
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory;
@@ -133,7 +134,7 @@ describe('publish command (git)', () => {
       dependentChangeType: null,
     };
 
-    const bumpInfo = gatherBumpInfo(options);
+    const bumpInfo = gatherBumpInfo(options, getPackageInfos(repo1.rootPath));
 
     // 3. Meanwhile, in repo2, also create a new change file
     const repo2 = repositoryFactory.cloneRepository();

--- a/src/__e2e__/validation.test.ts
+++ b/src/__e2e__/validation.test.ts
@@ -5,6 +5,7 @@ import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { areChangeFilesDeleted } from '../validation/areChangeFilesDeleted';
 import { getChangePath } from '../paths';
 import fs from 'fs-extra';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 describe('validation', () => {
   let repositoryFactory: RepositoryFactory;
@@ -25,33 +26,42 @@ describe('validation', () => {
     });
 
     it('is false when no changes have been made', () => {
-      const result = isChangeFileNeeded({
-        branch: 'origin/master',
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions);
+      const result = isChangeFileNeeded(
+        {
+          branch: 'origin/master',
+          path: repository.rootPath,
+          fetch: false,
+        } as BeachballOptions,
+        getPackageInfos(repository.rootPath)
+      );
       expect(result).toBeFalsy();
     });
 
     it('is true when changes exist in a new branch', () => {
       repository.branch('feature-0');
       repository.commitChange('myFilename');
-      const result = isChangeFileNeeded({
-        branch: 'origin/master',
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions);
+      const result = isChangeFileNeeded(
+        {
+          branch: 'origin/master',
+          path: repository.rootPath,
+          fetch: false,
+        } as BeachballOptions,
+        getPackageInfos(repository.rootPath)
+      );
       expect(result).toBeTruthy();
     });
 
     it('is false when changes are CHANGELOG files', () => {
       repository.branch('feature-0');
       repository.commitChange('CHANGELOG.md');
-      const result = isChangeFileNeeded({
-        branch: 'origin/master',
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions);
+      const result = isChangeFileNeeded(
+        {
+          branch: 'origin/master',
+          path: repository.rootPath,
+          fetch: false,
+        } as BeachballOptions,
+        getPackageInfos(repository.rootPath)
+      );
       expect(result).toBeFalsy();
     });
 
@@ -61,11 +71,14 @@ describe('validation', () => {
       repository.commitChange('CHANGELOG.md');
 
       expect(() => {
-        isChangeFileNeeded({
-          branch: 'origin/master',
-          path: repository.rootPath,
-          fetch: true,
-        } as BeachballOptions);
+        isChangeFileNeeded(
+          {
+            branch: 'origin/master',
+            path: repository.rootPath,
+            fetch: true,
+          } as BeachballOptions,
+          getPackageInfos(repository.rootPath)
+        );
       }).toThrow();
     });
   });

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -1,6 +1,5 @@
 import { initializePackageChangeInfo } from '../changefile/getPackageChangeTypes';
 import { readChangeFiles } from '../changefile/readChangeFiles';
-import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { ChangeSet } from '../types/ChangeInfo';
 import { BumpInfo } from '../types/BumpInfo';
 import { bumpInPlace } from './bumpInPlace';
@@ -8,12 +7,12 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getChangePath } from '../paths';
 import path from 'path';
+import { PackageInfos } from '../types/PackageInfo';
 
-function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
+function gatherPreBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
   const { path: cwd } = options;
   // Collate the changes per package
-  const packageInfos = getPackageInfos(cwd);
-  const changes = readChangeFiles(options);
+  const changes = readChangeFiles(options, packageInfos);
   const changePath = getChangePath(cwd);
 
   const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
@@ -52,7 +51,7 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
     changeFileChangeInfos: filteredChanges,
     modifiedPackages: new Set<string>(),
     newPackages: new Set<string>(),
-    scopedPackages: new Set(getScopedPackages(options)),
+    scopedPackages: new Set(getScopedPackages(options, packageInfos)),
     dependentChangeTypes,
     groupOptions,
     dependents: {},
@@ -60,8 +59,8 @@ function gatherPreBumpInfo(options: BeachballOptions): BumpInfo {
   };
 }
 
-export function gatherBumpInfo(options: BeachballOptions): BumpInfo {
-  const bumpInfo = gatherPreBumpInfo(options);
+export function gatherBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
+  const bumpInfo = gatherPreBumpInfo(options, packageInfos);
   bumpInPlace(bumpInfo, options);
   return bumpInfo;
 }

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -5,15 +5,16 @@ import fs from 'fs-extra';
 import path from 'path';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { PackageInfos } from '../types/PackageInfo';
 
 /**
  * Gets all the changed packages, regardless of the change files
  */
-function getAllChangedPackages(options: BeachballOptions) {
+function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
   const { branch, path: cwd } = options;
 
   const changes = [...(getChanges(branch, cwd) || []), ...(getStagedChanges(cwd) || [])];
-  const scopedPackages = getScopedPackages(options);
+  const scopedPackages = getScopedPackages(options, packageInfos);
   const ignoredFiles = ['CHANGELOG.md', 'CHANGELOG.json'];
   const packageRoots: { [pathName: string]: string } = {};
   if (changes) {
@@ -47,7 +48,7 @@ function getAllChangedPackages(options: BeachballOptions) {
 /**
  * Gets all the changed packages, accounting for change files
  */
-export function getChangedPackages(options: BeachballOptions) {
+export function getChangedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
   const { fetch, path: cwd, branch } = options;
 
   const changePath = getChangePath(cwd);
@@ -58,7 +59,7 @@ export function getChangedPackages(options: BeachballOptions) {
     fetchRemoteBranch(remote, remoteBranch, cwd);
   }
 
-  const changedPackages = getAllChangedPackages(options);
+  const changedPackages = getAllChangedPackages(options, packageInfos);
 
   const changeFilesResult = git(
     ['diff', '--name-only', '--relative', '--no-renames', '--diff-filter=A', `${branch}...`],

--- a/src/changefile/getDisallowedChangeTypes.ts
+++ b/src/changefile/getDisallowedChangeTypes.ts
@@ -1,5 +1,6 @@
 import { ChangeType } from '../types/ChangeInfo';
 import { PackageGroups, PackageInfos } from '../types/PackageInfo';
+
 export function getDisallowedChangeTypes(
   packageName: string,
   packageInfos: PackageInfos,

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -16,11 +16,11 @@ import { getDisallowedChangeTypes } from './getDisallowedChangeTypes';
 export async function promptForChange(options: BeachballOptions) {
   const { branch, path: cwd, package: specificPackage } = options;
 
-  const changedPackages = specificPackage ? [specificPackage] : getChangedPackages(options);
+  const packageInfos = getPackageInfos(cwd);
+  const changedPackages = specificPackage ? [specificPackage] : getChangedPackages(options, packageInfos);
   const recentMessages = getRecentCommitMessages(branch, cwd) || [];
   const packageChangeInfo: { [pkgname: string]: ChangeFileInfo } = {};
 
-  const packageInfos = getPackageInfos(cwd);
   const packageGroups = getPackageGroups(packageInfos, options.path, options.groups);
 
   for (let pkg of changedPackages) {

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -5,10 +5,11 @@ import path from 'path';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getChangesBetweenRefs } from 'workspace-tools';
+import { PackageInfos } from '../types/PackageInfo';
 
-export function readChangeFiles(options: BeachballOptions): ChangeSet {
+export function readChangeFiles(options: BeachballOptions, packageInfos: PackageInfos): ChangeSet {
   const { path: cwd } = options;
-  const scopedPackages = getScopedPackages(options);
+  const scopedPackages = getScopedPackages(options, packageInfos);
   const changeSet: ChangeSet = new Map();
   const changePath = getChangePath(cwd);
   const fromRef = options.fromRef;

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -1,7 +1,9 @@
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { performBump } from '../bump/performBump';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 export async function bump(options: BeachballOptions) {
-  return await performBump(gatherBumpInfo(options), options);
+  const bumpInfo = gatherBumpInfo(options, getPackageInfos(options.path));
+  return await performBump(bumpInfo, options);
 }

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -10,7 +10,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 export async function canary(options: BeachballOptions) {
   const oldPackageInfo = getPackageInfos(options.path);
 
-  const bumpInfo = gatherBumpInfo(options);
+  const bumpInfo = gatherBumpInfo(options, oldPackageInfo);
 
   options.keepChangeFiles = true;
   options.generateChangelog = false;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -7,11 +7,13 @@ import { readChangeFiles } from '../changefile/readChangeFiles';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publishToRegistry } from '../publish/publishToRegistry';
 import { getNewPackages } from '../publish/getNewPackages';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 export async function publish(options: BeachballOptions) {
   const { path: cwd, branch, registry, tag } = options;
   // First, validate that we have changes to publish
-  const changes = readChangeFiles(options);
+  const oldPackageInfos = getPackageInfos(cwd);
+  const changes = readChangeFiles(options, oldPackageInfos);
   const packageChangeTypes = initializePackageChangeInfo(changes);
   if (Object.keys(packageChangeTypes).length === 0) {
     console.log('Nothing to bump, skipping publish!');
@@ -54,7 +56,7 @@ export async function publish(options: BeachballOptions) {
     console.log('Bumping version for npm publish');
   }
 
-  const bumpInfo = gatherBumpInfo(options);
+  const bumpInfo = gatherBumpInfo(options, oldPackageInfos);
 
   if (options.new) {
     bumpInfo.newPackages = new Set<string>(await getNewPackages(bumpInfo, options.registry));

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -8,7 +8,7 @@ import { writePackageJson } from '../bump/performBump';
 
 export async function sync(options: BeachballOptions) {
   const packageInfos = getPackageInfos(options.path);
-  const scopedPackages = new Set(getScopedPackages(options));
+  const scopedPackages = new Set(getScopedPackages(options, packageInfos));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));
   const publishedVersions = await listPackageVersionsByTag(

--- a/src/monorepo/getAllPackages.ts
+++ b/src/monorepo/getAllPackages.ts
@@ -1,6 +1,0 @@
-import { getPackageInfos } from './getPackageInfos';
-
-export function getAllPackages(cwd: string): string[] {
-  const infos = getPackageInfos(cwd);
-  return Object.keys(infos);
-}

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -5,7 +5,11 @@ import { getWorkspaces, listAllTrackedFiles } from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 
-export function getPackageInfos(cwd: string) {
+/**
+ * Get a mapping from package name to package info for all packages in the workspace
+ * (reading from package.json files)
+ */
+export function getPackageInfos(cwd: string): PackageInfos {
   const projectRoot = findProjectRoot(cwd);
   const packageRoot = findPackageRoot(cwd);
 

--- a/src/monorepo/getScopedPackages.ts
+++ b/src/monorepo/getScopedPackages.ts
@@ -1,10 +1,9 @@
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getPackageInfos } from './getPackageInfos';
+import { PackageInfos } from '../types/PackageInfo';
 import path from 'path';
 import { isPathIncluded } from './utils';
 
-export function getScopedPackages(options: BeachballOptions) {
-  const packageInfos = getPackageInfos(options.path);
+export function getScopedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
   if (!options.scope) {
     return Object.keys(packageInfos);
   }

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -20,4 +20,7 @@ export interface ChangeInfo extends ChangeFileInfo {
   commit: string;
 }
 
+/**
+ * Map from change file name to change info
+ */
 export type ChangeSet = Map<string, ChangeInfo>;

--- a/src/validation/isChangeFileNeeded.ts
+++ b/src/validation/isChangeFileNeeded.ts
@@ -1,11 +1,12 @@
 import { getChangedPackages } from '../changefile/getChangedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { PackageInfos } from '../types/PackageInfo';
 
-export function isChangeFileNeeded(options: BeachballOptions) {
+export function isChangeFileNeeded(options: BeachballOptions, packageInfos: PackageInfos) {
   const { branch } = options;
 
   console.log(`Checking for changes against "${branch}"`);
-  const changedPackages = getChangedPackages(options);
+  const changedPackages = getChangedPackages(options, packageInfos);
   if (changedPackages.length > 0) {
     console.log(
       `Found changes in the following packages: ${[...changedPackages]

--- a/src/validation/isValidPackageName.ts
+++ b/src/validation/isValidPackageName.ts
@@ -1,6 +1,0 @@
-import { getAllPackages } from '../monorepo/getAllPackages';
-
-export function isValidPackageName(pkg: string, cwd: string) {
-  const packages = getAllPackages(cwd);
-  return packages.includes(pkg);
-}

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -1,6 +1,5 @@
 import { isGitAvailable } from './isGitAvailable';
 import { getUntrackedChanges } from 'workspace-tools';
-import { isValidPackageName } from './isValidPackageName';
 import { isValidAuthType } from './isValidAuthType';
 import { isValidChangeType } from './isValidChangeType';
 import { isChangeFileNeeded } from './isChangeFileNeeded';
@@ -16,20 +15,16 @@ import { validatePackageDependencies } from '../publish/validatePackageDependenc
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { isValidDependentChangeType } from './isValidDependantChangeType';
 
-type ValidationOptions = { allowMissingChangeFiles: boolean; allowFetching: boolean };
-type PartialValidateOptions = Partial<ValidationOptions>;
-const defaultValidationOptions: ValidationOptions = {
-  allowMissingChangeFiles: false,
-  allowFetching: true,
+type ValidationOptions = {
+  allowMissingChangeFiles?: boolean;
+  allowFetching?: boolean;
 };
 
-export function validate(options: BeachballOptions, validateOptionsOverride?: PartialValidateOptions) {
-  const validateOptions: ValidationOptions = Object.assign({}, defaultValidationOptions, validateOptionsOverride || {});
+export function validate(options: BeachballOptions, validateOptions?: Partial<ValidationOptions>) {
+  const { allowMissingChangeFiles = false, allowFetching = true } = validateOptions || {};
 
-  // Validation Steps
   if (!isGitAvailable(options.path)) {
     console.error('ERROR: Please make sure git is installed and initialize the repository with "git init".');
-    process.exit(1);
   }
 
   const untracked = getUntrackedChanges(options.path);
@@ -40,11 +35,12 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     console.warn('Changes in these files will not trigger a prompt for change descriptions');
   }
 
-  if (options.package && !isValidPackageName(options.package, options.path)) {
+  const packageInfos = getPackageInfos(options.path);
+
+  if (options.package && !packageInfos[options.package]) {
     console.error('ERROR: Specified package name is not valid');
     process.exit(1);
   }
-
   if (options.authType && !isValidAuthType(options.authType)) {
     console.error(`ERROR: auth type ${options.authType} is not valid`);
     process.exit(1);
@@ -62,10 +58,10 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
 
   let isChangeNeeded = false;
 
-  if (validateOptions.allowFetching) {
-    isChangeNeeded = isChangeFileNeeded(options);
+  if (allowFetching) {
+    isChangeNeeded = isChangeFileNeeded(options, packageInfos);
 
-    if (isChangeNeeded && !validateOptions.allowMissingChangeFiles) {
+    if (isChangeNeeded && !allowMissingChangeFiles) {
       console.error('ERROR: Change files are needed!');
       console.log(options.changehint);
       process.exit(1);
@@ -89,8 +85,7 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
     process.exit(1);
   }
 
-  const changeSet = readChangeFiles(options);
-  const packageInfos = getPackageInfos(options.path);
+  const changeSet = readChangeFiles(options, packageInfos);
   const packageGroups = getPackageGroups(packageInfos, options.path, options.groups);
 
   for (const [changeFile, change] of changeSet) {
@@ -111,12 +106,12 @@ export function validate(options: BeachballOptions, validateOptionsOverride?: Pa
   }
 
   if (!isChangeNeeded) {
-    const bumpInfo = gatherBumpInfo(options);
+    const bumpInfo = gatherBumpInfo(options, packageInfos);
     if (!validatePackageDependencies(bumpInfo)) {
       console.error(`ERROR: one or more published packages depend on an unpublished package!
 
 Consider one of the following solutions:
-- If the unpublished package should be published, remove "private": true from its package.json.
+- If the unpublished package should be published, remove \`"private": true\` from its package.json.
 - If it should NOT be published, verify that it is only listed under devDependencies of published packages.
 `);
       process.exit(1);


### PR DESCRIPTION
I noticed while cleaning up the validation code that `getPackageInfos()` (which reads all packages from the filesystem) was unnecessarily called multiple times within the same method, instead of being passed around. So I added it as a parameter to several utility functions and passed it through from the appropriate higher-level functions. 

This also caused a bunch of churn in tests for the utilities, since I had to add explicit calls to `getPackageInfos`.