### PR TITLE
Don't write change files if prompt is cancelled

### DIFF
--- a/change/beachball-8b44483a-cbcf-4bce-a338-df4c3eef32fb.json
+++ b/change/beachball-8b44483a-cbcf-4bce-a338-df4c3eef32fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't write change files if prompt is cancelled",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/types/ChangeFilePrompt.ts
+++ b/src/types/ChangeFilePrompt.ts
@@ -7,6 +7,7 @@ export interface DefaultPrompt {
 
 /**
  * Options for customizing change file prompt.
+ * The package name is provided so that the prompt can be customized by package if desired.
  */
 export interface ChangeFilePromptOptions {
   changePrompt?(defaultPrompt: DefaultPrompt, pkg: string): prompts.PromptObject[];


### PR DESCRIPTION
Previously, if the user did ctrl+c partway through the change file prompt, beachball would write all the change files so far. This could include partial change files (missing the message) if the cancellation occurred partway through the questions for a package. For example, it might write a change file like:
```json
{
  "type": "none",
  "packageName": "beachball",
  "email": "whatever",
  "dependentChangeType": "none"
}
```

This PR switches to a more accurate cancellation check (via prompts options), with NO change files written if it's triggered. 