### PR TITLE
Fix handling of shallow clones when checking for change files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - run: yarn docs:build
 
-      - run: yarn checkchange
+      - run: yarn checkchange --verbose
 
       - run: yarn test:unit
 

--- a/change/beachball-bb84d74d-c4d5-49bd-9671-d01dfe9c962c.json
+++ b/change/beachball-bb84d74d-c4d5-49bd-9671-d01dfe9c962c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix handling of shallow clones when checking for change files",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -5,6 +5,7 @@ import { initMockLogs } from '../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { change } from '../commands/change';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { defaultBranchName } from '../__fixtures__/gitDefaults';
 
 describe('change command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -28,6 +29,7 @@ describe('change command', () => {
       package: repositoryFactory.fixture.rootPackage!.name,
       message: 'stage me please',
       path: repo.rootPath,
+      branch: defaultBranchName,
       commit: false,
     } as BeachballOptions);
 
@@ -54,6 +56,7 @@ describe('change command', () => {
       package: ['pkg-1', 'pkg-2'],
       message: 'stage me please',
       path: repo.rootPath,
+      branch: defaultBranchName,
       commit: false,
       groupChanges: true,
     } as BeachballOptions);
@@ -79,6 +82,7 @@ describe('change command', () => {
       package: repositoryFactory.fixture.rootPackage!.name,
       message: 'commit me please',
       path: repo.rootPath,
+      branch: defaultBranchName,
     } as BeachballOptions);
 
     expect(repo.status()).toBe('');


### PR DESCRIPTION
By default, [github `actions/checkout`](https://github.com/actions/checkout) only fetches the current merge ref of the PR (no history and no other branches). This causes problems for `beachball check`, because it doesn't have all the history that it needs to compare against.

These problems have existed for quite some time, in any repo using `actions/checkout` > v1 without `fetch-depth: 0`. And the `workspace-tools` git changed files helpers were hiding the issue by returning empty arrays if git commands failed.

Fix is to add explicit checks on the beachball side for various conditions related to missing history. If history is missing and fetching is enabled, it will fetch the extra history. If fetching is disabled, it will print informative error messages.

(You can see that it works because this PR's initial build includes the log about unshallowing, and ultimately failed due to a missing change file!)