### PR TITLE
Improve auth error handling and other logs during publishing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm i -g npm@6
       - run: yarn
       - run: yarn build
       - run: yarn docs:build

--- a/change/beachball-c53bf487-69d7-42d5-a37b-a4cd0a3e2003.json
+++ b/change/beachball-c53bf487-69d7-42d5-a37b-a4cd0a3e2003.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve auth error handling and other logs during publishing, and use the npm helper everywhere",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/packageManager.test.ts
+++ b/src/__e2e__/packageManager.test.ts
@@ -23,8 +23,8 @@ describe('packageManager', () => {
       await registry.reset();
     });
 
-    it('can publish', () => {
-      const publishResult = packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    it('can publish', async () => {
+      const publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
       expect(publishResult.success).toBeTruthy();
 
       const showResult = npm(['--registry', registry.getUrl(), 'show', testPackageInfo.name, '--json']);
@@ -37,16 +37,16 @@ describe('packageManager', () => {
       expect(show.versions[0]).toEqual(testPackageInfo.version);
     });
 
-    it('errors on republish', () => {
-      let publishResult = packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    it('errors on republish', async () => {
+      let publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
       expect(publishResult.success).toBeTruthy();
 
-      publishResult = packagePublish(testPackageInfo, registry.getUrl(), '', '');
+      publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
       expect(publishResult.success).toBeFalsy();
     });
 
-    it('publish with no tag publishes latest', () => {
-      const publishResult = packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    it('publish with no tag publishes latest', async () => {
+      const publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
       expect(publishResult.success).toBeTruthy();
 
       const showResult = npm(['--registry', registry.getUrl(), 'show', testPackageInfo.name, '--json']);
@@ -59,7 +59,7 @@ describe('packageManager', () => {
       expect(show.versions[0]).toEqual(testPackageInfo.version);
     });
 
-    it('publish package with defaultNpmTag publishes as defaultNpmTag', () => {
+    it('publish package with defaultNpmTag publishes as defaultNpmTag', async () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
         combinedOptions: {
@@ -69,7 +69,7 @@ describe('packageManager', () => {
           disallowedChangeTypes: null,
         },
       };
-      const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
+      const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
       expect(publishResult.success).toBeTruthy();
 
       const showResult = npm([
@@ -88,7 +88,7 @@ describe('packageManager', () => {
       expect(show.versions[0]).toEqual(testPackageInfoWithDefaultNpmTag.version);
     });
 
-    it('publish with specified tag overrides defaultNpmTag', () => {
+    it('publish with specified tag overrides defaultNpmTag', async () => {
       const testPackageInfoWithDefaultNpmTag = {
         ...testPackageInfo,
         combinedOptions: {
@@ -98,7 +98,7 @@ describe('packageManager', () => {
           disallowedChangeTypes: null,
         },
       };
-      const publishResult = packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
+      const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
       expect(publishResult.success).toBeTruthy();
 
       const showResult = npm([

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -35,7 +35,7 @@ describe('publish command (registry)', () => {
     }
   });
 
-  it.only('can perform a successful npm publish', async () => {
+  it('can perform a successful npm publish', async () => {
     repositoryFactory = new RepositoryFactory();
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -341,6 +341,9 @@ describe('publish command (registry)', () => {
   it('will perform retries', async () => {
     registry.stop();
 
+    // hide the errors for this test--it's supposed to have errors, and showing them is misleading
+    logs.init();
+
     repositoryFactory = new RepositoryFactory();
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
@@ -391,7 +394,9 @@ describe('publish command (registry)', () => {
     });
 
     await expect(publishPromise).rejects.toThrow();
-    expect(logs.mocks.log).toHaveBeenCalledWith('\nRetrying... (3/3)');
+    expect(
+      logs.mocks.log.mock.calls.some(([arg0]) => typeof arg0 === 'string' && arg0.includes('Retrying... (3/3)'))
+    ).toBeTruthy();
 
     await registry.start();
   });

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -70,14 +70,14 @@ describe('sync command (e2e)', () => {
 
     const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
 
-    expect(packagePublish(packageInfosBeforeSync['foopkg'], registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(packageInfosBeforeSync['barpkg'], registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(packageInfosBeforeSync['foopkg'], registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(packageInfosBeforeSync['barpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
 
     const newFooInfo = createTempPackage('foopkg', '1.2.0');
     const newBarInfo = createTempPackage('barpkg', '3.0.0');
 
-    expect(packagePublish(newFooInfo, registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(newBarInfo, registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
 
     await sync({
       all: false,
@@ -124,14 +124,14 @@ describe('sync command (e2e)', () => {
 
     const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
 
-    expect(packagePublish(packageInfosBeforeSync['apkg'], registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(packageInfosBeforeSync['bpkg'], registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(packageInfosBeforeSync['apkg'], registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(packageInfosBeforeSync['bpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
 
     const newFooInfo = createTempPackage('apkg', '2.0.0', 'beta');
     const newBarInfo = createTempPackage('bpkg', '3.0.0', 'latest');
 
-    expect(packagePublish(newFooInfo, registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(newBarInfo, registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
 
     await sync({
       all: false,
@@ -184,8 +184,8 @@ describe('sync command (e2e)', () => {
     epkg.combinedOptions.tag = 'latest';
     fpkg.combinedOptions.tag = 'latest';
 
-    expect(packagePublish(epkg, registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(fpkg, registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(epkg, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(fpkg, registry.getUrl(), '', '')).success).toBeTruthy();
 
     const newFooInfo = createTempPackage('epkg', '1.0.0-1');
     const newBarInfo = createTempPackage('fpkg', '3.0.0');
@@ -193,8 +193,8 @@ describe('sync command (e2e)', () => {
     newFooInfo.combinedOptions.tag = 'prerelease';
     newBarInfo.combinedOptions.tag = 'latest';
 
-    expect(packagePublish(newFooInfo, registry.getUrl(), '', '').success).toBeTruthy();
-    expect(packagePublish(newBarInfo, registry.getUrl(), '', '').success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
 
     await sync({
       all: false,

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -1,6 +1,4 @@
-import { spawnSync } from 'child_process';
 import fs from 'fs-extra';
-import os from 'os';
 import path from 'path';
 import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
 import { writeChangelog } from '../changelog/writeChangelog';
@@ -8,6 +6,7 @@ import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import { PackageDeps, PackageInfos } from '../types/PackageInfo';
 import { findProjectRoot } from 'workspace-tools';
+import { npm } from '../packageManager/npm';
 
 export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos) {
   for (const pkgName of modifiedPackages) {
@@ -44,9 +43,8 @@ export function updatePackageLock(cwd: string) {
   const root = findProjectRoot(cwd);
   if (root && fs.existsSync(path.join(root, 'package-lock.json'))) {
     console.log('Updating package-lock.json after bumping packages');
-    const npm = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-    const res = spawnSync(npm, ['install', '--package-lock-only'], { stdio: 'inherit' });
-    if (res.status !== 0) {
+    const res = npm(['install', '--package-lock-only'], { stdio: 'inherit' });
+    if (!res.success) {
       console.warn('Updating package-lock.json failed. Continuing...');
     }
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,9 +1,8 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawnSync } from 'child_process';
-import * as os from 'os';
 import { findProjectRoot } from 'workspace-tools';
+import { npm } from '../packageManager/npm';
 
 export async function init(options: BeachballOptions) {
   let root: string;
@@ -15,10 +14,9 @@ export async function init(options: BeachballOptions) {
   }
 
   const packageJsonFilePath = path.join(root, 'package.json');
-  const npmCmd = path.join(path.dirname(process.execPath), os.platform() === 'win32' ? 'npm.cmd' : 'npm');
 
   if (fs.existsSync(packageJsonFilePath)) {
-    const beachballInfo = JSON.parse(spawnSync(npmCmd, ['info', 'beachball', '--json']).stdout.toString());
+    const beachballInfo = JSON.parse(npm(['info', 'beachball', '--json']).stdout.toString());
     const beachballVersion = beachballInfo['dist-tags'].latest;
 
     const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath, 'utf-8'));

--- a/src/packageManager/npm.ts
+++ b/src/packageManager/npm.ts
@@ -1,7 +1,10 @@
 import execa from 'execa';
 import { AuthType } from '../types/Auth';
 
-export function npm(args: string[], options: execa.SyncOptions = {}) {
+export function npm(
+  args: string[],
+  options: execa.SyncOptions = {}
+): execa.ExecaSyncReturnValue & { success: boolean } {
   try {
     const result = execa.sync('npm', args, { ...options });
     return {
@@ -10,13 +13,16 @@ export function npm(args: string[], options: execa.SyncOptions = {}) {
     };
   } catch (e) {
     return {
-      ...e,
+      ...(e as execa.ExecaSyncError),
       success: false,
     };
   }
 }
 
-export async function npmAsync(args: string[], options: execa.Options = {}) {
+export async function npmAsync(
+  args: string[],
+  options: execa.Options = {}
+): Promise<execa.ExecaReturnValue & { success: boolean }> {
   try {
     const result = await execa('npm', args, { ...options });
     return {
@@ -25,7 +31,7 @@ export async function npmAsync(args: string[], options: execa.Options = {}) {
     };
   } catch (e) {
     return {
-      ...e,
+      ...(e as execa.ExecaError),
       success: false,
     };
   }

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -1,6 +1,6 @@
 import { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
-import { getNpmAuthArgs, npm } from './npm';
+import { getNpmAuthArgs, npmAsync } from './npm';
 import { AuthType } from '../types/Auth';
 
 export function packagePublish(
@@ -29,5 +29,5 @@ export function packagePublish(
     args.push(access);
   }
   console.log(`publish command: ${args.join(' ')}`);
-  return npm(args, { cwd: packagePath, timeout });
+  return npmAsync(args, { cwd: packagePath, timeout, all: true });
 }

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -1,7 +1,7 @@
 import { BumpInfo } from '../types/BumpInfo';
 
 export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()) {
-  console.error('Something went wrong with the publish! Manually update these package and versions:');
+  const errorLines = ['Something went wrong with publishing! Manually update these package and versions:'];
   const succeededLines: string[] = [];
 
   bumpInfo.modifiedPackages.forEach(pkg => {
@@ -10,22 +10,19 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
     if (succeededPackages.has(packageInfo.name)) {
       succeededLines.push(entry);
     } else {
-      console.error(entry);
+      errorLines.push(entry);
     }
   });
 
+  console.error(errorLines.join('\n') + '\n');
+
   if (succeededLines.length) {
     console.warn(
-      'These packages and versions were successfully published, but may be invalid due to depending on ' +
-        'package versions for which publishing failed:'
-    );
-
-    succeededLines.forEach(console.warn);
-
-    console.warn(
-      'To recover from this, you should run "beachball sync" to update local package.json ' +
-        'files to synchronize package.json version. If necessary, unpublish any invalid packages from the above ' +
-        'list after "beachball sync".'
+      'These packages and versions were successfully published, but may be invalid if they depend on ' +
+        'package versions for which publishing failed:\n' +
+        succeededLines.join('\n') +
+        '\n\nTo recover from this, run "beachball sync" to synchronize local package.json files with the registry. ' +
+        'If necessary, unpublish or deprecate any invalid packages from the above list after "beachball sync".'
     );
   }
 }

--- a/src/publish/validatePackageVersions.ts
+++ b/src/publish/validatePackageVersions.ts
@@ -22,14 +22,14 @@ export async function validatePackageVersions(bumpInfo: BumpInfo, registry: stri
 
   for (const pkg of packages) {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    process.stdout.write(`Validating package version - ${packageInfo.name}@${packageInfo.version}`);
+    console.log(`Validating package version - ${packageInfo.name}@${packageInfo.version}`);
     if (publishedVersions[pkg].includes(packageInfo.version)) {
       console.error(
         `\nERROR: Attempting to bump to a version that already exists in the registry: ${packageInfo.name}@${packageInfo.version}`
       );
       hasErrors = true;
     } else {
-      process.stdout.write(' OK!\n');
+      console.log(' OK!\n');
     }
   }
 


### PR DESCRIPTION
While debugging the issues with verdaccio that turned out to be due to npm 8 (somehow), I noticed that handling of logs during publishing could use some improvement. 

This PR improves the logging and some related things:
- Update the logs to be clearer in places
- Specifically check for auth errors during publishing, and doesn't retry if found (retries won't help in that case). Also don't try to publish any of the other packages since they'll presumably have the same issue.
- Reduce the number of separate `console.log`/`console.error` calls, mainly for convenient reading while testing
- Fix the types of the npm helper method
- Use the npm helper method everywhere (a couple places were still using `spawnSync` directly)