### PR TITLE
Add tests for getDisallowedChangeTypes

### DIFF
--- a/change/beachball-2c265b94-ba34-484c-9f99-0221c36c8d52.json
+++ b/change/beachball-2c265b94-ba34-484c-9f99-0221c36c8d52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Simplify getDisallowedChangeTypes implementation",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/packageInfos.ts
+++ b/src/__fixtures__/packageInfos.ts
@@ -1,0 +1,22 @@
+import { BeachballOptions } from '../types/BeachballOptions';
+import { PackageInfo, PackageInfos } from '../types/PackageInfo';
+
+/**
+ * Makes a properly typed PackageInfos object from a partial object, filling in the `name`,
+ * `version` 1.0.0, and an empty `combinedOptions` object. (Other properties are not set, but this
+ * at least makes the fixture code a bit more concise and ensures that any properties provided in
+ * the override object are valid.)
+ */
+export function makePackageInfos(packageInfos: {
+  [name: string]: Partial<Omit<PackageInfo, 'combinedOptions'>> & { combinedOptions?: Partial<BeachballOptions> };
+}): PackageInfos {
+  const result: PackageInfos = {};
+  for (const [name, info] of Object.entries(packageInfos)) {
+    result[name] = {
+      name,
+      combinedOptions: {} as BeachballOptions,
+      ...info,
+    } as PackageInfo;
+  }
+  return result;
+}

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -3,7 +3,7 @@ import { updateRelatedChangeType } from '../../bump/updateRelatedChangeType';
 import { BumpInfo } from '../../types/BumpInfo';
 import _ from 'lodash';
 import { ChangeInfo, ChangeSet, ChangeType } from '../../types/ChangeInfo';
-import { PackageInfo, PackageInfos } from '../../types/PackageInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : DeepPartial<T[P]>;
@@ -21,20 +21,11 @@ describe('updateRelatedChangeType', () => {
         changeFileChangeInfos: [],
         dependents: {},
         calculatedChangeTypes: {},
-        packageInfos: {
-          foo: {
-            name: 'foo',
-            combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-          },
-          bar: {
-            name: 'bar',
-            combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-          },
-          baz: {
-            name: 'baz',
-            combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-          },
-        } as { [packageName: string]: DeepPartial<PackageInfo> } as PackageInfos,
+        packageInfos: makePackageInfos({
+          foo: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
+          bar: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
+          baz: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
+        }),
         modifiedPackages: new Set(),
         newPackages: new Set(),
         packageGroups: {},
@@ -66,11 +57,7 @@ describe('updateRelatedChangeType', () => {
         foo: 'minor',
       },
       packageInfos: {
-        bar: {
-          dependencies: {
-            foo: '1.0.0',
-          },
-        },
+        bar: { dependencies: { foo: '1.0.0' } },
       },
     });
 
@@ -92,11 +79,7 @@ describe('updateRelatedChangeType', () => {
         foo: 'patch',
       },
       packageInfos: {
-        bar: {
-          dependencies: {
-            foo: '1.0.0',
-          },
-        },
+        bar: { dependencies: { foo: '1.0.0' } },
       },
     });
 
@@ -127,16 +110,8 @@ describe('updateRelatedChangeType', () => {
         bar: 'major',
       },
       packageInfos: {
-        app: {
-          dependencies: {
-            bar: '1.0.0',
-          },
-        },
-        bar: {
-          dependencies: {
-            foo: '1.0.0',
-          },
-        },
+        app: { dependencies: { bar: '1.0.0' } },
+        bar: { dependencies: { foo: '1.0.0' } },
       },
     });
 
@@ -176,17 +151,8 @@ describe('updateRelatedChangeType', () => {
         baz: 'minor',
       },
       packageInfos: {
-        app: {
-          dependencies: {
-            bar: '1.0.0',
-          },
-        },
-        bar: {
-          dependencies: {
-            foo: '1.0.0',
-            baz: '2.0.0',
-          },
-        },
+        app: { dependencies: { bar: '1.0.0' } },
+        bar: { dependencies: { foo: '1.0.0', baz: '2.0.0' } },
       },
     });
 
@@ -218,18 +184,8 @@ describe('updateRelatedChangeType', () => {
         baz: 'patch',
       },
       packageInfos: {
-        app: {
-          dependencies: {
-            bar: '1.0.0',
-            baz: '2.0.0',
-          },
-        },
-        bar: {
-          dependencies: {
-            foo: '1.0.0',
-            baz: '2.0.0',
-          },
-        },
+        app: { dependencies: { bar: '1.0.0', baz: '2.0.0' } },
+        bar: { dependencies: { foo: '1.0.0', baz: '2.0.0' } },
       },
     });
 
@@ -329,22 +285,12 @@ describe('updateRelatedChangeType', () => {
       dependents: {
         dep: ['bar'],
       },
-      packageInfos: {
+      packageInfos: makePackageInfos({
         foo: {},
-        bar: {
-          dependencies: {
-            dep: '1.0.0',
-          },
-        },
-        dep: {
-          name: 'dep',
-          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-        },
-        unrelated: {
-          name: 'unrelated',
-          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-        },
-      },
+        bar: { dependencies: { dep: '1.0.0' } },
+        dep: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
+        unrelated: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
+      }),
       changeFileChangeInfos: [
         {
           changeFile: 'dep.json',
@@ -367,27 +313,16 @@ describe('updateRelatedChangeType', () => {
         dep: ['bar'],
         foo: ['app'],
       },
-      packageInfos: {
+      packageInfos: makePackageInfos({
         foo: {},
-        bar: {
-          dependencies: {
-            dep: '1.0.0',
-          },
-        },
-        dep: {
-          name: 'dep',
-          combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
-        },
+        bar: { dependencies: { dep: '1.0.0' } },
+        dep: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
         app: {
-          name: 'app',
-          dependencies: {
-            foo: '1.0.0',
-          },
+          dependencies: { foo: '1.0.0' },
           combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' },
         },
-      },
+      }),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
-
       changeFileChangeInfos: [
         {
           changeFile: 'dep.json',
@@ -412,37 +347,15 @@ describe('updateRelatedChangeType', () => {
         bar: ['datetime'],
         datetimeUtils: ['datetime'],
       },
-      packageInfos: {
-        styling: {
-          name: 'styling',
-          dependencies: {
-            mergeStyles: '1.0.0',
-          },
-        },
-        utils: {
-          name: 'utils',
-        },
-        mergeStyles: {
-          name: 'mergeStyles',
-        },
+      packageInfos: makePackageInfos({
+        styling: { dependencies: { mergeStyles: '1.0.0' } },
+        utils: {},
+        mergeStyles: {},
         foo: {},
-        bar: {
-          dependencies: {
-            styling: '1.0.0',
-            utils: '1.0.0',
-          },
-        },
-        datetime: {
-          name: 'datetime',
-          dependencies: {
-            bar: '1.0.0',
-            datetimeUtils: '1.0.0',
-          },
-        },
-        datetimeUtils: {
-          name: 'datetimeUtils',
-        },
-      },
+        bar: { dependencies: { styling: '1.0.0', utils: '1.0.0' } },
+        datetime: { dependencies: { bar: '1.0.0', datetimeUtils: '1.0.0' } },
+        datetimeUtils: {},
+      }),
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
       changeFileChangeInfos: [
         {

--- a/src/__tests__/changefile/getDisallowedChangeTypes.test.ts
+++ b/src/__tests__/changefile/getDisallowedChangeTypes.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import { getDisallowedChangeTypes } from '../../changefile/getDisallowedChangeTypes';
+import { PackageGroups } from '../../types/PackageInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+describe('getDisallowedChangeTypes', () => {
+  it('returns null for unknown package', () => {
+    expect(getDisallowedChangeTypes('foo', {}, {})).toBeNull();
+  });
+
+  it('returns null for package without disallowedChangeTypes', () => {
+    expect(getDisallowedChangeTypes('foo', makePackageInfos({ foo: {} }), {})).toBeNull();
+  });
+
+  it('returns disallowedChangeTypes for package', () => {
+    const packageInfos = makePackageInfos({
+      foo: { combinedOptions: { disallowedChangeTypes: ['major', 'minor'] } },
+    });
+    expect(getDisallowedChangeTypes('foo', packageInfos, {})).toEqual(['major', 'minor']);
+  });
+
+  it('returns disallowedChangeTypes for package group', () => {
+    const packageInfos = makePackageInfos({ foo: {} });
+    const packageGroups: PackageGroups = {
+      group: { packageNames: ['foo'], disallowedChangeTypes: ['major', 'minor'] },
+    };
+    expect(getDisallowedChangeTypes('foo', packageInfos, packageGroups)).toEqual(['major', 'minor']);
+  });
+
+  it('returns disallowedChangeTypes for package if not in a group', () => {
+    const packageInfos = makePackageInfos({
+      foo: { combinedOptions: { disallowedChangeTypes: ['patch'] } },
+    });
+    const packageGroups: PackageGroups = {
+      group: { packageNames: ['bar'], disallowedChangeTypes: ['major', 'minor'] },
+    };
+    expect(getDisallowedChangeTypes('foo', packageInfos, packageGroups)).toEqual(['patch']);
+  });
+
+  it('prefers disallowedChangeTypes for group over package', () => {
+    const packageInfos = makePackageInfos({
+      foo: { combinedOptions: { disallowedChangeTypes: ['patch'] } },
+    });
+    const packageGroups: PackageGroups = {
+      group: { packageNames: ['foo'], disallowedChangeTypes: ['major', 'minor'] },
+    };
+    expect(getDisallowedChangeTypes('foo', packageInfos, packageGroups)).toEqual(['major', 'minor']);
+  });
+});

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -5,6 +5,7 @@ import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { tagPackages, tagDistTag } from '../../publish/tagPackages';
 import { generateTag } from '../../tag';
 import { BumpInfo } from '../../types/BumpInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 jest.mock('workspace-tools', () => ({
   gitFailFast: jest.fn(),
@@ -19,22 +20,16 @@ const noTagBumpInfo = {
     foo: 'minor',
     bar: 'major',
   },
-  packageInfos: {
+  packageInfos: makePackageInfos({
     foo: {
-      name: 'foo',
       version: '1.0.0',
-      combinedOptions: {
-        gitTags: false,
-      },
+      combinedOptions: { gitTags: false },
     },
     bar: {
-      name: 'bar',
       version: '1.0.1',
-      combinedOptions: {
-        gitTags: false,
-      },
+      combinedOptions: { gitTags: false },
     },
-  },
+  }),
   modifiedPackages: new Set(['foo', 'bar']),
   newPackages: new Set(),
 } as unknown as BumpInfo;
@@ -44,22 +39,16 @@ const oneTagBumpInfo = {
     foo: 'minor',
     bar: 'major',
   },
-  packageInfos: {
+  packageInfos: makePackageInfos({
     foo: {
-      name: 'foo',
       version: '1.0.0',
-      combinedOptions: {
-        gitTags: true,
-      },
+      combinedOptions: { gitTags: true },
     },
     bar: {
-      name: 'bar',
       version: '1.0.1',
-      combinedOptions: {
-        gitTags: false,
-      },
+      combinedOptions: { gitTags: false },
     },
-  },
+  }),
   modifiedPackages: new Set(['foo', 'bar']),
   newPackages: new Set(),
 } as unknown as BumpInfo;

--- a/src/__tests__/publish/toposortPackages.test.ts
+++ b/src/__tests__/publish/toposortPackages.test.ts
@@ -1,98 +1,53 @@
 import { describe, expect, it } from '@jest/globals';
 import { toposortPackages } from '../../publish/toposortPackages';
-import { PackageInfos, PackageInfo } from '../../types/PackageInfo';
+import { PackageInfos } from '../../types/PackageInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 describe('toposortPackages', () => {
   it('sort packages which none of them has dependency', () => {
-    const packageInfos: PackageInfos = {
-      foo: {} as PackageInfo,
-      bar: {} as PackageInfo,
-    };
+    const packageInfos: PackageInfos = makePackageInfos({ foo: {}, bar: {} });
 
     expect(toposortPackages(['foo', 'bar'], packageInfos)).toEqual(['foo', 'bar']);
   });
 
   it('sort packages with dependencies', () => {
-    const packageInfos = {
+    const packageInfos = makePackageInfos({
       foo: {
-        dependencies: {
-          foo3: '1.0.0',
-          bar2: '1.0.0',
-        },
+        dependencies: { foo3: '1.0.0', bar2: '1.0.0' },
       },
-      foo3: {
-        dependencies: {
-          foo2: '1.0.0',
-        },
-      },
+      foo3: { dependencies: { foo2: '1.0.0' } },
       foo2: {},
-    } as any as PackageInfos;
+    });
 
     expect(toposortPackages(['foo', 'foo2', 'foo3'], packageInfos)).toEqual(['foo2', 'foo3', 'foo']);
   });
 
   it('sort packages with different kinds of dependencies', () => {
-    const packageInfos = {
-      foo: {
-        dependencies: {
-          foo3: '1.0.0',
-        },
-        peerDependencies: {
-          foo4: '1.0.0',
-          bar: '1.0.0',
-        },
-      },
-      foo2: {
-        dependencies: {},
-      },
-      foo3: {
-        dependencies: {
-          foo2: '1.0.0',
-        },
-      },
-      foo4: {
-        devDependencies: {
-          foo2: '1.0.0',
-        },
-      },
-    } as any as PackageInfos;
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0' }, peerDependencies: { foo4: '1.0.0', bar: '1.0.0' } },
+      foo2: { dependencies: {} },
+      foo3: { dependencies: { foo2: '1.0.0' } },
+      foo4: { devDependencies: { foo2: '1.0.0' } },
+    });
 
     expect(toposortPackages(['foo', 'foo2', 'foo3', 'foo4'], packageInfos)).toEqual(['foo2', 'foo3', 'foo4', 'foo']);
   });
 
   it('do not sort packages if it is not included', () => {
-    const packageInfos = {
-      foo: {
-        dependencies: {
-          foo3: '1.0.0',
-          bar: '1.0.0',
-        },
-      },
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0', bar: '1.0.0' } },
       foo2: {},
-      foo3: {
-        dependencies: {
-          foo2: '1.0.0',
-        },
-      },
-    } as any as PackageInfos;
+      foo3: { dependencies: { foo2: '1.0.0' } },
+    });
 
     expect(toposortPackages(['foo', 'foo3'], packageInfos)).toEqual(['foo3', 'foo']);
   });
 
   it('throws if contains circular dependencies', () => {
-    const packageInfos = {
-      foo: {
-        dependencies: {
-          bar: '1.0.0',
-          bar2: '1.0.0',
-        },
-      },
-      bar: {
-        dependencies: {
-          foo: '1.0.0',
-        },
-      },
-    } as any as PackageInfos;
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { bar: '1.0.0', bar2: '1.0.0' } },
+      bar: { dependencies: { foo: '1.0.0' } },
+    });
 
     expect(() => {
       toposortPackages(['foo', 'bar'], packageInfos);

--- a/src/changefile/getDisallowedChangeTypes.ts
+++ b/src/changefile/getDisallowedChangeTypes.ts
@@ -6,11 +6,10 @@ export function getDisallowedChangeTypes(
   packageInfos: PackageInfos,
   packageGroups: PackageGroups
 ): ChangeType[] | null {
-  for (const groupName of Object.keys(packageGroups)) {
-    const groupsInfo = packageGroups[groupName];
-    if (groupsInfo.packageNames.indexOf(packageName) > -1) {
-      return groupsInfo.disallowedChangeTypes;
+  for (const group of Object.values(packageGroups)) {
+    if (group.packageNames.includes(packageName)) {
+      return group.disallowedChangeTypes || null;
     }
   }
-  return packageInfos[packageName].combinedOptions.disallowedChangeTypes;
+  return packageInfos[packageName]?.combinedOptions.disallowedChangeTypes || null;
 }


### PR DESCRIPTION
Add tests for `getDisallowedChangeTypes`, as part of adding tests for the `change` command.

As part of those tests, I added a `makePackageInfos` helper for type safety and conciseness, and updated some of the other tests to use that where relevant.