### PR TITLE
Use ES2019 output (compatible with Node 12+)

### DIFF
--- a/change/beachball-a48ce55c-e925-4c80-b1ad-be124a5662c9.json
+++ b/change/beachball-a48ce55c-e925-4c80-b1ad-be124a5662c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use ES2019 output (compatible with Node 12+)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "ES2016",
+    // compatible with node 12 https://kangax.github.io/compat-table/es2016plus/#node12_11
+    "target": "ES2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
Main motivation for this is that async/await doesn't need to be transpiled in ES2019, so it's easier to debug. 

I noticed this because I was trying to debug something and a lot of important frames were marked as "skipped by smartStep," which the [VS Code docs](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_smart-stepping) mention can happen due to transpiled async/await.