### PR TITLE
Add test helpers for generating and reading change files

### DIFF
--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,22 +1,15 @@
 import fs from 'fs-extra';
-import path from 'path';
 import { git } from 'workspace-tools';
+import { getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../__fixtures__/repository';
 import { change } from '../commands/change';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getChangePath } from '../paths';
 
 describe('change command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
 
   initMockLogs();
-
-  function getChangeFiles(cwd: string): string[] {
-    const changePath = getChangePath(cwd);
-    const changeFiles = fs.existsSync(changePath) ? fs.readdirSync(changePath) : [];
-    return changeFiles;
-  }
 
   afterEach(() => {
     if (repositoryFactory) {
@@ -52,7 +45,7 @@ describe('change command', () => {
     expect(output.stdout.startsWith('A')).toBeTruthy();
 
     const changeFiles = getChangeFiles(repo.rootPath);
-    expect(changeFiles.length).toBe(1);
+    expect(changeFiles).toHaveLength(1);
   });
 
   it('create change file but git stage only multiple changes', async () => {
@@ -91,11 +84,11 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(repo.rootPath);
     for (const file of changeFiles) {
-      const contents = await fs.readJSON(path.join(repo.rootPath, 'change', file));
+      const contents = await fs.readJSON(file);
       expect(contents.changes.length).toBe(2);
     }
 
-    expect(changeFiles.length).toBe(1);
+    expect(changeFiles).toHaveLength(1);
   });
 
   it('create change file and commit', async () => {
@@ -124,6 +117,6 @@ describe('change command', () => {
     expect(output.stdout.length).toBe(0);
 
     const changeFiles = getChangeFiles(repo.rootPath);
-    expect(changeFiles.length).toBe(1);
+    expect(changeFiles).toHaveLength(1);
   });
 });

--- a/src/__e2e__/multiMonorepo.test.ts
+++ b/src/__e2e__/multiMonorepo.test.ts
@@ -1,25 +1,17 @@
-import fs from 'fs-extra';
 import path from 'path';
 import { git } from 'workspace-tools';
+import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
-import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getChangePath } from '../paths';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
 
   initMockLogs();
-
-  function getChangeFiles(cwd: string): string[] {
-    const changePath = getChangePath(cwd);
-    const changeFiles = fs.existsSync(changePath) ? fs.readdirSync(changePath) : [];
-    return changeFiles;
-  }
 
   afterEach(() => {
     if (repositoryFactory) {
@@ -36,31 +28,8 @@ describe('version bumping', () => {
     const repoARoot = path.join(repo.rootPath, 'repo-a');
     const repoBRoot = path.join(repo.rootPath, 'repo-b');
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: '@repo-a/foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repoARoot,
-    });
-
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'major',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: '@repo-b/foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repoBRoot,
-    });
+    generateChangeFiles([{ packageName: '@repo-a/foo' }], repoARoot);
+    generateChangeFiles([{ packageName: '@repo-a/foo', type: 'major' }], repoBRoot);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -1,12 +1,12 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { git, addGitObserver } from 'workspace-tools';
+import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
 import { Repository, RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
-import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { publish } from '../commands/publish';
 import { getDefaultOptions } from '../options/getDefaultOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -59,18 +59,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -98,18 +87,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -132,18 +110,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -205,18 +172,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -275,18 +231,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -313,31 +258,8 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
-
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'bar',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
+    generateChangeFiles(['bar'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -371,18 +293,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -428,18 +339,7 @@ describe('publish command (e2e)', () => {
     const repo = repositoryFactory.cloneRepository();
     let notified;
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -469,18 +369,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -513,18 +402,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,11 +1,11 @@
 import { git } from 'workspace-tools';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
+import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MonoRepoFactory, packageJsonFixtures } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
 import { Repository, RepositoryFactory } from '../__fixtures__/repository';
 import { npm } from '../packageManager/npm';
-import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { publish } from '../commands/publish';
 import { getDefaultOptions } from '../options/getDefaultOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -60,18 +60,7 @@ describe('publish command (registry)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -117,18 +106,7 @@ describe('publish command (registry)', () => {
       })
     );
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foopkg',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foopkg'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -163,25 +141,7 @@ describe('publish command (registry)', () => {
       })
     );
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foopkg',
-          dependentChangeType: 'patch',
-        },
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'barpkg',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foopkg', 'barpkg'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -228,18 +188,7 @@ describe('publish command (registry)', () => {
       })
     );
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'badname',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['badname'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -260,27 +209,7 @@ describe('publish command (registry)', () => {
       JSON.stringify({ ...packageJsonFixtures['packages/bar'], private: true })
     );
 
-    writeChangeFiles({
-      changes: [
-        {
-          // package is private
-          packageName: 'bar',
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          dependentChangeType: 'patch',
-        },
-        {
-          // package doesn't exist
-          packageName: 'fake',
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['bar', 'fake'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 
@@ -306,18 +235,7 @@ describe('publish command (registry)', () => {
     repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
-    writeChangeFiles({
-      changes: [
-        {
-          type: 'minor',
-          comment: 'test',
-          email: 'test@test.com',
-          packageName: 'foo',
-          dependentChangeType: 'patch',
-        },
-      ],
-      cwd: repo.rootPath,
-    });
+    generateChangeFiles(['foo'], repo.rootPath);
 
     git(['push', 'origin', 'master'], { cwd: repo.rootPath });
 

--- a/src/__e2e__/validation.test.ts
+++ b/src/__e2e__/validation.test.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
+import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory, Repository } from '../__fixtures__/repository';
 import { isChangeFileNeeded } from '../validation/isChangeFileNeeded';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { writeChangeFiles } from '../changefile/writeChangeFiles';
 import { areChangeFilesDeleted } from '../validation/areChangeFilesDeleted';
 import { getChangePath } from '../paths';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
@@ -91,20 +91,7 @@ describe('validation', () => {
 
     beforeEach(() => {
       repository = repositoryFactory.cloneRepository();
-
-      writeChangeFiles({
-        changes: [
-          {
-            type: 'minor',
-            comment: 'test',
-            email: 'test@test.com',
-            packageName: 'pkg-1',
-            dependentChangeType: 'patch',
-          },
-        ],
-        cwd: repository.rootPath,
-      });
-
+      generateChangeFiles(['pkg-1'], repository.rootPath);
       repository.push('origin', 'master');
     });
 

--- a/src/__fixtures__/changeFiles.ts
+++ b/src/__fixtures__/changeFiles.ts
@@ -16,13 +16,16 @@ export type PartialChangeFile = { packageName: string } & Partial<ChangeFileInfo
  */
 export function generateChangeFiles(changes: (string | PartialChangeFile)[], cwd: string, groupChanges?: boolean) {
   writeChangeFiles({
-    changes: changes.map(c => ({
-      comment: 'test',
-      email: 'test@test.com',
-      type: 'minor',
-      dependentChangeType: 'patch',
-      ...(typeof c === 'string' ? { packageName: c } : c),
-    })),
+    changes: changes.map(change => {
+      change = typeof change === 'string' ? { packageName: change } : change;
+      return {
+        comment: `${change.packageName} test comment`,
+        email: 'test@test.com',
+        type: 'minor',
+        dependentChangeType: 'patch',
+        ...change,
+      };
+    }),
     groupChanges,
     cwd,
   });

--- a/src/__fixtures__/changeFiles.ts
+++ b/src/__fixtures__/changeFiles.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { writeChangeFiles } from '../changefile/writeChangeFiles';
+import { getChangePath } from '../paths';
+import { ChangeFileInfo } from '../types/ChangeInfo';
+
+/** Change file with `packageName` required and other props optional */
+export type PartialChangeFile = { packageName: string } & Partial<ChangeFileInfo>;
+
+/**
+ * Generates and writes change files for the given packages.
+ * @param changes Array of package names or partial change files (which must include `packageName`).
+ * Default values are `type: 'minor'`, `dependentChangeType: 'patch'`, and placeholders for other fields.
+ * @param cwd Working directory
+ * @param groupChanges Whether to group all changes into one change file.
+ */
+export function generateChangeFiles(changes: (string | PartialChangeFile)[], cwd: string, groupChanges?: boolean) {
+  writeChangeFiles({
+    changes: changes.map(c => ({
+      comment: 'test',
+      email: 'test@test.com',
+      type: 'minor',
+      dependentChangeType: 'patch',
+      ...(typeof c === 'string' ? { packageName: c } : c),
+    })),
+    groupChanges,
+    cwd,
+  });
+}
+
+/** Get full paths to existing change files under `cwd` */
+export function getChangeFiles(cwd: string): string[] {
+  const changePath = getChangePath(cwd);
+  return changePath && fs.existsSync(changePath) ? fs.readdirSync(changePath).map(p => path.join(changePath, p)) : [];
+}


### PR DESCRIPTION
Add `generateChangeFiles` and `readChangeFiles` helpers to reduce the amount of redundant code in tests and make them easier to read. 

This is especially impactful for the bump and publishE2E tests due to overall number and complexity of the tests.