### PR TITLE
Fix changelog generation for dependent and fixes version group bumping - adding more tests to validate the changelog

### DIFF
--- a/change/beachball-ee61e91a-12c5-4cf6-b6a1-198ef94cfa65.json
+++ b/change/beachball-ee61e91a-12c5-4cf6-b6a1-198ef94cfa65.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Some refactoring; fixing the dependent change bump message generation so it is back in line with what we had",
+  "packageName": "beachball",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -17,7 +17,7 @@ This log was last generated on (date) and should not be manually modified.
 - comment 1 (test@testtestme.com)
 - additional comment 1 (test@testtestme.com)
 - additional comment 2 (test@testtestme.com)
-- bump foo to v1.0.1 (test@testtestme.com)
+- bump foo to v1.0.0 (beachball)
 "
 `;
 
@@ -52,8 +52,8 @@ Object {
             "package": "foo",
           },
           Object {
-            "author": "test@testtestme.com",
-            "comment": "bump foo to v1.0.1",
+            "author": "beachball",
+            "comment": "bump foo to v1.0.0",
             "commit": "(sha1)",
             "package": "foo",
           },
@@ -174,7 +174,7 @@ This log was last generated on (date) and should not be manually modified.
 
 ### Patches
 
-- Bump baz to v1.3.5 (test@testtestme.com)
+- bump baz to v1.3.4 (beachball)
 "
 `;
 
@@ -210,6 +210,8 @@ This log was last generated on (date) and should not be manually modified.
 
 - \`baz\`
   - comment 1 (test@testtestme.com)
+- \`bar\`
+  - bump baz to v1.3.4 (beachball)
 "
 `;
 
@@ -227,7 +229,7 @@ This log was last generated on (date) and should not be manually modified.
 ### Patches
 
 - comment 1 (test@testtestme.com)
-- Bump baz to v1.3.5 (test@testtestme.com)
+- bump baz to v1.3.4 (beachball)
 "
 `;
 
@@ -263,6 +265,7 @@ This log was last generated on (date) and should not be manually modified.
 
 - \`bar\`
   - comment 1 (test@testtestme.com)
+  - bump baz to v1.3.4 (beachball)
 - \`baz\`
   - comment 1 (test@testtestme.com)
 "

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -210,8 +210,6 @@ This log was last generated on (date) and should not be manually modified.
 
 - \`baz\`
   - comment 1 (test@testtestme.com)
-- \`bar\`
-  - bump baz to v1.3.4
 "
 `;
 
@@ -265,7 +263,6 @@ This log was last generated on (date) and should not be manually modified.
 
 - \`bar\`
   - comment 1 (test@testtestme.com)
-  - bump baz to v1.3.4
 - \`baz\`
   - comment 1 (test@testtestme.com)
 "

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -17,7 +17,7 @@ This log was last generated on (date) and should not be manually modified.
 - comment 1 (test@testtestme.com)
 - additional comment 1 (test@testtestme.com)
 - additional comment 2 (test@testtestme.com)
-- bump foo to v1.0.0 (beachball)
+- bump foo to v1.0.0
 "
 `;
 
@@ -174,7 +174,7 @@ This log was last generated on (date) and should not be manually modified.
 
 ### Patches
 
-- bump baz to v1.3.4 (beachball)
+- bump baz to v1.3.4
 "
 `;
 
@@ -211,7 +211,7 @@ This log was last generated on (date) and should not be manually modified.
 - \`baz\`
   - comment 1 (test@testtestme.com)
 - \`bar\`
-  - bump baz to v1.3.4 (beachball)
+  - bump baz to v1.3.4
 "
 `;
 
@@ -229,7 +229,7 @@ This log was last generated on (date) and should not be manually modified.
 ### Patches
 
 - comment 1 (test@testtestme.com)
-- bump baz to v1.3.4 (beachball)
+- bump baz to v1.3.4
 "
 `;
 
@@ -265,7 +265,7 @@ This log was last generated on (date) and should not be manually modified.
 
 - \`bar\`
   - comment 1 (test@testtestme.com)
-  - bump baz to v1.3.4 (beachball)
+  - bump baz to v1.3.4
 - \`baz\`
   - comment 1 (test@testtestme.com)
 "

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -17,7 +17,7 @@ This log was last generated on (date) and should not be manually modified.
 - comment 1 (test@testtestme.com)
 - additional comment 1 (test@testtestme.com)
 - additional comment 2 (test@testtestme.com)
-- bump foo to v1.0.0
+- Bump foo to v1.0.0
 "
 `;
 
@@ -53,7 +53,7 @@ Object {
           },
           Object {
             "author": "beachball",
-            "comment": "bump foo to v1.0.0",
+            "comment": "Bump foo to v1.0.0",
             "commit": "(sha1)",
             "package": "foo",
           },
@@ -174,7 +174,7 @@ This log was last generated on (date) and should not be manually modified.
 
 ### Patches
 
-- bump baz to v1.3.4
+- Bump baz to v1.3.4
 "
 `;
 
@@ -227,7 +227,7 @@ This log was last generated on (date) and should not be manually modified.
 ### Patches
 
 - comment 1 (test@testtestme.com)
-- bump baz to v1.3.4
+- Bump baz to v1.3.4
 "
 `;
 

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -949,7 +949,7 @@ describe('version bumping', () => {
     const changelogJson = JSON.parse(jsonText);
 
     expect(changelogJson.entries[0].comments.patch[0].comment).toBe(
-      'bump @beachball-comments-repro/package1 to v0.0.2'
+      'Bump @beachball-comments-repro/package1 to v0.0.2'
     );
   });
 });

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -949,7 +949,7 @@ describe('version bumping', () => {
     const changelogJson = JSON.parse(jsonText);
 
     expect(changelogJson.entries[0].comments.patch[0].comment).toBe(
-      'Bump @beachball-comments-repro/package1 to v0.0.2'
+      'bump @beachball-comments-repro/package1 to v0.0.2'
     );
   });
 });

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -7,6 +7,7 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getChangePath } from '../paths';
 import { MonoRepoFactory } from '../fixtures/monorepo';
+import path from 'path';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -874,5 +875,81 @@ describe('version bumping', () => {
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles.length).toBe(0);
+  });
+
+  it('will generate correct dependent changelogs (bumps by dependent change), in monorepo', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'beachball-comments-repro',
+        version: '1.0.0',
+        license: 'UNLICENSED',
+        workspaces: {
+          packages: ['packages/*'],
+        },
+        private: true,
+        repository: {
+          type: 'git',
+        },
+      })
+    );
+
+    repo.commitChange(
+      'packages/package1/package.json',
+      JSON.stringify({
+        name: '@beachball-comments-repro/package1',
+        version: '0.0.1',
+        description: 'A simple repro.',
+        beachball: {
+          disallowedChangeTypes: ['major'],
+        },
+      })
+    );
+    repo.commitChange(
+      'packages/package2/package.json',
+      JSON.stringify({
+        name: '@beachball-comments-repro/package2',
+        version: '0.0.1',
+        description: 'A simple repro.',
+        beachball: {
+          disallowedChangeTypes: ['major'],
+        },
+        dependencies: {
+          '@beachball-comments-repro/package1': '^0.0.1',
+        },
+      })
+    );
+
+    repo.commitChange(
+      'change/@beachball-comments-repro-package1.json',
+      JSON.stringify({
+        type: 'patch',
+        comment: 'This package1 test comment should be absorbed into the changelog.',
+        packageName: '@beachball-comments-repro/package1',
+        email: 'jagore@microsoft.com',
+        dependentChangeType: 'patch',
+      })
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: true,
+      keepChangeFiles: false,
+      generateChangelog: true,
+    } as BeachballOptions);
+
+    const changelogJsonFile = path.join(repo.rootPath, 'packages', 'package2', 'CHANGELOG.json');
+    const jsonText = fs.readFileSync(changelogJsonFile, { encoding: 'utf-8' });
+    const changelogJson = JSON.parse(jsonText);
+
+    expect(changelogJson.entries[0].comments.patch[0].comment).toBe(
+      'Bump @beachball-comments-repro/package1 to v0.0.2'
+    );
   });
 });

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -952,4 +952,76 @@ describe('version bumping', () => {
       'Bump @beachball-comments-repro/package1 to v0.0.2'
     );
   });
+
+  it('will generate correct bumpInfo.modifiedPackages with dep bumps', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'package.json',
+      JSON.stringify({
+        name: 'beachball-comments-repro',
+        version: '1.0.0',
+        license: 'UNLICENSED',
+        workspaces: {
+          packages: ['packages/*'],
+        },
+        private: true,
+        repository: {
+          type: 'git',
+        },
+      })
+    );
+
+    repo.commitChange(
+      'packages/package1/package.json',
+      JSON.stringify({
+        name: '@beachball-comments-repro/package1',
+        version: '0.0.1',
+        description: 'A simple repro.',
+        beachball: {
+          disallowedChangeTypes: ['major'],
+        },
+      })
+    );
+    repo.commitChange(
+      'packages/package2/package.json',
+      JSON.stringify({
+        name: '@beachball-comments-repro/package2',
+        version: '0.0.1',
+        description: 'A simple repro.',
+        beachball: {
+          disallowedChangeTypes: ['major'],
+        },
+        dependencies: {
+          '@beachball-comments-repro/package1': '^0.0.1',
+        },
+      })
+    );
+
+    repo.commitChange(
+      'change/@beachball-comments-repro-package1.json',
+      JSON.stringify({
+        type: 'patch',
+        comment: 'This package1 test comment should be absorbed into the changelog.',
+        packageName: '@beachball-comments-repro/package1',
+        email: 'jagore@microsoft.com',
+        dependentChangeType: 'patch',
+      })
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    const bumpInfo = await bump({
+      path: repo.rootPath,
+      bumpDeps: true,
+      keepChangeFiles: false,
+      generateChangelog: true,
+    } as BeachballOptions);
+
+    const modified = [...bumpInfo.modifiedPackages];
+    expect(modified).toContain('@beachball-comments-repro/package1');
+    expect(modified).toContain('@beachball-comments-repro/package2');
+  });
 });

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -14,9 +14,8 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { MonoRepoFactory } from '../fixtures/monorepo';
 import { ChangelogJson } from '../types/ChangeLog';
-import { BumpInfo } from '../types/BumpInfo';
 
-function getChange(partialChange: Partial<ChangeFileInfo> = {}): ChangeFileInfo{
+function getChange(partialChange: Partial<ChangeFileInfo> = {}): ChangeFileInfo {
   return {
     comment: 'comment 1',
     email: 'test@testtestme.com',
@@ -91,12 +90,7 @@ describe('changelog generation', () => {
       const packageInfos = getPackageInfos(repository.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
 
-      await writeChangelog(
-        beachballOptions,
-        changes,
-        { foo: { ...getChange({ comment: 'bump foo to v1.0.1' }), commit: 'bogus' } },
-        packageInfos
-      );
+      await writeChangelog(beachballOptions, changes, { foo: 'patch' }, { foo: new Set(['foo']) }, packageInfos);
 
       const changelogFile = path.join(repository.rootPath, 'CHANGELOG.md');
       const text = fs.readFileSync(changelogFile, { encoding: 'utf-8' });
@@ -136,7 +130,7 @@ describe('changelog generation', () => {
       const packageInfos = getPackageInfos(monoRepo.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
 
-      await writeChangelog(beachballOptions, changes, {}, packageInfos);
+      await writeChangelog(beachballOptions, changes, {}, {}, packageInfos);
 
       // Validate changelog for foo package
       const fooChangelogFile = path.join(monoRepo.rootPath, 'packages', 'foo', 'CHANGELOG.md');
@@ -174,14 +168,14 @@ describe('changelog generation', () => {
 
       const packageInfos = getPackageInfos(monoRepo.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
-      // Simulates a dependent change from updateRelatedChangeType
-      const dependentChanges: BumpInfo['dependentChangeInfos'] = {
-        bar: {
-          commit: '0xdeadbeef',
-          ...getChange({ packageName: 'bar', comment: 'Bump baz to v1.3.5'}),
-        },
-      }
-      await writeChangelog(beachballOptions, changes, dependentChanges, packageInfos);
+
+      await writeChangelog(
+        beachballOptions,
+        changes,
+        { bar: 'patch', baz: 'patch' },
+        { bar: new Set(['baz']) },
+        packageInfos
+      );
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');
@@ -203,7 +197,7 @@ describe('changelog generation', () => {
       const monoRepo = monoRepoFactory.cloneRepository();
       monoRepo.commitChange('baz');
       writeChangeFiles({ baz: getChange({ packageName: 'baz' }) }, monoRepo.rootPath);
-      writeChangeFiles({ bar : getChange({ packageName: 'bar' }) }, monoRepo.rootPath);
+      writeChangeFiles({ bar: getChange({ packageName: 'bar' }) }, monoRepo.rootPath);
 
       const beachballOptions = {
         path: monoRepo.rootPath,
@@ -220,14 +214,14 @@ describe('changelog generation', () => {
 
       const packageInfos = getPackageInfos(monoRepo.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
-      // Simulates a dependent change from updateRelatedChangeType
-      const dependentChanges: BumpInfo['dependentChangeInfos'] = {
-        bar: {
-          commit: '0xdeadbeef',
-          ...getChange({ packageName: 'bar', comment: 'Bump baz to v1.3.5'}),
-        },
-      }
-      await writeChangelog(beachballOptions, changes, dependentChanges, packageInfos);
+
+      await writeChangelog(
+        beachballOptions,
+        changes,
+        { bar: 'patch', baz: 'patch' },
+        { bar: new Set(['baz']) },
+        packageInfos
+      );
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');
@@ -269,7 +263,7 @@ describe('changelog generation', () => {
       const packageInfos = getPackageInfos(monoRepo.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
 
-      await writeChangelog(beachballOptions, changes, {}, packageInfos);
+      await writeChangelog(beachballOptions, changes, {}, {}, packageInfos);
 
       // Validate changelog for bar package
       const barChangelogFile = path.join(monoRepo.rootPath, 'packages', 'bar', 'CHANGELOG.md');

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -56,7 +56,13 @@ describe('getPackageChangelogs', () => {
       },
     };
 
-    const changelogs = getPackageChangelogs(changeFileChangeInfos, {}, dependentChangedBy, packageInfos, '.');
+    const changelogs = getPackageChangelogs(
+      changeFileChangeInfos,
+      { foo: 'patch', bar: 'patch' },
+      dependentChangedBy,
+      packageInfos,
+      '.'
+    );
 
     expect(Object.keys(changelogs.bar.comments.patch!).length).toBe(2);
     expect(Object.keys(changelogs.foo.comments.patch!).length).toBe(1);

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -30,15 +30,8 @@ describe('getPackageChangelogs', () => {
       ],
     ]);
 
-    const dependentChangeInfos: BumpInfo['dependentChangeInfos'] = {
-      bar: {
-        comment: 'bumped due to foo',
-        commit: 'deadbeef',
-        dependentChangeType: 'patch',
-        email: 'something@something.com',
-        packageName: 'bar',
-        type: 'patch',
-      },
+    const dependentChangedBy: BumpInfo['dependentChangedBy'] = {
+      bar: new Set(['foo']),
     };
 
     const packageInfos: PackageInfos = {
@@ -63,7 +56,7 @@ describe('getPackageChangelogs', () => {
       },
     };
 
-    const changelogs = getPackageChangelogs(changeFileChangeInfos, dependentChangeInfos, packageInfos, '.');
+    const changelogs = getPackageChangelogs(changeFileChangeInfos, {}, dependentChangedBy, packageInfos, '.');
 
     expect(Object.keys(changelogs.bar.comments.patch!).length).toBe(2);
     expect(Object.keys(changelogs.foo.comments.patch!).length).toBe(1);

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -12,7 +12,7 @@ const createTagParameters = (tag: string, cwd: string) => {
 };
 
 const noTagBumpInfo = {
-  calculatedChangeInfos: {
+  calculatedChangeTypes: {
     foo: 'minor',
     bar: 'major',
   },
@@ -37,7 +37,7 @@ const noTagBumpInfo = {
 } as unknown as BumpInfo;
 
 const oneTagBumpInfo = {
-  calculatedChangeInfos: {
+  calculatedChangeTypes: {
     foo: 'minor',
     bar: 'major',
   },

--- a/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -6,8 +6,7 @@ describe('validatePackageDependencies', () => {
   const bumpInfoFixture = {
     changes: new Map(),
     dependents: {},
-    calculatedChangeInfos: {},
-    dependentChangeTypes: {
+    calculatedChangeTypes: {
       foo: 'patch',
     },
     packageInfos: {

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -22,6 +22,11 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
 
   setGroupsInBumpInfo(bumpInfo, options);
 
+  // TODO: when we do "locked", or "lock step" versioning, we could simply skip setting grouped change types
+  //       - set the version for all packages in the group in (bumpPackageInfoVersion())
+  //       - the main concern is how to capture the bump reason in grouped changelog
+
+  // pass 2: initialize grouped calculatedChangeTypes together
   for (const changeInfo of changeFileChangeInfos.values()) {
     const groupName = Object.keys(bumpInfo.packageGroups).find(group =>
       bumpInfo.packageGroups[group].packageNames.includes(changeInfo.packageName)
@@ -38,12 +43,12 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
     updateRelatedChangeType(changeFile, bumpInfo, bumpDeps);
   }
 
-  // pass 2: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
+  // pass 3: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(calculatedChangeTypes).forEach(pkgName => {
     bumpPackageInfoVersion(pkgName, bumpInfo, options);
   });
 
-  // pass 4: Bump all the dependencies packages
+  // step 4: Bump all the dependencies packages
   bumpInfo.dependentChangedBy = setDependentVersions(packageInfos, scopedPackages);
   Object.keys(bumpInfo.dependentChangedBy).forEach(pkg => modifiedPackages.add(pkg));
 

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -6,9 +6,9 @@ import { BeachballOptions } from '../types/BeachballOptions';
  * Bumps an individual package version based on the change type
  */
 export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { calculatedChangeInfos, packageInfos, modifiedPackages } = bumpInfo;
+  const { calculatedChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
-  const changeType = calculatedChangeInfos[pkgName]?.type;
+  const changeType = calculatedChangeTypes[pkgName];
   if (!info) {
     console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
     return;

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -1,4 +1,4 @@
-import { initializePackageChangeInfo } from '../changefile/getPackageChangeTypes';
+import { initializePackageChangeInfo as initializePackageChangeTypes } from '../changefile/getPackageChangeTypes';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { ChangeSet } from '../types/ChangeInfo';
 import { BumpInfo } from '../types/BumpInfo';
@@ -15,7 +15,7 @@ function gatherPreBumpInfo(options: BeachballOptions, packageInfos: PackageInfos
   const changes = readChangeFiles(options, packageInfos);
   const changePath = getChangePath(cwd);
 
-  const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
+  // const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
   const groupOptions = {};
 
   // Clear changes for non-existent and accidental private packages
@@ -33,34 +33,33 @@ function gatherPreBumpInfo(options: BeachballOptions, packageInfos: PackageInfos
     }
 
     filteredChanges.set(changeFile, change);
-    dependentChangeTypes[change.packageName] = change.dependentChangeType || 'patch';
   }
 
   // Clear non-existent packages from changefiles infos
-  const calculatedChangeInfos = initializePackageChangeInfo(filteredChanges);
-  Object.keys(calculatedChangeInfos).forEach(packageName => {
+  const calculatedChangeTypes = initializePackageChangeTypes(filteredChanges);
+  Object.keys(calculatedChangeTypes).forEach(packageName => {
     if (!packageInfos[packageName]) {
-      delete calculatedChangeInfos[packageName];
+      delete calculatedChangeTypes[packageName];
     }
   });
 
   return {
-    calculatedChangeInfos,
+    calculatedChangeTypes,
     packageInfos,
     packageGroups: {},
     changeFileChangeInfos: filteredChanges,
     modifiedPackages: new Set<string>(),
     newPackages: new Set<string>(),
     scopedPackages: new Set(getScopedPackages(options, packageInfos)),
-    dependentChangeTypes,
+    dependentChangedBy: {},
     groupOptions,
     dependents: {},
-    dependentChangeInfos: {},
   };
 }
 
 export function gatherBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
   const bumpInfo = gatherPreBumpInfo(options, packageInfos);
+
   bumpInPlace(bumpInfo, options);
   return bumpInfo;
 }

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -52,4 +52,6 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
     // Unlink changelogs
     unlinkChangeFiles(changeFileChangeInfos, packageInfos, options.path);
   }
+
+  return bumpInfo;
 }

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -39,13 +39,13 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
  * deletes change files, update package.json, and changelogs
  */
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
-  const { modifiedPackages, packageInfos, changeFileChangeInfos, dependentChangeInfos } = bumpInfo;
+  const { modifiedPackages, packageInfos, changeFileChangeInfos, dependentChangedBy, calculatedChangeTypes } = bumpInfo;
 
   writePackageJson(modifiedPackages, packageInfos);
 
   if (options.generateChangelog) {
     // Generate changelog
-    await writeChangelog(options, changeFileChangeInfos, dependentChangeInfos, packageInfos);
+    await writeChangelog(options, changeFileChangeInfos, calculatedChangeTypes, dependentChangedBy, packageInfos);
   }
 
   if (!options.keepChangeFiles) {

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -2,7 +2,8 @@ import { PackageInfos, PackageDeps } from '../types/PackageInfo';
 import { bumpMinSemverRange } from './bumpMinSemverRange';
 
 export function setDependentVersions(packageInfos: PackageInfos, scopedPackages: Set<string>) {
-  const modifiedPackages = new Set<string>();
+  const dependentChangedBy: {[dependent: string]: Set<string>} = {};
+
   Object.keys(packageInfos).forEach(pkgName => {
     if (!scopedPackages.has(pkgName)) {
       return;
@@ -19,7 +20,9 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
             const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, existingVersionRange);
             if (existingVersionRange !== bumpedVersionRange) {
               deps[dep] = bumpedVersionRange;
-              modifiedPackages.add(pkgName);
+
+              dependentChangedBy[pkgName] = dependentChangedBy[pkgName] || new Set<string>();
+              dependentChangedBy[pkgName].add(dep);
             }
           }
         });
@@ -27,5 +30,5 @@ export function setDependentVersions(packageInfos: PackageInfos, scopedPackages:
     });
   });
 
-  return modifiedPackages;
+  return dependentChangedBy;
 }

--- a/src/changefile/getPackageChangeTypes.ts
+++ b/src/changefile/getPackageChangeTypes.ts
@@ -21,15 +21,17 @@ const ChangeTypeWeights: { [t in ChangeType]: number } = SortedChangeTypes.reduc
 
 export function initializePackageChangeInfo(changeSet: ChangeSet) {
   const changePerPackage: {
-    [pkgName: string]: ChangeInfo;
+    [pkgName: string]: ChangeType;
   } = {};
 
   for (let change of changeSet.values()) {
     const { packageName } = change;
-    if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName].type)) {
-      changePerPackage[packageName] = change;
+
+    if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName])) {
+      changePerPackage[packageName] = change.type;
     }
   }
+
   return changePerPackage;
 }
 

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -54,7 +54,7 @@ export function getPackageChangelogs(
       changelogs[dependent].comments[changeType]!.push({
         author: 'beachball',
         package: dependent,
-        comment: `bump ${dep} to v${packageInfos[dep].version}`,
+        comment: `Bump ${dep} to v${packageInfos[dep].version}`,
         commit,
       });
     }

--- a/src/changelog/renderPackageChangelog.ts
+++ b/src/changelog/renderPackageChangelog.ts
@@ -91,5 +91,9 @@ async function _renderEntriesBasic(
 }
 
 async function _renderEntry(entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo): Promise<string> {
+  if (entry.author === 'beachball') {
+    return `- ${entry.comment}`;
+  }
+
   return `- ${entry.comment} (${entry.author})`;
 }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -15,7 +15,8 @@ import { ChangeSet } from '../types/ChangeInfo';
 export async function writeChangelog(
   options: BeachballOptions,
   changeFileChangeInfos: ChangeSet,
-  dependentChangeInfos: BumpInfo['dependentChangeInfos'],
+  calculatedChangeTypes: BumpInfo['calculatedChangeTypes'],
+  dependentChangedBy: BumpInfo['dependentChangedBy'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
@@ -23,11 +24,13 @@ export async function writeChangelog(
   const groupedChangelogPaths = await writeGroupedChangelog(
     options,
     changeFileChangeInfos,
+    calculatedChangeTypes,
+    dependentChangedBy,
     packageInfos
   );
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
 
-  const changelogs = getPackageChangelogs(changeFileChangeInfos, dependentChangeInfos, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(changeFileChangeInfos, calculatedChangeTypes, dependentChangedBy, packageInfos, options.path);
   // Use a standard for loop here to prevent potentially firing off multiple network requests at once
   // (in case any custom renderers have network requests)
   for (const pkg of Object.keys(changelogs)) {
@@ -43,6 +46,8 @@ export async function writeChangelog(
 async function writeGroupedChangelog(
   options: BeachballOptions,
   changeFileChangeInfos: ChangeSet,
+  calculatedChangeTypes: BumpInfo['calculatedChangeTypes'],
+  dependentChangedBy: BumpInfo['dependentChangedBy'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }
@@ -57,7 +62,7 @@ async function writeGroupedChangelog(
   }
 
   // Grouped changelogs should not contain dependency bump entries
-  const changelogs = getPackageChangelogs(changeFileChangeInfos, {}, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(changeFileChangeInfos, calculatedChangeTypes, dependentChangedBy, packageInfos, options.path);
   const groupedChangelogs: {
     [path: string]: {
       changelogs: PackageChangelog[];

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -30,7 +30,13 @@ export async function writeChangelog(
   );
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
 
-  const changelogs = getPackageChangelogs(changeFileChangeInfos, calculatedChangeTypes, dependentChangedBy, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(
+    changeFileChangeInfos,
+    calculatedChangeTypes,
+    dependentChangedBy,
+    packageInfos,
+    options.path
+  );
   // Use a standard for loop here to prevent potentially firing off multiple network requests at once
   // (in case any custom renderers have network requests)
   for (const pkg of Object.keys(changelogs)) {
@@ -62,12 +68,12 @@ async function writeGroupedChangelog(
   }
 
   // Grouped changelogs should not contain dependency bump entries
-  const changelogs = getPackageChangelogs(changeFileChangeInfos, calculatedChangeTypes, dependentChangedBy, packageInfos, options.path);
+  const changelogs = getPackageChangelogs(changeFileChangeInfos, calculatedChangeTypes, {}, packageInfos, options.path);
   const groupedChangelogs: {
     [path: string]: {
       changelogs: PackageChangelog[];
-      masterPackage: PackageInfo ;
-    }
+      masterPackage: PackageInfo;
+    };
   } = {};
 
   for (const pkg in changelogs) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -37,7 +37,7 @@ export async function sync(options: BeachballOptions) {
   }
 
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages);
-  dependentModifiedPackages.forEach(pkg => modifiedPackages.add(pkg));
+  Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
   writePackageJson(modifiedPackages, packageInfos);
 }

--- a/src/publish/shouldPublishPackage.ts
+++ b/src/publish/shouldPublishPackage.ts
@@ -8,7 +8,7 @@ export function shouldPublishPackage(
   reasonToSkip?: string;
 } {
   const packageInfo = bumpInfo.packageInfos[pkgName];
-  const changeType = bumpInfo.calculatedChangeInfos[pkgName]?.type;
+  const changeType = bumpInfo.calculatedChangeTypes[pkgName];
 
   if (changeType === 'none') {
     return {

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -11,7 +11,7 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
 
   [...modifiedPackages, ...newPackages].forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    const changeType = bumpInfo.calculatedChangeInfos[pkg]?.type;
+    const changeType = bumpInfo.calculatedChangeTypes[pkg];
     // Do not tag change type of "none", private packages, or packages opting out of tagging
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       return;

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -1,4 +1,4 @@
-import { ChangeInfo, ChangeSet, ChangeType } from './ChangeInfo';
+import { ChangeSet, ChangeType } from './ChangeInfo';
 import { PackageInfo, PackageGroups } from './PackageInfo';
 import { VersionGroupOptions } from './BeachballOptions';
 
@@ -9,8 +9,8 @@ export type BumpInfo = {
   /** Cached version of package info (e.g. package.json, package path) */
   packageInfos: { [pkgName: string]: PackageInfo };
 
-  /** Change info collated by the package names */
-  calculatedChangeInfos: { [pkgName: string]: ChangeInfo };
+  /** Change types collated by the package names */
+  calculatedChangeTypes: { [pkgName: string]: ChangeType };
 
   /** Package grouping */
   packageGroups: PackageGroups;
@@ -21,17 +21,13 @@ export type BumpInfo = {
   /** Dependents cache (if A depends on B, then {B: [A]}) - child points to parents */
   dependents: { [pkgName: string]: string[] };
 
-  /** Dependent change types (if A depends on B & B has a change, B would specify what its dependents would be change to - i.e. A would be changed to this type) */
-  dependentChangeTypes: { [pkgName: string]: ChangeType };
-
-  /** A Cache of the ChangeInfo for all the dependents in this bump session */
-  dependentChangeInfos: { [pkgName: string]: ChangeInfo };
-
   /** Set of packages that had been modified */
   modifiedPackages: Set<string>;
 
   /** Set of new packages detected in this info */
   newPackages: Set<string>;
+
+  dependentChangedBy: { [pkgName: string]: Set<string> };
 
   /** Set of packages that are in scope for this bump */
   scopedPackages: Set<string>;


### PR DESCRIPTION
This is a change that is long in coming where we get rid of data structures internally that are no longer needed. Sticking to the principle that we keep the state as close to what is needed rather than just having a free-for-all style in the BumpInfo.

This fixes #596 with the updateRelatedChangeType changes. The grouped version was not set correctly before, and this addresses that issue as well.

Note: the snapshots are updated because the changeinfo that was created before was "fake" - and now we actually teach the changelog generation to understand dep bumps with a new "dependentChangedBy" field in BumpInfo. Since the changelog now doesn't take in faked changeinfo objects for dependent bumps, we actually will see the existing versions in these changelog tests.