### PR TITLE
Exit publishing early if only invalid change files are present

### DIFF
--- a/change/beachball-42aa9898-e458-4620-84d6-6ef87ec4a32f.json
+++ b/change/beachball-42aa9898-e458-4620-84d6-6ef87ec4a32f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exit publishing early if only invalid change files are present",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/__snapshots__/changelog.test.ts.snap
+++ b/src/__e2e__/__snapshots__/changelog.test.ts.snap
@@ -307,7 +307,7 @@ This log was last generated on (date) and should not be manually modified.
 "
 `;
 
-exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependenc changes 1`] = `
+exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes 1`] = `
 "# Change Log - bar
 
 This log was last generated on (date) and should not be manually modified.
@@ -325,7 +325,7 @@ This log was last generated on (date) and should not be manually modified.
 "
 `;
 
-exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependenc changes 2`] = `
+exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes 2`] = `
 "# Change Log - baz
 
 This log was last generated on (date) and should not be manually modified.
@@ -342,7 +342,7 @@ This log was last generated on (date) and should not be manually modified.
 "
 `;
 
-exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependenc changes 3`] = `
+exports[`changelog generation writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes 3`] = `
 "# Change Log - foo
 
 This log was last generated on (date) and should not be manually modified.

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -251,7 +251,7 @@ describe('changelog generation', () => {
       expect(cleanMarkdownForSnapshot(groupedChangelogText)).toMatchSnapshot();
     });
 
-    it('generates grouped changelog without dependent change entries where packages have normal changes and dependenc changes', async () => {
+    it('generates grouped changelog without dependent change entries where packages have normal changes and dependency changes', async () => {
       const monoRepo = monoRepoFactory.cloneRepository();
       monoRepo.commitChange('baz');
       writeChangeFiles({ changes: [getChange('baz', 'comment 1')], cwd: monoRepo.rootPath });

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { git, addGitObserver } from 'workspace-tools';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { MonoRepoFactory } from '../__fixtures__/monorepo';
+import { MonoRepoFactory, packageJsonFixtures } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
 import { RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
@@ -508,6 +508,86 @@ describe('publish command (e2e)', () => {
 
     expect(barGitResults.success).toBeTruthy();
     expect(barGitResults.stdout).toBe('bar_v1.4.0');
+  });
+
+  it('should exit publishing early if only invalid change files exist', async () => {
+    repositoryFactory = new MonoRepoFactory();
+    repositoryFactory.create();
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.commitChange(
+      'packages/bar/package.json',
+      JSON.stringify({ ...packageJsonFixtures['packages/bar'], private: true })
+    );
+
+    writeChangeFiles({
+      changes: [
+        {
+          // package is private
+          packageName: 'bar',
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          dependentChangeType: 'patch',
+        },
+        {
+          // package doesn't exist
+          packageName: 'fake',
+          type: 'minor',
+          comment: 'test',
+          email: 'test@test.com',
+          dependentChangeType: 'patch',
+        },
+      ],
+      cwd: repo.rootPath,
+    });
+
+    git(['push', 'origin', 'master'], { cwd: repo.rootPath });
+
+    await publish({
+      all: false,
+      authType: 'authtoken',
+      branch: 'origin/master',
+      command: 'publish',
+      message: 'apply package updates',
+      path: repo.rootPath,
+      publish: true,
+      bumpDeps: true,
+      push: true,
+      registry: registry.getUrl(),
+      gitTags: true,
+      tag: 'latest',
+      token: '',
+      yes: true,
+      new: false,
+      access: 'public',
+      package: '',
+      changehint: 'Run "beachball change" to create a change file',
+      type: null,
+      fetch: true,
+      disallowedChangeTypes: null,
+      defaultNpmTag: 'latest',
+      retries: 3,
+      bump: true,
+      generateChangelog: true,
+      dependentChangeType: null,
+    });
+
+    const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
+
+    expect(showResult.success).toBeTruthy();
+
+    const show = JSON.parse(showResult.stdout);
+    expect(show.name).toEqual('foo');
+    expect(show.versions.length).toEqual(1);
+    expect(show['dist-tags'].latest).toEqual('1.1.0');
+
+    git(['checkout', 'master'], { cwd: repo.rootPath });
+    git(['pull'], { cwd: repo.rootPath });
+    const gitResults = git(['describe', '--abbrev=0'], { cwd: repo.rootPath });
+
+    expect(gitResults.success).toBeTruthy();
+    expect(gitResults.stdout).toBe('foo_v1.1.0');
   });
 
   it('should respect prepublish hooks', async () => {

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -394,9 +394,7 @@ describe('publish command (registry)', () => {
     });
 
     await expect(publishPromise).rejects.toThrow();
-    expect(
-      logs.mocks.log.mock.calls.some(([arg0]) => typeof arg0 === 'string' && arg0.includes('Retrying... (3/3)'))
-    ).toBeTruthy();
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringMatching('Retrying... (3/3)'));
 
     await registry.start();
   });

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -394,7 +394,9 @@ describe('publish command (registry)', () => {
     });
 
     await expect(publishPromise).rejects.toThrow();
-    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringMatching('Retrying... (3/3)'));
+    expect(
+      logs.mocks.log.mock.calls.some(([arg0]) => typeof arg0 === 'string' && arg0.includes('Retrying... (3/3)'))
+    ).toBeTruthy();
 
     await registry.start();
   });

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,47 +1,51 @@
+/** Methods that will be mocked. More could be added later if needed. */
+export type MockLogMethod = 'log' | 'warn' | 'error';
+const mockedMethods: MockLogMethod[] = ['log', 'warn', 'error'];
+
 export type MockLogs = {
-  /** Mocked methods (to access calls etc). More could be added later if needed. */
-  mocks: { [k in 'log' | 'warn' | 'error']: jest.SpyInstance<void, Parameters<typeof console.log>> };
+  /** Mocked methods (to access calls etc) */
+  mocks: { [k in MockLogMethod]: jest.SpyInstance<void, Parameters<typeof console.log>> };
   /** Actual console methods */
   realConsole: typeof console;
-  /** Re-init the mocks (you only need to manually call this after resetting or restoring mocks) */
-  init: (alsoLog?: boolean) => void;
-  /** Clear mock results */
-  clear: () => void;
+  /** Re-init the mocks for the current test (to use different options for this test) */
+  init: (alsoLog?: boolean | MockLogMethod[]) => void;
   /** Restore mock implementations */
   restore: () => void;
 };
 
 /**
- * Initialize console log mocks, which will be cleared (but not reset) after each test.
- * This should be called **outside** of any lifecycle hooks or tests because it calls `beforeAll`,
- * `afterEach`, and `afterAll` for setup and teardown.
- * @param alsoLog Whether to also log to the real console. Can be controlled by VERBOSE env var.
+ * Initialize console log mocks, which will be reset after each test. This should be called **outside**
+ * of any lifecycle hooks or tests because it calls `beforeEach` and `afterEach` for setup and teardown.
+ * @param alsoLog Whether to also log to the real console (or subset of methods to log to the console).
+ * All logging can be enabled by setting the VERBOSE env var.
  */
-export function initMockLogs(alsoLog: boolean = !!process.env.VERBOSE): MockLogs {
-  const mock = (method: 'log' | 'warn' | 'error', shouldLog: boolean) => {
-    logs.mocks[method] = jest
-      .spyOn(console, method)
-      .mockImplementation((...args) => (shouldLog ? realConsole[method](...args) : undefined));
-  };
-
-  const realConsole = { ...console };
+export function initMockLogs(alsoLog?: boolean | MockLogMethod[]): MockLogs {
   const logs: MockLogs = {
     mocks: {} as MockLogs['mocks'],
-    realConsole,
-    init: (shouldLog = alsoLog) => (['log', 'warn', 'error'] as const).forEach(method => mock(method, shouldLog)),
-    clear: () => Object.values(logs.mocks).forEach(mock => mock.mockClear()),
-    restore: () => Object.values(logs.mocks).forEach(mock => mock.mockRestore()),
+    realConsole: { ...console },
+    init: (shouldLog = alsoLog) => {
+      logs.restore(); // clear any previous mocks
+      mockedMethods.forEach(method => {
+        const shouldLogMethod = typeof shouldLog === 'boolean' ? shouldLog : shouldLog?.includes(method);
+        logs.mocks[method] = jest
+          .spyOn(console, method)
+          .mockImplementation((...args) =>
+            shouldLogMethod || process.env.VERBOSE ? logs.realConsole[method](...args) : undefined
+          );
+      });
+    },
+    restore: () =>
+      Object.entries(logs.mocks).forEach(([name, mock]) => {
+        mock.mockRestore();
+        delete (logs.mocks as any)[name];
+      }),
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
     logs.init(alsoLog);
   });
 
   afterEach(() => {
-    logs.clear();
-  });
-
-  afterAll(() => {
     logs.restore();
   });
 

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -4,53 +4,20 @@ import { BumpInfo } from '../types/BumpInfo';
 import { bumpInPlace } from './bumpInPlace';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
-import { getChangePath } from '../paths';
-import path from 'path';
 import { PackageInfos } from '../types/PackageInfo';
 
 function gatherPreBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
-  const { path: cwd } = options;
   // Collate the changes per package
   const changes = readChangeFiles(options, packageInfos);
-  const changePath = getChangePath(cwd);
 
   // const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
   const groupOptions = {};
 
-  // Clear changes for non-existent and accidental private packages
-  // NOTE: likely these are from the same PR that deleted or modified the private flag
-  const filteredChanges = changes.filter(({ changeFile, change }) => {
-    const errorType = !packageInfos[change.packageName]
-      ? 'nonexistent'
-      : packageInfos[change.packageName].private
-      ? 'private'
-      : undefined;
-    if (errorType) {
-      const resolution = options.groupChanges ? 'remove the entry from this file' : 'delete this file';
-      console.warn(
-        `Change detected for ${errorType} package ${change.packageName}; ${resolution}: "${path.resolve(
-          changePath,
-          changeFile
-        )}"`
-      );
-      return false;
-    }
-    return true;
-  });
-
-  // Clear non-existent packages from changefiles infos
-  const calculatedChangeTypes = initializePackageChangeTypes(filteredChanges);
-  Object.keys(calculatedChangeTypes).forEach(packageName => {
-    if (!packageInfos[packageName]) {
-      delete calculatedChangeTypes[packageName];
-    }
-  });
-
   return {
-    calculatedChangeTypes,
+    calculatedChangeTypes: initializePackageChangeTypes(changes),
     packageInfos,
     packageGroups: {},
-    changeFileChangeInfos: filteredChanges,
+    changeFileChangeInfos: changes,
     modifiedPackages: new Set<string>(),
     newPackages: new Set<string>(),
     scopedPackages: new Set(getScopedPackages(options, packageInfos)),

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -13,8 +13,16 @@ function gatherPreBumpInfo(options: BeachballOptions, packageInfos: PackageInfos
   // const dependentChangeTypes: BumpInfo['dependentChangeTypes'] = {};
   const groupOptions = {};
 
+  // Clear non-existent packages from changefiles infos
+  const calculatedChangeTypes = initializePackageChangeTypes(changes);
+  Object.keys(calculatedChangeTypes).forEach(packageName => {
+    if (!packageInfos[packageName]) {
+      delete calculatedChangeTypes[packageName];
+    }
+  });
+
   return {
-    calculatedChangeTypes: initializePackageChangeTypes(changes),
+    calculatedChangeTypes,
     packageInfos,
     packageGroups: {},
     changeFileChangeInfos: changes,

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -7,19 +7,28 @@ import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getChangesBetweenRefs } from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 
+/**
+ * Read change files, excluding any changes for packages that are:
+ * - out of scope (as defined in `options.scope`)
+ * - private
+ * - nonexistent
+ *
+ * The changes will also be transformed if `options.transform.changeFiles` is provided.
+ *
+ * Changes from grouped change files will be flattened into individual entries in the returned array
+ * (so it's possible that multiple entries will have the same filename).
+ */
 export function readChangeFiles(options: BeachballOptions, packageInfos: PackageInfos): ChangeSet {
-  const { path: cwd } = options;
+  const { path: cwd, fromRef } = options;
   const scopedPackages = getScopedPackages(options, packageInfos);
-  const changeSet: ChangeSet = [];
   const changePath = getChangePath(cwd);
-  const fromRef = options.fromRef;
 
   if (!fs.existsSync(changePath)) {
-    return changeSet;
+    return [];
   }
 
   const allChangeFiles = fs.readdirSync(changePath);
-  const filteredChangeFiles: string[] = [];
+  let filteredChangeFiles = allChangeFiles;
 
   if (fromRef) {
     const changeFilesSinceFromRef = getChangesBetweenRefs(
@@ -33,25 +42,23 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
       changePath
     );
 
-    allChangeFiles
-      .filter(fileName => changeFilesSinceFromRef?.includes(fileName))
-      .forEach(fileName => filteredChangeFiles.push(fileName));
-  } else {
-    filteredChangeFiles.push(...allChangeFiles);
+    filteredChangeFiles = allChangeFiles.filter(fileName => changeFilesSinceFromRef?.includes(fileName));
   }
 
   try {
     // sort the change files by modified time. Most recent modified file comes first.
-    filteredChangeFiles.sort(function (f1, f2) {
-      return (
+    filteredChangeFiles.sort(
+      (f1, f2) =>
         fs.statSync(path.join(changePath, f2)).mtime.getTime() - fs.statSync(path.join(changePath, f1)).mtime.getTime()
-      );
-    });
+    );
   } catch (err) {
     console.warn('Failed to sort change files', err);
   }
 
-  filteredChangeFiles.forEach(changeFile => {
+  const changeSet: ChangeSet = [];
+
+  // Read, transform, and filter the change files
+  for (const changeFile of filteredChangeFiles) {
     const changeFilePath = path.join(changePath, changeFile);
 
     let changeInfo: ChangeInfo | ChangeInfoMultiple;
@@ -59,7 +66,7 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
       changeInfo = fs.readJSONSync(changeFilePath);
     } catch (e) {
       console.warn(`Error reading or parsing change file ${changeFilePath}: ${e}`);
-      return;
+      continue;
     }
 
     // Transform the change files, if the option is provided
@@ -68,18 +75,37 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
         changeInfo = options.transform?.changeFiles(changeInfo, changeFilePath);
       } catch (e) {
         console.warn(`Error transforming ${changeFilePath}: ${e}`);
-        return;
+        continue;
       }
     }
 
     const changes: ChangeInfo[] = changeInfo.changes || [changeInfo as ChangeInfo];
 
+    // Filter the changes from this file
     for (const change of changes) {
-      if (scopedPackages.includes(change.packageName)) {
+      // Log warnings about change entries for nonexistent and private packages.
+      // (This may happen if a package is renamed or its private flag is changed.)
+      const warningType = !packageInfos[change.packageName]
+        ? 'nonexistent'
+        : packageInfos[change.packageName].private
+        ? 'private'
+        : undefined;
+      if (warningType) {
+        const resolution = options.groupChanges ? 'remove the entry from this file' : 'delete this file';
+        console.warn(
+          `Change detected for ${warningType} package ${change.packageName}; ${resolution}: "${path.resolve(
+            changePath!,
+            changeFile
+          )}"`
+        );
+      }
+
+      // Add the change to the final list if it's valid and in scope
+      if (!warningType && scopedPackages.includes(change.packageName)) {
         changeSet.push({ changeFile, change });
       }
     }
-  });
+  }
 
   return changeSet;
 }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -61,7 +61,7 @@ async function writeGroupedChangelog(
   }
 
   const { groups: changelogGroups } = options.changelog;
-  if (!changelogGroups || changelogGroups.length < 1) {
+  if (!changelogGroups?.length) {
     return [];
   }
 
@@ -74,7 +74,7 @@ async function writeGroupedChangelog(
     };
   } = {};
 
-  for (const pkg in changelogs) {
+  for (const pkg of Object.keys(changelogs)) {
     const packagePath = path.dirname(packageInfos[pkg].packageJsonPath);
     const relativePath = path.relative(options.path, packagePath);
     for (const group of changelogGroups) {


### PR DESCRIPTION
If a package had only invalid change files (packages that were private or didn't exist), beachball would start the publish process but then fail partway through because there was nothing to commit. `getBumpInfo` had attempted to filter out those files, but by that point it was too late because the publish process had already started.

This PR fixes the issue at the root by modifying `readChangeFiles` to exclude (and warn about) any change files from private or nonexistent packages. 

Fixes #597