### PR TITLE
Respect ignorePatterns in getPackageInfos

### DIFF
--- a/change/beachball-d9a5a809-bde2-42fe-8358-3d9843e604ec.json
+++ b/change/beachball-d9a5a809-bde2-42fe-8358-3d9843e604ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Respect ignorePatterns in getPackageInfos",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -39,7 +39,7 @@ describe('version bumping', () => {
 
     await bump({ path: repo.rootPath, bumpDeps: false } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
@@ -69,8 +69,8 @@ describe('version bumping', () => {
 
     await bump({ path: workspaceARoot, bumpDeps: true } as BeachballOptions);
 
-    const packageInfosA = getPackageInfos(workspaceARoot);
-    const packageInfosB = getPackageInfos(workspaceBRoot);
+    const packageInfosA = getPackageInfos({ path: workspaceARoot });
+    const packageInfosB = getPackageInfos({ path: workspaceBRoot });
     expect(packageInfosA['@workspace-a/foo'].version).toBe('1.1.0');
     expect(packageInfosB['@workspace-b/foo'].version).toBe('1.0.0');
 
@@ -105,7 +105,7 @@ describe('version bumping', () => {
       fromRef: oldCommit,
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     expect(packageInfos['pkg-1'].version).toBe(monorepo['packages']['pkg-1'].version);
     expect(packageInfos['pkg-2'].version).toBe(monorepo['packages']['pkg-2'].version);
@@ -134,7 +134,7 @@ describe('version bumping', () => {
 
     await bump({ path: repo.rootPath, bumpDeps: true } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const pkg1NewVersion = '1.1.0';
     const dependentNewVersion = '1.0.1';
@@ -173,7 +173,7 @@ describe('version bumping', () => {
       groups: [{ include: 'packages/*', name: 'testgroup' }],
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const newVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -212,7 +212,7 @@ describe('version bumping', () => {
       bumpDeps: true,
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const groupNewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(groupNewVersion);
@@ -241,7 +241,7 @@ describe('version bumping', () => {
       scope: ['!packages/foo'],
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
     expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
     expect(packageInfos['bar'].version).toBe(monorepo['packages']['bar'].version);
 
@@ -264,7 +264,7 @@ describe('version bumping', () => {
       scope: ['!packages/foo'],
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
     expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
     expect(packageInfos['bar'].version).toBe('1.3.5');
     expect(packageInfos['foo'].dependencies!['bar']).toBe(monorepo['packages']['foo'].dependencies!['bar']);
@@ -295,7 +295,7 @@ describe('version bumping', () => {
       keepChangeFiles: true,
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
@@ -333,7 +333,7 @@ describe('version bumping', () => {
       prereleasePrefix: 'beta',
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const newVersion = '1.0.1-beta.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -374,7 +374,7 @@ describe('version bumping', () => {
       prereleasePrefix: 'beta',
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const newVersion = '1.0.1-beta.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -415,7 +415,7 @@ describe('version bumping', () => {
       prereleasePrefix: 'beta',
     } as BeachballOptions);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos({ path: repo.rootPath });
 
     const pkg1NewVersion = '1.0.1-beta.1';
     const othersNewVersion = '1.0.1-beta.0';

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -19,7 +19,7 @@ describe('getChangedPackages', () => {
     repositoryFactory = new RepositoryFactory('single');
     const repo = repositoryFactory.cloneRepository();
     const options = { fetch: false, path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(options);
 
     expect(getChangedPackages(options, packageInfos)).toStrictEqual([]);
 
@@ -36,7 +36,7 @@ describe('getChangedPackages', () => {
       branch: defaultBranchName,
       ignorePatterns: ['*.test.js', 'tests/**', 'yarn.lock'],
     } as BeachballOptions;
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(options);
 
     repo.stageChange('src/foo.test.js');
     repo.stageChange('tests/stuff.js');
@@ -49,7 +49,7 @@ describe('getChangedPackages', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     const repo = repositoryFactory.cloneRepository();
     const options = { fetch: false, path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(options);
 
     expect(getChangedPackages(options, packageInfos)).toStrictEqual([]);
 
@@ -65,7 +65,7 @@ describe('getChangedPackages', () => {
 
     const workspaceARoot = repo.pathTo('workspace-a');
     const workspaceBRoot = repo.pathTo('workspace-b');
-    const rootPackageInfos = getPackageInfos(repo.rootPath);
+    const rootPackageInfos = getPackageInfos(rootOptions);
 
     expect(getChangedPackages(rootOptions, rootPackageInfos)).toStrictEqual([]);
 
@@ -73,11 +73,11 @@ describe('getChangedPackages', () => {
 
     const changedPackagesA = getChangedPackages(
       { ...rootOptions, path: workspaceARoot },
-      getPackageInfos(workspaceARoot)
+      getPackageInfos({ path: workspaceARoot })
     );
     const changedPackagesB = getChangedPackages(
       { ...rootOptions, path: workspaceBRoot },
-      getPackageInfos(workspaceBRoot)
+      getPackageInfos({ path: workspaceBRoot })
     );
     const changedPackagesRoot = getChangedPackages(rootOptions, rootPackageInfos);
 

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -76,7 +76,7 @@ describe('publish command (git)', () => {
 
     const options: BeachballOptions = getOptions(repo1);
 
-    const bumpInfo = gatherBumpInfo(options, getPackageInfos(repo1.rootPath));
+    const bumpInfo = gatherBumpInfo(options, getPackageInfos(options));
 
     // 3. Meanwhile, in repo2, also create a new change file
     const repo2 = repositoryFactory.cloneRepository();

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -91,7 +91,7 @@ describe('sync command (e2e)', () => {
     });
     const repo = repositoryFactory.cloneRepository();
 
-    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+    const packageInfosBeforeSync = getPackageInfos({ path: repo.rootPath });
 
     expect((await packagePublish(packageInfosBeforeSync['foopkg'], registry.getUrl(), '', '')).success).toBeTruthy();
     expect((await packagePublish(packageInfosBeforeSync['barpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
@@ -104,7 +104,7 @@ describe('sync command (e2e)', () => {
 
     await sync(getOptions(repo, { tag: '' }));
 
-    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+    const packageInfosAfterSync = getPackageInfos({ path: repo.rootPath });
 
     expect(packageInfosAfterSync['foopkg'].version).toEqual('1.2.0');
     expect(packageInfosAfterSync['barpkg'].version).toEqual('3.0.0');
@@ -123,7 +123,7 @@ describe('sync command (e2e)', () => {
     });
     const repo = repositoryFactory.cloneRepository();
 
-    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+    const packageInfosBeforeSync = getPackageInfos({ path: repo.rootPath });
 
     expect((await packagePublish(packageInfosBeforeSync['apkg'], registry.getUrl(), '', '')).success).toBeTruthy();
     expect((await packagePublish(packageInfosBeforeSync['bpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
@@ -136,7 +136,7 @@ describe('sync command (e2e)', () => {
 
     await sync(getOptions(repo, { tag: 'beta' }));
 
-    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+    const packageInfosAfterSync = getPackageInfos({ path: repo.rootPath });
 
     expect(packageInfosAfterSync['apkg'].version).toEqual('2.0.0');
     expect(packageInfosAfterSync['bpkg'].version).toEqual('2.2.0');
@@ -155,7 +155,7 @@ describe('sync command (e2e)', () => {
     });
     const repo = repositoryFactory.cloneRepository();
 
-    const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
+    const packageInfosBeforeSync = getPackageInfos({ path: repo.rootPath });
 
     const epkg = packageInfosBeforeSync['epkg'];
     const fpkg = packageInfosBeforeSync['fpkg'];
@@ -177,7 +177,7 @@ describe('sync command (e2e)', () => {
 
     await sync(getOptions(repo, { tag: 'prerelease', forceVersions: true }));
 
-    const packageInfosAfterSync = getPackageInfos(repo.rootPath);
+    const packageInfosAfterSync = getPackageInfos({ path: repo.rootPath });
 
     expect(packageInfosAfterSync['epkg'].version).toEqual('1.0.0-1');
     expect(packageInfosAfterSync['fpkg'].version).toEqual('2.2.0');

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -73,10 +73,10 @@ ${gitResult.stderr.toString()}`);
   }
 
   /**
-   * Create (or update) and stage a file, creating the intermediate directories if necessary.
+   * Create or update a file, creating the intermediate directories if necessary.
    * Automatically uses root path; do not pass absolute paths here.
    */
-  stageChange(newFilename: string, content?: string) {
+  writeChange(newFilename: string, content?: string) {
     const filePath = this.pathTo(newFilename);
     fs.ensureDirSync(path.dirname(filePath));
     fs.ensureFileSync(filePath);
@@ -84,7 +84,14 @@ ${gitResult.stderr.toString()}`);
     if (content) {
       fs.writeFileSync(filePath, content);
     }
+  }
 
+  /**
+   * Create (or update) and stage a file, creating the intermediate directories if necessary.
+   * Automatically uses root path; do not pass absolute paths here.
+   */
+  stageChange(newFilename: string, content?: string) {
+    this.writeChange(newFilename, content);
     this.git(['add', newFilename]);
   }
 

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -32,8 +32,8 @@ describe('readChangeFiles', () => {
     repository.commitChange('foo');
     generateChangeFiles(['foo'], repository.rootPath);
 
-    const packageInfos = getPackageInfos(repository.rootPath);
-    const changeSet = readChangeFiles({ path: repository.rootPath } as BeachballOptions, packageInfos);
+    const options = { path: repository.rootPath } as BeachballOptions;
+    const changeSet = readChangeFiles(options, getPackageInfos(options));
     expect(changeSet).toHaveLength(1);
     expect(changeSet[0].change.commit).toBe(undefined);
   });
@@ -44,8 +44,8 @@ describe('readChangeFiles', () => {
     // fake doesn't exist, bar is private, foo is okay
     generateChangeFiles(['fake', 'bar', 'foo'], monoRepo.rootPath);
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
-    const changeSet = readChangeFiles({ path: monoRepo.rootPath } as BeachballOptions, packageInfos);
+    const options = { path: monoRepo.rootPath } as BeachballOptions;
+    const changeSet = readChangeFiles(options, getPackageInfos(options));
     expect(changeSet).toHaveLength(1);
 
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package bar'));
@@ -60,11 +60,8 @@ describe('readChangeFiles', () => {
     // fake doesn't exist, bar is private, foo is okay
     generateChangeFiles(['fake', 'bar', 'foo'], monoRepo.rootPath, true /*groupChanges*/);
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
-    const changeSet = readChangeFiles(
-      { path: monoRepo.rootPath, groupChanges: true } as BeachballOptions,
-      packageInfos
-    );
+    const options = { path: monoRepo.rootPath, groupChanges: true } as BeachballOptions;
+    const changeSet = readChangeFiles(options, getPackageInfos(options));
     expect(changeSet).toHaveLength(1);
 
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package bar'));
@@ -77,11 +74,8 @@ describe('readChangeFiles', () => {
     const monoRepo = monoRepoFactory.cloneRepository();
     generateChangeFiles(['bar', 'foo'], monoRepo.rootPath);
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
-    const changeSet = readChangeFiles(
-      { path: monoRepo.rootPath, scope: ['packages/foo'] } as BeachballOptions,
-      packageInfos
-    );
+    const options = { path: monoRepo.rootPath, scope: ['packages/foo'] } as BeachballOptions;
+    const changeSet = readChangeFiles(options, getPackageInfos(options));
     expect(changeSet).toHaveLength(1);
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
@@ -90,11 +84,8 @@ describe('readChangeFiles', () => {
     const monoRepo = monoRepoFactory.cloneRepository();
     generateChangeFiles(['bar', 'foo'], monoRepo.rootPath, true /*groupChanges*/);
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
-    const changeSet = readChangeFiles(
-      { path: monoRepo.rootPath, scope: ['packages/foo'], groupChanges: true } as BeachballOptions,
-      packageInfos
-    );
+    const options = { path: monoRepo.rootPath, scope: ['packages/foo'], groupChanges: true } as BeachballOptions;
+    const changeSet = readChangeFiles(options, getPackageInfos(options));
     expect(changeSet).toHaveLength(1);
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -49,7 +49,7 @@ describe('writeChangelog', () => {
     generateChangeFiles([getChange('foo', 'comment 2')], repository.rootPath);
 
     const beachballOptions = { path: repository.rootPath } as BeachballOptions;
-    const packageInfos = getPackageInfos(repository.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions);
     const changes = readChangeFiles(beachballOptions, packageInfos);
 
     await writeChangelog(beachballOptions, changes, { foo: 'patch' }, { foo: new Set(['foo']) }, packageInfos);
@@ -83,7 +83,7 @@ describe('writeChangelog', () => {
     generateChangeFiles([getChange('foo', 'comment 2')], ...params);
 
     const beachballOptions = { path: monoRepo.rootPath, groupChanges: true } as BeachballOptions;
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions);
     const changes = readChangeFiles(beachballOptions, packageInfos);
 
     await writeChangelog(beachballOptions, changes, { foo: 'patch', bar: 'patch' }, {}, packageInfos);
@@ -127,7 +127,7 @@ describe('writeChangelog', () => {
       },
     };
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions as { path: string });
     const changes = readChangeFiles(beachballOptions as BeachballOptions, packageInfos);
 
     await writeChangelog(beachballOptions as BeachballOptions, changes, {}, {}, packageInfos);
@@ -158,7 +158,7 @@ describe('writeChangelog', () => {
       },
     };
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions as { path: string });
     const changes = readChangeFiles(beachballOptions as BeachballOptions, packageInfos);
 
     await writeChangelog(
@@ -203,7 +203,7 @@ describe('writeChangelog', () => {
       },
     };
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions as { path: string });
     const changes = readChangeFiles(beachballOptions as BeachballOptions, packageInfos);
 
     await writeChangelog(
@@ -243,7 +243,7 @@ describe('writeChangelog', () => {
       },
     };
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions as { path: string });
     const changes = readChangeFiles(beachballOptions as BeachballOptions, packageInfos);
 
     await writeChangelog(beachballOptions as BeachballOptions, changes, {}, {}, packageInfos);
@@ -286,7 +286,7 @@ describe('writeChangelog', () => {
       },
     };
 
-    const packageInfos = getPackageInfos(monoRepo.rootPath);
+    const packageInfos = getPackageInfos(beachballOptions as { path: string });
     const changes = readChangeFiles(beachballOptions as BeachballOptions, packageInfos);
 
     // Verify that the comment of only the intended change file is changed

--- a/src/__functional__/monorepo/getScopedPackages.test.ts
+++ b/src/__functional__/monorepo/getScopedPackages.test.ts
@@ -14,7 +14,7 @@ describe('getScopedPackages', () => {
   beforeAll(() => {
     repoFactory = new RepositoryFactory('monorepo');
     repo = repoFactory.cloneRepository();
-    packageInfos = getPackageInfos(repo.rootPath);
+    packageInfos = getPackageInfos({ path: repo.rootPath });
   });
   afterAll(() => {
     repoFactory.cleanUp();

--- a/src/__functional__/validation/isChangeFileNeeded.test.ts
+++ b/src/__functional__/validation/isChangeFileNeeded.test.ts
@@ -25,42 +25,36 @@ describe('isChangeFileNeeded', () => {
   });
 
   it('is false when no changes have been made', () => {
-    const result = isChangeFileNeeded(
-      {
-        branch: defaultRemoteBranchName,
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions,
-      getPackageInfos(repository.rootPath)
-    );
+    const options = {
+      branch: defaultRemoteBranchName,
+      path: repository.rootPath,
+      fetch: false,
+    } as BeachballOptions;
+    const result = isChangeFileNeeded(options, getPackageInfos(options));
     expect(result).toBeFalsy();
   });
 
   it('is true when changes exist in a new branch', () => {
     repository.checkout('-b', 'feature-0');
     repository.commitChange('myFilename');
-    const result = isChangeFileNeeded(
-      {
-        branch: defaultRemoteBranchName,
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions,
-      getPackageInfos(repository.rootPath)
-    );
+    const options = {
+      branch: defaultRemoteBranchName,
+      path: repository.rootPath,
+      fetch: false,
+    } as BeachballOptions;
+    const result = isChangeFileNeeded(options, getPackageInfos(options));
     expect(result).toBeTruthy();
   });
 
   it('is false when changes are CHANGELOG files', () => {
     repository.checkout('-b', 'feature-0');
     repository.commitChange('CHANGELOG.md');
-    const result = isChangeFileNeeded(
-      {
-        branch: defaultRemoteBranchName,
-        path: repository.rootPath,
-        fetch: false,
-      } as BeachballOptions,
-      getPackageInfos(repository.rootPath)
-    );
+    const options = {
+      branch: defaultRemoteBranchName,
+      path: repository.rootPath,
+      fetch: false,
+    } as BeachballOptions;
+    const result = isChangeFileNeeded(options, getPackageInfos(options));
     expect(result).toBeFalsy();
   });
 
@@ -71,15 +65,11 @@ describe('isChangeFileNeeded', () => {
     repo.checkout('-b', 'feature-0');
     repo.commitChange('CHANGELOG.md');
 
-    expect(() => {
-      isChangeFileNeeded(
-        {
-          branch: defaultRemoteBranchName,
-          path: repo.rootPath,
-          fetch: true,
-        } as BeachballOptions,
-        getPackageInfos(repo.rootPath)
-      );
-    }).toThrow();
+    const options = {
+      branch: defaultRemoteBranchName,
+      path: repo.rootPath,
+      fetch: true,
+    } as BeachballOptions;
+    expect(() => isChangeFileNeeded(options, getPackageInfos(options))).toThrow();
   });
 });

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -20,7 +20,7 @@ export async function promptForChange(options: BeachballOptions): Promise<Change
   if (specificPackage && !Array.isArray(specificPackage)) {
     specificPackage = [specificPackage];
   }
-  const packageInfos = getPackageInfos(cwd);
+  const packageInfos = getPackageInfos(options);
   const changedPackages = specificPackage || getChangedPackages(options, packageInfos);
   const recentMessages = getRecentCommitMessages(branch, cwd) || [];
   const packageChangeInfo: ChangeFileInfo[] = [];

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -4,6 +4,6 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 export async function bump(options: BeachballOptions) {
-  const bumpInfo = gatherBumpInfo(options, getPackageInfos(options.path));
+  const bumpInfo = gatherBumpInfo(options, getPackageInfos(options));
   return await performBump(bumpInfo, options);
 }

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -8,7 +8,7 @@ import { publishToRegistry } from '../publish/publishToRegistry';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 export async function canary(options: BeachballOptions) {
-  const oldPackageInfo = getPackageInfos(options.path);
+  const oldPackageInfo = getPackageInfos(options);
 
   const bumpInfo = gatherBumpInfo(options, oldPackageInfo);
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -12,7 +12,7 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 export async function publish(options: BeachballOptions) {
   const { path: cwd, branch, registry, tag } = options;
   // First, validate that we have changes to publish
-  const oldPackageInfos = getPackageInfos(cwd);
+  const oldPackageInfos = getPackageInfos(options);
   const changes = readChangeFiles(options, oldPackageInfos);
   const packageChangeTypes = initializePackageChangeInfo(changes);
   if (Object.keys(packageChangeTypes).length === 0) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -7,7 +7,7 @@ import { setDependentVersions } from '../bump/setDependentVersions';
 import { writePackageJson, updatePackageLock } from '../bump/performBump';
 
 export async function sync(options: BeachballOptions) {
-  const packageInfos = getPackageInfos(options.path);
+  const packageInfos = getPackageInfos(options);
   const scopedPackages = new Set(getScopedPackages(options, packageInfos));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -1,8 +1,9 @@
-import { VersionGroupOptions } from '../types/BeachballOptions';
+import { BeachballOptions } from '../types/BeachballOptions';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 
-export function isValidGroupOptions(root: string, groups: VersionGroupOptions[]) {
+export function isValidGroupOptions(options: BeachballOptions) {
+  const { path: root, groups } = options;
   if (!Array.isArray(groups)) {
     return false;
   }
@@ -13,7 +14,7 @@ export function isValidGroupOptions(root: string, groups: VersionGroupOptions[])
     }
   }
 
-  const packageInfos = getPackageInfos(root);
+  const packageInfos = getPackageInfos(options);
   const packageGroups = getPackageGroups(packageInfos, root, groups);
   // make sure no disallowed changetype options exist inside an individual package
 

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -36,7 +36,7 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
     console.warn('Changes in these files will not trigger a prompt for change descriptions');
   }
 
-  const packageInfos = getPackageInfos(options.path);
+  const packageInfos = getPackageInfos(options);
 
   if (options.package && !Array.isArray(options.package) && !packageInfos[options.package]) {
     console.error('ERROR: Specified package name is not valid');
@@ -74,7 +74,7 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
     }
   }
 
-  if (options.groups && !isValidGroupOptions(options.path, options.groups)) {
+  if (options.groups && !isValidGroupOptions(options)) {
     console.error('ERROR: Groups defined inside the configuration is invalid');
     console.log(options.groups);
     process.exit(1);


### PR DESCRIPTION
#761 added error checking for duplicate package names, which accidentally caused issues in `workspace-tools` when trying to update beachball  (see https://github.com/microsoft/workspace-tools/pull/172#issuecomment-1217942421).

`workspace-tools` is a single package, but it has some other test fixture monorepos inside it. Because `getScopedPackages` has to scan for non-workspace monorepos before assuming a single package setup, `workspace-tools` is getting detected that way and there's an error because several fixture packages share a name.

One way to fix this is to respect the `ignorePatterns` option when scanning for packages. This adds a bit of cost but is probably the right thing to do, and will likely help avoid other subtle issues in the future with similar fixture setups.

NOTE: The actual fix is simple (in `src/monorepo/getPackageInfos.ts`) but a LOT of references needed to be updated due to the signature change.