### PR TITLE
Do npm 6 and 8 builds in parallel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,21 @@ on:
     branches: [master]
 
 env:
-  npmVersion: 8
-  oldNpmVersion: 6
   nodeVersion: 12
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
+        # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
+        # but test against both versions to be safe.
+        npm: [6, 8]
+
+    name: ${{ matrix.os }}, npm ${{ matrix.npm }}
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out code
@@ -27,20 +35,16 @@ jobs:
 
       # Guarantee a predictable version of npm for the first round of tests
       - name: Install package managers
-        run: npm install --global npm@${{ env.npmVersion }} yarn@1
+        run: npm install --global npm@${{ matrix.npm }} yarn@1
 
-      - run: yarn
+      - run: yarn --frozen-lockfile
+
       - run: yarn build
+
       - run: yarn docs:build
+
       - run: yarn checkchange
 
-      # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
-      # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
-      # but test against both versions to be safe.
-      - name: yarn test (npm ${{ env.npmVersion }})
-        run: yarn test
+      - run: yarn test:unit
 
-      - name: yarn test (npm ${{ env.oldNpmVersion }})
-        run: |
-          npm i -g npm@${{ env.oldNpmVersion }}
-          yarn test
+      - run: yarn test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,14 @@ jobs:
       - name: Install package managers
         run: npm install --global npm@${{ env.npmVersion }} yarn@1
 
-      - run: yarn
+      - run: yarn --frozen-lockfile
+
       - run: yarn build
-      - name: yarn test (npm ${{ env.npmVersion}})
-        run: yarn test
+
+      - run: yarn test:unit
+
+      - name: yarn test:e2e (npm ${{ env.npmVersion }})
+        run: yarn test:e2e
 
       - name: Publish package
         run: |


### PR DESCRIPTION
#735 added e2e test runs against both npm 6 and 8. Since the e2e tests are the slowest part of the build, this also slows down the build overall. 

Switching to complete parallel runs will make the overall build faster again. (If this causes resource constraint issues in the future, we could go back to the previous approach.)

I also broke out test:unit and test:e2e into separate steps to make it clearer what's running/failed and the timings.