### PR TITLE
Remove docs for nonexistent changelog command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ a tool to help create change files in the change/ folder
 
 checks whether a change file is needed for this branch
 
-### changelog
-
-based on change files, create changelogs and then unlinks the change files
-
 ### [bump](https://microsoft.github.io/beachball/cli/bump.html)
 
 bumps versions as well as generating changelogs

--- a/change/beachball-e1c73f61-4a19-45ee-a264-2d1a42932db7.json
+++ b/change/beachball-e1c73f61-4a19-45ee-a264-2d1a42932db7.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Remove docs for nonexistent changelog command",
+  "type": "patch",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -18,7 +18,6 @@ Commands:
 
   change (default)    - a tool to help create change files in the change/ folder
   check               - checks whether a change file is needed for this branch
-  changelog           - based on change files, create changelogs and then unlinks the change files
   bump                - bumps versions as well as generating changelogs
   publish             - bumps, publishes to npm registry (optionally does dist-tags), and pushes changelogs back into master
   sync                - synchronizes published versions of packages from a registry, makes local package.json changes to match what is published


### PR DESCRIPTION
`--help` and the readme mention a `changelog` command that doesn't exist. Remove this.

Fixes #634