### PR TITLE
Error on duplicate package names

### DIFF
--- a/change/beachball-0b973948-5e88-4403-9731-6fbb9b375e4a.json
+++ b/change/beachball-0b973948-5e88-4403-9731-6fbb9b375e4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Error on duplicate package names in different workspaces (for a monorepo with multiple workspaces)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -33,6 +33,13 @@ function getPackageInfosFromWorkspace(projectRoot: string) {
         const packageJsonPath = path.join(packagePath, 'package.json');
 
         try {
+          if (packageInfos[packageJson.name]) {
+            throw new Error(
+              `Two packages in different workspaces have the same name. Please rename one of these packages:\n- ${
+                packageInfos[packageJson.name].packageJsonPath
+              }\n- ${packageJsonPath}`
+            );
+          }
           packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
         } catch (e) {
           // Pass, the package.json is invalid


### PR DESCRIPTION
In a monorepo with multiple workspaces, it's theoretically possible that a package name could be reused across the different workspace roots (this happened with the multi-workspace fixture until I recently added scopes to the package names). This creates problems in `getPackageInfos` because the packages are stored in an object indexed by package name, and prior to this PR, it would silently overwrite the first package with the second. 

This PR makes beachball exit with an error instead. Arguably it could do just a console warning instead, but a package being entirely ignored (due to the duplicate name) is a bad enough situation that I think it's better to fail loudly and make the user fix it.