### PR TITLE
fix: check npm show stdout for valid (non-empty) output

### DIFF
--- a/change/beachball-2222cbfe-8464-46da-b620-d7fab0a21dcd.json
+++ b/change/beachball-2222cbfe-8464-46da-b620-d7fab0a21dcd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes JSON parse failure when npm show output is an empty string and 0 exit code",
+  "packageName": "beachball",
+  "email": "dab5879@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -12,7 +12,7 @@ export async function getNpmPackageInfo(packageName: string, registry: string, t
     const args = ['show', '--registry', registry, '--json', packageName, ...getNpmAuthArgs(registry, token, authType)];
 
     const showResult = await npmAsync(args);
-    if (showResult.success) {
+    if (showResult.success && showResult.stdout !== '') {
       const packageInfo = JSON.parse(showResult.stdout);
       packageVersions[packageName] = packageInfo;
     } else {


### PR DESCRIPTION
Closes #678