### PR TITLE
feat: Adds precommit hook

### DIFF
--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -49,7 +49,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     await performBump(bumpInfo, options);
 
     // checkin
-    const mergePublishBranchResult = mergePublishBranch(publishBranch, branch, message, cwd);
+    const mergePublishBranchResult = await mergePublishBranch(publishBranch, branch, message, cwd, options);
     if (!mergePublishBranchResult.success) {
       console.warn(`[WARN ${tryNumber}/${BUMP_PUSH_RETRIES}]: merging to target has failed!`);
       continue;

--- a/src/publish/mergePublishBranch.ts
+++ b/src/publish/mergePublishBranch.ts
@@ -31,9 +31,7 @@ export async function mergePublishBranch(
   return result!;
 }
 
-/**
- * Calls a specified hook for each package being bumped
- */
+/** Calls the `precommit` hook specified in `options` */
 async function precommitHook(options: BeachballOptions) {
   const hook = options.hooks?.precommit;
   if (!hook) {

--- a/src/publish/mergePublishBranch.ts
+++ b/src/publish/mergePublishBranch.ts
@@ -8,6 +8,8 @@ export async function mergePublishBranch(
   cwd: string,
   options: BeachballOptions
 ) {
+  await precommitHook(options);
+
   let result: GitProcessOutput;
   let mergeSteps = [
     ['add', '.'],
@@ -15,8 +17,6 @@ export async function mergePublishBranch(
     ['checkout', branch],
     ['merge', '-X', 'ours', publishBranch],
   ];
-
-  await precommitHook(options);
 
   for (let index = 0; index < mergeSteps.length; index++) {
     const step = mergeSteps[index];
@@ -40,8 +40,5 @@ async function precommitHook(options: BeachballOptions) {
     return;
   }
 
-  const hookRet = hook(options.path);
-  if (hookRet instanceof Promise) {
-    await hookRet;
-  }
+  await hook(options.path);
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -155,7 +155,7 @@ export interface HooksOptions {
   postbump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
 
   /**
-   * Runs once after all bumps to all packages before commiting changes
+   * Runs once after all bumps to all packages before committing changes
    */
   precommit?: (cwd: string) => void | Promise<void>;
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -153,6 +153,11 @@ export interface HooksOptions {
    * to the filesystem. May be called multiple times during publish.
    */
   postbump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+
+  /**
+   * Runs once after all bumps to all packages before commiting changes
+   */
+  precommit?: (cwd: string) => void | Promise<void>;
 }
 
 export interface TransformOptions {


### PR DESCRIPTION
Adds a precommit hook that is called before bumps are committed and pushed. Allows users to modify or create files based on the entire release instead of per package.