### PR TITLE
Make test tmpdir utility return real paths

### DIFF
--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -1,4 +1,5 @@
 import * as tmp from 'tmp';
+import fs from 'fs-extra';
 
 // tmp is supposed to be able to clean up automatically, but this doesn't always work within jest.
 // So we attempt to use its built-in cleanup mechanisms, but tests should ideally do their own cleanup too.
@@ -7,6 +8,13 @@ import * as tmp from 'tmp';
 tmp.setGracefulCleanup();
 
 export function tmpdir(options: tmp.DirOptions): string {
-  // "unsafe" means delete on exit even if it still contains files...which actually is safe
-  return tmp.dirSync({ ...options, unsafeCleanup: true }).name;
+  // Get the real path because on Mac, tmp will return /var/... which is actually a symlink to /private/var/...
+  // (and mixing the symlink path and the real path causes issues in functions that use relative paths)
+  return fs.realpathSync(
+    tmp.dirSync({
+      ...options,
+      // "Unsafe" means delete on exit even if it still contains files...which actually is safe.
+      unsafeCleanup: true,
+    }).name
+  );
 }


### PR DESCRIPTION
On Mac, the `tmp` utility returns paths like `/var/...` which is actually a symlink to `/private/var/...`. Mixing the symlink path returned there with real paths used in other places causes test failures/inconsistency in any tests involving functions that use relative paths.

The easiest workaround is to fix the wrapping `tmpdir` utility to return the real path.