### PR TITLE
Add helper methods for git operations in tests

### DIFF
--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import { git } from 'workspace-tools';
 import { getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../__fixtures__/repository';
@@ -39,9 +38,7 @@ describe('change command', () => {
       commit: false,
     } as BeachballOptions);
 
-    const output = git(['status', '-s'], { cwd: repo.rootPath });
-    expect(output.success).toBeTruthy();
-    expect(output.stdout.startsWith('A')).toBeTruthy();
+    expect(repo.status()).toMatch(/^A  change/);
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles).toHaveLength(1);
@@ -76,9 +73,7 @@ describe('change command', () => {
       groupChanges: true,
     } as BeachballOptions);
 
-    const output = git(['status', '-s'], { cwd: repo.rootPath });
-    expect(output.success).toBeTruthy();
-    expect(output.stdout.startsWith('A')).toBeTruthy();
+    expect(repo.status()).toMatch(/^A  change/);
 
     const changeFiles = getChangeFiles(repo.rootPath);
     for (const file of changeFiles) {
@@ -109,9 +104,7 @@ describe('change command', () => {
       path: repo.rootPath,
     } as BeachballOptions);
 
-    const output = git(['status', '-s'], { cwd: repo.rootPath });
-    expect(output.success).toBeTruthy();
-    expect(output.stdout).toHaveLength(0);
+    expect(repo.status()).toBe('');
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles).toHaveLength(1);

--- a/src/__e2e__/changelog.test.ts
+++ b/src/__e2e__/changelog.test.ts
@@ -1,10 +1,9 @@
-import path from 'path';
 import _ from 'lodash';
 
 import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { cleanChangelogJson, readChangelogJson, readChangelogMd } from '../__fixtures__/changelog';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { MonoRepoFactory, packageJsonFixtures } from '../__fixtures__/monorepo';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
 
 import { writeChangelog } from '../changelog/writeChangelog';
@@ -30,6 +29,8 @@ describe('changelog generation', () => {
   const logs = initMockLogs();
 
   beforeAll(() => {
+    // These tests can share the same repo factories because they don't push to origin
+    // (the actual tests run against a clone)
     repositoryFactory = new RepositoryFactory();
     monoRepoFactory = new MonoRepoFactory();
   });
@@ -53,10 +54,7 @@ describe('changelog generation', () => {
 
     it('excludes invalid change files', () => {
       const monoRepo = monoRepoFactory.cloneRepository();
-      monoRepo.commitChange(
-        'packages/bar/package.json',
-        JSON.stringify({ ...packageJsonFixtures['packages/bar'], private: true })
-      );
+      monoRepo.updateJsonFile('packages/bar/package.json', { private: true });
       // fake doesn't exist, bar is private, foo is okay
       generateChangeFiles(['fake', 'bar', 'foo'], monoRepo.rootPath);
 
@@ -72,10 +70,7 @@ describe('changelog generation', () => {
 
     it('excludes invalid changes from grouped change file', () => {
       const monoRepo = monoRepoFactory.cloneRepository();
-      monoRepo.commitChange(
-        'packages/bar/package.json',
-        JSON.stringify({ ...packageJsonFixtures['packages/bar'], private: true })
-      );
+      monoRepo.updateJsonFile('packages/bar/package.json', { private: true });
       // fake doesn't exist, bar is private, foo is okay
       generateChangeFiles(['fake', 'bar', 'foo'], monoRepo.rootPath, true /*groupChanges*/);
 
@@ -136,9 +131,9 @@ describe('changelog generation', () => {
 
       await writeChangelog(beachballOptions, changes, { foo: 'patch' }, { foo: new Set(['foo']) }, packageInfos);
 
-      expect(readChangelogMd([repository.rootPath])).toMatchSnapshot('changelog md');
+      expect(readChangelogMd(repository.rootPath)).toMatchSnapshot('changelog md');
 
-      const changelogJson = readChangelogJson([repository.rootPath]);
+      const changelogJson = readChangelogJson(repository.rootPath);
       expect(cleanChangelogJson(changelogJson)).toMatchSnapshot('changelog json');
 
       // Every entry should have a different commit hash
@@ -171,14 +166,12 @@ describe('changelog generation', () => {
       await writeChangelog(beachballOptions, changes, { foo: 'patch', bar: 'patch' }, {}, packageInfos);
 
       // check changelogs for both foo and bar
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/foo'])).toMatchSnapshot('foo CHANGELOG.md');
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/bar'])).toMatchSnapshot('bar CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/foo'))).toMatchSnapshot('foo CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/bar'))).toMatchSnapshot('bar CHANGELOG.md');
 
-      const fooJson = readChangelogJson([monoRepo.rootPath, 'packages/foo']);
+      const fooJson = readChangelogJson(monoRepo.pathTo('packages/foo'));
       expect(cleanChangelogJson(fooJson)).toMatchSnapshot('foo CHANGELOG.json');
-      expect(readChangelogJson([monoRepo.rootPath, 'packages/bar'], true /*clean*/)).toMatchSnapshot(
-        'bar CHANGELOG.json'
-      );
+      expect(readChangelogJson(monoRepo.pathTo('packages/bar'), true /*clean*/)).toMatchSnapshot('bar CHANGELOG.json');
 
       // Every entry should have a different commit hash
       const patchComments = fooJson.entries[0].comments.patch!;
@@ -217,11 +210,11 @@ describe('changelog generation', () => {
       await writeChangelog(beachballOptions as BeachballOptions, changes, {}, {}, packageInfos);
 
       // Validate changelog for foo and bar packages
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/foo'])).toMatchSnapshot('foo CHANGELOG.md');
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/bar'])).toMatchSnapshot('bar CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/foo'))).toMatchSnapshot('foo CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/bar'))).toMatchSnapshot('bar CHANGELOG.md');
 
       // Validate grouped changelog for foo and bar packages
-      expect(readChangelogMd([monoRepo.rootPath])).toMatchSnapshot('grouped CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.rootPath)).toMatchSnapshot('grouped CHANGELOG.md');
     });
 
     it('generates grouped changelog without dependent change entries', async () => {
@@ -254,15 +247,15 @@ describe('changelog generation', () => {
       );
 
       // Validate changelog for bar package
-      const barChangelogText = readChangelogMd([monoRepo.rootPath, 'packages/bar']);
+      const barChangelogText = readChangelogMd(monoRepo.pathTo('packages/bar'));
       expect(barChangelogText).toContain('- Bump baz');
       expect(barChangelogText).toMatchSnapshot('bar CHANGELOG.md');
 
       // Validate changelog for baz package
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/baz'])).toMatchSnapshot('baz CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/baz'))).toMatchSnapshot('baz CHANGELOG.md');
 
       // Validate grouped changelog for foo master package
-      const groupedChangelogText = readChangelogMd([monoRepo.rootPath]);
+      const groupedChangelogText = readChangelogMd(monoRepo.rootPath);
       expect(groupedChangelogText).toContain('- comment 1');
       expect(groupedChangelogText).not.toContain('- Bump baz');
       expect(groupedChangelogText).toMatchSnapshot('grouped CHANGELOG.md');
@@ -299,11 +292,11 @@ describe('changelog generation', () => {
       );
 
       // Validate changelog for bar and baz packages
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/bar'])).toMatchSnapshot('bar CHANGELOG.md');
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/baz'])).toMatchSnapshot('baz CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/bar'))).toMatchSnapshot('bar CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.pathTo('packages/baz'))).toMatchSnapshot('baz CHANGELOG.md');
 
       // Validate grouped changelog for foo master package
-      expect(readChangelogMd([monoRepo.rootPath])).toMatchSnapshot('grouped CHANGELOG.md');
+      expect(readChangelogMd(monoRepo.rootPath)).toMatchSnapshot('grouped CHANGELOG.md');
     });
 
     it('generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog', async () => {
@@ -320,7 +313,7 @@ describe('changelog generation', () => {
           groups: [
             {
               masterPackageName: 'foo',
-              changelogPath: path.join(monoRepo.rootPath, 'packages', 'foo'),
+              changelogPath: monoRepo.pathTo('packages/foo'),
               include: ['packages/foo', 'packages/bar'],
             },
           ],
@@ -333,10 +326,10 @@ describe('changelog generation', () => {
       await writeChangelog(beachballOptions as BeachballOptions, changes, {}, {}, packageInfos);
 
       // Validate changelog for bar package
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/bar'])).toMatchSnapshot();
+      expect(readChangelogMd(monoRepo.pathTo('packages/bar'))).toMatchSnapshot();
 
       // Validate grouped changelog for foo and bar packages
-      expect(readChangelogMd([monoRepo.rootPath, 'packages/foo'])).toMatchSnapshot();
+      expect(readChangelogMd(monoRepo.pathTo('packages/foo'))).toMatchSnapshot();
     });
 
     it('Verify that the changeFile transform functions are run, if provided', async () => {
@@ -363,7 +356,7 @@ describe('changelog generation', () => {
           groups: [
             {
               masterPackageName: 'foo',
-              changelogPath: path.join(monoRepo.rootPath, 'packages', 'foo'),
+              changelogPath: monoRepo.pathTo('packages/foo'),
               include: ['packages/foo', 'packages/bar'],
             },
           ],

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -1,23 +1,14 @@
-import fs from 'fs-extra';
 import path from 'path';
+import { defaultBranchName } from '../__fixtures__/gitDefaults';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
+import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
 import { RepositoryFactory } from '../__fixtures__/repository';
-import { git } from 'workspace-tools';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
 import { getChangedPackages } from '../changefile/getChangedPackages';
-import { MonoRepoFactory } from '../__fixtures__/monorepo';
-import { defaultBranchName } from '../__fixtures__/gitDefaults';
 
 describe('getChangedPackages', () => {
   let repositoryFactory: RepositoryFactory | MonoRepoFactory | MultiMonoRepoFactory | undefined;
-
-  function writeAndAdd(repoRoot: string, filePath: string) {
-    const testFilePath = path.join(repoRoot, filePath);
-    fs.ensureDirSync(path.dirname(testFilePath));
-    fs.writeFileSync(testFilePath, '');
-    git(['add', testFilePath], { cwd: repoRoot });
-  }
 
   afterEach(() => {
     if (repositoryFactory) {
@@ -34,7 +25,7 @@ describe('getChangedPackages', () => {
 
     expect(getChangedPackages(options, packageInfos)).toStrictEqual([]);
 
-    writeAndAdd(repo.rootPath, 'foo.js');
+    repo.stageChange('foo.js');
     expect(getChangedPackages(options, packageInfos)).toStrictEqual(['foo']);
   });
 
@@ -49,9 +40,9 @@ describe('getChangedPackages', () => {
     } as BeachballOptions;
     const packageInfos = getPackageInfos(repo.rootPath);
 
-    writeAndAdd(repo.rootPath, 'src/foo.test.js');
-    writeAndAdd(repo.rootPath, 'tests/stuff.js');
-    writeAndAdd(repo.rootPath, 'yarn.lock');
+    repo.stageChange('src/foo.test.js');
+    repo.stageChange('tests/stuff.js');
+    repo.stageChange('yarn.lock');
 
     expect(getChangedPackages(options, packageInfos)).toStrictEqual([]);
   });
@@ -64,7 +55,7 @@ describe('getChangedPackages', () => {
 
     expect(getChangedPackages(options, packageInfos)).toStrictEqual([]);
 
-    writeAndAdd(repo.rootPath, 'packages/foo/test.js');
+    repo.stageChange('packages/foo/test.js');
     expect(getChangedPackages(options, packageInfos)).toStrictEqual(['foo']);
   });
 
@@ -78,7 +69,7 @@ describe('getChangedPackages', () => {
 
     expect(getChangedPackages(rootOptions, rootPackageInfos)).toStrictEqual([]);
 
-    writeAndAdd(repoARoot, 'packages/foo/test.js');
+    repo.stageChange('repo-a/packages/foo/test.js');
 
     const changedPackagesA = getChangedPackages({ ...rootOptions, path: repoARoot }, getPackageInfos(repoARoot));
     const changedPackagesB = getChangedPackages({ ...rootOptions, path: repoBRoot }, getPackageInfos(repoBRoot));

--- a/src/__e2e__/multiMonorepo.test.ts
+++ b/src/__e2e__/multiMonorepo.test.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { MultiMonoRepoFactory } from '../__fixtures__/multiMonorepo';
@@ -22,8 +21,8 @@ describe('version bumping', () => {
     repositoryFactory = new MultiMonoRepoFactory();
     const repo = repositoryFactory.cloneRepository();
 
-    const repoARoot = path.join(repo.rootPath, 'repo-a');
-    const repoBRoot = path.join(repo.rootPath, 'repo-b');
+    const repoARoot = repo.pathTo('repo-a');
+    const repoBRoot = repo.pathTo('repo-b');
 
     generateChangeFiles([{ packageName: '@repo-a/foo' }], repoARoot);
     generateChangeFiles([{ packageName: '@repo-a/foo', type: 'major' }], repoBRoot);

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,6 +1,4 @@
 import fs from 'fs-extra';
-import path from 'path';
-import { gitFailFast } from 'workspace-tools';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
@@ -59,7 +57,7 @@ describe('publish command (git)', () => {
 
     const newRepo = repositoryFactory.cloneRepository();
 
-    const packageJson = fs.readJSONSync(path.join(newRepo.rootPath, 'package.json'));
+    const packageJson = fs.readJSONSync(newRepo.pathTo('package.json'));
 
     expect(packageJson.version).toBe('1.1.0');
   });
@@ -72,7 +70,7 @@ describe('publish command (git)', () => {
 
     // 2. simulate the start of a publish from repo1
     const publishBranch = 'publish_test';
-    gitFailFast(['checkout', '-b', publishBranch], { cwd: repo1.rootPath });
+    repo1.checkout('-b', publishBranch);
 
     const options: BeachballOptions = getOptions(repo1);
 

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,7 +1,7 @@
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { MonoRepoFactory, packageJsonFixtures } from '../__fixtures__/monorepo';
+import { MonoRepoFactory } from '../__fixtures__/monorepo';
 import { npmShow } from '../__fixtures__/npmShow';
 import { Registry } from '../__fixtures__/registry';
 import { Repository, RepositoryFactory } from '../__fixtures__/repository';
@@ -186,10 +186,7 @@ describe('publish command (registry)', () => {
     repositoryFactory = new MonoRepoFactory();
     const repo = repositoryFactory.cloneRepository();
 
-    repo.commitChange(
-      'packages/bar/package.json',
-      JSON.stringify({ ...packageJsonFixtures['packages/bar'], private: true })
-    );
+    repo.updateJsonFile('packages/bar/package.json', { private: true });
 
     generateChangeFiles(['bar', 'fake'], repo.rootPath);
 

--- a/src/__e2e__/validation.test.ts
+++ b/src/__e2e__/validation.test.ts
@@ -41,7 +41,7 @@ describe('validation', () => {
     });
 
     it('is true when changes exist in a new branch', () => {
-      repository.checkoutNewBranch('feature-0');
+      repository.checkout('-b', 'feature-0');
       repository.commitChange('myFilename');
       const result = isChangeFileNeeded(
         {
@@ -55,7 +55,7 @@ describe('validation', () => {
     });
 
     it('is false when changes are CHANGELOG files', () => {
-      repository.checkoutNewBranch('feature-0');
+      repository.checkout('-b', 'feature-0');
       repository.commitChange('CHANGELOG.md');
       const result = isChangeFileNeeded(
         {
@@ -69,8 +69,8 @@ describe('validation', () => {
     });
 
     it('throws if the remote is invalid', () => {
-      repository.setRemoteUrl(defaultRemoteName, 'file:///__nonexistent');
-      repository.checkoutNewBranch('feature-0');
+      repository.git(['remote', 'set-url', defaultRemoteName, 'file:///__nonexistent']);
+      repository.checkout('-b', 'feature-0');
       repository.commitChange('CHANGELOG.md');
 
       expect(() => {
@@ -96,7 +96,7 @@ describe('validation', () => {
     });
 
     it('is false when no change files are deleted', () => {
-      repository.checkoutNewBranch('feature-0');
+      repository.checkout('-b', 'feature-0');
 
       const result = areChangeFilesDeleted({
         branch: defaultRemoteBranchName,
@@ -106,7 +106,7 @@ describe('validation', () => {
     });
 
     it('is true when change files are deleted', () => {
-      repository.checkoutNewBranch('feature-0');
+      repository.checkout('-b', 'feature-0');
 
       const changeDirPath = getChangePath(repository.rootPath);
       fs.removeSync(changeDirPath);

--- a/src/__fixtures__/changelog.ts
+++ b/src/__fixtures__/changelog.ts
@@ -5,15 +5,15 @@ import { SortedChangeTypes } from '../changefile/getPackageChangeTypes';
 import { ChangelogJson } from '../types/ChangeLog';
 
 /** Read the CHANGELOG.md under the given package path, sanitizing any dates for snapshots */
-export function readChangelogMd(packagePathParts: string[]): string {
-  const changelogFile = path.join(...packagePathParts, 'CHANGELOG.md');
+export function readChangelogMd(packagePath: string): string {
+  const changelogFile = path.join(packagePath, 'CHANGELOG.md');
   const text = fs.readFileSync(changelogFile, { encoding: 'utf-8' });
   return text.replace(/\w\w\w, \d\d \w\w\w [\d :]+?GMT/gm, '(date)');
 }
 
 /** Read the CHANGELOG.json under the given package path */
-export function readChangelogJson(packagePathParts: string[], cleanForSnapshot: boolean = false): ChangelogJson {
-  const changelogJsonFile = path.join(...packagePathParts, 'CHANGELOG.json');
+export function readChangelogJson(packagePath: string, cleanForSnapshot: boolean = false): ChangelogJson {
+  const changelogJsonFile = path.join(packagePath, 'CHANGELOG.json');
   const json = fs.readJSONSync(changelogJsonFile, { encoding: 'utf-8' });
   return cleanForSnapshot ? cleanChangelogJson(json) : json;
 }

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -39,7 +39,7 @@ export abstract class BaseRepositoryFactory {
     tmpRepo.commitChange('README');
     this.initFixture(tmpRepo);
 
-    tmpRepo.push(defaultRemoteName, 'HEAD:' + defaultBranchName);
+    tmpRepo.push();
 
     process.chdir(originalDirectory);
   }
@@ -78,19 +78,51 @@ export class RepositoryFactory extends BaseRepositoryFactory {
   }
 }
 
+/**
+ * Represents a git repository.
+ *
+ * All git operations will throw on error (or if the repo has already been cleaned up),
+ * to make error detection easier.
+ *
+ * If the repository was created by a `RepositoryFactory`, cleanup will be handled automatically
+ * as long as you call `repositoryFactory.cleanUp()`.
+ */
 export class Repository {
+  /** Root temp directory for the repo */
   private root?: string;
 
   constructor() {
     this.root = tmpdir({ prefix: 'beachball-repository-cloned-' });
   }
 
-  /** Root temp directory for the repo (throws if not initialized) */
+  /** Root temp directory for the repo (throws if already cleaned up) */
   get rootPath(): string {
     if (!this.root) {
       throw new Error('Repo has been cleaned up');
     }
     return this.root;
+  }
+
+  /**
+   * Get the path to a file in the repo. The path segments MUST be relative to the repo root,
+   * and MUST NOT start with `..`.
+   *
+   * These restrictions are primarily to reduce issues with path comparison and help detect
+   * possible issues with operating systems representing the same path different ways, which can
+   * cause flaky tests. (e.g. Mac temp files are under `/private/var` which is symlinked as `/var`,
+   * and Windows can use either standard paths or short DOS paths.)
+   */
+  pathTo(...segments: string[]) {
+    const filename = path.join(...segments);
+    if (path.isAbsolute(filename)) {
+      throw new Error('Path must be relative: ' + filename);
+    }
+    if (filename.startsWith('..')) {
+      throw new Error(
+        'Path must not start with .. (this may indicate an OS-specific path handling error): ' + filename
+      );
+    }
+    return path.join(this.rootPath, filename);
   }
 
   /** Git helper that throws on error */
@@ -104,17 +136,25 @@ ${gitResult.stderr.toString()}`);
     return gitResult;
   }
 
-  cloneFrom(path: string) {
-    this.git(['clone', path, '.']);
+  /**
+   * Clone the given remote repo into the temp directory and configure settings that are needed
+   * by certain tests (user name+email and default branch).
+   */
+  cloneFrom(remotePath: string) {
+    this.git(['clone', remotePath, '.']);
     this.git(['config', 'user.email', 'ci@example.com']);
     this.git(['config', 'user.name', 'CIUSER']);
 
     setDefaultBranchName(this.rootPath);
   }
 
-  /** Commits a change, automatically uses root path, do not pass absolute paths here */
-  commitChange(newFilename: string, content?: string) {
-    const filePath = path.join(this.rootPath, newFilename);
+  /**
+   * Create (or update) and stage a file, creating the intermediate directories if necessary.
+   * Automatically uses root path; do not pass absolute paths here.
+   */
+  stageChange(newFilename: string, content?: string) {
+    const filePath = this.pathTo(newFilename);
+    fs.ensureDirSync(path.dirname(filePath));
     fs.ensureFileSync(filePath);
 
     if (content) {
@@ -122,40 +162,77 @@ ${gitResult.stderr.toString()}`);
     }
 
     this.git(['add', newFilename]);
+  }
+
+  /**
+   * Commit a change, creating the intermediate directories if necessary.
+   * Automatically uses root path; do not pass absolute paths here.
+   */
+  commitChange(newFilename: string, content?: string) {
+    this.stageChange(newFilename, content);
     this.git(['commit', '-m', `"${newFilename}"`]);
   }
 
-  /** Commits a change, automatically uses root path, do not pass absolute paths here */
-  commitAll() {
+  /** Commit all changes to tracked and untracked files. */
+  commitAll(message: string = 'Committing everything') {
     this.git(['add', '-A']);
-    this.git(['commit', '-m', 'Committing everything']);
+    this.git(['commit', '-m', message]);
   }
 
+  /**
+   * Update the content of a JSON file that already exists in the repo.
+   * The updates will be merged with the original.
+   *
+   * This is useful if you'd like to mostly use a built-in fixture but change one package,
+   * such as making it private.
+   */
+  updateJsonFile(filename: string, updates: {}) {
+    if (!filename.endsWith('.json')) {
+      throw new Error('This method only works with json files');
+    }
+
+    const fullPath = this.pathTo(filename);
+    const oldContent = fs.readJSONSync(fullPath);
+    fs.writeJSONSync(fullPath, { ...oldContent, ...updates });
+
+    this.git(['add', filename]);
+    this.git(['commit', '-m', `"${filename}"`]);
+  }
+
+  /** Get the current HEAD sha1 */
   getCurrentHash() {
     const result = this.git(['rev-parse', 'HEAD']);
     return result.stdout.trim();
   }
 
-  checkoutNewBranch(branchName: string) {
-    this.git(['checkout', '-b', branchName]);
+  /** Get tags pointing to the current HEAD commit */
+  getCurrentTags() {
+    const tagsResult = this.git(['tag', '--points-at', 'HEAD']);
+    const trimmedResult = tagsResult.stdout.trim();
+    return trimmedResult ? trimmedResult.split('\n') : [];
   }
 
-  checkoutDefaultBranch() {
-    this.git(['checkout', defaultBranchName]);
+  /** Get status with `--porcelain` */
+  status() {
+    return this.git(['status', '--porcelain']).stdout.trim();
   }
 
-  pull(remote?: string, branch?: string) {
-    this.git(['pull', remote ?? defaultRemoteName, branch ?? `HEAD:${defaultBranchName}`]);
+  /** Check out a branch. Args can be the name and/or any options. */
+  checkout(...args: string[]) {
+    this.git(['checkout', ...args]);
   }
 
-  push(remote?: string, branch?: string) {
-    this.git(['push', remote ?? defaultRemoteName, branch ?? `HEAD:${defaultBranchName}`]);
+  /** Pull from the default remote and branch.  */
+  pull() {
+    this.git(['pull', defaultRemoteName, `HEAD:${defaultBranchName}`]);
   }
 
-  setRemoteUrl(remote: string, remoteUrl: string) {
-    this.git(['remote', 'set-url', remote, remoteUrl]);
+  /** Push to the default remote and branch. */
+  push() {
+    this.git(['push', defaultRemoteName, `HEAD:${defaultBranchName}`]);
   }
 
+  /** Delete the temp files for this repository. */
   cleanUp() {
     this.root && fs.removeSync(this.root);
     this.root = undefined;


### PR DESCRIPTION
Instead of calling `git()` directly in tests, add helper methods on `Repository` to run most of the operations and process the output. 

Centralizing git operations like this reduces boilerplate and makes the tests easier to read.