### PR TITLE
Add validation for multiple specified packages

### DIFF
--- a/change/beachball-170dbbeb-641f-4ec6-9d18-622916d40210.json
+++ b/change/beachball-170dbbeb-641f-4ec6-9d18-622916d40210.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add validation for multiple specified packages",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import { validate } from './validation/validate';
       break;
 
     case 'sync':
-      sync(options);
+      await sync(options);
       break;
 
     default:
@@ -63,14 +63,14 @@ import { validate } from './validation/validate';
         return;
       }
 
-      change(options);
+      await change(options);
 
       break;
   }
 })().catch(e => {
   showVersion();
   console.error('An error has been detected while running beachball!');
-  console.error(e);
+  console.error(e?.stack || e);
 
   process.exit(1);
 });

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -16,7 +16,6 @@ export function getDefaultOptions() {
     tag: '',
     yes: false,
     access: 'restricted',
-    package: '',
     changehint: 'Run "beachball change" to create a change file',
     type: null,
     fetch: true,

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -40,7 +40,7 @@ export interface CliOptions
   help?: boolean;
   keepChangeFiles?: boolean;
   new: boolean;
-  package: string | string[];
+  package?: string | string[];
   timeout?: number;
   token: string;
   type?: ChangeType | null;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -38,10 +38,15 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
 
   const packageInfos = getPackageInfos(options.path);
 
-  if (options.package && !Array.isArray(options.package) && !packageInfos[options.package]) {
+  if (typeof options.package === 'string' && !packageInfos[options.package]) {
     console.error('ERROR: Specified package name is not valid');
     process.exit(1);
   }
+  if (Array.isArray(options.package) && options.package.some(pkg => !packageInfos[pkg])) {
+    console.error('ERROR: Specified package names are not valid');
+    process.exit(1);
+  }
+
   if (options.authType && !isValidAuthType(options.authType)) {
     console.error(`ERROR: auth type ${options.authType} is not valid`);
     process.exit(1);

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -39,26 +39,29 @@ export function validate(options: BeachballOptions, validateOptions?: Partial<Va
   const packageInfos = getPackageInfos(options.path);
 
   if (typeof options.package === 'string' && !packageInfos[options.package]) {
-    console.error('ERROR: Specified package name is not valid');
+    console.error(`ERROR: package "${options.package}" was not found`);
     process.exit(1);
   }
-  if (Array.isArray(options.package) && options.package.some(pkg => !packageInfos[pkg])) {
-    console.error('ERROR: Specified package names are not valid');
+  const invalidPackages = Array.isArray(options.package)
+    ? options.package.filter(pkg => !packageInfos[pkg])
+    : undefined;
+  if (invalidPackages?.length) {
+    console.error(`ERROR: package(s) ${invalidPackages.map(pkg => `"${pkg}"`).join(', ')} were not found`);
     process.exit(1);
   }
 
   if (options.authType && !isValidAuthType(options.authType)) {
-    console.error(`ERROR: auth type ${options.authType} is not valid`);
+    console.error(`ERROR: auth type "${options.authType}" is not valid`);
     process.exit(1);
   }
 
   if (options.dependentChangeType && !isValidChangeType(options.dependentChangeType)) {
-    console.error(`ERROR: dependent change type ${options.dependentChangeType} is not valid`);
+    console.error(`ERROR: dependent change type "${options.dependentChangeType}" is not valid`);
     process.exit(1);
   }
 
   if (options.type && !isValidChangeType(options.type)) {
-    console.error(`ERROR: change type ${options.type} is not valid`);
+    console.error(`ERROR: change type "${options.type}" is not valid`);
     process.exit(1);
   }
 


### PR DESCRIPTION
If multiple package names are passed to `--package`, all of them should be validated.

I also fixed a couple of missing `await`s in the main CLI function.