### PR TITLE
Fix calculation of changed packages on Windows

### DIFF
--- a/change/beachball-ab2abe4c-7638-43fd-94ff-115d684717bf.json
+++ b/change/beachball-ab2abe4c-7638-43fd-94ff-115d684717bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix calculation of changed packages on Windows",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -11,14 +11,16 @@ import { PackageInfos, PackageInfo } from '../types/PackageInfo';
 function getMatchingPackageInfo(
   file: string,
   cwd: string,
-  packageInfosByPath: { [packageAbsPosixPath: string]: PackageInfo }
+  packageInfosByPath: { [packageAbsNormalizedPath: string]: PackageInfo }
 ) {
-  cwd = path.posix.normalize(cwd);
-  const absFile = path.posix.normalize(path.join(cwd, file));
+  // Normalize all the paths before comparing (the packageInfosByPath entries should also be normalized)
+  // to ensure ensure that this doesn't break on Windows if any input paths have forward slashes
+  cwd = path.normalize(cwd);
+  const absFile = path.normalize(path.join(cwd, file));
   let absDir = '';
 
   do {
-    absDir = path.posix.dirname(absDir || absFile);
+    absDir = path.dirname(absDir || absFile);
     if (packageInfosByPath[absDir]) {
       return packageInfosByPath[absDir];
     }
@@ -62,9 +64,9 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
   const includedPackages = new Set<string>();
   let fileCount = 0;
   const scopedPackages = getScopedPackages(options, packageInfos);
-  const packageInfosByPath: { [packageAbsPosixPath: string]: PackageInfo } = {};
+  const packageInfosByPath: { [packageAbsNormalizedPath: string]: PackageInfo } = {};
   for (const info of Object.values(packageInfos)) {
-    packageInfosByPath[path.posix.normalize(path.dirname(info.packageJsonPath))] = info;
+    packageInfosByPath[path.normalize(path.dirname(info.packageJsonPath))] = info;
   }
   for (const moddedFile of nonIgnoredChanges) {
     const packageInfo = getMatchingPackageInfo(moddedFile, cwd, packageInfosByPath);


### PR DESCRIPTION
#693 introduced an infinite loop when trying to match a modified file to its corresponding package, because `path.posix.normalize` wasn't replacing backslashes with forward slashes. This PR should fix it by using standard `path.normalize` on everything.

(Thankfully a version with the break was not released, and this fix will go in before the release.)