### PR TITLE
Mock logs in tests

### DIFF
--- a/change/beachball-a657dddd-867a-412e-a137-df458a16f2c0.json
+++ b/change/beachball-a657dddd-867a-412e-a137-df458a16f2c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Always use console.log not process.stdout for logging",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1,16 +1,19 @@
 import fs from 'fs-extra';
+import path from 'path';
+import { git } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
-import { git } from 'workspace-tools';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getChangePath } from '../paths';
-import { MonoRepoFactory } from '../__fixtures__/monorepo';
-import path from 'path';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
+
+  initMockLogs();
 
   function getChangeFiles(cwd: string): string[] {
     const changePath = getChangePath(cwd);

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,13 +1,16 @@
 import fs from 'fs-extra';
-import { RepositoryFactory } from '../__fixtures__/repository';
+import path from 'path';
 import { git } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { RepositoryFactory } from '../__fixtures__/repository';
 import { change } from '../commands/change';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getChangePath } from '../paths';
-import path from 'path';
 
 describe('change command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
+
+  initMockLogs();
 
   function getChangeFiles(cwd: string): string[] {
     const changePath = getChangePath(cwd);

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -2,17 +2,17 @@ import path from 'path';
 import fs from 'fs-extra';
 import _ from 'lodash';
 
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
+
 import { writeChangelog } from '../changelog/writeChangelog';
-
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { readChangeFiles } from '../changefile/readChangeFiles';
 import { SortedChangeTypes } from '../changefile/getPackageChangeTypes';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo, ChangeInfo } from '../types/ChangeInfo';
-import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { ChangelogJson } from '../types/ChangeLog';
 
 function getChange(packageName: string, comment: string): ChangeFileInfo {
@@ -54,6 +54,8 @@ function cleanJsonForSnapshot(changelog: ChangelogJson) {
 describe('changelog generation', () => {
   let repositoryFactory: RepositoryFactory;
   let monoRepoFactory: MonoRepoFactory;
+
+  initMockLogs();
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory();

--- a/src/__e2e__/multiMonorepo.test.ts
+++ b/src/__e2e__/multiMonorepo.test.ts
@@ -1,16 +1,19 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { git } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
-import { git } from 'workspace-tools';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getChangePath } from '../paths';
-import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
+
+  initMockLogs();
 
   function getChangeFiles(cwd: string): string[] {
     const changePath = getChangePath(cwd);

--- a/src/__e2e__/packageManager.test.ts
+++ b/src/__e2e__/packageManager.test.ts
@@ -1,10 +1,13 @@
-import { Registry } from '../__fixtures__/registry';
+import { initMockLogs } from '../__fixtures__/mockLogs';
 import { testPackageInfo, testTag } from '../__fixtures__/package';
+import { Registry } from '../__fixtures__/registry';
 import { packagePublish } from '../packageManager/packagePublish';
 import { npm } from '../packageManager/npm';
 
 describe('packageManager', () => {
   let registry: Registry;
+
+  initMockLogs();
 
   beforeAll(() => {
     registry = new Registry();

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -1,16 +1,19 @@
-import { Registry } from '../__fixtures__/registry';
-import { npm } from '../packageManager/npm';
-import { writeChangeFiles } from '../changefile/writeChangeFiles';
-import { git, addGitObserver } from 'workspace-tools';
-import { publish } from '../commands/publish';
-import { RepositoryFactory } from '../__fixtures__/repository';
-import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import fs from 'fs-extra';
 import path from 'path';
+import { git, addGitObserver } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
+import { Registry } from '../__fixtures__/registry';
+import { RepositoryFactory } from '../__fixtures__/repository';
+import { npm } from '../packageManager/npm';
+import { writeChangeFiles } from '../changefile/writeChangeFiles';
+import { publish } from '../commands/publish';
 
 describe('publish command (e2e)', () => {
   let registry: Registry;
   let repositoryFactory: RepositoryFactory | undefined;
+
+  initMockLogs();
 
   beforeAll(() => {
     registry = new Registry();

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,10 +1,11 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { git, gitFailFast } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../__fixtures__/repository';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publish } from '../commands/publish';
-import path from 'path';
-import fs from 'fs-extra';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
-import { git, gitFailFast } from 'workspace-tools';
 import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
@@ -12,6 +13,8 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory;
+
+  initMockLogs();
 
   beforeAll(() => {
     jest.setTimeout(30000);

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,14 +1,17 @@
+import { git } from 'workspace-tools';
+import { initMockLogs } from '../__fixtures__/mockLogs';
 import { Registry } from '../__fixtures__/registry';
+import { RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
-import { git } from 'workspace-tools';
 import { publish } from '../commands/publish';
-import { RepositoryFactory } from '../__fixtures__/repository';
 
 describe('publish command (registry)', () => {
   let registry: Registry;
   let repositoryFactory: RepositoryFactory | undefined;
   let spy: jest.SpyInstance | undefined;
+
+  initMockLogs();
 
   beforeAll(() => {
     registry = new Registry();

--- a/src/__e2e__/validation.test.ts
+++ b/src/__e2e__/validation.test.ts
@@ -1,14 +1,17 @@
+import fs from 'fs-extra';
+import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory, Repository } from '../__fixtures__/repository';
 import { isChangeFileNeeded } from '../validation/isChangeFileNeeded';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { areChangeFilesDeleted } from '../validation/areChangeFilesDeleted';
 import { getChangePath } from '../paths';
-import fs from 'fs-extra';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 describe('validation', () => {
   let repositoryFactory: RepositoryFactory;
+  initMockLogs();
+
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory();
     repositoryFactory.create();

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,0 +1,49 @@
+export type MockLogs = {
+  /** Mocked methods (to access calls etc). More could be added later if needed. */
+  mocks: { [k in 'log' | 'warn' | 'error']: jest.SpyInstance<void, Parameters<typeof console.log>> };
+  /** Actual console methods */
+  realConsole: typeof console;
+  /** Re-init the mocks (you only need to manually call this after resetting or restoring mocks) */
+  init: (alsoLog?: boolean) => void;
+  /** Clear mock results */
+  clear: () => void;
+  /** Restore mock implementations */
+  restore: () => void;
+};
+
+/**
+ * Initialize console log mocks, which will be cleared (but not reset) after each test.
+ * This should be called **outside** of any lifecycle hooks or tests because it calls `beforeAll`,
+ * `afterEach`, and `afterAll` for setup and teardown.
+ * @param alsoLog Whether to also log to the real console. Can be controlled by VERBOSE env var.
+ */
+export function initMockLogs(alsoLog: boolean = !!process.env.VERBOSE): MockLogs {
+  const mock = (method: 'log' | 'warn' | 'error', shouldLog: boolean) => {
+    logs.mocks[method] = jest
+      .spyOn(console, method)
+      .mockImplementation((...args) => (shouldLog ? realConsole[method](...args) : undefined));
+  };
+
+  const realConsole = { ...console };
+  const logs: MockLogs = {
+    mocks: {} as MockLogs['mocks'],
+    realConsole,
+    init: (shouldLog = alsoLog) => (['log', 'warn', 'error'] as const).forEach(method => mock(method, shouldLog)),
+    clear: () => Object.values(logs.mocks).forEach(mock => mock.mockClear()),
+    restore: () => Object.values(logs.mocks).forEach(mock => mock.mockRestore()),
+  };
+
+  beforeAll(() => {
+    logs.init(alsoLog);
+  });
+
+  afterEach(() => {
+    logs.clear();
+  });
+
+  afterAll(() => {
+    logs.restore();
+  });
+
+  return logs;
+}

--- a/src/__tests__/changelog/renderChangelog.test.ts
+++ b/src/__tests__/changelog/renderChangelog.test.ts
@@ -1,3 +1,4 @@
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { MarkdownChangelogRenderOptions, renderChangelog, markerComment } from '../../changelog/renderChangelog';
 
 const previousHeader = `# Change Log - foo
@@ -10,6 +11,8 @@ const previousVersion = `## 1.2.0
 `;
 
 describe('renderChangelog', () => {
+  initMockLogs();
+
   function getOptions(): MarkdownChangelogRenderOptions {
     return {
       isGrouped: false,

--- a/src/__tests__/publish/performPublishOverrides.test.ts
+++ b/src/__tests__/publish/performPublishOverrides.test.ts
@@ -1,8 +1,8 @@
-import { acceptedKeys, performPublishOverrides } from '../../publish/performPublishOverrides';
-import { PackageInfos } from '../../types/PackageInfo';
+import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as fs from 'fs';
+import { acceptedKeys, performPublishOverrides } from '../../publish/performPublishOverrides';
+import { PackageInfos } from '../../types/PackageInfo';
 
 describe('perform publishConfig overrides', () => {
   function createFixture(publishConfig: any = {}) {
@@ -38,10 +38,6 @@ describe('perform publishConfig overrides', () => {
     return { packageInfos, tmpDir };
   }
 
-  function cleanUp(tmpDir: string) {
-    fs.rmdirSync(tmpDir, { recursive: true });
-  }
-
   it('overrides accepted keys', () => {
     const { packageInfos, tmpDir } = createFixture({
       main: 'lib/index.js',
@@ -62,7 +58,7 @@ describe('perform publishConfig overrides', () => {
     expect(modified.publishConfig.main).toBeUndefined();
     expect(modified.publishConfig.types).toBeUndefined();
 
-    cleanUp(tmpDir);
+    fs.removeSync(tmpDir);
   });
 
   it('uses values on packageJson root as fallback values when present', () => {
@@ -87,7 +83,7 @@ describe('perform publishConfig overrides', () => {
     expect(modified.publishConfig.bin).toBeUndefined();
     expect(modified.publishConfig.files).toBeUndefined();
 
-    cleanUp(tmpDir);
+    fs.removeSync(tmpDir);
   });
 
   it('should always at least accept types, main, and module', () => {
@@ -152,10 +148,6 @@ describe('perform workspace version overrides', () => {
     return { packageInfos, tmpDir };
   }
 
-  function cleanUp(tmpDir: string) {
-    fs.rmdirSync(tmpDir, { recursive: true });
-  }
-
   it.each([
     ['workspace:*', '1.0.0'],
     ['workspace:~', '~1.0.0'],
@@ -173,6 +165,6 @@ describe('perform workspace version overrides', () => {
     const modified = JSON.parse(fs.readFileSync(packageInfos['bar'].packageJsonPath, 'utf-8'));
     expect(modified.dependencies.foo).toBe(expectedPublishVersion);
 
-    cleanUp(tmpDir);
+    fs.removeSync(tmpDir);
   });
 });

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -85,6 +85,12 @@ describe('tagPackages', () => {
 });
 
 describe('tagDistTag', () => {
+  initMockLogs();
+
+  beforeEach(() => {
+    (gitFailFast as jest.Mock).mockReset();
+  });
+
   it('createTag is not called for an empty dist tag', () => {
     tagDistTag(/* tag */ '', /* cwd*/ '');
     expect(gitFailFast).not.toHaveBeenCalled();

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -1,7 +1,8 @@
+import { gitFailFast } from 'workspace-tools';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { tagPackages, tagDistTag } from '../../publish/tagPackages';
 import { generateTag } from '../../tag';
 import { BumpInfo } from '../../types/BumpInfo';
-import { gitFailFast } from 'workspace-tools';
 
 jest.mock('workspace-tools', () => ({
   gitFailFast: jest.fn(),
@@ -61,11 +62,13 @@ const oneTagBumpInfo = {
   newPackages: new Set(),
 } as unknown as BumpInfo;
 
-beforeEach(() => {
-  (gitFailFast as jest.Mock).mockReset();
-});
-
 describe('tagPackages', () => {
+  initMockLogs();
+
+  beforeEach(() => {
+    (gitFailFast as jest.Mock).mockReset();
+  });
+
   it('createTag is not called for packages without gitTags', () => {
     tagPackages(noTagBumpInfo, /* cwd*/ '');
     expect(gitFailFast).not.toHaveBeenCalled();

--- a/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -1,8 +1,11 @@
+import _ from 'lodash';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { validatePackageDependencies } from '../../publish/validatePackageDependencies';
 import { BumpInfo } from '../../types/BumpInfo';
-import _ from 'lodash';
 
 describe('validatePackageDependencies', () => {
+  initMockLogs();
+
   const bumpInfoFixture = {
     changes: new Map(),
     dependents: {},

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -29,7 +29,7 @@ export function validatePackageDependencies(bumpInfo: BumpInfo): boolean {
     }
   }
 
-  process.stdout.write(`Validating no private package among package dependencies`);
+  console.log(`Validating no private package among package dependencies`);
   for (const [dep, usedBy] of Object.entries(allDeps)) {
     if (packageInfos[dep] && packageInfos[dep].private === true) {
       console.error(
@@ -40,7 +40,7 @@ export function validatePackageDependencies(bumpInfo: BumpInfo): boolean {
   }
 
   if (!hasErrors) {
-    process.stdout.write(' OK!\n');
+    console.log(' OK!\n');
   }
   return !hasErrors;
 }


### PR DESCRIPTION
For tests involving code which logs to the console, it can be hard to find the actual errors due to all the random logs. 

This PR adds a helper `initMockLogs()` which mocks `console.log`, `console.warn`, and `console.error`, and uses it in relevant tests. If you do want to see the console logs, you can pass `VERBOSE=1` as an environment variable.