### PR TITLE
Remove PackageInfo.group side effect

### DIFF
--- a/change/beachball-446b7dbb-7400-46bf-ba2a-f539ef4ccdb8.json
+++ b/change/beachball-446b7dbb-7400-46bf-ba2a-f539ef4ccdb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove `group` from `PackageInfo`, and calculate as needed instead of setting it as a side effect",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -96,7 +96,9 @@ export function updateRelatedChangeType(
       }
 
       // handle the group dependent updates
-      const groupName = packageInfo.group;
+      const groupName = Object.keys(packageGroups).find(group =>
+        packageGroups[group].packageNames.includes(packageInfo.name)
+      );
 
       if (groupName) {
         for (const packageNameInGroup of packageGroups[groupName].packageNames) {

--- a/src/monorepo/getPackageGroups.ts
+++ b/src/monorepo/getPackageGroups.ts
@@ -6,7 +6,9 @@ import { isPathIncluded } from './utils';
 export function getPackageGroups(packageInfos: PackageInfos, root: string, groups: VersionGroupOptions[] | undefined) {
   const packageGroups: PackageGroups = {};
 
-  if (groups) {
+  const packageNameToGroup: { [packageName: string]: string } = {};
+
+  if (groups && groups.length) {
     // Check every package to see which group it belongs to
     for (const [pkgName, info] of Object.entries(packageInfos)) {
       const packagePath = path.dirname(info.packageJsonPath);
@@ -16,14 +18,14 @@ export function getPackageGroups(packageInfos: PackageInfos, root: string, group
         if (isPathIncluded(relativePath, groupOption.include, groupOption.exclude)) {
           const groupName = groupOption.name;
 
-          if (packageInfos[pkgName].group) {
+          if (packageNameToGroup[pkgName]) {
             console.error(
-              `Error: ${pkgName} cannot belong to multiple groups: [${groupName}, ${packageInfos[pkgName].group}]!`
+              `Error: ${pkgName} cannot belong to multiple groups: [${groupName}, ${packageNameToGroup[pkgName]}]!`
             );
             process.exit(1);
           }
 
-          packageInfos[pkgName].group = groupName;
+          packageNameToGroup[pkgName] = groupName;
 
           if (!packageGroups[groupName]) {
             packageGroups[groupName] = {

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -30,7 +30,6 @@ export interface PackageInfo {
 
   /** options that are SPECIFIC to the package from its configuration file (might be nothing) */
   packageOptions: Partial<PackageOptions>;
-  group?: string;
 }
 
 export interface PackageInfos {

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -25,6 +25,7 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
 
   if (!isGitAvailable(options.path)) {
     console.error('ERROR: Please make sure git is installed and initialize the repository with "git init".');
+    process.exit(1);
   }
 
   const untracked = getUntrackedChanges(options.path);


### PR DESCRIPTION
`PackageInfo.group` was being set as a side effect in `getPackageGroups`, and only read in `updateRelatedChangeType`. This PR removes the property and the side effect, and determines the group within `updateRelatedChangeType` in a different way using information already available.

This is technically a breaking change due to removal of the property, but since it's optional and only set (and hopefully only read) internally, it's unlikely to cause issues in practice.

(I also added back a line in `validate.ts` which was accidentally removed in the previous change.)