### PR TITLE
Simplify repository fixture setup

### DIFF
--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -11,7 +11,7 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 describe('version bumping', () => {
-  let repositoryFactory: RepositoryFactory | undefined;
+  let repositoryFactory: RepositoryFactory | MonoRepoFactory | undefined;
 
   initMockLogs();
 
@@ -24,7 +24,6 @@ describe('version bumping', () => {
 
   it('bumps only packages with change files', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -99,7 +98,6 @@ describe('version bumping', () => {
 
   it('bumps only packages with change files committed between specified ref and head using `since` flag', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -168,7 +166,6 @@ describe('version bumping', () => {
 
   it('bumps all dependent packages with `bumpDeps` flag', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -243,7 +240,6 @@ describe('version bumping', () => {
 
   it('bumps all grouped packages', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -300,7 +296,6 @@ describe('version bumping', () => {
 
   it('bumps all grouped AND dependent packages', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -382,7 +377,6 @@ describe('version bumping', () => {
 
   it('should not bump out-of-scope package even if package has change', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -405,7 +399,6 @@ describe('version bumping', () => {
 
   it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles([{ packageName: 'bar', type: 'patch' }], repo.rootPath);
@@ -429,7 +422,6 @@ describe('version bumping', () => {
 
   it('bumps all packages and keeps change files with `keep-change-files` flag', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -504,7 +496,6 @@ describe('version bumping', () => {
 
   it('bumps all packages and uses prefix in the version', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -584,7 +575,6 @@ describe('version bumping', () => {
 
   it('bumps all packages and uses prefixed versions in dependents', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -667,7 +657,6 @@ describe('version bumping', () => {
 
   it('bumps all packages and increments prefixed versions in dependents', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -750,7 +739,6 @@ describe('version bumping', () => {
 
   it('generates correct changelogs and modified packages when bumpDeps is true', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -813,7 +801,6 @@ describe('version bumping', () => {
 
   it('calls sync prebump hook before packages are bumped', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -851,7 +838,6 @@ describe('version bumping', () => {
 
   it('calls async prebump hook before packages are bumped', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -889,7 +875,6 @@ describe('version bumping', () => {
 
   it('propagates prebump hook exceptions', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -919,7 +904,6 @@ describe('version bumping', () => {
 
   it('calls sync postbump hook before packages are bumped', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -957,7 +941,6 @@ describe('version bumping', () => {
 
   it('calls async postbump hook before packages are bumped', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -995,7 +978,6 @@ describe('version bumping', () => {
 
   it('propagates postbump hook exceptions', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -20,7 +20,6 @@ describe('change command', () => {
 
   it('create change file but git stage only', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -50,7 +49,6 @@ describe('change command', () => {
 
   it('create change file but git stage only multiple changes', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -93,7 +91,6 @@ describe('change command', () => {
 
   it('create change file and commit', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -31,9 +31,7 @@ describe('changelog generation', () => {
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     monoRepoFactory = new MonoRepoFactory();
-    monoRepoFactory.create();
   });
 
   afterAll(() => {

--- a/src/__e2e__/config.test.ts
+++ b/src/__e2e__/config.test.ts
@@ -7,9 +7,8 @@ const baseArgv = ['node.exe', 'bin.js'];
 describe('config', () => {
   it('uses the branch name defined in beachball.config.js', () => {
     const repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
-    const config = inDirectory(repo.root!, () => {
+    const config = inDirectory(repo.rootPath, () => {
       writeConfig('module.exports = { branch: "origin/main" };');
       return getOptions(baseArgv);
     });
@@ -19,9 +18,8 @@ describe('config', () => {
 
 it('--config overrides configuration path', () => {
   const repositoryFactory = new RepositoryFactory();
-  repositoryFactory.create();
   const repo = repositoryFactory.cloneRepository();
-  const config = inDirectory(repo.root!, () => {
+  const config = inDirectory(repo.rootPath, () => {
     writeConfig('module.exports = { branch: "origin/main" };');
     fs.writeFileSync('alternate.config.js', 'module.exports = { branch: "origin/foo" };');
     return getOptions([...baseArgv, '--config', 'alternate.config.js']);

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -10,7 +10,7 @@ import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { defaultBranchName } from '../__fixtures__/gitDefaults';
 
 describe('getChangedPackages', () => {
-  let repositoryFactory: RepositoryFactory | undefined;
+  let repositoryFactory: RepositoryFactory | MonoRepoFactory | MultiMonoRepoFactory | undefined;
 
   function writeAndAdd(repoRoot: string, filePath: string) {
     const testFilePath = path.join(repoRoot, filePath);
@@ -28,7 +28,6 @@ describe('getChangedPackages', () => {
 
   it('detects changed files in single repo', () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
     const options = { fetch: false, path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
     const packageInfos = getPackageInfos(repo.rootPath);
@@ -41,7 +40,6 @@ describe('getChangedPackages', () => {
 
   it('respects ignorePatterns option', () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
     const options = {
       fetch: false,
@@ -60,7 +58,6 @@ describe('getChangedPackages', () => {
 
   it('detects changed files in monorepo', () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
     const options = { fetch: false, path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
     const packageInfos = getPackageInfos(repo.rootPath);
@@ -73,7 +70,6 @@ describe('getChangedPackages', () => {
 
   it('detects changed files in multi-monorepo (multi-workspace) repo', () => {
     repositoryFactory = new MultiMonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
     const rootOptions = { fetch: false, branch: defaultBranchName, path: repo.rootPath } as BeachballOptions;
     const repoARoot = path.join(repo.rootPath, 'repo-a');

--- a/src/__e2e__/monorepo/getScopedPackages.test.ts
+++ b/src/__e2e__/monorepo/getScopedPackages.test.ts
@@ -12,7 +12,6 @@ describe('getScopedPackages', () => {
 
   beforeAll(() => {
     repoFactory = new MonoRepoFactory();
-    repoFactory.create();
     repo = repoFactory.cloneRepository();
     packageInfos = getPackageInfos(repo.rootPath);
   });

--- a/src/__e2e__/multiMonorepo.test.ts
+++ b/src/__e2e__/multiMonorepo.test.ts
@@ -2,13 +2,12 @@ import path from 'path';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
-import { RepositoryFactory } from '../__fixtures__/repository';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 describe('version bumping', () => {
-  let repositoryFactory: RepositoryFactory | undefined;
+  let repositoryFactory: MultiMonoRepoFactory | undefined;
 
   initMockLogs();
 
@@ -21,7 +20,6 @@ describe('version bumping', () => {
 
   it('only bumps workspace package', async () => {
     repositoryFactory = new MultiMonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     const repoARoot = path.join(repo.rootPath, 'repo-a');

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -14,7 +14,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 
 describe('publish command (e2e)', () => {
   let registry: Registry;
-  let repositoryFactory: RepositoryFactory | undefined;
+  let repositoryFactory: RepositoryFactory | MonoRepoFactory | undefined;
 
   // show error logs for these tests
   initMockLogs(['error']);
@@ -58,7 +58,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -82,7 +81,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish in detached HEAD', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -102,7 +100,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish from a race condition', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -160,7 +157,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish from a race condition in the dependencies', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -215,7 +211,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish without bump', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -238,7 +233,6 @@ describe('publish command (e2e)', () => {
 
   it('should not perform npm publish on out-of-scope package', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -268,7 +262,6 @@ describe('publish command (e2e)', () => {
 
   it('should respect prepublish hooks', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -310,7 +303,6 @@ describe('publish command (e2e)', () => {
 
   it('should respect postpublish hooks', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
     let notified;
 
@@ -340,7 +332,6 @@ describe('publish command (e2e)', () => {
 
   it('can perform a successful npm publish without fetch', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -370,7 +361,6 @@ describe('publish command (e2e)', () => {
 
   it('should specify fetch depth when depth param is defined', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -42,7 +42,6 @@ describe('publish command (git)', () => {
 
   beforeEach(() => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
   });
 
   afterEach(() => {

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -56,7 +56,6 @@ describe('publish command (registry)', () => {
 
   it('can perform a successful npm publish', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);
@@ -72,7 +71,6 @@ describe('publish command (registry)', () => {
 
   it('can perform a successful npm publish even with private packages', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -112,7 +110,6 @@ describe('publish command (registry)', () => {
 
   it('can perform a successful npm publish when multiple packages changed at same time', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -149,7 +146,6 @@ describe('publish command (registry)', () => {
 
   it('can perform a successful npm publish even with a non-existent package listed in the change file', async () => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -188,7 +184,6 @@ describe('publish command (registry)', () => {
 
   it('should exit publishing early if only invalid change files exist', async () => {
     repositoryFactory = new MonoRepoFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     repo.commitChange(
@@ -218,7 +213,6 @@ describe('publish command (registry)', () => {
     logs.init(false);
 
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
     const repo = repositoryFactory.cloneRepository();
 
     generateChangeFiles(['foo'], repo.rootPath);

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -22,7 +22,7 @@ function createRepoPackage(repo: Repository, name: string, version: string) {
 }
 
 describe('sync command (e2e)', () => {
-  const repositoryFactory = new RepositoryFactory();
+  let repositoryFactory: RepositoryFactory;
   let registry: Registry;
   const tempDirs: tmp.DirResult[] = [];
 
@@ -74,8 +74,8 @@ describe('sync command (e2e)', () => {
   });
 
   beforeEach(async () => {
+    repositoryFactory = new RepositoryFactory();
     await registry.reset();
-    repositoryFactory.create();
   });
 
   afterEach(() => {

--- a/src/__e2e__/validation.test.ts
+++ b/src/__e2e__/validation.test.ts
@@ -15,7 +15,6 @@ describe('validation', () => {
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory();
-    repositoryFactory.create();
   });
 
   afterAll(() => {

--- a/src/__fixtures__/monorepo.ts
+++ b/src/__fixtures__/monorepo.ts
@@ -1,11 +1,8 @@
-import * as process from 'process';
 import path from 'path';
 import * as fs from 'fs-extra';
-import { tmpdir } from './tmpdir';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { Repository, RepositoryFactory } from './repository';
+import { BaseRepositoryFactory, Repository } from './repository';
 import { PackageJson } from '../types/PackageInfo';
-import { defaultBranchName, defaultRemoteName, gitInitWithDefaultBranchName } from './gitDefaults';
 
 export const packageJsonFixtures: { [path: string]: PackageJson } = {
   'packages/foo': {
@@ -58,22 +55,12 @@ const beachballConfigFixture = {
   ],
 } as BeachballOptions;
 
-export class MonoRepoFactory extends RepositoryFactory {
-  root?: string;
+export class MonoRepoFactory extends BaseRepositoryFactory {
+  constructor() {
+    super('beachball-monorepo-upstream-');
+  }
 
-  create() {
-    const originalDirectory = process.cwd();
-
-    this.root = tmpdir({ prefix: 'beachball-monorepository-upstream-' });
-    process.chdir(this.root);
-    gitInitWithDefaultBranchName(this.root);
-
-    const tmpRepo = new Repository();
-    this.childRepos.push(tmpRepo);
-    tmpRepo.initialize();
-    tmpRepo.cloneFrom(this.root);
-    tmpRepo.commitChange('README');
-
+  protected initFixture(tmpRepo: Repository) {
     for (const pkg of Object.keys(packageJsonFixtures)) {
       const packageJsonFixture = packageJsonFixtures[pkg];
       const packageJsonFile = path.join(pkg, 'package.json');
@@ -89,9 +76,5 @@ export class MonoRepoFactory extends RepositoryFactory {
     tmpRepo.commitChange('package.json', JSON.stringify({ name: 'monorepo-fixture', version: '1.0.0' }, null, 2));
 
     tmpRepo.commitChange('beachball.config.js', 'module.exports = ' + JSON.stringify(beachballConfigFixture, null, 2));
-
-    tmpRepo.push(defaultRemoteName, `HEAD:${defaultBranchName}`);
-
-    process.chdir(originalDirectory);
   }
 }


### PR DESCRIPTION
This change simplifies various aspects of repository fixture setup and internals, to reduce boilerplate in tests.

### Initialization on construction

Instead of having separate `repositoryFactory.create()` and `repository.init()` methods, it's simpler to just have the constructor do the initialization, because construction and create/init happened 1:1 right after each other except in one test.

### Base class for factories

Introduce an abstract class `BaseRepositoryFactory` which handles all the basic repo setup (which was identical between the different factories) and has an abstract method for creating the actual fixture files.

### Repository git operations

Add a helper method `repository.git()` for running git operations on a repository in the correct `cwd`, and throwing if the operation fails. This will also reduce boilerplate once it's more widely adopted in other tests.