### PR TITLE
Fix issue with publishing tests in npm 8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,26 +7,40 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  npmVersion: 8
+  oldNpmVersion: 6
+  nodeVersion: 12
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
-      - uses: actions/checkout@v3
-        with:
-          # needed to ensure checkchange works
-          fetch-depth: 0
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js ${{ env.nodeVersion }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@6
+          node-version: ${{ env.nodeVersion }}
+
+      # Guarantee a predictable version of npm for the first round of tests
+      - name: Install package managers
+        run: npm install --global npm@${{ env.npmVersion }} yarn@1
+
       - run: yarn
       - run: yarn build
       - run: yarn docs:build
       - run: yarn checkchange
-      - run: yarn test
+
+      # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
+      # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
+      # but test against both versions to be safe.
+      - name: yarn test (npm ${{ env.npmVersion }})
+        run: yarn test
+
+      - name: yarn test (npm ${{ env.oldNpmVersion }})
+        run: |
+          npm i -g npm@${{ env.oldNpmVersion }}
+          yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,32 +11,43 @@ on:
   # or on manual trigger
   workflow_dispatch:
 
+env:
+  npmVersion: 8
+  nodeVersion: 12
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.repo_pat }}
-      - name: Use Node.js ${{ matrix.node-version }}
+
+      - name: Set up Node.js ${{ env.nodeVersion }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.nodeVersion }}
+
+      # Guarantee a predictable version of npm (the PR build tests against both 6 and 8)
+      - name: Install package managers
+        run: npm install --global npm@${{ env.npmVersion }} yarn@1
+
       - run: yarn
       - run: yarn build
-      - run: yarn test
-      - run: |
+      - run: yarn test (npm ${{ env.npmVersion}})
+
+      - name: Publish package
+        run: |
           git config user.email "kchau@microsoft.com"
           git config user.name "Ken Chau"
-      - run: yarn release -y -n $NPM_AUTHTOKEN
+          yarn release -y -n $NPM_AUTHTOKEN
         env:
           NPM_AUTHTOKEN: ${{ secrets.npm_authtoken }}
-      - run: |
+
+      - name: Update docs
+        run: |
           git remote set-url origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
           yarn release:docs
         env:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "search.exclude": {
     "**/node_modules": true,
-    "**/lib": true
+    "**/lib": true,
+    "**/*.svg": true
   },
   "files.associations": {
     // VS Code doesn't have json5 support, so handle .json5 files as jsonc.

--- a/change/beachball-08dc36b3-0449-4b5c-ad64-919679dc19ac.json
+++ b/change/beachball-08dc36b3-0449-4b5c-ad64-919679dc19ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update publishing tests to work with npm 8",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ts-jest": "27.1.5",
     "typescript": "4.3.5",
     "verdaccio": "4.13.2",
+    "verdaccio-auth-memory": "10.2.0",
     "verdaccio-memory": "8.5.2",
     "vuepress": "1.9.7",
     "vuepress-plugin-mermaidjs": "1.9.1"

--- a/src/__fixtures__/verdaccio.js
+++ b/src/__fixtures__/verdaccio.js
@@ -1,43 +1,62 @@
 // This is a helper file to make it easier to tell when verdaccio successfully launches or fails to launch.
 // Using verdaccio CLI has the same output whether it fails or succeeds, just one additional line if it fails,
 // making it very hard to tell if it spawned correctly.
+// @ts-ignore
 const startServer = require('verdaccio').default;
 const store = require('verdaccio-memory').default;
 
-const args = {
-  port: process.argv[2],
-};
-
-const port = args.port;
-
+const [port, logFile] = process.argv.slice(2);
 if (!port) {
   console.error('Please provide a port');
-} else {
-  const config = {
-    packages: {
-      '**': {
-        access: '$anonymous',
-        publish: '$anonymous',
-      },
-    },
-    store: {
-      memory: {
-        limit: 1000,
-      },
-    },
-  };
-
-  const addr = {
-    port: port,
-    path: '/',
-    host: 'localhost',
-  };
-
-  startServer(config, port, store, '1.0.0', 'verdaccio', (webServer, addrs, pkgName, pkgVersion) => {
-    webServer.listen(addr.port || addr.path, addr.host, () => {
-      // This is logged to tell whoever spawns us that we're ready.
-      console.log('verdaccio running');
-      console.dir({ addrs });
-    });
-  });
+  process.exit(1);
 }
+
+const config = {
+  // Something about npm 8 makes publishing fail with anonymous access--from debugging, it might be trying
+  // to read the package from the registry before publishing it, and verdaccio doesn't handle that well.
+  // To work around this, add fake user info, which is also used in registry.ts to authenticate.
+  auth: {
+    'auth-memory': {
+      users: {
+        fake: require('./verdaccioUser'),
+      },
+    },
+  },
+  // This is the old anonymous access config--it still works for accessing packages, but not for publishing
+  packages: {
+    '**': {
+      access: '$anonymous',
+      publish: '$anonymous',
+    },
+  },
+  store: {
+    memory: {
+      limit: 1000,
+    },
+  },
+  ...(logFile && {
+    logs: [
+      {
+        type: 'file',
+        level: 'trace',
+        colors: false,
+        path: logFile,
+      },
+    ],
+  }),
+};
+
+const addr = {
+  port: port,
+  path: '/',
+  host: 'localhost',
+};
+
+// @ts-ignore
+startServer(config, port, store, '1.0.0', 'verdaccio', (webServer, addrs) => {
+  webServer.listen(addr.port || addr.path, addr.host, () => {
+    // This is logged to tell whoever spawns us that we're ready.
+    console.log('verdaccio running');
+    console.dir({ addrs });
+  });
+});

--- a/src/__fixtures__/verdaccioUser.js
+++ b/src/__fixtures__/verdaccioUser.js
@@ -1,0 +1,5 @@
+// constants used by verdaccio.js and registry.ts
+module.exports = {
+  username: 'fake',
+  password: 'fake',
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
+    "allowJs": true,
+    "checkJs": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,6 +1570,14 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@verdaccio/commons-api@10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@verdaccio/commons-api/-/commons-api-10.2.0.tgz#3b684c31749837b0574375bb2e10644ecea9fcca"
+  integrity sha512-F/YZANu4DmpcEV0jronzI7v2fGVWkQ5Mwi+bVmV+ACJ+EzR0c9Jbhtbe5QyLUuzR97t8R5E/Xe53O0cc2LukdQ==
+  dependencies:
+    http-errors "2.0.0"
+    http-status-codes "2.2.0"
+
 "@verdaccio/commons-api@9.7.1", "@verdaccio/commons-api@^9.7.1":
   version "9.7.1"
   resolved "https://registry.yarnpkg.com/@verdaccio/commons-api/-/commons-api-9.7.1.tgz#816f08eb6cb0dbe345f2546428c837be6804796d"
@@ -4435,15 +4443,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
-depd@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -6016,6 +6024,17 @@ http-errors@1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -6083,6 +6102,11 @@ http-status-codes@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
   integrity sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==
+
+http-status-codes@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.2.0.tgz#bb2efe63d941dfc2be18e15f703da525169622be"
+  integrity sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -10329,6 +10353,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -10786,6 +10815,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 toml@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
@@ -11221,6 +11255,13 @@ verdaccio-audit@9.7.3:
   dependencies:
     express "4.17.1"
     request "2.88.2"
+
+verdaccio-auth-memory@10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/verdaccio-auth-memory/-/verdaccio-auth-memory-10.2.0.tgz#97eaa22fe9f4d0536469a9a16ba33817ba65df3d"
+  integrity sha512-HP8LHdNpHVFO4isL7VR8pNPoRzBlJUKQlNqma5xBPtSRKvKEc9Co3D6Sg2y9NofD8Yr1Q3dMBDDRtx8dxs9xZQ==
+  dependencies:
+    "@verdaccio/commons-api" "10.2.0"
 
 verdaccio-htpasswd@9.7.2:
   version "9.7.2"


### PR DESCRIPTION
Any e2e tests involving publishing to a mock verdaccio registry were failing for me locally, and I eventually figured out this was somehow due to a difference in behavior between npm 6 and 7/8: something about the newer versions messes up verdaccio's handling of anonymous access for publishing (even when it's enabled in the verdaccio config). 

Since I couldn't figure out the underlying issue and how to fix it properly (not for lack of trying...), I added a step in the mock registry setup to log in as a fake user. This works on both npm 6 and 8. (The `verdaccio-auth-memory` package is used to configure the fake user credentials.)

I also updated the PR build to test against npm 6 and 8, and updated the release build to specifically use npm 8.

Another issue I was sometimes having locally is that the mock registry setup couldn't find a free port. So I updated it to try 1000 ports instead of only 10.

Finally, while debugging all of this, I needed to see verdaccio logs. It doesn't really work to output the logs to the console due to the child process handling, so I added an environment variable VERDACCIO_LOG which will make it log to a file if set.