### PR TITLE
Update the api call for prerelease to semver

### DIFF
--- a/change/beachball-a33d8be0-b765-47ac-a8c8-c94d80374735.json
+++ b/change/beachball-a33d8be0-b765-47ac-a8c8-c94d80374735.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update the api call for prerelease to semver",
+  "packageName": "beachball",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -684,12 +684,12 @@ describe('version bumping', () => {
     const packageInfos = getPackageInfos(repo.rootPath);
 
     expect(packageInfos['pkg-1'].version).toBe('1.0.1-beta.0');
-    expect(packageInfos['pkg-2'].version).toBe('1.0.1');
-    expect(packageInfos['pkg-3'].version).toBe('1.0.1');
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-3'].version).toBe('1.0.1-beta.0');
 
     expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe('1.0.1-beta.0');
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.1');
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.1');
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe('1.0.1-beta.0');
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe('1.0.1-beta.0');
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles.length).toBe(0);

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -22,7 +22,7 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
     return;
   }
   if (!info.private) {
-    info.version = semver.inc(info.version, changeType, options.prereleasePrefix || undefined) as string;
+    info.version = semver.inc(info.version, options.prereleasePrefix ? 'prerelease' : changeType, options.prereleasePrefix || undefined) as string;
     modifiedPackages.add(pkgName);
   }
 }


### PR DESCRIPTION
This PR is a re-up of #633 by @PorterNan, which fixes the failing e2e test.

From the original PR:

> This PR is to fix the logic of prerelease tag not working.
According to api doc from semver, prerelease bump should be like this:
https://www.npmjs.com/package/semver#:~:text=semver.inc(%271.2.3%27%2C%20%27prerelease%27%2C%20%27beta%27)
> 
> This change will allow beachball to call semver using 'prerelease' parameter to do a correct prerelease bump