### PR TITLE
Add helpers for generating beachball options in tests

### DIFF
--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -4,10 +4,13 @@ import { git, addGitObserver } from 'workspace-tools';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
-import { RepositoryFactory } from '../__fixtures__/repository';
+import { Repository, RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { publish } from '../commands/publish';
+import { getDefaultOptions } from '../options/getDefaultOptions';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 
 describe('publish command (e2e)', () => {
   let registry: Registry;
@@ -15,6 +18,21 @@ describe('publish command (e2e)', () => {
 
   // show error logs for these tests
   initMockLogs(['error']);
+
+  function getOptions(repo: Repository, overrides?: Partial<BeachballOptions>): BeachballOptions {
+    return {
+      ...getDefaultOptions(),
+      branch: defaultRemoteBranchName,
+      registry: registry.getUrl(),
+      path: repo.rootPath,
+      command: 'publish',
+      message: 'apply package updates',
+      tag: 'latest',
+      yes: true,
+      access: 'public',
+      ...overrides,
+    };
+  }
 
   beforeAll(() => {
     registry = new Registry();
@@ -56,34 +74,7 @@ describe('publish command (e2e)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -124,34 +115,7 @@ describe('publish command (e2e)', () => {
 
     git(['checkout', '--detach'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: false,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { push: false }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -214,34 +178,7 @@ describe('publish command (e2e)', () => {
       }
     });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -307,34 +244,7 @@ describe('publish command (e2e)', () => {
       }
     });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -380,34 +290,7 @@ describe('publish command (e2e)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: false,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { bump: false }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -458,35 +341,7 @@ describe('publish command (e2e)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      scope: ['!packages/foo'],
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { scope: ['!packages/foo'] }));
 
     const fooNpmResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
     expect(fooNpmResult.success).toBeFalsy();
@@ -531,45 +386,22 @@ describe('publish command (e2e)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      hooks: {
-        prepublish: (packagePath: string) => {
-          const packageJsonPath = path.join(packagePath, 'package.json');
-          const packageJson = fs.readJSONSync(packageJsonPath);
-          if (packageJson.onPublish) {
-            Object.assign(packageJson, packageJson.onPublish);
-            delete packageJson.onPublish;
-            fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-          }
+    await publish(
+      getOptions(repo, {
+        path: repo.rootPath,
+        hooks: {
+          prepublish: (packagePath: string) => {
+            const packageJsonPath = path.join(packagePath, 'package.json');
+            const packageJson = fs.readJSONSync(packageJsonPath);
+            if (packageJson.onPublish) {
+              Object.assign(packageJson, packageJson.onPublish);
+              delete packageJson.onPublish;
+              fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+            }
+          },
         },
-      },
-      dependentChangeType: null,
-    });
+      })
+    );
 
     // Query the information from package.json from the registry to see if it was successfully patched
     const fooNpmResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
@@ -611,43 +443,20 @@ describe('publish command (e2e)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      hooks: {
-        postpublish: packagePath => {
-          const packageJsonPath = path.join(packagePath, 'package.json');
-          const packageJson = fs.readJSONSync(packageJsonPath);
-          if (packageJson.afterPublish) {
-            notified = packageJson.afterPublish.notify;
-          }
+    await publish(
+      getOptions(repo, {
+        path: repo.rootPath,
+        hooks: {
+          postpublish: packagePath => {
+            const packageJsonPath = path.join(packagePath, 'package.json');
+            const packageJson = fs.readJSONSync(packageJsonPath);
+            if (packageJson.afterPublish) {
+              notified = packageJson.afterPublish.notify;
+            }
+          },
         },
-      },
-      dependentChangeType: null,
-    });
+      })
+    );
 
     const fooPackageJson = fs.readJSONSync(path.join(repo.rootPath, 'packages/foo/package.json'));
     expect(fooPackageJson.main).toBe('src/index.ts');
@@ -684,34 +493,7 @@ describe('publish command (e2e)', () => {
       }
     });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: false,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { fetch: false }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -755,35 +537,7 @@ describe('publish command (e2e)', () => {
       }
     });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-      depth: 10,
-    });
+    await publish(getOptions(repo, { depth: 10 }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,8 +1,9 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { git, gitFailFast } from 'workspace-tools';
+import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { RepositoryFactory } from '../__fixtures__/repository';
+import { Repository, RepositoryFactory } from '../__fixtures__/repository';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publish } from '../commands/publish';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
@@ -10,6 +11,25 @@ import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { getDefaultOptions } from '../options/getDefaultOptions';
+
+function getOptions(repo: Repository, overrides?: Partial<BeachballOptions>): BeachballOptions {
+  return {
+    ...getDefaultOptions(),
+    package: 'foo',
+    branch: defaultRemoteBranchName,
+    path: repo.rootPath,
+    registry: 'http://localhost:99999/',
+    command: 'publish',
+    message: 'apply package updates',
+    publish: false,
+    bumpDeps: false,
+    tag: 'latest',
+    yes: true,
+    access: 'public',
+    ...overrides,
+  };
+}
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory;
@@ -47,34 +67,7 @@ describe('publish command (git)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: false,
-      bumpDeps: false,
-      push: true,
-      registry: 'http://localhost:99999/',
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      new: false,
-      yes: true,
-      access: 'public',
-      package: 'foo',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo));
 
     const newRepo = repositoryFactory.cloneRepository();
 
@@ -106,36 +99,7 @@ describe('publish command (git)', () => {
     const publishBranch = 'publish_test';
     gitFailFast(['checkout', '-b', publishBranch], { cwd: repo1.rootPath });
 
-    console.log('Bumping version for npm publish');
-
-    const options: BeachballOptions = {
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo1.rootPath,
-      publish: false,
-      bumpDeps: false,
-      push: true,
-      registry: 'http://localhost:99999/',
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foo',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    };
+    const options: BeachballOptions = getOptions(repo1);
 
     const bumpInfo = gatherBumpInfo(options, getPackageInfos(repo1.rootPath));
 

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,11 +1,14 @@
 import { git } from 'workspace-tools';
+import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MonoRepoFactory, packageJsonFixtures } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
-import { RepositoryFactory } from '../__fixtures__/repository';
+import { Repository, RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { publish } from '../commands/publish';
+import { getDefaultOptions } from '../options/getDefaultOptions';
+import { BeachballOptions } from '../types/BeachballOptions';
 
 describe('publish command (registry)', () => {
   let registry: Registry;
@@ -13,6 +16,24 @@ describe('publish command (registry)', () => {
 
   // show error logs for these tests
   const logs = initMockLogs(['error']);
+
+  function getOptions(repo: Repository, overrides: Partial<BeachballOptions>): BeachballOptions {
+    return {
+      ...getDefaultOptions(),
+      branch: defaultRemoteBranchName,
+      path: repo.rootPath,
+      registry: registry.getUrl(),
+      command: 'publish',
+      message: 'apply package updates',
+      bumpDeps: false,
+      push: false,
+      gitTags: false,
+      tag: 'latest',
+      yes: true,
+      access: 'public',
+      ...overrides,
+    };
+  }
 
   beforeAll(() => {
     registry = new Registry();
@@ -54,34 +75,7 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: false,
-      push: false,
-      registry: registry.getUrl(),
-      gitTags: false,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foo',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { package: 'foo' }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foo', '--json']);
 
@@ -138,34 +132,7 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: false,
-      push: false,
-      registry: registry.getUrl(),
-      gitTags: false,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foopkg',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { package: 'foopkg' }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
 
@@ -218,34 +185,7 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: false,
-      push: false,
-      registry: registry.getUrl(),
-      gitTags: false,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foopkg',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { package: 'foopkg' }));
 
     const showResultFoo = npm(['--registry', registry.getUrl(), 'show', 'foopkg', '--json']);
     expect(showResultFoo.success).toBeTruthy();
@@ -303,34 +243,7 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: false,
-      push: false,
-      registry: registry.getUrl(),
-      gitTags: false,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foopkg',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { package: 'foopkg' }));
 
     const showResult = npm(['--registry', registry.getUrl(), 'show', 'badname', '--json']);
 
@@ -371,34 +284,7 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    await publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: true,
-      push: true,
-      registry: registry.getUrl(),
-      gitTags: true,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: '',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    await publish(getOptions(repo, { package: 'foopkg' }));
 
     expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package bar'));
@@ -435,35 +321,13 @@ describe('publish command (registry)', () => {
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
-    const publishPromise = publish({
-      all: false,
-      authType: 'authtoken',
-      branch: 'origin/master',
-      command: 'publish',
-      message: 'apply package updates',
-      path: repo.rootPath,
-      publish: true,
-      bumpDeps: false,
-      push: false,
-      registry: 'httppppp://somethingwrong',
-      gitTags: false,
-      tag: 'latest',
-      token: '',
-      yes: true,
-      new: false,
-      access: 'public',
-      package: 'foo',
-      changehint: 'Run "beachball change" to create a change file',
-      type: null,
-      fetch: true,
-      disallowedChangeTypes: null,
-      defaultNpmTag: 'latest',
-      retries: 3,
-      timeout: 100,
-      bump: true,
-      generateChangelog: true,
-      dependentChangeType: null,
-    });
+    const publishPromise = publish(
+      getOptions(repo, {
+        registry: 'httppppp://somethingwrong',
+        package: 'foo',
+        timeout: 100,
+      })
+    );
 
     await expect(publishPromise).rejects.toThrow();
     expect(


### PR DESCRIPTION
Some of the E2E tests had complete beachball options objects repeated in every test, which made the file harder to read and made it harder to see which options were important to the test.

This PR adds helpers for generating the shared options in each test, deferring to `getDefaultOptions()` where possible, and allowing per-test overrides.

It also starts removing literal references to `master` as the default branch name, to make things more portable across git versions and eventually migrate towards using `main`. (There will be more work on this in the future.)