### PR TITLE
Prevent generation of changelog files for private packages

### DIFF
--- a/change/beachball-38cfe027-5bee-45bf-b7f8-7f044ca8f60a.json
+++ b/change/beachball-38cfe027-5bee-45bf-b7f8-7f044ca8f60a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent generation of changelog files for private packages",
+  "packageName": "beachball",
+  "email": "dlannoye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -116,7 +116,7 @@ describe('getPackageChangelogs', () => {
       packageInfos,
       '.'
     );
-    console.log(changelogs);
+
     expect(changelogs['private-pkg']).toBeUndefined();
   });
 });

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -67,4 +67,56 @@ describe('getPackageChangelogs', () => {
     expect(Object.keys(changelogs.bar.comments.patch!).length).toBe(2);
     expect(Object.keys(changelogs.foo.comments.patch!).length).toBe(1);
   });
+
+  it('should not generate change logs for dependent bumps of private packages', () => {
+    const changeFileChangeInfos: ChangeSet = [
+      {
+        changeFile: 'bar.json',
+        change: {
+          comment: 'comment for bar',
+          commit: 'deadbeef',
+          dependentChangeType: 'patch',
+          email: 'something@something.com',
+          packageName: 'bar',
+          type: 'patch',
+        },
+      },
+    ];
+
+    const dependentChangedBy: BumpInfo['dependentChangedBy'] = {
+      'private-pkg': new Set(['bar']),
+    };
+
+    const packageInfos: PackageInfos = {
+      'private-pkg': {
+        combinedOptions: {} as any,
+        name: 'private-pkg',
+        packageJsonPath: 'packages/private-pkg/package.json',
+        packageOptions: {},
+        private: true,
+        version: '1.0.0',
+        dependencies: {
+          bar: '^1.0.0',
+        },
+      },
+      bar: {
+        combinedOptions: {} as any,
+        name: 'bar',
+        packageJsonPath: 'packages/bar/package.json',
+        packageOptions: {},
+        private: false,
+        version: '1.0.0',
+      },
+    };
+
+    const changelogs = getPackageChangelogs(
+      changeFileChangeInfos,
+      { bar: 'patch', 'private-pkg': 'patch' },
+      dependentChangedBy,
+      packageInfos,
+      '.'
+    );
+    console.log(changelogs);
+    expect(changelogs['private-pkg']).toBeUndefined();
+  });
 });

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -48,6 +48,12 @@ export function getPackageChangelogs(
   const commit = getCurrentHash(cwd) || 'not available';
 
   for (let [dependent, changedBy] of Object.entries(dependentChangedBy)) {
+    if (packageInfos[dependent].private === true) {
+      // Avoid creation of change log files for private packages since the version is
+      // not managed by beachball and the log would only contain bumps to dependencies.
+      continue;
+    }
+
     if (!changelogs[dependent]) {
       changelogs[dependent] = createChangeLog(packageInfos[dependent]);
     }


### PR DESCRIPTION
Addresses issue #480, which was a un-documented behavior introduced in version 1.49.0 from the "Roll-up the changelogs to dependents" feature.