### PR TITLE
Add Windows PR build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,13 +16,16 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
-        # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
-        # but test against both versions to be safe.
-        npm: [6, 8]
+        os: [ubuntu-latest, windows-latest]
+        npm: [8]
+        include:
+          - os: ubuntu-latest
+            # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
+            # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
+            # but test against both versions to be safe. (Only do this on the ubuntu build for speed.)
+            npm: 6
 
-    name: ${{ matrix.os }}, npm ${{ matrix.npm }}
+    name: build (${{ matrix.os }}, npm ${{ matrix.npm }})
 
     runs-on: ${{ matrix.os }}
 

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -159,6 +159,7 @@ ${gitResult.stderr.toString()}`);
   /** Delete the temp files for this repository. */
   cleanUp() {
     try {
+      // This occasionally throws on Windows with "resource busy"
       this.root && fs.removeSync(this.root);
     } catch (err) {
       // This is non-fatal since the temp dir will eventually be cleaned up automatically

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -158,7 +158,12 @@ ${gitResult.stderr.toString()}`);
 
   /** Delete the temp files for this repository. */
   cleanUp() {
-    this.root && fs.removeSync(this.root);
+    try {
+      this.root && fs.removeSync(this.root);
+    } catch (err) {
+      // This is non-fatal since the temp dir will eventually be cleaned up automatically
+      console.warn('Could not clean up repository: ' + err);
+    }
     this.root = undefined;
   }
 }

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -229,6 +229,7 @@ export class RepositoryFactory {
     if (!this.root) return;
 
     try {
+      // This occasionally throws on Windows with "resource busy"
       this.root && fs.removeSync(this.root);
     } catch (err) {
       // This is non-fatal since the temp dir will eventually be cleaned up automatically

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -228,7 +228,12 @@ export class RepositoryFactory {
   cleanUp() {
     if (!this.root) return;
 
-    fs.removeSync(this.root);
+    try {
+      this.root && fs.removeSync(this.root);
+    } catch (err) {
+      // This is non-fatal since the temp dir will eventually be cleaned up automatically
+      console.warn('Could not clean up factory: ' + err);
+    }
     this.root = undefined;
     for (const repo of this.childRepos) {
       repo.cleanUp();

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -10,10 +10,13 @@ import realConsole from 'console';
 // Clean up created directories when the program exits (even on uncaught exception)
 tmp.setGracefulCleanup();
 
-const windowsUserRegex = /^[a-z]:\\Users\\[^\\]+/i;
-let windowsShortUserDir: string | undefined;
-let windowsLongUserDir: string | undefined;
-
+/**
+ * Create a temporary directory and return the normalized real path to the directory.
+ * This includes workarounds for both Mac and Windows quirks which cause path comparison problems.
+ *
+ * @param options See {@link tmp.DirOptions}. The default for `prefix` is `beachball-`, and
+ * `unsafeCleanup` (try to delete on exit even if the dir contains files) is always enabled.
+ */
 export function tmpdir(options?: tmp.DirOptions): string {
   // Get the real path because on Mac, tmp will return /var/... which is actually a symlink to /private/var/...
   // (and mixing the symlink path and the real path causes issues in functions that use relative paths)
@@ -27,19 +30,22 @@ export function tmpdir(options?: tmp.DirOptions): string {
   );
 
   if (os.platform() === 'win32' && dir.includes('~')) {
-    // On Windows, if the user directory is more than 8 characters, os.tmpdir() (used by tmp) apparently
-    // returns a path with the user directory segment as a short (8.3) name, like C:\Users\RUNNER~1\AppData\Local\Temp.
-    // This messes up path comparisons with process.cwd() which uses long names.
-    // There's no utility in Node to fix this,
-    if (!(windowsShortUserDir && windowsLongUserDir)) {
-      // Try to get the short and long versions of the user dir
-      windowsShortUserDir = dir.match(windowsUserRegex)?.[0];
-      windowsLongUserDir = os.homedir().match(windowsUserRegex)?.[0];
-    }
-    if (windowsShortUserDir && windowsLongUserDir) {
-      dir = dir.replace(windowsShortUserDir, windowsLongUserDir);
+    // On Windows, if the user directory is more than 8 characters, os.tmpdir() (used by tmp)
+    // apparently returns a path with the user directory segment as a short (8.3) name, such as
+    // C:\Users\RUNNER~1\AppData\Local\Temp on the github actions runner. This messes up path
+    // comparisons against anything based on process.cwd() which uses long names.
+    //
+    // There's no official way to convert between short and long names in Node, so try a string
+    // replacement of the short user segment with the home directory.
+    const windowsShortUserDir = dir.match(/^[a-z]:\\Users\\[^\\]+/i)?.[0];
+    const homedir = os.homedir();
+    // replace if the drive letter is the same
+    if (windowsShortUserDir && homedir[0].toLowerCase() === windowsShortUserDir[0].toLowerCase()) {
+      dir = dir.replace(windowsShortUserDir, homedir);
     }
     if (dir.includes('~')) {
+      // This could happen if the ~ was somewhere else besides the user directory, or if the
+      // temp directory is not under the home directory.
       realConsole.warn(
         `⚠️⚠️⚠️\nWARNING: temp directory "${dir}" contains a short (8.3) path segment which could not be expanded ` +
           'by available heuristics. This will likely cause test failures due to comparisons with long paths.\n⚠️⚠️⚠️'

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -1,5 +1,8 @@
 import * as tmp from 'tmp';
 import fs from 'fs-extra';
+import os from 'os';
+// import console to ensure that warnings are always logged if needed (no mocking)
+import realConsole from 'console';
 
 // tmp is supposed to be able to clean up automatically, but this doesn't always work within jest.
 // So we attempt to use its built-in cleanup mechanisms, but tests should ideally do their own cleanup too.
@@ -7,10 +10,14 @@ import fs from 'fs-extra';
 // Clean up created directories when the program exits (even on uncaught exception)
 tmp.setGracefulCleanup();
 
+const windowsUserRegex = /^[a-z]:\\Users\\[^\\]+/i;
+let windowsShortUserDir: string | undefined;
+let windowsLongUserDir: string | undefined;
+
 export function tmpdir(options?: tmp.DirOptions): string {
   // Get the real path because on Mac, tmp will return /var/... which is actually a symlink to /private/var/...
   // (and mixing the symlink path and the real path causes issues in functions that use relative paths)
-  return fs.realpathSync(
+  let dir = fs.realpathSync(
     tmp.dirSync({
       prefix: 'beachball-',
       ...options,
@@ -18,4 +25,27 @@ export function tmpdir(options?: tmp.DirOptions): string {
       unsafeCleanup: true,
     }).name
   );
+
+  if (os.platform() === 'win32' && dir.includes('~')) {
+    // On Windows, if the user directory is more than 8 characters, os.tmpdir() (used by tmp) apparently
+    // returns a path with the user directory segment as a short (8.3) name, like C:\Users\RUNNER~1\AppData\Local\Temp.
+    // This messes up path comparisons with process.cwd() which uses long names.
+    // There's no utility in Node to fix this,
+    if (!(windowsShortUserDir && windowsLongUserDir)) {
+      // Try to get the short and long versions of the user dir
+      windowsShortUserDir = dir.match(windowsUserRegex)?.[0];
+      windowsLongUserDir = os.homedir().match(windowsUserRegex)?.[0];
+    }
+    if (windowsShortUserDir && windowsLongUserDir) {
+      dir = dir.replace(windowsShortUserDir, windowsLongUserDir);
+    }
+    if (dir.includes('~')) {
+      realConsole.warn(
+        `⚠️⚠️⚠️\nWARNING: temp directory "${dir}" contains a short (8.3) path segment which could not be expanded ` +
+          'by available heuristics. This will likely cause test failures due to comparisons with long paths.\n⚠️⚠️⚠️'
+      );
+    }
+  }
+
+  return dir;
 }


### PR DESCRIPTION
Build on Ubuntu and Windows in PRs to reduce the chance of breaking something.

This required adding workarounds for different possible ways of writing the same temp path on Windows.