### PR TITLE
fix: security issue with `workspace-tools`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^6.1.1",
     "toposort": "^2.0.2",
     "uuid": "^8.3.1",
-    "workspace-tools": "^0.16.2",
+    "workspace-tools": "^0.18.4",
     "yargs-parser": "^20.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes a security issue with `workspace-tools` package, by bumping package version to `0.18.4`.