### PR TITLE
Update typescript to 4.3

### DIFF
--- a/change/beachball-8301b1dc-df80-4dee-817a-ce1a0c97f705.json
+++ b/change/beachball-8301b1dc-df80-4dee-817a-ce1a0c97f705.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update typescript to 4.3",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prettier": "2.7.1",
     "tmp": "0.2.1",
     "ts-jest": "27.1.5",
-    "typescript": "3.9.10",
+    "typescript": "4.3.5",
     "verdaccio": "4.13.2",
     "verdaccio-memory": "8.5.2",
     "vuepress": "1.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10939,10 +10939,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.10:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Typescript 4.3 was released in May 2021 and is required by `ts-jest` 28 and probably an increasing number of other tools (also the latest `@types/jest` needs 4.1+). Especially since beachball is a command line tool where the primary use case doesn't involve types at all, upgrading to 4.3 seems fairly safe at this point.