### PR TITLE
Update help and readme to not refer to 'master' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bumps versions as well as generating changelogs
 
 ### [publish](https://microsoft.github.io/beachball/cli/publish.html)
 
-bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
+bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into the default branch
 
 ### [sync](https://microsoft.github.io/beachball/cli/sync.html)
 
@@ -61,7 +61,7 @@ registry, defaults to https://registry.npmjs.org
 
 ### --branch, -b
 
-target branch from origin (default: master)
+target branch from origin (default: as configured in 'git config init.defaultBranch')
 
 ### --message, -m
 

--- a/change/beachball-b87a5254-ef04-4728-8e25-f5db13d0b15f.json
+++ b/change/beachball-b87a5254-ef04-4728-8e25-f5db13d0b15f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update help and readme to not refer to 'master' branch",
+  "packageName": "beachball",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -20,7 +20,7 @@ Commands:
   check               - checks whether a change file is needed for this branch
   changelog           - based on change files, create changelogs and then unlinks the change files
   bump                - bumps versions as well as generating changelogs
-  publish             - bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
+  publish             - bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into the default branch
   sync                - synchronizes published versions of packages from a registry, makes local package.json changes to match what is published
 
 Options:
@@ -28,7 +28,7 @@ Options:
   --registry, -r                  - registry, defaults to https://registry.npmjs.org
   --tag, -t                       - for the publish command: dist-tag for npm publishes
                                   - for the sync command: will use specified tag to set the version
-  --branch, -b                    - target branch from origin (default: master)
+  --branch, -b                    - target branch from origin (default: as configured in 'git config init.defaultBranch')
   --message, -m                   - for the publish command: custom publish message for the checkin (default: applying package updates);
                                     for the change command: description of the change
   --no-push                       - skip pushing changes back to git remote origin


### PR DESCRIPTION
Now that beachball picks up the default branch which is now usually 'main' rather than the older 'master'.
This change updates the docs to reflect that.