### PR TITLE
Update the api call for prerelease to semver

### DIFF
--- a/change/beachball-06d5d001-14ad-4767-bd88-1f59e62af52a.json
+++ b/change/beachball-06d5d001-14ad-4767-bd88-1f59e62af52a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update the api call for prerelease to semver",
+  "packageName": "beachball",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -22,7 +22,7 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
     return;
   }
   if (!info.private) {
-    info.version = semver.inc(info.version, changeType, options.prereleasePrefix || undefined) as string;
+    info.version = semver.inc(info.version, options.prereleasePrefix ? 'prerelease' : changeType, options.prereleasePrefix || undefined) as string;
     modifiedPackages.add(pkgName);
   }
 }


### PR DESCRIPTION
This PR is to fix the logic of prerelease tag not working.
According to api doc from semver, prerelease bump should be like this:
https://www.npmjs.com/package/semver#:~:text=semver.inc(%271.2.3%27%2C%20%27prerelease%27%2C%20%27beta%27)

This change will allow beachball to call semver using 'prerelease' parameter to do a correct prerelease bump