### PR TITLE
Prevent grouped change infos from overwriting each other

### DIFF
--- a/change/beachball-d56d5619-7139-4aae-b8b9-2027f8e2e3a0.json
+++ b/change/beachball-d56d5619-7139-4aae-b8b9-2027f8e2e3a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Prevent grouped change infos from overwriting each other",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -68,7 +68,7 @@ Object {
 }
 `;
 
-exports[`changelog generation writeChangelog generates correct changelog with multiple changes changefile 1`] = `
+exports[`changelog generation writeChangelog generates correct changelog with groupChanges 1`] = `
 "# Change Log - foo
 
 This log was last generated on (date) and should not be manually modified.
@@ -84,12 +84,12 @@ This log was last generated on (date) and should not be manually modified.
 - comment 2 (test@testtestme.com)
 - comment 1 (test@testtestme.com)
 - additional comment 1 (test@testtestme.com)
-- comment from bar change  (test@testtestme.com)
 - additional comment 2 (test@testtestme.com)
+- comment from bar change  (test@testtestme.com)
 "
 `;
 
-exports[`changelog generation writeChangelog generates correct changelog with multiple changes changefile 2`] = `
+exports[`changelog generation writeChangelog generates correct changelog with groupChanges 2`] = `
 Object {
   "entries": Array [
     Object {
@@ -115,13 +115,13 @@ Object {
           },
           Object {
             "author": "test@testtestme.com",
-            "comment": "comment from bar change ",
+            "comment": "additional comment 2",
             "commit": "(sha1)",
             "package": "foo",
           },
           Object {
             "author": "test@testtestme.com",
-            "comment": "additional comment 2",
+            "comment": "comment from bar change ",
             "commit": "(sha1)",
             "package": "foo",
           },

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -69,21 +69,24 @@ describe('changelog generation', () => {
 
       const packageInfos = getPackageInfos(repository.rootPath);
       const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions, packageInfos);
-      const changes = [...changeSet.values()];
-      expect(changes).toHaveLength(1);
-      expect(changes[0].commit).toBe(undefined);
+      expect(changeSet).toHaveLength(1);
+      expect(changeSet[0].change.commit).toBe(undefined);
     });
 
-    it('does not add commit hash', () => {
+    it('does not add commit hash with groupChanges', () => {
       const repository = repositoryFactory.cloneRepository();
       repository.commitChange('foo');
-      writeChangeFiles({ foo: getChange(), bar: getChange() }, repository.rootPath);
+      writeChangeFiles(
+        { foo: getChange(), bar: getChange() },
+        repository.rootPath,
+        true, // commit
+        true // groupChanges
+      );
 
       const packageInfos = getPackageInfos(repository.rootPath);
       const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions, packageInfos);
-      const changes = [...changeSet.values()];
-      expect(changes).toHaveLength(2);
-      expect(changes[0].commit).toBe(undefined);
+      expect(changeSet).toHaveLength(2);
+      expect(changeSet[0].change.commit).toBe(undefined);
     });
   });
 
@@ -116,7 +119,7 @@ describe('changelog generation', () => {
       expect(changelogJson.entries[0].comments.patch[0].commit).toBe(repository.getCurrentHash());
     });
 
-    it('generates correct changelog with multiple changes changefile', async () => {
+    it.only('generates correct changelog with groupChanges', async () => {
       const repository = repositoryFactory.cloneRepository();
       repository.commitChange('foo');
       writeChangeFiles(
@@ -124,15 +127,17 @@ describe('changelog generation', () => {
           foo: getChange({ comment: 'additional comment 2' }),
           bar: getChange({ comment: 'comment from bar change ' }),
         },
-        repository.rootPath
+        repository.rootPath,
+        true,
+        true
       );
-      writeChangeFiles({ foo: getChange({ comment: 'additional comment 1' }) }, repository.rootPath);
-      writeChangeFiles({ foo: getChange() }, repository.rootPath);
+      writeChangeFiles({ foo: getChange({ comment: 'additional comment 1' }) }, repository.rootPath, true, true);
+      writeChangeFiles({ foo: getChange() }, repository.rootPath, true, true);
 
       repository.commitChange('bar');
-      writeChangeFiles({ foo: getChange({ comment: 'comment 2' }) }, repository.rootPath);
+      writeChangeFiles({ foo: getChange({ comment: 'comment 2' }) }, repository.rootPath, true, true);
 
-      const beachballOptions = { path: repository.rootPath } as BeachballOptions;
+      const beachballOptions = { path: repository.rootPath, groupChanges: true } as BeachballOptions;
       const packageInfos = getPackageInfos(repository.rootPath);
       const changes = readChangeFiles(beachballOptions, packageInfos);
 
@@ -357,11 +362,11 @@ describe('changelog generation', () => {
       const changes = readChangeFiles(beachballOptions, packageInfos);
 
       // Verify that the comment of only the intended change file is changed
-      for (const [changeFileName, changeInfo] of changes) {
-        if (changeFileName.substr(0, 3) === 'foo') {
-          expect(changeInfo.comment).toBe(editedComment);
+      for (const { change, changeFile } of changes) {
+        if (changeFile.substr(0, 3) === 'foo') {
+          expect(change.comment).toBe(editedComment);
         } else {
-          expect(changeInfo.comment).toBe('comment 2');
+          expect(change.comment).toBe('comment 2');
         }
       }
     });

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -5,10 +5,10 @@ import { PackageInfos } from '../../types/PackageInfo';
 
 describe('getPackageChangelogs', () => {
   it('should have multiple comment entries when a package has a changefile AND was part of a dependent bump', () => {
-    const changeFileChangeInfos: ChangeSet = new Map([
-      [
-        'foo.json',
-        {
+    const changeFileChangeInfos: ChangeSet = [
+      {
+        changeFile: 'foo.json',
+        change: {
           comment: 'comment for foo',
           commit: 'deadbeef',
           dependentChangeType: 'patch',
@@ -16,10 +16,10 @@ describe('getPackageChangelogs', () => {
           packageName: 'foo',
           type: 'patch',
         },
-      ],
-      [
-        'bar.json',
-        {
+      },
+      {
+        changeFile: 'bar.json',
+        change: {
           comment: 'comment for bar',
           commit: 'deadbeef',
           dependentChangeType: 'patch',
@@ -27,8 +27,8 @@ describe('getPackageChangelogs', () => {
           packageName: 'bar',
           type: 'patch',
         },
-      ],
-    ]);
+      },
+    ];
 
     const dependentChangedBy: BumpInfo['dependentChangedBy'] = {
       bar: new Set(['foo']),

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -27,7 +27,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   //       - the main concern is how to capture the bump reason in grouped changelog
 
   // pass 2: initialize grouped calculatedChangeTypes together
-  for (const changeInfo of changeFileChangeInfos.values()) {
+  for (const { change: changeInfo } of changeFileChangeInfos) {
     const groupName = Object.keys(bumpInfo.packageGroups).find(group =>
       bumpInfo.packageGroups[group].packageNames.includes(changeInfo.packageName)
     );
@@ -39,7 +39,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
     }
   }
 
-  for (const changeFile of changeFileChangeInfos.keys()) {
+  for (const { changeFile } of changeFileChangeInfos) {
     updateRelatedChangeType(changeFile, bumpInfo, bumpDeps);
   }
 

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -31,72 +31,74 @@ export function updateRelatedChangeType(changeFile: string, bumpInfo: BumpInfo, 
   /** [^1]: all the information needed from `bumpInfo` */
   const { calculatedChangeTypes, packageGroups, dependents, packageInfos, groupOptions } = bumpInfo;
 
-  const changeFileChangeInfo = bumpInfo.changeFileChangeInfos.get(changeFile)!;
-  const entryPointPackageName = changeFileChangeInfo.packageName;
-  const dependentChangeType = changeFileChangeInfo.dependentChangeType;
+  const changesForFile = bumpInfo.changeFileChangeInfos.filter(info => info.changeFile === changeFile);
+  for (const { change: changeFileChangeInfo } of changesForFile) {
+    const entryPointPackageName = changeFileChangeInfo.packageName;
+    const dependentChangeType = changeFileChangeInfo.dependentChangeType;
 
-  // Do not do anything if packageInfo is not present: it means this was an invalid changefile that somehow got checked in
-  if (!packageInfos[entryPointPackageName]) {
-    return;
-  }
+    // Do not do anything if packageInfo is not present: it means this was an invalid changefile that somehow got checked in
+    if (!packageInfos[entryPointPackageName]) {
+      return;
+    }
 
-  let updatedChangeType = getMaxChangeType(dependentChangeType, MinChangeType, []);
+    let updatedChangeType = getMaxChangeType(dependentChangeType, MinChangeType, []);
 
-  const queue = [{ subjectPackage: entryPointPackageName, changeType: MinChangeType }];
+    const queue = [{ subjectPackage: entryPointPackageName, changeType: MinChangeType }];
 
-  // visited is a set of package names that already has been seen by this algorithm - this allows the algo to scale
-  const visited = new Set<string>();
+    // visited is a set of package names that already has been seen by this algorithm - this allows the algo to scale
+    const visited = new Set<string>();
 
-  while (queue.length > 0) {
-    let { subjectPackage, changeType } = queue.shift()!;
+    while (queue.length > 0) {
+      let { subjectPackage, changeType } = queue.shift()!;
 
-    if (!visited.has(subjectPackage)) {
-      visited.add(subjectPackage);
+      if (!visited.has(subjectPackage)) {
+        visited.add(subjectPackage);
 
-      // Step 1. Update change type of the subjectPackage according to the dependent change type propagation
-      const packageInfo = packageInfos[subjectPackage];
+        // Step 1. Update change type of the subjectPackage according to the dependent change type propagation
+        const packageInfo = packageInfos[subjectPackage];
 
-      if (!packageInfo) {
-        continue;
-      }
-
-      const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
-
-      if (subjectPackage !== entryPointPackageName) {
-        updateChangeType(subjectPackage, changeType, disallowedChangeTypes);
-      }
-
-      // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"
-      const dependentPackages = dependents[subjectPackage];
-
-      if (bumpDeps && dependentPackages && dependentPackages.length > 0) {
-        for (const dependentPackage of dependentPackages) {
-          queue.push({
-            subjectPackage: dependentPackage,
-            changeType: updatedChangeType,
-          });
+        if (!packageInfo) {
+          continue;
         }
-      }
 
-      // TODO: when we do "locked", or "lock step" versioning, we could simply skip this grouped traversal,
-      //       - set the version for all packages in the group in (bumpPackageInfoVersion())
-      //       - the main concern is how to capture the bump reason in grouped changelog
+        const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
 
-      // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
-      const groupName = Object.keys(packageGroups).find(group =>
-        packageGroups[group].packageNames.includes(packageInfo.name)
-      );
+        if (subjectPackage !== entryPointPackageName) {
+          updateChangeType(subjectPackage, changeType, disallowedChangeTypes);
+        }
 
-      if (groupName) {
-        for (const packageNameInGroup of packageGroups[groupName].packageNames) {
-          if (
-            !groupOptions[groupName] ||
-            !groupOptions[groupName]?.disallowedChangeTypes?.includes(updatedChangeType)
-          ) {
+        // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"
+        const dependentPackages = dependents[subjectPackage];
+
+        if (bumpDeps && dependentPackages && dependentPackages.length > 0) {
+          for (const dependentPackage of dependentPackages) {
             queue.push({
-              subjectPackage: packageNameInGroup,
+              subjectPackage: dependentPackage,
               changeType: updatedChangeType,
             });
+          }
+        }
+
+        // TODO: when we do "locked", or "lock step" versioning, we could simply skip this grouped traversal,
+        //       - set the version for all packages in the group in (bumpPackageInfoVersion())
+        //       - the main concern is how to capture the bump reason in grouped changelog
+
+        // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
+        const groupName = Object.keys(packageGroups).find(group =>
+          packageGroups[group].packageNames.includes(packageInfo.name)
+        );
+
+        if (groupName) {
+          for (const packageNameInGroup of packageGroups[groupName].packageNames) {
+            if (
+              !groupOptions[groupName] ||
+              !groupOptions[groupName]?.disallowedChangeTypes?.includes(updatedChangeType)
+            ) {
+              queue.push({
+                subjectPackage: packageNameInGroup,
+                changeType: updatedChangeType,
+              });
+            }
           }
         }
       }

--- a/src/changefile/getPackageChangeTypes.ts
+++ b/src/changefile/getPackageChangeTypes.ts
@@ -24,7 +24,7 @@ export function initializePackageChangeInfo(changeSet: ChangeSet) {
     [pkgName: string]: ChangeType;
   } = {};
 
-  for (let change of changeSet.values()) {
+  for (let { change } of changeSet) {
     const { packageName } = change;
 
     if (!changePerPackage[packageName] || isChangeTypeGreater(change.type, changePerPackage[packageName])) {

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -10,7 +10,7 @@ import { PackageInfos } from '../types/PackageInfo';
 export function readChangeFiles(options: BeachballOptions, packageInfos: PackageInfos): ChangeSet {
   const { path: cwd } = options;
   const scopedPackages = getScopedPackages(options, packageInfos);
-  const changeSet: ChangeSet = new Map();
+  const changeSet: ChangeSet = [];
   const changePath = getChangePath(cwd);
   const fromRef = options.fromRef;
 
@@ -71,13 +71,12 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
         return;
       }
     }
+
     const changes: ChangeInfo[] = changeInfo.changes || [changeInfo as ChangeInfo];
 
     for (const change of changes) {
-      const packageName = (change as ChangeInfo).packageName;
-
-      if (scopedPackages.includes(packageName)) {
-        changeSet.set(changeFile, change as ChangeInfo);
+      if (scopedPackages.includes(change.packageName)) {
+        changeSet.push({ changeFile, change });
       }
     }
   });

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -17,11 +17,11 @@ export function unlinkChangeFiles(
   cwd: string
 ) {
   const changePath = getChangePath(cwd);
-  if (!changePath || !changeSet || changeSet.size === 0) {
+  if (!changePath || !changeSet || !changeSet.length) {
     return;
   }
   console.log('Removing change files:');
-  for (let [changeFile, change] of changeSet) {
+  for (let { changeFile, change } of changeSet) {
     if (changeFile && packageInfos[change.packageName] && !packageInfos[change.packageName].private) {
       console.log(`- ${changeFile}`);
       fs.removeSync(path.join(changePath, changeFile));

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -14,15 +14,13 @@ export function getPackageChangelogs(
   },
   cwd: string
 ) {
-  const changeInfos = changeFileChangeInfos.values();
-
   const changelogs: {
     [pkgName: string]: PackageChangelog;
   } = {};
 
   const commit = getCurrentHash(cwd) || 'not available';
 
-  for (let change of changeInfos) {
+  for (let { change } of changeFileChangeInfos) {
     const { packageName, type: changeType, dependentChangeType, email, ...rest } = change;
     if (!changelogs[packageName]) {
       changelogs[packageName] = createChangeLog(packageInfos[packageName]);

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -25,7 +25,6 @@ export async function writeChangelog(
     options,
     changeFileChangeInfos,
     calculatedChangeTypes,
-    dependentChangedBy,
     packageInfos
   );
   const groupedChangelogPathSet = new Set(groupedChangelogPaths);
@@ -53,7 +52,6 @@ async function writeGroupedChangelog(
   options: BeachballOptions,
   changeFileChangeInfos: ChangeSet,
   calculatedChangeTypes: BumpInfo['calculatedChangeTypes'],
-  dependentChangedBy: BumpInfo['dependentChangedBy'],
   packageInfos: {
     [pkg: string]: PackageInfo;
   }

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -21,11 +21,10 @@ export interface ChangeInfo extends ChangeFileInfo {
 }
 
 export interface ChangeInfoMultiple {
-  summary: string;
   changes: ChangeInfo[];
 }
 
 /**
- * Map from change file name to change info
+ * List of change file infos
  */
-export type ChangeSet = Map<string, ChangeInfo>;
+export type ChangeSet = { changeFile: string; change: ChangeInfo }[];

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -89,7 +89,7 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
   const changeSet = readChangeFiles(options, packageInfos);
   const packageGroups = getPackageGroups(packageInfos, options.path, options.groups);
 
-  for (const [changeFile, change] of changeSet) {
+  for (const { changeFile, change } of changeSet) {
     const disallowedChangeTypes = getDisallowedChangeTypes(change.packageName, packageInfos, packageGroups);
 
     if (!change.type || !isValidChangeType(change.type) || disallowedChangeTypes?.includes(change.type)) {


### PR DESCRIPTION
#584 introduced `groupChanges` but didn't update some logic with generating a `ChangeSet` map from change file name to change info, which implicitly assumes a 1:1 correspondence between change file and change info (and causes changes to overwrite each other in the `ChangeSet` when there's more than one change per file).

Fix is to switch `ChangeSet` to be an array of objects instead. This works fine because basically all the places using `ChangeSet` were iterating over all the values, and the one place that wasn't needed some logic updates for `groupChanges` as well.

I also noticed that the tests added in that PR weren't actually running with `groupChanges` enabled, so I fixed that (which helped me to track down the issue).