### PR TITLE
Remove non-meaningful or outdated default options

### DIFF
--- a/change/beachball-4c6ad658-2d31-47ee-b8d7-6159244c9467.json
+++ b/change/beachball-4c6ad658-2d31-47ee-b8d7-6159244c9467.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Remove non-meaningful or outdated default options",
+  "type": "patch",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -1,34 +1,20 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 
-export function getDefaultOptions() {
+export function getDefaultOptions(): Partial<BeachballOptions> {
   return {
-    all: false,
     authType: 'authtoken',
-    branch: 'origin/master',
     command: 'change',
-    message: '',
     publish: true,
     bumpDeps: true,
     push: true,
     registry: 'https://registry.npmjs.org/',
-    token: '',
     gitTags: true,
-    tag: '',
-    yes: false,
     access: 'restricted',
-    package: '',
     changehint: 'Run "beachball change" to create a change file',
-    type: null,
     fetch: true,
-    version: false,
-    disallowedChangeTypes: null,
     defaultNpmTag: 'latest',
-    scope: null,
     retries: 3,
-    timeout: undefined,
     bump: true,
-    canaryName: undefined,
     generateChangelog: true,
-    depth: undefined,
-  } as BeachballOptions;
+  };
 }


### PR DESCRIPTION
Noticed when reviewing #618 that `getDefaultOptions` returned a default of `origin/master` which actually is not used at all (it's overridden by a default or the CLI option in `getRepoOptions`).

Remove that default and some other defaults of `false`, `''`, `null`, or `undefined` that are not meaningful, so the actual defaults are easier to read.