### PR TITLE
Fix behavior of VersionGroupOptions.exclude

### DIFF
--- a/change/beachball-9c18f781-7c73-4b14-adb7-a5fc6930628a.json
+++ b/change/beachball-9c18f781-7c73-4b14-adb7-a5fc6930628a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "**Breaking change to `VersionGroupOptions.exclude`**: Fix behavior so that `exclude` patterns will work as is likely expected (if a package path matches any exclude pattern, it's excluded), rather than requiring negation. This is not marked as a major version because the previous behavior was counterintuitive enough that it's less likely anyone relied on it.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/monorepo/isPathIncluded.test.ts
+++ b/src/__tests__/monorepo/isPathIncluded.test.ts
@@ -5,16 +5,21 @@ describe('isPathIncluded', () => {
     expect(isPathIncluded('packages/a', 'packages/*')).toBeTruthy();
   });
 
+  it('should return false if path is not included with single include path', () => {
+    expect(isPathIncluded('stuff/b', 'packages/*')).toBeFalsy();
+    expect(isPathIncluded('packages/b', 'packages/!(b)')).toBeFalsy();
+  });
+
   it('should return false if path is excluded with single exclude path', () => {
-    expect(isPathIncluded('packages/a', 'packages/*', '!packages/a')).toBeFalsy();
+    expect(isPathIncluded('packages/a', 'packages/*', 'packages/a')).toBeFalsy();
   });
 
   it('should return true if path is included with multiple include paths', () => {
-    expect(isPathIncluded('packages/a', ['packages/b', 'packages/a'], ['!packages/b'])).toBeTruthy();
+    expect(isPathIncluded('packages/a', ['packages/b', 'packages/a'], ['packages/b'])).toBeTruthy();
   });
 
   it('should return false if path is excluded with multiple exclude paths', () => {
-    expect(isPathIncluded('packages/a', ['packages/*'], ['!packages/a'])).toBeFalsy();
+    expect(isPathIncluded('packages/a', ['packages/*'], ['packages/a'])).toBeFalsy();
   });
 
   it('should return false if include path is empty', () => {

--- a/src/monorepo/isPathIncluded.ts
+++ b/src/monorepo/isPathIncluded.ts
@@ -5,17 +5,11 @@ import minimatch from 'minimatch';
  */
 export function isPathIncluded(relativePath: string, include: string | string[], exclude?: string | string[]) {
   const includePatterns = typeof include === 'string' ? [include] : include;
-  let shouldInclude = includePatterns.reduce(
-    (included, pattern) => included || minimatch(relativePath, pattern),
-    false
-  );
+  let shouldInclude = includePatterns.some(pattern => minimatch(relativePath, pattern));
 
-  if (exclude) {
+  if (exclude && shouldInclude) {
     const excludePatterns = typeof exclude === 'string' ? [exclude] : exclude;
-    shouldInclude = excludePatterns.reduce(
-      (excluded: boolean, pattern: string) => excluded && minimatch(relativePath, pattern),
-      shouldInclude
-    );
+    shouldInclude = !excludePatterns.some(pattern => minimatch(relativePath, pattern));
   }
 
   return shouldInclude;


### PR DESCRIPTION
While working on another change, I noticed that the behavior of the `VersionGroupOptions.exclude` option was basically acting like a second `include` option: the passed patterns would have to be negated to work. This is very counterintuitive, not useful, and likely was a mistake.

Maybe this diff from one of the tests helps illustrate the before/after behavior. Before, `minimatch(packagePath, excludePattern)` must *return true* for one of the exclude patterns, so the exclude pattern had to be negated. After, the option behaves as expected.
```diff
  it('should return false if path is excluded with single exclude path', () => {
      // isPathIncluded(packagePath, include, exclude)
-    expect(isPathIncluded('packages/a', 'packages/*', '!packages/a')).toBeFalsy();
+    expect(isPathIncluded('packages/a', 'packages/*', 'packages/a')).toBeFalsy();
  });
```

This **could be a breaking change** if anyone was using `group.exclude`, but given the odd behavior, it seems less likely that anyone was relying on it.

(I also renamed the file the function is located in from `utils.ts` to `isPathIncluded` since it only has that one function.)