### PR TITLE
Add Bump Hooks

### DIFF
--- a/change/beachball-4e5b7fbd-6a4c-4994-b038-9c0cf2b507dd.json
+++ b/change/beachball-4e5b7fbd-6a4c-4994-b038-9c0cf2b507dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Bump Hooks",
+  "packageName": "beachball",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1024,4 +1024,200 @@ describe('version bumping', () => {
     expect(modified).toContain('@beachball-comments-repro/package1');
     expect(modified).toContain('@beachball-comments-repro/package2');
   });
+
+  it('calls sync prebump hook before packages are bumped', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    let prebumpCalled = false;
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: false,
+      hooks: {
+        prebump: (packagePath, name, version) => {
+          prebumpCalled = true;
+          expect(packagePath).toBe('packages/pkg-1');
+          expect(name).toBe('pkg-1');
+          expect(version).toBe('1.1.0');
+
+          const jsonPath = path.join(packagePath, 'package.json');
+          expect(fs.readJSONSync(jsonPath).version).toBe('1.0.0');
+        },
+      },
+    } as BeachballOptions);
+
+    expect(prebumpCalled).toBe(true);
+  });
+
+  it('calls async prebump hook before packages are bumped', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    let prebumpCalled = false;
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: false,
+      hooks: {
+        prebump: async (packagePath, name, version) => {
+          prebumpCalled = true;
+          expect(packagePath).toBe('packages/pkg-1');
+          expect(name).toBe('pkg-1');
+          expect(version).toBe('1.1.0');
+
+          const jsonPath = path.join(packagePath, 'package.json');
+          expect((await fs.readJSON(jsonPath)).version).toBe('1.0.0');
+        },
+      },
+    } as BeachballOptions);
+
+    expect(prebumpCalled).toBe(true);
+  });
+
+  it('calls sync postbump hook before packages are bumped', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    let prebumpCalled = false;
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: false,
+      hooks: {
+        postbump: (packagePath, name, version) => {
+          prebumpCalled = true;
+          expect(packagePath).toBe('packages/pkg-1');
+          expect(name).toBe('pkg-1');
+          expect(version).toBe('1.1.0');
+
+          const jsonPath = path.join(packagePath, 'package.json');
+          expect(fs.readJSONSync(jsonPath).version).toBe('1.1.0');
+        },
+      },
+    } as BeachballOptions);
+
+    expect(prebumpCalled).toBe(true);
+  });
+
+  it('calls async postbump hook before packages are bumped', async () => {
+    repositoryFactory = new RepositoryFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/pkg-1/package.json',
+      JSON.stringify({
+        name: 'pkg-1',
+        version: '1.0.0',
+      })
+    );
+
+    writeChangeFiles(
+      {
+        'pkg-1': {
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          packageName: 'pkg-1',
+          dependentChangeType: 'patch',
+        },
+      },
+      repo.rootPath
+    );
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    let prebumpCalled = false;
+
+    await bump({
+      path: repo.rootPath,
+      bumpDeps: false,
+      hooks: {
+        postbump: async (packagePath, name, version) => {
+          prebumpCalled = true;
+          expect(packagePath).toBe('packages/pkg-1');
+          expect(name).toBe('pkg-1');
+          expect(version).toBe('1.1.0');
+
+          const jsonPath = path.join(packagePath, 'package.json');
+          expect((await fs.readJSON(jsonPath)).version).toBe('1.1.0');
+        },
+      },
+    } as BeachballOptions);
+
+    expect(prebumpCalled).toBe(true);
+  });
 });

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1038,18 +1038,18 @@ describe('version bumping', () => {
       })
     );
 
-    writeChangeFiles(
-      {
-        'pkg-1': {
+    writeChangeFiles({
+      changes: [
+        {
           type: 'minor',
           comment: 'test',
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
         },
-      },
-      repo.rootPath
-    );
+      ],
+      cwd: repo.rootPath,
+    });
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -1087,18 +1087,18 @@ describe('version bumping', () => {
       })
     );
 
-    writeChangeFiles(
-      {
-        'pkg-1': {
+    writeChangeFiles({
+      changes: [
+        {
           type: 'minor',
           comment: 'test',
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
         },
-      },
-      repo.rootPath
-    );
+      ],
+      cwd: repo.rootPath,
+    });
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -1136,18 +1136,18 @@ describe('version bumping', () => {
       })
     );
 
-    writeChangeFiles(
-      {
-        'pkg-1': {
+    writeChangeFiles({
+      changes: [
+        {
           type: 'minor',
           comment: 'test',
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
         },
-      },
-      repo.rootPath
-    );
+      ],
+      cwd: repo.rootPath,
+    });
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -1185,18 +1185,18 @@ describe('version bumping', () => {
       })
     );
 
-    writeChangeFiles(
-      {
-        'pkg-1': {
+    writeChangeFiles({
+      changes: [
+        {
           type: 'minor',
           comment: 'test',
           email: 'test@test.com',
           packageName: 'pkg-1',
           dependentChangeType: 'patch',
         },
-      },
-      repo.rootPath
-    );
+      ],
+      cwd: repo.rootPath,
+    });
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1061,7 +1061,7 @@ describe('version bumping', () => {
       hooks: {
         prebump: (packagePath, name, version) => {
           prebumpCalled = true;
-          expect(packagePath).toBe('packages/pkg-1');
+          expect(packagePath.endsWith(path.sep + path.join('packages', 'pkg-1')));
           expect(name).toBe('pkg-1');
           expect(version).toBe('1.1.0');
 
@@ -1110,7 +1110,7 @@ describe('version bumping', () => {
       hooks: {
         prebump: async (packagePath, name, version) => {
           prebumpCalled = true;
-          expect(packagePath).toBe('packages/pkg-1');
+          expect(packagePath.endsWith(path.sep + path.join('packages', 'pkg-1')));
           expect(name).toBe('pkg-1');
           expect(version).toBe('1.1.0');
 
@@ -1151,15 +1151,15 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    let prebumpCalled = false;
+    let postBumpCalled = false;
 
     await bump({
       path: repo.rootPath,
       bumpDeps: false,
       hooks: {
         postbump: (packagePath, name, version) => {
-          prebumpCalled = true;
-          expect(packagePath).toBe('packages/pkg-1');
+          postBumpCalled = true;
+          expect(packagePath.endsWith(path.sep + path.join('packages', 'pkg-1')));
           expect(name).toBe('pkg-1');
           expect(version).toBe('1.1.0');
 
@@ -1169,7 +1169,7 @@ describe('version bumping', () => {
       },
     } as BeachballOptions);
 
-    expect(prebumpCalled).toBe(true);
+    expect(postBumpCalled).toBe(true);
   });
 
   it('calls async postbump hook before packages are bumped', async () => {
@@ -1200,15 +1200,15 @@ describe('version bumping', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    let prebumpCalled = false;
+    let postbumpCalled = false;
 
     await bump({
       path: repo.rootPath,
       bumpDeps: false,
       hooks: {
         postbump: async (packagePath, name, version) => {
-          prebumpCalled = true;
-          expect(packagePath).toBe('packages/pkg-1');
+          postbumpCalled = true;
+          expect(packagePath.endsWith(path.sep + path.join('packages', 'pkg-1')));
           expect(name).toBe('pkg-1');
           expect(version).toBe('1.1.0');
 
@@ -1218,6 +1218,6 @@ describe('version bumping', () => {
       },
     } as BeachballOptions);
 
-    expect(prebumpCalled).toBe(true);
+    expect(postbumpCalled).toBe(true);
   });
 });

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -1,6 +1,7 @@
 import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
 import { writeChangelog } from '../changelog/writeChangelog';
 import fs from 'fs-extra';
+import path from 'path';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import { PackageDeps, PackageInfos } from '../types/PackageInfo';

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -2,7 +2,7 @@ import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
 import { writeChangelog } from '../changelog/writeChangelog';
 import fs from 'fs-extra';
 import { BumpInfo } from '../types/BumpInfo';
-import { BeachballOptions } from '../types/BeachballOptions';
+import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import { PackageDeps, PackageInfos } from '../types/PackageInfo';
 
 export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos) {
@@ -41,6 +41,8 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
   const { modifiedPackages, packageInfos, changeFileChangeInfos, dependentChangedBy, calculatedChangeTypes } = bumpInfo;
 
+  await callHook('prebump', bumpInfo, options);
+
   writePackageJson(modifiedPackages, packageInfos);
 
   if (options.generateChangelog) {
@@ -53,5 +55,26 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
     unlinkChangeFiles(changeFileChangeInfos, packageInfos, options.path);
   }
 
+  await callHook('postbump', bumpInfo, options);
+
   return bumpInfo;
+}
+
+/**
+ * Calls a specified hook for each package being bumped
+ */
+async function callHook(hookName: keyof HooksOptions, bumpInfo: BumpInfo, options: BeachballOptions) {
+  const hook = options.hooks?.[hookName];
+  if (!hook) {
+    return;
+  }
+
+  for (const packageName of bumpInfo.modifiedPackages) {
+    const packageInfo = bumpInfo.packageInfos[packageName];
+
+    const hookRet = hook(packageInfo.packageJsonPath, packageName, packageInfo.version);
+    if (hookRet instanceof Promise) {
+      await hookRet;
+    }
+  }
 }

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -72,7 +72,7 @@ async function callHook(hookName: keyof HooksOptions, bumpInfo: BumpInfo, option
   for (const packageName of bumpInfo.modifiedPackages) {
     const packageInfo = bumpInfo.packageInfos[packageName];
 
-    const hookRet = hook(packageInfo.packageJsonPath, packageName, packageInfo.version);
+    const hookRet = hook(path.dirname(packageInfo.packageJsonPath), packageName, packageInfo.version);
     if (hookRet instanceof Promise) {
       await hookRet;
     }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -132,6 +132,18 @@ export interface HooksOptions {
    * Any file changes made in this step will **not** be committed automatically.
    */
   postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+
+  /**
+   * Runs for each package, before writing changelog and package.json updates
+   * to the filesystem. May be called multiple times during publish.
+   */
+   prebump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+
+  /**
+   * Runs for each package, after writing changelog and package.json updates
+   * to the filesystem. May be called multiple times during publish.
+   */
+  postbump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
 }
 
 export interface TransformOptions {


### PR DESCRIPTION
These hooks allow for mutating the filesystem during a bump. E.g. to allow stamping files apart from package.json, to be checked in and added to the package.

Validated by adding E2E tests.