### PR TITLE
Use path utilities from workspace-tools

### DIFF
--- a/change/beachball-e8e41d79-466d-48e2-bc0d-91615011c641.json
+++ b/change/beachball-e8e41d79-466d-48e2-bc0d-91615011c641.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Use path utilities from workspace-tools",
+  "comment": "Use path utilities from workspace-tools and remove beachball's redundant implementations",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/beachball-e8e41d79-466d-48e2-bc0d-91615011c641.json
+++ b/change/beachball-e8e41d79-466d-48e2-bc0d-91615011c641.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use path utilities from workspace-tools",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^6.1.1",
     "toposort": "^2.0.2",
     "uuid": "^8.3.1",
-    "workspace-tools": "^0.19.0",
+    "workspace-tools": "^0.21.0",
     "yargs-parser": "^20.2.4"
   },
   "devDependencies": {

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -7,7 +7,7 @@ import { writeChangelog } from '../changelog/writeChangelog';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import { PackageDeps, PackageInfos } from '../types/PackageInfo';
-import { findProjectRoot } from '../paths';
+import { findProjectRoot } from 'workspace-tools';
 
 export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos) {
   for (const pkgName of modifiedPackages) {

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -1,6 +1,13 @@
 import { ChangeFileInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
-import { findPackageRoot, getChangePath } from '../paths';
-import { getChanges, getStagedChanges, git, fetchRemoteBranch, parseRemoteBranch } from 'workspace-tools';
+import { getChangePath } from '../paths';
+import {
+  getChanges,
+  getStagedChanges,
+  git,
+  fetchRemoteBranch,
+  parseRemoteBranch,
+  findPackageRoot,
+} from 'workspace-tools';
 import fs from 'fs-extra';
 import path from 'path';
 import minimatch from 'minimatch';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import * as os from 'os';
-import { findProjectRoot } from '../paths';
+import { findProjectRoot } from 'workspace-tools';
 
 export async function init(options: BeachballOptions) {
   const root = findProjectRoot(options.path);

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -1,7 +1,6 @@
-import { findPackageRoot, findProjectRoot } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
-import { getWorkspaces, listAllTrackedFiles } from 'workspace-tools';
+import { getWorkspaces, listAllTrackedFiles, findPackageRoot, findProjectRoot } from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -1,7 +1,6 @@
 import parser from 'yargs-parser';
 import { CliOptions } from '../types/BeachballOptions';
-import { findProjectRoot } from '../paths';
-import { getDefaultRemoteBranch } from 'workspace-tools';
+import { getDefaultRemoteBranch, findProjectRoot } from 'workspace-tools';
 
 let cachedCliOptions: CliOptions;
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,48 +1,9 @@
 import path from 'path';
-import fs from 'fs-extra';
-import { getWorkspaceRoot } from 'workspace-tools';
+import { findProjectRoot } from 'workspace-tools';
 
 /**
- * Starting from `cwd`, searches up the directory hierarchy for `pathName`
+ * Get the folder containing beachball change files.
  */
-export function searchUp(pathName: string, cwd: string) {
-  const root = path.parse(cwd).root;
-
-  let found = false;
-
-  while (!found && cwd !== root) {
-    if (fs.existsSync(path.join(cwd, pathName))) {
-      found = true;
-      break;
-    }
-
-    cwd = path.dirname(cwd);
-  }
-
-  if (found) {
-    return cwd;
-  }
-
-  return null;
-}
-
-export function findGitRoot(cwd: string) {
-  return searchUp('.git', cwd);
-}
-
-export function findProjectRoot(cwd: string) {
-  let workspaceRoot: string | undefined;
-  try {
-    workspaceRoot = getWorkspaceRoot(cwd);
-  } catch {}
-
-  return workspaceRoot || findGitRoot(cwd);
-}
-
-export function findPackageRoot(cwd: string) {
-  return searchUp('package.json', cwd);
-}
-
 export function getChangePath(cwd: string) {
   const root = findProjectRoot(cwd);
 
@@ -51,9 +12,4 @@ export function getChangePath(cwd: string) {
   }
 
   return null;
-}
-
-export function isChildOf(child: string, parent: string) {
-  const relativePath = path.relative(child, parent);
-  return /^[.\/\\]+$/.test(relativePath);
 }

--- a/src/validation/areChangeFilesDeleted.ts
+++ b/src/validation/areChangeFilesDeleted.ts
@@ -1,6 +1,6 @@
-import { findProjectRoot, getChangePath } from '../paths';
+import { getChangePath } from '../paths';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getChangesBetweenRefs } from 'workspace-tools';
+import { getChangesBetweenRefs, findProjectRoot } from 'workspace-tools';
 
 export function areChangeFilesDeleted(options: BeachballOptions): boolean {
   const { branch, path: cwd } = options;

--- a/src/validation/isGitAvailable.ts
+++ b/src/validation/isGitAvailable.ts
@@ -1,5 +1,4 @@
-import { findGitRoot } from '../paths';
-import { git } from 'workspace-tools';
+import { git, findGitRoot } from 'workspace-tools';
 
 export function isGitAvailable(cwd: string) {
   const result = git(['--version']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11490,10 +11490,10 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.19.0.tgz#96d5a18b425b898e722cb2295f13773ad238181b"
-  integrity sha512-2I/b9dwxeWxJp5iOMs1uc7hAGuQOd2terwtu/SBAbrU6YbZfR5TWarFteTzwMPlt1y0VzIoZZg5M7o63eFj4Nw==
+workspace-tools@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.21.0.tgz#eab13d4fac2cace36f6ecef1fe30ed6d912124cb"
+  integrity sha512-ZOGOr42brfDFJcKUz8AonRabORtq0UbuoF6chmcQUwRYmu+Qs85/ZhfflrrMSJLP3yRoqcBe/lvDjGzkWYViww==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"


### PR DESCRIPTION
Beachball has a file with various path utilities which are now redundant with utilities provided by workspace-tools (probably because they were copied from beachball into workspace-tools). This PR updates it to use the workspace-tools versions instead.

The only path utility I decided to keep in beachball is `getChangePath`, because that's definitely specific to beachball and not used elsewhere. (It exists in workspace-tools currently, but I have a PR https://github.com/microsoft/workspace-tools/pull/115 to remove it since it's really not appropriate for that package.)

Removal of the utilities is technically not a breaking change because they're not exported. If anybody was using the utilities via deep imports, they can switch to using the workspace-tools versions.