### PR TITLE
Update workspace-tools and clean up git observers in tests

### DIFF
--- a/change/beachball-b30f1e87-c619-41f6-a73b-8d82f13228c0.json
+++ b/change/beachball-b30f1e87-c619-41f6-a73b-8d82f13228c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update local version of workspace-tools to 0.26.2",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { git, addGitObserver } from 'workspace-tools';
+import { git, addGitObserver, clearGitObservers } from 'workspace-tools';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { Registry } from '../__fixtures__/registry';
@@ -48,6 +48,8 @@ describe('publish command (e2e)', () => {
   });
 
   afterEach(() => {
+    clearGitObservers();
+
     if (repositoryFactory) {
       repositoryFactory.cleanUp();
       repositoryFactory = undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11841,9 +11841,9 @@ worker-farm@^1.7.0:
     errno "~0.1.7"
 
 workspace-tools@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.26.1.tgz#7967fc2fd9dcb7c590a386370c0e755f20a06c6d"
-  integrity sha512-wNr6nQqmxEyZDSMc0E9eLDiax0aYxkkF7qjqOME13nnYptL5c9pVzv0sdiSChYwz+cxBZh/O51qiyQAYaIXQAw==
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.26.2.tgz#72762e9bceebb48c99aa8a393800381ccbbdecb7"
+  integrity sha512-r80J8nebQ0XfbvFFgZhwk61AVPGKbYLgnER1LbW3IrOvmBi985QFQVwaNxdA7TekMDnZ75m+C4ctAF884nwFYw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^5.0.0"


### PR DESCRIPTION
Pick up https://github.com/microsoft/workspace-tools/pull/167 and call the new `clearGitObservers` method in the `publishE2E` test.