### PR TITLE
Add --verbose flag for making debugging easier

### DIFF
--- a/change/beachball-131dbea8-982d-4330-9638-931d0bed08ec.json
+++ b/change/beachball-131dbea8-982d-4330-9638-931d0bed08ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add `--verbose` flag to make it easier to debug why some packages are being bumped",
+  "packageName": "beachball",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -42,4 +42,5 @@ These options are applicable for the `publish` command, as well as `bump` and/or
 | `--retries`                   |       | `3`                            | number of retries for a package publish before failing                                                                                     |
 | `--tag`                       | `-t`  | `'latest'`                     | dist-tag for npm publishes                                                                                                                 |
 | `--token`                     | `-n`  |                                | credential to use with npm commands. its type is specified with the `--authType` argument                                                  |
+| `--verbose`                   |       | `false`                        | prints additional information to the console                                                                                               |
 | `--yes`                       | `-y`  |                                | skips the prompts for publish                                                                                                              |

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -49,7 +49,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   });
 
   // step 4: Bump all the dependencies packages
-  bumpInfo.dependentChangedBy = setDependentVersions(packageInfos, scopedPackages);
+  bumpInfo.dependentChangedBy = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(bumpInfo.dependentChangedBy).forEach(pkg => modifiedPackages.add(pkg));
 
   return bumpInfo;

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -1,7 +1,12 @@
-import { PackageInfos, PackageDeps } from '../types/PackageInfo';
+import type { BeachballOptions } from '../types/BeachballOptions';
+import type { PackageInfos } from '../types/PackageInfo';
 import { bumpMinSemverRange } from './bumpMinSemverRange';
 
-export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>) {
+export function setDependentVersions(
+  packageInfos: PackageInfos,
+  scopedPackages: Set<string>,
+  { verbose }: BeachballOptions
+) {
   const dependentChangedBy: {[dependent: string]: Set<string>} = {};
 
   Object.keys(packageInfos).forEach(pkgName => {
@@ -10,8 +15,9 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
     }
 
     const info = packageInfos[pkgName];
-    ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depKind => {
-      const deps: PackageDeps | undefined = (info as any)[depKind];
+    const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'] as const;
+    depTypes.forEach(depKind => {
+      const deps = info[depKind];
       if (deps) {
         Object.keys(deps).forEach(dep => {
           const packageInfo = packageInfos[dep];
@@ -23,6 +29,11 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
 
               dependentChangedBy[pkgName] = dependentChangedBy[pkgName] || new Set<string>();
               dependentChangedBy[pkgName].add(dep);
+              if (verbose) {
+                console.log(
+                  `${pkgName} needs to be bumped because ${dep} ${existingVersionRange} -> ${bumpedVersionRange}`
+                );
+              }
             }
           }
         });

--- a/src/bump/setDependentsInBumpInfo.ts
+++ b/src/bump/setDependentsInBumpInfo.ts
@@ -1,5 +1,4 @@
-import { BumpInfo } from '../types/BumpInfo';
-import { PackageDeps } from '../types/PackageInfo';
+import type { BumpInfo } from '../types/BumpInfo';
 
 /**
  * Gets dependents for all packages
@@ -17,9 +16,9 @@ export function setDependentsInBumpInfo(bumpInfo: BumpInfo): void {
     }
 
     const info = packageInfos[pkgName];
-    const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'];
+    const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'] as const;
     depTypes.forEach(depType => {
-      const deps: PackageDeps | undefined = (info as any)[depType];
+      const deps = info[depType];
       if (deps) {
         for (let dep of Object.keys(deps)) {
           if (packages.includes(dep)) {

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -33,7 +33,7 @@ export async function canary(options: BeachballOptions) {
     bumpInfo.packageInfos[pkg].version = newVersion;
   }
 
-  setDependentVersions(bumpInfo.packageInfos, bumpInfo.scopedPackages);
+  setDependentVersions(bumpInfo.packageInfos, bumpInfo.scopedPackages, options);
 
   await performBump(bumpInfo, options);
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -36,7 +36,7 @@ export async function sync(options: BeachballOptions) {
     }
   }
 
-  const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages);
+  const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
   writePackageJson(modifiedPackages, packageInfos);

--- a/src/help.ts
+++ b/src/help.ts
@@ -46,6 +46,7 @@ Options:
   --dependent-change-type         - for the change command: override the default dependent-change-type that will end-up in the change file.
   --disallow-deleted-change-files - for the check command: verifies that no change files were deleted between head and target branch.
   --prerelease-prefix             - for the bump and publish commands: specify a prerelease prefix for packages that will receive a prerelease bump.
+  --verbose                       - prints additional information to the console
 
 Examples:
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -43,6 +43,7 @@ export interface CliOptions
   timeout?: number;
   token: string;
   type?: ChangeType | null;
+  verbose?: boolean;
   version?: boolean;
   yes: boolean;
 }


### PR DESCRIPTION
We've had several incidents where Beachball was trying to bump packages that were completely unrelated to the current changes and failing. Having this extra output would at least make it easier for us to see where Beachball is tripping.

Related build logs:
- https://github.com/microsoft/rnx-kit/runs/3266347469?check_suite_focus=true
- https://github.com/microsoft/rnx-kit/runs/3338523522?check_suite_focus=true

Example output:
```
$ beachball publish --bump-deps --verbose
Skipping bumping private package "@rnx-kit/test-app"
@rnx-kit/cli needs to be bumped because @rnx-kit/console ^1.0.1 -> ^1.0.2
@rnx-kit/metro-config needs to be bumped because @rnx-kit/babel-preset-metro-react-native ^1.0.3 -> ^1.0.4
Validating no private package among package dependencies OK!
```