### PR TITLE
support multiple packages per changefile

### DIFF
--- a/change/change-chatty-cloths-develop.json
+++ b/change/change-chatty-cloths-develop.json
@@ -1,0 +1,9 @@
+{
+"changes": [{
+  "packageName": "beachball",
+  "type": "minor",
+  "dependentChangeType": "patch",
+  "email": "jcreamer@microsoft.com",
+  "comment": "support multiple changes per changefile"
+  }]
+}

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -68,6 +68,7 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 | `generateChangelog`     | bool                                     | `true`            | repo                 | whether to generate changelog files                                                             |
 | `gitTags`               | bool                                     | `true`            | repo, package        | whether to create git tags for published packages (eg: foo_v1.0.1)                              |
 | `groups`                | `VersionGroupOptions[]` ([details][3])   |                   | repo                 | specifies groups of packages that need to be version bumped at the same time                    |
+| `groupChanges`          | bool                                     | `false`           | repo                 | will write multiple changes to a single changefile                                              |
 | `hooks`                 | `HooksOptions` ([details][4])            |                   | repo                 | hooks for custom pre/post publish actions                                                       |
 | `ignorePatterns`        | string[]                                 |                   | repo                 | ignore changes in these files (minimatch patterns; negations not supported)                     |
 | `package`               | string                                   |                   | repo                 | specifies which package the command relates to (overrides change detection based on `git diff`) |

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fs-extra": "^8.0.1",
     "git-url-parse": "^11.1.2",
     "glob": "^7.1.4",
+    "human-id": "^2.0.1",
     "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
     "p-limit": "^3.0.2",

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -68,6 +68,74 @@ Object {
 }
 `;
 
+exports[`changelog generation writeChangelog generates correct changelog with multiple changes changefile 1`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- comment 2 (test@testtestme.com)
+- comment 1 (test@testtestme.com)
+- additional comment 1 (test@testtestme.com)
+- comment from bar change  (test@testtestme.com)
+- additional comment 2 (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog generates correct changelog with multiple changes changefile 2`] = `
+Object {
+  "entries": Array [
+    Object {
+      "comments": Object {
+        "patch": Array [
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "comment 2",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "comment 1",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "additional comment 1",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "comment from bar change ",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+          Object {
+            "author": "test@testtestme.com",
+            "comment": "additional comment 2",
+            "commit": "(sha1)",
+            "package": "foo",
+          },
+        ],
+      },
+      "date": "(date)",
+      "tag": "foo_v1.0.0",
+      "version": "1.0.0",
+    },
+  ],
+  "name": "foo",
+}
+`;
+
 exports[`changelog generation writeChangelog generates correct grouped changelog 1`] = `
 "# Change Log - foo
 

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -4,6 +4,7 @@ import { git } from 'workspace-tools';
 import { change } from '../commands/change';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getChangePath } from '../paths';
+import path from 'path';
 
 describe('change command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -48,6 +49,49 @@ describe('change command', () => {
     expect(output.stdout.startsWith('A')).toBeTruthy();
 
     const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles.length).toBe(1);
+  });
+
+  it('create change file but git stage only multiple changes', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+    repo.commitChange(
+      'packages/pkg-2/package.json',
+      JSON.stringify({
+        name: 'pkg-2',
+        version: '2.0.0',
+      })
+    );
+
+    await change({
+      type: 'minor',
+      dependentChangeType: 'patch',
+      package: ['pkg-1', 'pkg-2'],
+      message: 'stage me please',
+      path: repo.rootPath,
+      commit: false,
+      groupChanges: true,
+    } as BeachballOptions);
+
+    const output = git(['status', '-s'], { cwd: repo.rootPath });
+    expect(output.success).toBeTruthy();
+    expect(output.stdout.startsWith('A')).toBeTruthy();
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    for (const file of changeFiles) {
+      const contents = await fs.readJSON(path.join(repo.rootPath, 'change', file));
+      expect(contents.changes.length).toBe(2);
+    }
+
     expect(changeFiles.length).toBe(1);
   });
 

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -1,4 +1,4 @@
-import { ChangeFileInfo } from '../types/ChangeInfo';
+import { ChangeFileInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
 import { findPackageRoot, getChangePath } from '../paths';
 import { getChanges, getStagedChanges, git, fetchRemoteBranch, parseRemoteBranch } from 'workspace-tools';
 import fs from 'fs-extra';
@@ -79,8 +79,15 @@ export function getChangedPackages(options: BeachballOptions, packageInfos: Pack
   // Loop through the change files, building up a set of packages that we can skip
   changeFiles.forEach(file => {
     try {
-      const changeInfo: ChangeFileInfo = fs.readJSONSync(path.join(cwd, file));
-      changeFilePackageSet.add(changeInfo.packageName);
+      const changeInfo: ChangeFileInfo | ChangeInfoMultiple = fs.readJSONSync(file);
+
+      if ('changes' in changeInfo) {
+        for (const change of (changeInfo as ChangeInfoMultiple).changes) {
+          changeFilePackageSet.add(change.packageName);
+        }
+      } else {
+        changeFilePackageSet.add((changeInfo as ChangeFileInfo).packageName);
+      }
     } catch (e) {
       console.warn(`Error reading or parsing change file ${file}: ${e}`);
     }

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -14,10 +14,14 @@ import { getDisallowedChangeTypes } from './getDisallowedChangeTypes';
  * Uses `prompts` package to prompt for change type and description, fills in git user.email and scope
  */
 export async function promptForChange(options: BeachballOptions) {
-  const { branch, path: cwd, package: specificPackage } = options;
+  const { branch, path: cwd } = options;
+  let { package: specificPackage } = options;
 
+  if (specificPackage && !Array.isArray(specificPackage)) {
+    specificPackage = [specificPackage];
+  }
   const packageInfos = getPackageInfos(cwd);
-  const changedPackages = specificPackage ? [specificPackage] : getChangedPackages(options, packageInfos);
+  const changedPackages = specificPackage || getChangedPackages(options, packageInfos);
   const recentMessages = getRecentCommitMessages(branch, cwd) || [];
   const packageChangeInfo: { [pkgname: string]: ChangeFileInfo } = {};
 

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -1,4 +1,4 @@
-import { ChangeSet, ChangeInfo } from '../types/ChangeInfo';
+import { ChangeSet, ChangeInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
@@ -53,7 +53,8 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
 
   filteredChangeFiles.forEach(changeFile => {
     const changeFilePath = path.join(changePath, changeFile);
-    let changeInfo: ChangeInfo;
+
+    let changeInfo: ChangeInfo | ChangeInfoMultiple;
     try {
       changeInfo = fs.readJSONSync(changeFilePath);
     } catch (e) {
@@ -70,10 +71,16 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
         return;
       }
     }
+    const changes: ChangeInfo[] = changeInfo.changes || [changeInfo as ChangeInfo];
 
-    if (scopedPackages.includes(changeInfo.packageName)) {
-      changeSet.set(changeFile, changeInfo);
+    for (const change of changes) {
+      const packageName = (change as ChangeInfo).packageName;
+
+      if (scopedPackages.includes(packageName)) {
+        changeSet.set(changeFile, change as ChangeInfo);
+      }
     }
   });
+
   return changeSet;
 }

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -6,6 +6,6 @@ export async function change(options: BeachballOptions) {
   const changes = await promptForChange(options);
 
   if (changes) {
-    writeChangeFiles(changes, options.path, options.commit);
+    writeChangeFiles(changes, options.path, options.commit, options.groupChanges);
   }
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -1,5 +1,5 @@
 import { AuthType } from './Auth';
-import { ChangeInfo, ChangeType } from './ChangeInfo';
+import { ChangeInfo, ChangeInfoMultiple, ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
 
@@ -39,7 +39,7 @@ export interface CliOptions
   help?: boolean;
   keepChangeFiles?: boolean;
   new: boolean;
-  package: string;
+  package: string | string[];
   timeout?: number;
   token: string;
   type?: ChangeType | null;
@@ -92,6 +92,8 @@ export interface RepoOptions {
   tag: string;
   /** Transformations for change files */
   transform?: TransformOptions;
+  /** Put multiple changes in a single changefile */
+  groupChanges?: boolean;
 }
 
 export interface PackageOptions {
@@ -139,5 +141,5 @@ export interface TransformOptions {
    * This allows for adding or editing information to the change files
    * without having to modify anything on the disk.
    */
-  changeFiles?: (changeInfo: ChangeInfo, changeFilePath: string) => ChangeInfo;
+  changeFiles?: (changeInfo: ChangeInfo | ChangeInfoMultiple, changeFilePath: string) => ChangeInfo;
 }

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -20,6 +20,11 @@ export interface ChangeInfo extends ChangeFileInfo {
   commit: string;
 }
 
+export interface ChangeInfoMultiple {
+  summary: string;
+  changes: ChangeInfo[];
+}
+
 /**
  * Map from change file name to change info
  */

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -38,7 +38,7 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
 
   const packageInfos = getPackageInfos(options.path);
 
-  if (options.package && !packageInfos[options.package]) {
+  if (options.package && !Array.isArray(options.package) && !packageInfos[options.package]) {
     console.error('ERROR: Specified package name is not valid');
     process.exit(1);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,6 +5605,11 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+human-id@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/human-id/-/human-id-2.0.1.tgz#71aadd0f46d577fd982358133cfd43f2a46f1477"
+  integrity sha512-XWoYbGsEfBB0mtUHiyihsefgf+s1tNQHj7sX1kgDxUM0IEKk8rcZIPTwUpqDdFIQbkViOLejbc0t8jBzz5jL3w==
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"


### PR DESCRIPTION
In large repos when you're changing a bunch of packages at once, it can be kind of expensive to dump a bunch of JSON files into a single folder.

It's easy enough to just group the change files into single files expressing multiple packages per file.

Essentially, there would be a new `multiPackageChanges` option that would generate change files like...

```json
{
"changes": [{
  "packageName": "beachball",
  "type": "minor",
  "dependentChangeType": "patch",
  "email": "jcreamer@microsoft.com",
  "comment": "support multiple changes per changefile"
  }]
}
```

And there's a bit of confusion on my end as to why each `ChangeInfo` needs its own `comment` as I think that `comment` field is generated from the `yarn change` command? So perhaps we can bubble that `comment` field up into the `summary` as seen above.

Other than supporting multiple packages, in theory nothing else here functionally changes, other than I added the `human-id` library to give the change files a shorter and cleaner name.
