### PR TITLE
grouped packages propagate the change type based on ChangeType order

### DIFF
--- a/change/beachball-84084dc1-705a-499a-bf96-644bc4222a6f.json
+++ b/change/beachball-84084dc1-705a-499a-bf96-644bc4222a6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "grouped packages propagate the change type based on ChangeType order, not change file load order.",
+  "packageName": "beachball",
+  "email": "tanner.m.lyons@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -5,6 +5,7 @@ import { bumpPackageInfoVersion } from './bumpPackageInfoVersion';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { setGroupsInBumpInfo } from './setGroupsInBumpInfo';
 import { setDependentVersions } from './setDependentVersions';
+import { getMaxChangeType, MinChangeType } from '../changefile/getPackageChangeTypes';
 
 /**
  * Updates BumpInfo according to change types, bump deps, and version groups
@@ -33,8 +34,11 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
     );
 
     if (groupName) {
+      const maxChangeTypeInGroup = bumpInfo.packageGroups[groupName].packageNames
+        .map(packageNameInGroup => calculatedChangeTypes[packageNameInGroup])
+        .reduce((prev, next) => getMaxChangeType(prev, next, null), MinChangeType);
       for (const packageNameInGroup of bumpInfo.packageGroups[groupName].packageNames) {
-        calculatedChangeTypes[packageNameInGroup] = changeInfo.type;
+        calculatedChangeTypes[packageNameInGroup] = maxChangeTypeInGroup;
       }
     }
   }


### PR DESCRIPTION
Previously, they were ordered based on the filesystem's sort order. The change type of the last change file in the array of changes  for a group would be propagated to all the change files in that group.

This PR figures out the max change type for the entire group and sets that into the `calculatedChangeTypes` for the packages in the group.

