### PR TITLE
Add helper for running "npm show" in tests

### DIFF
--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -1,0 +1,25 @@
+import { npm } from '../packageManager/npm';
+import { Registry } from './registry';
+
+/** Partial JSON returned by registry from running `npm show` */
+export type NpmShowResult = {
+  name: string;
+  versions: string[];
+  main?: string;
+  'dist-tags': Record<string, string>;
+};
+
+/**
+ * Runs `npm show <packageName>` on the fake registry and returns the result.
+ * Also does an `expect()` to verify whether the command was successful
+ * (or unsuccessful if `shouldFail` is true).
+ */
+export function npmShow(
+  registry: Registry,
+  packageName: string,
+  shouldFail: boolean = false
+): NpmShowResult | undefined {
+  const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json']);
+  expect(showResult.failed).toBe(shouldFail);
+  return shouldFail ? undefined : JSON.parse(showResult.stdout);
+}


### PR DESCRIPTION
Add a helper to reduce boilerplate and potential errors around running `npm show` in tests.

Switch to mostly testing the returned object using [`expect(...).toMatchObject`](https://jestjs.io/docs/expect#tomatchobjectobject) because it's easier to read. Doing this also revealed a couple interesting things about the test results, such as the fact that publishing a brand new package will always create a `latest` tag in addition to any specified tag.

In the same tests, check the success of `packagePublish` using [`expect.objectContaining`](https://jestjs.io/docs/expect#expectobjectcontainingobject) instead of just looking at the `success` property. This causes any errors logged by npm to show up in the build output for debugging (otherwise it's impossible see what went wrong).