### PR TITLE
Update workspace-tools to improve remote detection

### DIFF
--- a/change/beachball-89771895-0bcc-432c-8657-2564c7c4d05e.json
+++ b/change/beachball-89771895-0bcc-432c-8657-2564c7c4d05e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update workspace-tools to fix remote detection",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "semver": "^6.1.1",
     "toposort": "^2.0.2",
     "uuid": "^8.3.1",
-    "workspace-tools": "^0.22.0",
+    "workspace-tools": "^0.24.0",
     "yargs-parser": "^20.2.4"
   },
   "devDependencies": {

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -59,7 +59,10 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
   }
 
   if (args.branch) {
-    cliOptions.branch = args.branch.indexOf('/') > -1 ? args.branch : getDefaultRemoteBranch(args.branch, cwd);
+    cliOptions.branch =
+      args.branch.indexOf('/') > -1
+        ? args.branch
+        : getDefaultRemoteBranch({ branch: args.branch, verbose: args.verbose, cwd });
   }
 
   if (cliOptions.command === 'canary') {

--- a/src/options/getRepoOptions.ts
+++ b/src/options/getRepoOptions.ts
@@ -1,11 +1,11 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import { getDefaultRemoteBranch } from 'workspace-tools';
-import { RepoOptions, CliOptions } from '../types/BeachballOptions';
+import { RepoOptions, CliOptions, BeachballOptions } from '../types/BeachballOptions';
 
 let cachedRepoOptions = new Map<CliOptions, RepoOptions>();
 
 export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
-  const { configPath, path: repoRoot, branch } = cliOptions;
+  const { configPath, path: cwd, branch } = cliOptions;
   if (cachedRepoOptions.has(cliOptions)) {
     return cachedRepoOptions.get(cliOptions)!;
   }
@@ -26,12 +26,13 @@ export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
   // avoid potential for log messages/errors which aren't relevant if the branch was specified on
   // the command line.)
   if (!branch) {
+    const verbose = (repoOptions as BeachballOptions).verbose;
     if (repoOptions.branch && !repoOptions.branch.includes('/')) {
       // Add a remote to the branch if it's not already included
-      repoOptions.branch = getDefaultRemoteBranch(repoOptions.branch, repoRoot);
+      repoOptions.branch = getDefaultRemoteBranch({ branch: repoOptions.branch, cwd, verbose });
     } else if (!repoOptions.branch) {
       // Branch is not specified at all. Add in the default remote and branch.
-      repoOptions.branch = getDefaultRemoteBranch(undefined, cliOptions.path);
+      repoOptions.branch = getDefaultRemoteBranch({ cwd, verbose });
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11489,10 +11489,10 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.22.0.tgz#485ab42664812980c1e3394cdc6c4393245d8d16"
-  integrity sha512-3BNHTncmtUCptpb5EWrcb88tRqYXqOqmfj8ASLp7445ixP2g9ddXzh2cbmH/vHb3KJXCM8nS+N/PQsrmhJxr5w==
+workspace-tools@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.24.0.tgz#92cd3c75217aa7b1eb4b7eb21eec35e7b6fcb094"
+  integrity sha512-KzFQyQq2bhlLFi38qBi3fpco6bGk+B75NS63Ui3yNwQYUYyZ8XRphQRKMuYWXD5YDuGN+GOjf9ylqdS7s/WZTA==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"


### PR DESCRIPTION
Pick up https://github.com/microsoft/workspace-tools/pull/34 to improve detection of which remote to compare against. This should result in more reliable detection by default in most cases. 

If a branch with remote isn't specified in any options, and there's no `repository` key in the repo/workspace root `package.json`, a message will be logged encouraging adding it. There will also be more logs about the remote choice if `--verbose` is enabled.

Fixes #490