### PR TITLE
Update package-lock.json after bumping packages

### DIFF
--- a/change/beachball-3e377ae5-505a-4a93-ac31-b03334e67971.json
+++ b/change/beachball-3e377ae5-505a-4a93-ac31-b03334e67971.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update package-lock.json after bumping packages",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -9,7 +9,7 @@ import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import { PackageDeps, PackageInfos } from '../types/PackageInfo';
 import { findProjectRoot } from '../paths';
 
-export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos, cwd: string) {
+export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos) {
   for (const pkgName of modifiedPackages) {
     const info = packageInfos[pkgName];
     const packageJson = fs.readJSONSync(info.packageJsonPath);
@@ -35,7 +35,12 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
 
     fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
   }
+}
 
+/**
+ * If `package-lock.json` exists, runs `npm install --package-lock-only` to update it.
+ */
+export function updatePackageLock(cwd: string) {
   const root = findProjectRoot(cwd);
   if (root && fs.existsSync(path.join(root, 'package-lock.json'))) {
     console.log('Updating package-lock.json after bumping packages');
@@ -57,7 +62,8 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
 
   await callHook('prebump', bumpInfo, options);
 
-  writePackageJson(modifiedPackages, packageInfos, options.path);
+  writePackageJson(modifiedPackages, packageInfos);
+  updatePackageLock(options.path);
 
   if (options.generateChangelog) {
     // Generate changelog

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,7 +4,7 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { listPackageVersionsByTag } from '../packageManager/listPackageVersions';
 import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
-import { writePackageJson } from '../bump/performBump';
+import { writePackageJson, updatePackageLock } from '../bump/performBump';
 
 export async function sync(options: BeachballOptions) {
   const packageInfos = getPackageInfos(options.path);
@@ -39,5 +39,6 @@ export async function sync(options: BeachballOptions) {
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
-  writePackageJson(modifiedPackages, packageInfos, options.path);
+  writePackageJson(modifiedPackages, packageInfos);
+  updatePackageLock(options.path);
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -39,5 +39,5 @@ export async function sync(options: BeachballOptions) {
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
-  writePackageJson(modifiedPackages, packageInfos);
+  writePackageJson(modifiedPackages, packageInfos, options.path);
 }


### PR DESCRIPTION
If the package manager is detected to be npm (as determined by presence of `package-lock.json`), beachball should run `npm install --package-lock-only` to update `package-lock.json` after bumping or syncing.

I currently have this new behavior happening automatically rather than under a flag, because arguably it's something beachball should have been doing all along (the only reason it didn't was because the maintainers were primarily using beachball with yarn). If that seems risky, I could add a flag, but if we do that it should definitely become the default behavior in a future major version.

Fixes #525