### PR TITLE
Switch from @types/jest to @jest/globals

### DIFF
--- a/change/beachball-4852a7e6-c8ce-4e66-a281-fde4e99e0ade.json
+++ b/change/beachball-4852a7e6-c8ce-4e66-a281-fde4e99e0ade.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Switch from @types/jest to @jest/globals",
+  "type": "none",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "yargs-parser": "^21.0.0"
   },
   "devDependencies": {
+    "@jest/globals": "28.1.3",
     "@types/cosmiconfig": "6.0.0",
     "@types/execa": "2.0.0",
     "@types/fs-extra": "9.0.13",
-    "@types/jest": "28.1.8",
     "@types/lodash": "4.14.184",
     "@types/minimatch": "3.0.5",
     "@types/node": "12.20.55",
@@ -70,6 +70,7 @@
     "find-free-port": "2.0.0",
     "gh-pages": "4.0.0",
     "jest": "28.1.3",
+    "jest-mock": "28.1.3",
     "prettier": "2.7.1",
     "tmp": "0.2.1",
     "ts-jest": "28.0.8",

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import { getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
 import { defaultBranchName } from '../__fixtures__/gitDefaults';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { getPackageInfos } from '../monorepo/getPackageInfos';

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, beforeEach, afterAll, afterEach, jest } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import { addGitObserver, clearGitObservers } from 'workspace-tools';
@@ -66,11 +67,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -89,11 +91,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { push: false }));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
   });
 
   it('can perform a successful npm publish from a race condition', async () => {
@@ -122,11 +125,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -165,11 +169,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -193,11 +198,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { bump: false }));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.0.0'],
       'dist-tags': { latest: '1.0.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -219,11 +225,12 @@ describe('publish command (e2e)', () => {
 
     expect(repo.getCurrentTags()).toEqual([]);
 
-    expect(npmShow(registry, 'bar')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'bar',
       versions: ['1.4.0'],
       'dist-tags': { latest: '1.4.0' },
-    });
+    };
+    expect(npmShow(registry, 'bar')).toMatchObject(expectedNpmResult);
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -319,11 +326,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { fetch: false }));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     // no fetch when flag set to false
     expect(fetchCount).toBe(0);
@@ -348,11 +356,12 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { depth: 10 }));
 
-    expect(npmShow(registry, 'foo')).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    });
+    };
+    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
     // no fetch when flag set to false
     expect(depthString).toEqual('--depth=10');

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
 import fs from 'fs-extra';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, jest } from '@jest/globals';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, jest } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,10 +1,13 @@
+import { jest, beforeEach, afterEach } from '@jest/globals';
+import type { SpyInstance } from 'jest-mock';
+
 /** Methods that will be mocked. More could be added later if needed. */
 export type MockLogMethod = 'log' | 'warn' | 'error';
 const mockedMethods: MockLogMethod[] = ['log', 'warn', 'error'];
 
 export type MockLogs = {
   /** Mocked methods (to access calls etc) */
-  mocks: { [k in MockLogMethod]: jest.SpyInstance<void, Parameters<typeof console.log>> };
+  mocks: { [k in MockLogMethod]: SpyInstance<typeof console.log> };
   /** Actual console methods */
   realConsole: typeof console;
   /** Re-init the mocks for the current test (to use different options for this test) */

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import { npm } from '../packageManager/npm';
 import { Registry } from './registry';
 

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import _ from 'lodash';
 
 import { generateChangeFiles } from '../../__fixtures__/changeFiles';

--- a/src/__functional__/changefile/writeChangeFiles.test.ts
+++ b/src/__functional__/changefile/writeChangeFiles.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import fs from 'fs-extra';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import { generateChangeFiles } from '../../__fixtures__/changeFiles';
 import { cleanChangelogJson, readChangelogJson, readChangelogMd } from '../../__fixtures__/changelog';
 import { initMockLogs } from '../../__fixtures__/mockLogs';

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { tmpdir } from '../../__fixtures__/tmpdir';

--- a/src/__functional__/monorepo/getScopedPackages.test.ts
+++ b/src/__functional__/monorepo/getScopedPackages.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import { Repository } from '../../__fixtures__/repository';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { getScopedPackages } from '../../monorepo/getScopedPackages';

--- a/src/__functional__/options/getOptions.test.ts
+++ b/src/__functional__/options/getOptions.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterEach, afterAll } from '@jest/globals';
 import fs from 'fs-extra';
 import { Repository } from '../../__fixtures__/repository';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, jest } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
@@ -65,12 +66,13 @@ describe('packagePublish', () => {
     // (hard to debug otherwise)
     expect(publishResult).toEqual(expect.objectContaining({ success: true }));
 
-    expect(npmShow(registry, testName)).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: testName,
       versions: [testVersion],
       // This will publish the test tag as well as "latest" because it's a new package
       'dist-tags': { [testTag]: testVersion, latest: testVersion },
-    });
+    };
+    expect(npmShow(registry, testName)).toMatchObject(expectedNpmResult);
   });
 
   it('errors on republish', async () => {
@@ -87,11 +89,12 @@ describe('packagePublish', () => {
     const publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
-    expect(npmShow(registry, testName)).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: testName,
       versions: [testVersion],
       'dist-tags': { latest: testVersion },
-    });
+    };
+    expect(npmShow(registry, testName)).toMatchObject(expectedNpmResult);
   });
 
   it('publish package with defaultNpmTag publishes as defaultNpmTag', async () => {
@@ -99,11 +102,12 @@ describe('packagePublish', () => {
     const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
-    expect(npmShow(registry, testName)).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: testName,
       versions: [testVersion],
       'dist-tags': { [testTag]: testVersion, latest: testVersion },
-    });
+    };
+    expect(npmShow(registry, testName)).toMatchObject(expectedNpmResult);
   });
 
   it('publish with specified tag overrides defaultNpmTag', async () => {
@@ -111,10 +115,11 @@ describe('packagePublish', () => {
     const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
-    expect(npmShow(registry, testName)).toMatchObject<NpmShowResult>({
+    const expectedNpmResult: NpmShowResult = {
       name: testName,
       versions: [testVersion],
       'dist-tags': { [testTag]: testVersion, latest: testVersion },
-    });
+    };
+    expect(npmShow(registry, testName)).toMatchObject(expectedNpmResult);
   });
 });

--- a/src/__functional__/validation/areChangeFilesDeleted.test.ts
+++ b/src/__functional__/validation/areChangeFilesDeleted.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, beforeEach, afterAll } from '@jest/globals';
 import fs from 'fs-extra';
 import { generateChangeFiles } from '../../__fixtures__/changeFiles';
 import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';

--- a/src/__functional__/validation/isChangeFileNeeded.test.ts
+++ b/src/__functional__/validation/isChangeFileNeeded.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, beforeAll, beforeEach, afterAll } from '@jest/globals';
 import { defaultRemoteBranchName, defaultRemoteName } from '../../__fixtures__/gitDefaults';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { Repository } from '../../__fixtures__/repository';

--- a/src/__tests__/bump/bumpMinSemverRange.test.ts
+++ b/src/__tests__/bump/bumpMinSemverRange.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { bumpMinSemverRange } from '../../bump/bumpMinSemverRange';
 
 describe('bumpMinSemverRange', () => {

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { updateRelatedChangeType } from '../../bump/updateRelatedChangeType';
 import { BumpInfo } from '../../types/BumpInfo';
 import _ from 'lodash';

--- a/src/__tests__/changefile/getPackageChangeTypes.test.ts
+++ b/src/__tests__/changefile/getPackageChangeTypes.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { getAllowedChangeType } from '../../changefile/getPackageChangeTypes';
 
 describe('getAllowedChangeTypes', () => {

--- a/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { getPackageChangelogs } from '../../changelog/getPackageChangelogs';
 import { BumpInfo } from '../../types/BumpInfo';
 import { ChangeSet } from '../../types/ChangeInfo';

--- a/src/__tests__/changelog/mergeChangelogs.test.ts
+++ b/src/__tests__/changelog/mergeChangelogs.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { PackageChangelog } from '../../types/ChangeLog';
 import { mergeChangelogs } from '../../changelog/mergeChangelogs';
 import { PackageInfo } from '../../types/PackageInfo';

--- a/src/__tests__/changelog/renderChangelog.test.ts
+++ b/src/__tests__/changelog/renderChangelog.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { MarkdownChangelogRenderOptions, renderChangelog, markerComment } from '../../changelog/renderChangelog';
 

--- a/src/__tests__/changelog/renderPackageChangelog.test.ts
+++ b/src/__tests__/changelog/renderPackageChangelog.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { PackageChangelogRenderInfo } from '../../types/ChangelogOptions';
 import { defaultRenderers, renderPackageChangelog } from '../../changelog/renderPackageChangelog';
 

--- a/src/__tests__/monorepo/isPathIncluded.test.ts
+++ b/src/__tests__/monorepo/isPathIncluded.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { isPathIncluded } from '../../monorepo/isPathIncluded';
 
 describe('isPathIncluded', () => {

--- a/src/__tests__/packageManager/npm.test.ts
+++ b/src/__tests__/packageManager/npm.test.ts
@@ -1,10 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
 import { getNpmAuthArgs } from '../../packageManager/npm';
 import { AuthType } from '../../types/Auth';
 
 type NpmAuthTestTuple = [string, string, AuthType | undefined, string];
 
 describe('getNpmAuthArgs', () => {
-  test.each<NpmAuthTestTuple>([
+  it.each<NpmAuthTestTuple>([
     ['https://testRegistry', 'someToken', undefined, '--//testRegistry:_authToken=someToken'],
     ['https://testRegistry', 'someToken', 'invalidvalue' as AuthType, '--//testRegistry:_authToken=someToken'],
     ['https://testRegistry', 'someToken', 'authtoken', '--//testRegistry:_authToken=someToken'],

--- a/src/__tests__/publish/performPublishOverrides.test.ts
+++ b/src/__tests__/publish/performPublishOverrides.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { tmpdir } from '../../__fixtures__/tmpdir';

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import type { Mock } from 'jest-mock';
 import { gitFailFast } from 'workspace-tools';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { tagPackages, tagDistTag } from '../../publish/tagPackages';
@@ -66,7 +68,7 @@ describe('tagPackages', () => {
   initMockLogs();
 
   beforeEach(() => {
-    (gitFailFast as jest.Mock).mockReset();
+    (gitFailFast as Mock).mockReset();
   });
 
   it('createTag is not called for packages without gitTags', () => {
@@ -88,7 +90,7 @@ describe('tagDistTag', () => {
   initMockLogs();
 
   beforeEach(() => {
-    (gitFailFast as jest.Mock).mockReset();
+    (gitFailFast as Mock).mockReset();
   });
 
   it('createTag is not called for an empty dist tag', () => {

--- a/src/__tests__/publish/toposortPackages.test.ts
+++ b/src/__tests__/publish/toposortPackages.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { toposortPackages } from '../../publish/toposortPackages';
 import { PackageInfos, PackageInfo } from '../../types/PackageInfo';
 

--- a/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import _ from 'lodash';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { validatePackageDependencies } from '../../publish/validatePackageDependencies';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,7 +1070,7 @@
     jest-mock "^28.1.3"
     jest-util "^28.1.3"
 
-"@jest/globals@^28.1.3":
+"@jest/globals@28.1.3", "@jest/globals@^28.1.3":
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-28.1.3.tgz#a601d78ddc5fdef542728309894895b4a42dc333"
   integrity sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==
@@ -1425,14 +1425,6 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
-
-"@types/jest@28.1.8":
-  version "28.1.8"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.8.tgz#6936409f3c9724ea431efd412ea0238a0f03b09b"
-  integrity sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==
-  dependencies:
-    expect "^28.0.0"
-    pretty-format "^28.0.0"
 
 "@types/json-schema@^7.0.5":
   version "7.0.11"
@@ -5227,7 +5219,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^28.0.0, expect@^28.1.3:
+expect@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
   integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
@@ -7110,7 +7102,7 @@ jest-message-util@^28.1.3:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^28.1.3:
+jest-mock@28.1.3, jest-mock@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.3.tgz#d4e9b1fc838bea595c77ab73672ebf513ab249da"
   integrity sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==
@@ -9361,7 +9353,7 @@ pretty-error@^2.0.2:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^28.0.0, pretty-format@^28.1.3:
+pretty-format@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
   integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==


### PR DESCRIPTION
Switch from using implicitly-available jest globals and types (via `@types/jest`) to explicitly importing things from `@jest/globals`, or `jest-mock` for the mock-related types.

The main motivation is to get rid of repeated issues where Jest releases a major version, but there's a delay before `@types/jest` (which is in DefinitelyTyped and not maintained by the Jest team) releases a corresponding major version...which creates problems because `@types/jest` has direct dependencies on `pretty-format` and `expect` to borrow their types, causing mismatches when Jest updates those packages to the new major version. It also reduces global namespace pollution in non-test files.