### PR TITLE
Option to specify custom transform method for the change files

### DIFF
--- a/change/beachball-c9ad3600-06b8-481e-a904-fbd622de09e1.json
+++ b/change/beachball-c9ad3600-06b8-481e-a904-fbd622de09e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added custom transform option for the changeFiles",
+  "packageName": "beachball",
+  "email": "pravcha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testRegex: '/__tests__/.*\\.(test|spec)\\.[jt]sx?$',
+  testTimeout: 60000
 };

--- a/jest.e2e.js
+++ b/jest.e2e.js
@@ -4,4 +4,5 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testRegex: '/__e2e__/.*\\.(test|spec)\\.[jt]sx?$',
+  testTimeout: 60000
 };

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -1,42 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`changelog generation writeChangelog Verify that the changeFile transform functions are run, if provided 1`] = `
-"# Change Log - bar
-
-This log was last generated on (date) and should not be manually modified.
-
-<!-- Start content -->
-
-## 1.3.4
-
-(date)
-
-### Patches
-
-- Edited comment for testing (test@testtestme.com)
-"
-`;
-
-exports[`changelog generation writeChangelog Verify that the changeFile transform functions are run, if provided 2`] = `
-"# Change Log - foo
-
-This log was last generated on (date) and should not be manually modified.
-
-<!-- Start content -->
-
-## 1.0.0
-
-(date)
-
-### Patches
-
-- \`bar\`
-  - Edited comment for testing (test@testtestme.com)
-- \`foo\`
-  - Edited comment for testing (test@testtestme.com)
-"
-`;
-
 exports[`changelog generation writeChangelog generates correct changelog 1`] = `
 "# Change Log - foo
 

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`changelog generation writeChangelog Verify that the changeFile transform functions are run, if provided 1`] = `
+"# Change Log - bar
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.3.4
+
+(date)
+
+### Patches
+
+- Edited comment for testing (test@testtestme.com)
+"
+`;
+
+exports[`changelog generation writeChangelog Verify that the changeFile transform functions are run, if provided 2`] = `
+"# Change Log - foo
+
+This log was last generated on (date) and should not be manually modified.
+
+<!-- Start content -->
+
+## 1.0.0
+
+(date)
+
+### Patches
+
+- \`bar\`
+  - Edited comment for testing (test@testtestme.com)
+- \`foo\`
+  - Edited comment for testing (test@testtestme.com)
+"
+`;
+
 exports[`changelog generation writeChangelog generates correct changelog 1`] = `
 "# Change Log - foo
 

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -202,7 +202,7 @@ describe('changelog generation', () => {
         path: monoRepo.rootPath,
         transform: {
           changeFiles: (changeFile, path) => {
-            changeFile.testParam = 'testParam';
+            changeFile.comment = 'Edited comment for testing';
             return changeFile;
           }
         },

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -54,7 +54,14 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
   filteredChangeFiles.forEach(changeFile => {
     try {
       const changeFilePath = path.join(changePath, changeFile);
-      const changeInfo: ChangeInfo = fs.readJSONSync(changeFilePath);
+      let changeInfo: ChangeInfo = fs.readJSONSync(changeFilePath);
+
+      /**
+       * Transform the change files, if the option is provided
+       */
+      if(options.transform?.changeFiles){
+       changeInfo = options.transform?.changeFiles(changeInfo, path.join(changePath, changeFile))
+      }
 
       const packageName = changeInfo.packageName;
       if (scopedPackages.includes(packageName)) {

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -85,6 +85,12 @@ export interface RepoOptions {
   };
 
   transform?: {
+    /**
+     * Runs for each of the filtered change files.
+     *
+     * This allows for adding or editing information to the change files
+     * without having to modify anything on the disk.
+     */
     changeFiles?: (changeInfo: ChangeInfo, changeFilePath: string) => ChangeInfo;
   }
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -1,5 +1,5 @@
 import { AuthType } from './Auth';
-import { ChangeType } from './ChangeInfo';
+import { ChangeInfo, ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
 
@@ -83,6 +83,10 @@ export interface RepoOptions {
      */
     postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
   };
+
+  transform?: {
+    changeFiles?: (changeInfo: ChangeInfo, changeFilePath: string) => ChangeInfo;
+  }
 }
 
 export interface PackageOptions {


### PR DESCRIPTION
This PR introduces an option to specify any custom transform method for the change files. It can be used to add more information to the change files which might not be present at the time of their generation. 

The consumer can have the following beachball config file to use this functionality - 

```
{
       ...

      transform: {
          changeFiles: (changeFile, path) => {
          // Add or Edit the information in the changeFile
          return changeFile;
          };
      }

       ...
}
```

