### PR TITLE
Run E2E tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "release:docs": "yarn docs:build && yarn gh-pages -d docs/.vuepress/dist --dotfiles",
     "start": "tsc -w --preserveWatchOutput",
     "test": "yarn test:unit && yarn test:e2e",
-    "test:e2e": "jest --runInBand --config jest.e2e.js",
+    "test:e2e": "jest --config jest.e2e.js",
     "test:unit": "jest --config jest.config.js",
     "test:watch": "jest --watch",
-    "update-snapshots": "jest --config jest.config.js --updateSnapshot"
+    "update-snapshots": "yarn test:unit -u && yarn test:e2e -u"
   },
   "dependencies": {
     "cosmiconfig": "^7.0.0",

--- a/src/__e2e__/packagePublish.test.ts
+++ b/src/__e2e__/packagePublish.test.ts
@@ -40,7 +40,7 @@ describe('packagePublish', () => {
   }
 
   beforeAll(() => {
-    registry = new Registry();
+    registry = new Registry(__filename);
     jest.setTimeout(30000);
 
     // Create a test package.json in a temporary location for use in tests.

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -35,7 +35,7 @@ describe('publish command (e2e)', () => {
   }
 
   beforeAll(() => {
-    registry = new Registry();
+    registry = new Registry(__filename);
     jest.setTimeout(30000);
   });
 

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -35,7 +35,7 @@ describe('publish command (registry)', () => {
   }
 
   beforeAll(() => {
-    registry = new Registry();
+    registry = new Registry(__filename);
     jest.setTimeout(30000);
   });
 

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -65,7 +65,7 @@ describe('sync command (e2e)', () => {
   }
 
   beforeAll(() => {
-    registry = new Registry();
+    registry = new Registry(__filename);
     jest.setTimeout(30000);
   });
 


### PR DESCRIPTION
The E2E tests were configured to run in series due to race conditions with getting ports for the fake registry. The problem with this is that the E2E tests are slow in general (due to amount of filesystem and local-network operations), so running them in series makes them very slow, particularly on Windows PR builds.

This PR adds logic to try a different range of ports for each test file which uses the fake registry. One way to do that would have been to have each test pass a start port to the constructor, but that could lead to intermittent failures if someone copy-pastes a test in the future. So instead I based the port ranges on array indices for a hardcoded list of test filenames. (That approach could cause very minor annoyance if adding or renaming test files in the future, but the failure will be obvious and easy to fix.)

I tried this locally and was getting a few failures on the sync test on the first couple runs, but then the failures went away on all the other runs I tried...so we'll have to keep an eye on it and further refine the approach if it seems to be causing issues.