### PR TITLE
Add tests for change command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "runtimeExecutable": "npm",
       "cwd": "${workspaceFolder}",
       "runtimeArgs": ["run-script", "test"],
-      "args": ["--", "--runInBand", "--watch", "${fileBasenameNoExtension}"],
+      "args": ["--", "--runInBand", "--watch", "--testTimeout=1000000", "${fileBasenameNoExtension}"],
       "sourceMaps": true,
       "outputCapture": "std",
       "console": "integratedTerminal"

--- a/change/beachball-00860b08-4d59-4349-ade2-61216f881b99.json
+++ b/change/beachball-00860b08-4d59-4349-ade2-61216f881b99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor change command and promptForChange helper for better testability",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "jest": "28.1.3",
     "jest-mock": "28.1.3",
     "prettier": "2.7.1",
+    "strip-ansi": "6.0.1",
     "tmp": "0.2.1",
     "ts-jest": "28.0.8",
     "typescript": "4.3.5",

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,93 +1,289 @@
-import { describe, expect, it, afterEach } from '@jest/globals';
+import { describe, expect, it, afterEach, jest, beforeEach } from '@jest/globals';
 import fs from 'fs-extra';
+import type prompts from 'prompts';
 import { getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
+import { RepoFixture, RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { change } from '../commands/change';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { defaultBranchName } from '../__fixtures__/gitDefaults';
+import { MockStdout } from '../__fixtures__/mockStdout';
+import { MockStdin } from '../__fixtures__/mockStdin';
+import { ChangeFileInfo } from '../types/ChangeInfo';
+import { Repository } from '../__fixtures__/repository';
+
+// prompts writes to stdout (not console) in a way that can't really be mocked with spies,
+// so instead we inject a custom mock stdout stream, as well as stdin for entering answers
+let stdin: MockStdin;
+let stdout: MockStdout;
+jest.mock(
+  'prompts',
+  (): typeof prompts =>
+    ((questions, options) => {
+      questions = Array.isArray(questions) ? questions : [questions];
+      questions = questions.map(q => ({ ...q, stdin, stdout }));
+      return (jest.requireActual('prompts') as typeof prompts)(questions, options);
+    }) as typeof prompts
+);
+
+/**
+ * Inject these options into `PackageInfo.combinedOptions` for every package to simulate a
+ * repo-wide config. (Actual repo-wide configs aren't usually read in tests because the current
+ * implementation depends on the actual cwd, not the temp repo directory.)
+ */
+let mockBeachballOptions: Partial<BeachballOptions> | undefined;
+jest.mock('../options/getDefaultOptions', () => ({
+  getDefaultOptions: () => ({
+    ...(jest.requireActual('../options/getDefaultOptions') as any).getDefaultOptions(),
+    ...mockBeachballOptions,
+  }),
+}));
+
+/** Wait for the prompt to finish rendering (simulates real user input) */
+const waitForPrompt = () => new Promise(resolve => process.nextTick(resolve));
+
+const monorepo: RepoFixture['folders'] = {
+  packages: { 'pkg-1': { version: '1.0.0' }, 'pkg-2': { version: '1.0.0' }, 'pkg-3': { version: '1.0.0' } },
+};
+
+function makeMonorepoChanges(repo: Repository) {
+  repo.checkout('-b', 'test');
+  repo.stageChange('packages/pkg-1/file.js');
+  repo.commitAll('commit 1');
+  repo.stageChange('packages/pkg-2/file.js');
+  repo.commitAll('commit 2');
+}
 
 describe('change command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
 
-  initMockLogs();
+  const logs = initMockLogs();
+
+  beforeEach(() => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+  });
 
   afterEach(() => {
-    if (repositoryFactory) {
-      repositoryFactory.cleanUp();
-      repositoryFactory = undefined;
-    }
+    stdin.destroy();
+    stdout.destroy();
+    repositoryFactory?.cleanUp();
+    repositoryFactory = undefined;
+    mockBeachballOptions = undefined;
   });
 
-  it('create change file but git stage only', async () => {
+  it('does not create change files when there are no changes', async () => {
     repositoryFactory = new RepositoryFactory('single');
     const repo = repositoryFactory.cloneRepository();
 
-    await change({
-      type: 'minor',
-      dependentChangeType: 'patch',
-      package: repositoryFactory.fixture.rootPackage!.name,
-      message: 'stage me please',
-      path: repo.rootPath,
-      branch: defaultBranchName,
-      commit: false,
-    } as BeachballOptions);
+    await change({ path: repo.rootPath, branch: defaultBranchName } as BeachballOptions);
+
+    expect(getChangeFiles(repo.rootPath)).toHaveLength(0);
+  });
+
+  it('creates and stages a change file', async () => {
+    repositoryFactory = new RepositoryFactory('single');
+    const repo = repositoryFactory.cloneRepository();
+
+    repo.checkout('-b', 'test');
+    repo.commitChange('file.js');
+
+    const changePromise = change({ path: repo.rootPath, branch: defaultBranchName, commit: false } as BeachballOptions);
+    await waitForPrompt();
+
+    // Use default change type and custom message
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    await stdin.sendByChar('\n');
+    // Also verify that the options shown are correct
+    expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+      "? Describe changes (type or choose one) ›
+      ❯   \\"file.js\\""
+    `);
+    await stdin.sendByChar('stage me please\n');
+    await changePromise;
 
     expect(repo.status()).toMatch(/^A  change/);
+    expect(logs.mocks.log).toHaveBeenLastCalledWith(expect.stringMatching(/^git staged these change files:/));
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles).toHaveLength(1);
-  });
-
-  it('create change file but git stage only multiple changes', async () => {
-    repositoryFactory = new RepositoryFactory({
-      folders: {
-        packages: {
-          'pkg-1': { version: '1.0.0' },
-          'pkg-2': { version: '2.0.0' },
-        },
-      },
+    expect(fs.readJSONSync(changeFiles[0])).toMatchObject({
+      comment: 'stage me please',
+      packageName: 'foo',
+      type: 'patch',
     });
-    const repo = repositoryFactory.cloneRepository();
-
-    await change({
-      type: 'minor',
-      dependentChangeType: 'patch',
-      package: ['pkg-1', 'pkg-2'],
-      message: 'stage me please',
-      path: repo.rootPath,
-      branch: defaultBranchName,
-      commit: false,
-      groupChanges: true,
-    } as BeachballOptions);
-
-    expect(repo.status()).toMatch(/^A  change/);
-
-    const changeFiles = getChangeFiles(repo.rootPath);
-    for (const file of changeFiles) {
-      const contents = await fs.readJSON(file);
-      expect(contents.changes).toHaveLength(2);
-    }
-
-    expect(changeFiles).toHaveLength(1);
   });
 
-  it('create change file and commit', async () => {
+  it('creates and commits a change file', async () => {
     repositoryFactory = new RepositoryFactory('single');
     const repo = repositoryFactory.cloneRepository();
 
-    await change({
-      type: 'minor',
-      dependentChangeType: 'patch',
-      package: repositoryFactory.fixture.rootPackage!.name,
-      message: 'commit me please',
-      path: repo.rootPath,
-      branch: defaultBranchName,
-    } as BeachballOptions);
+    repo.checkout('-b', 'test');
+    repo.commitChange('file.js');
 
+    const changePromise = change({ path: repo.rootPath, branch: defaultBranchName } as BeachballOptions);
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    await stdin.sendByChar('\n'); // default change type
+    await stdin.sendByChar('commit me please\n'); // custom message
+    await changePromise;
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith(expect.stringMatching(/^git committed these change files:/));
     expect(repo.status()).toBe('');
 
     const changeFiles = getChangeFiles(repo.rootPath);
     expect(changeFiles).toHaveLength(1);
+    expect(fs.readJSONSync(changeFiles[0])).toMatchObject({
+      comment: 'commit me please',
+      packageName: 'foo',
+      type: 'patch',
+    });
   });
+
+  it('creates a change file when there are no changes but package name is provided', async () => {
+    repositoryFactory = new RepositoryFactory('single');
+    const repo = repositoryFactory.cloneRepository();
+
+    const changePromise = change({
+      package: repositoryFactory.fixture.rootPackage!.name,
+      path: repo.rootPath,
+      branch: defaultBranchName,
+      commit: false,
+    } as BeachballOptions);
+    await waitForPrompt();
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    await stdin.sendByChar('\n'); // default change type
+    await stdin.sendByChar('stage me please\n'); // custom message
+    await changePromise;
+
+    expect(repo.status()).toMatch(/^A  change/);
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles).toHaveLength(1);
+  });
+
+  it('creates and commits change files for multiple packages', async () => {
+    repositoryFactory = new RepositoryFactory({ folders: monorepo });
+    const repo = repositoryFactory.cloneRepository();
+    makeMonorepoChanges(repo);
+
+    const changePromise = change({ path: repo.rootPath, branch: defaultBranchName } as BeachballOptions);
+
+    // use custom values for first package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-1');
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+    // also verify that the options shown are correct
+    expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+      "? Describe changes (type or choose one) ›
+      ❯   commit 2
+          commit 1"
+    `);
+    await stdin.sendByChar('custom\n');
+
+    // use defaults for second package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-2');
+    await stdin.sendByChar('\n\n');
+
+    await changePromise;
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith(expect.stringMatching(/^git committed these change files:/));
+    expect(repo.status()).toBe('');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles).toHaveLength(2);
+    const changeFileContents = changeFiles.map(changeFile => fs.readJSONSync(changeFile)) as ChangeFileInfo[];
+    expect(changeFileContents).toContainEqual(
+      expect.objectContaining({ comment: 'custom', packageName: 'pkg-1', type: 'minor' })
+    );
+    expect(changeFileContents).toContainEqual(
+      expect.objectContaining({ comment: 'commit 2', packageName: 'pkg-2', type: 'patch' })
+    );
+  });
+
+  it('creates and commits grouped change file for multiple packages', async () => {
+    repositoryFactory = new RepositoryFactory({ folders: monorepo });
+    const repo = repositoryFactory.cloneRepository();
+    makeMonorepoChanges(repo);
+
+    const changePromise = change({
+      path: repo.rootPath,
+      branch: defaultBranchName,
+      groupChanges: true,
+    } as BeachballOptions);
+
+    // use custom values for first package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-1');
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+    await stdin.sendByChar('custom\n');
+
+    // use defaults for second package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-2');
+    await stdin.sendByChar('\n\n');
+
+    await changePromise;
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith(expect.stringMatching(/^git committed these change files:/));
+    expect(repo.status()).toBe('');
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles).toHaveLength(1);
+    const contents = fs.readJSONSync(changeFiles[0]);
+    expect(contents.changes).toEqual([
+      expect.objectContaining({ comment: 'custom', packageName: 'pkg-1', type: 'minor' }),
+      expect.objectContaining({ comment: 'commit 2', packageName: 'pkg-2', type: 'patch' }),
+    ]);
+  });
+
+  it('uses custom per-package prompt', async () => {
+    repositoryFactory = new RepositoryFactory({ folders: monorepo });
+    const repo = repositoryFactory.cloneRepository();
+    makeMonorepoChanges(repo);
+
+    mockBeachballOptions = {
+      changeFilePrompt: {
+        changePrompt: (defaultPrompt, pkg) => {
+          const questions = [defaultPrompt.changeType!, defaultPrompt.description!];
+          return pkg === 'pkg-1'
+            ? questions
+            : [{ type: 'text', name: 'custom', message: 'custom question' }, ...questions];
+        },
+      },
+    };
+
+    const changePromise = change({
+      path: repo.rootPath,
+      branch: defaultBranchName,
+      groupChanges: true,
+    } as BeachballOptions);
+    await waitForPrompt();
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-1');
+    expect(stdout.lastOutput()).toMatch(/Change type/);
+    await stdin.sendByChar('\n');
+    expect(stdout.lastOutput()).toMatch(/Describe changes/);
+    await stdin.sendByChar('\n');
+
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: pkg-2');
+    expect(stdout.lastOutput()).toMatch(/custom question/);
+    await stdin.sendByChar('stuff\n');
+    expect(stdout.lastOutput()).toMatch(/Change type/);
+    await stdin.sendByChar('\n');
+    expect(stdout.lastOutput()).toMatch(/Describe changes/);
+    await stdin.sendByChar('\n');
+
+    await changePromise;
+
+    const changeFiles = getChangeFiles(repo.rootPath);
+    expect(changeFiles).toHaveLength(1);
+    const contents = fs.readJSONSync(changeFiles[0]);
+    expect(contents.changes).toEqual([
+      expect.objectContaining({ packageName: 'pkg-1', type: 'patch', comment: 'commit 2' }),
+      expect.objectContaining({ packageName: 'pkg-2', type: 'patch', comment: 'commit 2', custom: 'stuff' }),
+    ]);
+  });
+
+  // custom prompt for different packages (only truly doable here because elsewhere it uses combinedOptions)
 });

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -61,7 +61,7 @@ describe('change command', () => {
 
   beforeEach(() => {
     stdin = new MockStdin();
-    stdout = new MockStdout();
+    stdout = new MockStdout({ replace: 'prompts' });
   });
 
   afterEach(() => {
@@ -96,8 +96,8 @@ describe('change command', () => {
     await stdin.sendByChar('\n');
     // Also verify that the options shown are correct
     expect(stdout.lastOutput()).toMatchInlineSnapshot(`
-      "? Describe changes (type or choose one) ›
-      ❯   \\"file.js\\""
+      "? Describe changes (type or choose one) »
+      >   \\"file.js\\""
     `);
     await stdin.sendByChar('stage me please\n');
     await changePromise;
@@ -176,8 +176,8 @@ describe('change command', () => {
     await stdin.sendByChar('\n');
     // also verify that the options shown are correct
     expect(stdout.lastOutput()).toMatchInlineSnapshot(`
-      "? Describe changes (type or choose one) ›
-      ❯   commit 2
+      "? Describe changes (type or choose one) »
+      >   commit 2
           commit 1"
     `);
     await stdin.sendByChar('custom\n');

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,9 +1,22 @@
-import { jest, beforeEach, afterEach } from '@jest/globals';
+import { jest, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
 import type { SpyInstance } from 'jest-mock';
 
 /** Methods that will be mocked. More could be added later if needed. */
 export type MockLogMethod = 'log' | 'warn' | 'error';
 const mockedMethods: MockLogMethod[] = ['log', 'warn', 'error'];
+
+export type MockLogsOptions = {
+  /**
+   * Whether to also log to the real console (or subset of methods to log to the console).
+   * All logging can be enabled by setting the VERBOSE env var.
+   */
+  alsoLog?: boolean | MockLogMethod[];
+
+  /**
+   * If true, init and teardown in beforeAll/afterAll instead of beforeEach/afterEach.
+   */
+  onlyInitOnce?: boolean;
+};
 
 export type MockLogs = {
   /** Mocked methods (to access calls etc) */
@@ -14,15 +27,21 @@ export type MockLogs = {
   init: (alsoLog?: boolean | MockLogMethod[]) => void;
   /** Restore mock implementations */
   restore: () => void;
+  /** Get the lines logged to a particular method */
+  getMockLines: (method: MockLogMethod) => string;
 };
 
 /**
  * Initialize console log mocks, which will be reset after each test. This should be called **outside**
  * of any lifecycle hooks or tests because it calls `beforeEach` and `afterEach` for setup and teardown.
- * @param alsoLog Whether to also log to the real console (or subset of methods to log to the console).
- * All logging can be enabled by setting the VERBOSE env var.
  */
-export function initMockLogs(alsoLog?: boolean | MockLogMethod[]): MockLogs {
+export function initMockLogs(options?: MockLogsOptions): MockLogs;
+/** @deprecated use object param version */
+export function initMockLogs(alsoLog: boolean | MockLogMethod[]): MockLogs;
+export function initMockLogs(opts?: MockLogsOptions | boolean | MockLogMethod[]): MockLogs {
+  const options = typeof opts === 'boolean' || Array.isArray(opts) ? { alsoLog: opts } : opts || {};
+  const { alsoLog, onlyInitOnce } = options;
+
   const logs: MockLogs = {
     mocks: {} as MockLogs['mocks'],
     realConsole: { ...console },
@@ -42,13 +61,18 @@ export function initMockLogs(alsoLog?: boolean | MockLogMethod[]): MockLogs {
         mock.mockRestore();
         delete (logs.mocks as any)[name];
       }),
+    getMockLines: method =>
+      logs.mocks[method].mock.calls
+        .map(args => args.join(' '))
+        .join('\n')
+        .trim(),
   };
 
-  beforeEach(() => {
+  (onlyInitOnce ? beforeAll : beforeEach)(() => {
     logs.init(alsoLog);
   });
 
-  afterEach(() => {
+  (onlyInitOnce ? afterAll : afterEach)(() => {
     logs.restore();
   });
 

--- a/src/__fixtures__/mockStdin.ts
+++ b/src/__fixtures__/mockStdin.ts
@@ -1,0 +1,192 @@
+import stream from 'stream';
+import readline from 'readline';
+
+/**
+ * Mock stdin stream. This is a modernized version of https://www.npmjs.com/package/mock-stdin
+ * with a couple additional methods.
+ */
+export class MockStdin extends stream.Readable {
+  readonly isMock = true;
+  private readonly _mockData: MockData[] = [];
+  private readonly _flags: {
+    emittedData: boolean;
+    lastOutput: string | Buffer | null;
+  } = {
+    emittedData: false,
+    lastOutput: null,
+  };
+  // @ts-expect-error private property of parent class
+  private _readableState: { length: number; ended: boolean; endEmitted: boolean; buffer: any[] };
+
+  constructor(private restoreTarget?: stream.Stream) {
+    super({ highWaterMark: 0 });
+  }
+
+  emit(event: string, ...args: any[]): boolean {
+    if (event === 'data') {
+      this._flags.emittedData = true;
+      this._flags.lastOutput = null;
+    }
+    return super.emit(event, ...args);
+  }
+
+  /**
+   * Emit a keypress event as defined by `readline`
+   * https://nodejs.org/api/readline.html#rlwritedata-key
+   */
+  emitKey(key: readline.Key) {
+    return this.emit('keypress', null, key);
+  }
+
+  /**
+   * Send text in a way that's presumably intended to simulate real `process.stdin` input
+   * (this approach is copied from `mock-stdin`).
+   */
+  send(text: string[] | Buffer | string | null, encoding?: string) {
+    if (Array.isArray(text)) {
+      if (encoding) {
+        throw new TypeError('Cannot invoke MockStdin#send(): `encoding` specified while text specified as an array.');
+      }
+      text = text.join('\n');
+    }
+    if (Buffer.isBuffer(text) || typeof text === 'string' || text === null) {
+      this._mockData.push(new MockData(text, encoding));
+      this._read();
+      if (!this._flags.emittedData && this._readableState.length) {
+        this.drainData();
+      }
+      if (text === null) {
+        // Trigger an end event synchronously...
+        this.endReadable();
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Send `text` character by character (with `process.nextTick` in between) to simulate typing.
+   */
+  async sendByChar(text: string) {
+    await new Promise(resolve => process.nextTick(resolve));
+    for (const char of text) {
+      this.send(char);
+      await new Promise(resolve => process.nextTick(resolve));
+    }
+    return this;
+  }
+
+  end() {
+    this.send(null);
+    return this;
+  }
+
+  restore() {
+    if (this.restoreTarget) {
+      Object.defineProperty(process, 'stdin', {
+        value: this.restoreTarget,
+        configurable: true,
+        writable: false,
+      });
+    }
+    return this;
+  }
+
+  reset(removeListeners: boolean) {
+    this._readableState.ended = false;
+    this._readableState.endEmitted = false;
+    if (removeListeners) {
+      this.removeAllListeners();
+    }
+    return this;
+  }
+
+  _read(size: number = Infinity) {
+    let count = 0;
+    let read = true;
+    while (read && this._mockData.length && count < size) {
+      const item = this._mockData[0];
+      const leftInChunk = item.length - item.pos;
+      const remaining = size === Infinity ? leftInChunk : size - count;
+      const toProcess = Math.min(leftInChunk, remaining);
+      const chunk = (this._flags.lastOutput = item.chunk(toProcess));
+
+      if (!this.push(chunk, item.encoding)) {
+        read = false;
+      }
+
+      if (item.done) {
+        this._mockData.shift();
+      }
+
+      count += toProcess;
+    }
+  }
+
+  setRawMode() {
+    return this;
+  }
+
+  private endReadable() {
+    // Synchronously emit an end event, if possible.
+    if (!this._readableState.length) {
+      this._readableState.ended = true;
+      this._readableState.endEmitted = true;
+      this.readable = false;
+      this.emit('end');
+    }
+  }
+
+  private drainData() {
+    const state = this._readableState;
+    while (state.buffer.length) {
+      const chunk = state.buffer.shift();
+      if (chunk !== null && chunk !== undefined) {
+        state.length -= chunk.length;
+        this.emit('data', chunk);
+        this._flags.emittedData = false;
+      }
+    }
+  }
+}
+
+class MockData {
+  pos = 0;
+  done = false;
+
+  constructor(private data: Buffer | string | null, public encoding?: string) {}
+
+  get length() {
+    if (Buffer.isBuffer(this.data)) {
+      return this.data.length;
+    } else if (typeof this.data === 'string') {
+      return this.data.length;
+    }
+    return 0;
+  }
+
+  chunk(length: number) {
+    if (this.pos <= this.length) {
+      if (Buffer.isBuffer(this.data) || typeof this.data === 'string') {
+        const value = this.data.slice(this.pos, this.pos + length);
+        this.pos += length;
+        if (this.pos >= this.length) {
+          this.done = true;
+        }
+        return value;
+      }
+    }
+
+    this.done = true;
+    return null;
+  }
+}
+
+export function mockProcessStdin() {
+  const mock = new MockStdin(process.stdin);
+  Object.defineProperty(process, 'stdin', {
+    value: mock,
+    configurable: true,
+    writable: false,
+  });
+  return mock;
+}

--- a/src/__fixtures__/mockStdout.ts
+++ b/src/__fixtures__/mockStdout.ts
@@ -1,0 +1,69 @@
+import stream from 'stream';
+import stripAnsi from 'strip-ansi';
+
+/**
+ * prompts uses a different set of figures on Windows terminals vs. other platforms for compatibility.
+ * For snapshots, replace the non-Windows figures with Windows versions. (Doing a find/replace on the
+ * "pretty" non-Windows figures is less likely to accidentally replace sequences that might appear
+ * in standard text.)
+ * https://github.com/terkelg/prompts/blob/master/lib/util/figures.js
+ */
+const promptsFigures: [RegExp, string][] = [
+  [/◉/g, '(*)'],
+  [/◯/g, '( )'],
+  [/✔/g, '√'],
+  [/✖/g, '×'],
+  [/…/g, '...'],
+  [/›/g, '»'],
+  [/❯/g, '>'],
+];
+
+/**
+ * Mock stdout stream which keeps a record of the chunks written to it (transforming them in an
+ * appropriate way for snapshots) but doesn't actually output anything.
+ */
+export class MockStdout extends stream.Writable {
+  private chunks: string[] = [];
+  private ignoreChunks: RegExp[];
+  private replace: [RegExp, string][];
+
+  constructor(options: { ignoreChunks?: RegExp[]; replace?: [RegExp, string][] | 'prompts' } = {}) {
+    super();
+    this.ignoreChunks = options.ignoreChunks || [];
+    this.replace = options.replace === 'prompts' ? promptsFigures : options.replace || [];
+  }
+
+  /** Gets non-empty output chunks that have been written to the stream, joined with newlines */
+  getOutput() {
+    return this.chunks.join('\n');
+  }
+
+  /** Gets the last non-empty output chunk written to the stream */
+  lastOutput() {
+    return this.chunks.slice(-1)[0];
+  }
+
+  /** Clears the record of output to the stream */
+  clearOutput() {
+    this.chunks = [];
+  }
+
+  _write(chunk: any, encoding: string, callback: (error?: Error | null) => void) {
+    // Trim each line so that if it's used in a snapshot, there won't be trailing whitespace issues
+    let text = stripAnsi(chunk.toString())
+      .split('\n')
+      .map(line => line.trimEnd())
+      .join('\n')
+      .trim();
+
+    for (const [from, to] of this.replace) {
+      text = text.replace(from, to);
+    }
+
+    // Ignore blank lines, or lines containing sequences requested to be ignored
+    if (text && !this.ignoreChunks.some(r => r.test(text))) {
+      this.chunks.push(text);
+    }
+    callback();
+  }
+}

--- a/src/__tests__/changefile/promptForChange.test.ts
+++ b/src/__tests__/changefile/promptForChange.test.ts
@@ -1,0 +1,718 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import prompts from 'prompts';
+import {
+  promptForChange,
+  _getChangeFileInfoFromResponse,
+  _getQuestionsForPackage,
+  _promptForPackageChange,
+} from '../../changefile/promptForChange';
+import { BeachballOptions } from '../../types/BeachballOptions';
+import { ChangeFilePromptOptions } from '../../types/ChangeFilePrompt';
+import { ChangeFileInfo } from '../../types/ChangeInfo';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { MockStdin } from '../../__fixtures__/mockStdin';
+import { MockStdout } from '../../__fixtures__/mockStdout';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+// prompts writes to stdout (not console) in a way that can't really be mocked with spies,
+// so instead we inject a custom mock stdout stream, as well as stdin for entering answers
+let stdin: MockStdin;
+let stdout: MockStdout;
+jest.mock(
+  'prompts',
+  () =>
+    ((questions, options) => {
+      questions = Array.isArray(questions) ? questions : [questions];
+      questions = questions.map(q => ({ ...q, stdin, stdout }));
+      return (jest.requireActual('prompts') as typeof prompts)(questions, options);
+    }) as typeof prompts
+);
+
+/** Package name used in the tests */
+const pkg = 'foo';
+
+/** Basic params for `_getQuestionsForPackage`, for a package named `foo` */
+const defaultQuestionsParams: Parameters<typeof _getQuestionsForPackage>[0] = {
+  pkg,
+  packageInfos: makePackageInfos({ [pkg]: {} }),
+  packageGroups: {},
+  options: {} as BeachballOptions,
+  recentMessages: ['message'],
+};
+/** Make `prompts.Choice` objects from a list of messages */
+const makeChoices = (messages: string[]): prompts.Choice[] => messages.map(message => ({ title: message }));
+
+/** Wait for the prompt to finish rendering (simulates real user input) */
+const waitForPrompt = () => new Promise(resolve => process.nextTick(resolve));
+
+/**
+ * These tests cover the logic within `promptForChange` that does *not* require filesystem operations.
+ * `promptForChange` itself is covered by `__e2e__/change.test.ts`.
+ */
+describe('promptForChange', () => {
+  describe('_getQuestionsForPackage', () => {
+    /**
+     * Mock console logs. NOTE: Initialization is only done in before/after all (not cleared every test
+     * since only a few tests use logs), so tests should use `toHaveBeenLastCalledWith`.
+     */
+    const sharedLogs = initMockLogs({ onlyInitOnce: true });
+
+    it('works in basic case', () => {
+      const questions = _getQuestionsForPackage(defaultQuestionsParams);
+      expect(questions).toEqual([
+        {
+          choices: [
+            { title: expect.stringContaining('Patch'), value: 'patch' },
+            { title: expect.stringContaining('Minor'), value: 'minor' },
+            { title: expect.stringContaining('None'), value: 'none' },
+            { title: expect.stringContaining('Major'), value: 'major' },
+          ],
+          message: 'Change type',
+          name: 'type',
+          type: 'select',
+        },
+        {
+          choices: [{ title: 'message' }],
+          message: 'Describe changes (type or choose one)',
+          name: 'comment',
+          onState: expect.any(Function),
+          suggest: expect.any(Function),
+          type: 'autocomplete',
+        },
+      ]);
+    });
+
+    // it's somewhat debatable if this is correct (maybe --type should be the override for disallowedChangeTypes?)
+    it('errors if options.type is disallowed', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+        options: { type: 'major' } as BeachballOptions,
+      });
+      expect(questions).toBeUndefined();
+      expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('Change type "major" is not allowed for package "foo"');
+    });
+
+    it('errors if there are no valid change types for package', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({
+          [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+        }),
+      });
+      expect(questions).toBeUndefined();
+      expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "foo"');
+    });
+
+    it('respects disallowedChangeTypes', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+      });
+      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+      expect(choices).toEqual(['patch', 'minor', 'none']);
+    });
+
+    it('allows prerelease change for package with prerelease version', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({ [pkg]: { version: '1.0.0-beta.1' } }),
+      });
+      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+      expect(choices).toEqual(['prerelease', 'patch', 'minor', 'none', 'major']);
+    });
+
+    // this is a bit weird as well, but documenting current behavior
+    it('excludes prerelease if disallowed', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({
+          [pkg]: { version: '1.0.0-beta.1', combinedOptions: { disallowedChangeTypes: ['prerelease'] } },
+        }),
+      });
+      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+      expect(choices).toEqual(['patch', 'minor', 'none', 'major']);
+    });
+
+    it('excludes the change type question when options.type is specified', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        options: { type: 'patch' } as BeachballOptions,
+      });
+      expect(questions).toHaveLength(1);
+      expect(questions![0].name).toBe('comment');
+    });
+
+    it('excludes the change type question with only one valid option', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({
+          [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
+        }),
+      });
+      expect(questions).toHaveLength(1);
+      expect(questions![0].name).toBe('comment');
+    });
+
+    it('excludes the change type question when prerelease is implicitly the only valid option', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({
+          [pkg]: {
+            version: '1.0.0-beta.1',
+            combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
+          },
+        }),
+      });
+      expect(questions).toHaveLength(1);
+      expect(questions![0].name).toBe('comment');
+    });
+
+    it('excludes the comment question when options.message is set', () => {
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        options: { message: 'message' } as BeachballOptions,
+      });
+      expect(questions).toHaveLength(1);
+      expect(questions![0].name).toBe('type');
+    });
+
+    it('uses options.changeFilePrompt if set', () => {
+      const customQuestions: prompts.PromptObject[] = [{ name: 'custom', message: 'custom prompt', type: 'text' }];
+      const changePrompt: ChangeFilePromptOptions['changePrompt'] = jest.fn(() => customQuestions);
+
+      const questions = _getQuestionsForPackage({
+        ...defaultQuestionsParams,
+        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { changeFilePrompt: { changePrompt } } } }),
+      });
+
+      expect(questions).toEqual(customQuestions);
+      // includes the original prompts as parameters
+      expect(changePrompt).toHaveBeenLastCalledWith(
+        {
+          changeType: expect.objectContaining({ name: 'type' }),
+          description: expect.objectContaining({ name: 'comment' }),
+        },
+        pkg
+      );
+    });
+
+    it('does case-insensitive filtering on description suggestions', async () => {
+      const recentMessages = ['Foo', 'Bar', 'Baz'];
+      const recentMessageChoices = makeChoices(recentMessages);
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
+      expect(questions).toEqual([
+        expect.anything(),
+        expect.objectContaining({
+          name: 'comment',
+          choices: recentMessageChoices,
+          suggest: expect.any(Function),
+        }),
+      ]);
+
+      const suggestions = await questions![1].suggest!('ba', recentMessageChoices);
+      expect(suggestions).toEqual(makeChoices(['Bar', 'Baz']));
+    });
+  });
+
+  describe('_promptForPackageChange', () => {
+    const expectedQuestions = [
+      expect.objectContaining({ name: 'type', type: 'select' }),
+      expect.objectContaining({ name: 'comment', type: 'autocomplete' }),
+    ];
+    const logs = initMockLogs();
+
+    beforeEach(() => {
+      stdin = new MockStdin();
+      // prompts writes a near-duplicate chunk with ... while it's processing input, so ignore that.
+      // Also replace
+      stdout = new MockStdout({ ignoreChunks: [/ (…|\.\.\.)( |$)/m], replace: 'prompts' });
+    });
+
+    afterEach(() => {
+      stdin.destroy();
+      stdout.destroy();
+    });
+
+    it('returns an empty object and logs nothing if there are no questions', async () => {
+      const answers = await _promptForPackageChange([], pkg);
+      expect(answers).toEqual({});
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    it('prompts for change type and description', async () => {
+      const questions = _getQuestionsForPackage(defaultQuestionsParams);
+      expect(questions).toEqual(expectedQuestions);
+
+      const answersPromise = _promptForPackageChange(questions!, pkg);
+
+      // input: press enter twice to use defaults (with a pause in between to simulate real user input)
+      await stdin.sendByChar('\n\n');
+      const answers = await answersPromise;
+
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  Patch      - bug fixes; no API changes.
+        ? Describe changes (type or choose one) »
+        >   message
+        √ Describe changes (type or choose one) » message"
+      `);
+      expect(answers).toEqual({ type: 'patch', comment: 'message' });
+    });
+
+    it('accepts custom description typed by character', async () => {
+      // For this one we provide a type in options and only ask for the description
+      const options = { type: 'minor' } as BeachballOptions;
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+      expect(questions).toEqual(expectedQuestions.slice(1));
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+      await waitForPrompt();
+      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+      stdout.clearOutput();
+
+      // input: a message which isn't included in the recent commits, sent by individual characters
+      // (as if it was typed)
+      await stdin.sendByChar('abc\n');
+      const answers = await answerPromise;
+
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) » a
+        ? Describe changes (type or choose one) » ab
+        ? Describe changes (type or choose one) » abc
+        √ Describe changes (type or choose one) » abc"
+      `);
+      expect(answers).toEqual({ comment: 'abc' });
+    });
+
+    it('accepts custom description pasted', async () => {
+      // For this one we provide a type in options and only ask for the description
+      const options = { type: 'minor' } as BeachballOptions;
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+      expect(questions).toEqual(expectedQuestions.slice(1));
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+      await waitForPrompt();
+      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+      stdout.clearOutput();
+
+      // input: a message which isn't included in the recent commits, sent all at once
+      // (as if it was pasted)
+      stdin.send('abc');
+      await stdin.sendByChar('\n');
+      const answers = await answerPromise;
+
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) » abc
+        √ Describe changes (type or choose one) » abc"
+      `);
+      expect(answers).toEqual({ comment: 'abc' });
+    });
+
+    it('accepts custom description pasted with newline', async () => {
+      // For this one we provide a type in options and only ask for the description
+      const options = { type: 'minor' } as BeachballOptions;
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+      expect(questions).toEqual(expectedQuestions.slice(1));
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+      await waitForPrompt();
+      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+      stdout.clearOutput();
+
+      // input: a message which isn't included in the recent commits, sent all at once
+      // (as if it was pasted)
+      stdin.send('abc\n');
+      const answers = await answerPromise;
+
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`""`);
+      expect(answers).toEqual({ comment: 'abc' });
+    });
+
+    it('uses options selected with arrow keys', async () => {
+      const recentMessages = ['first', 'second', 'third'];
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
+      expect(questions).toEqual(expectedQuestions);
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+
+      // arrow down to select the third type
+      stdin.emitKey({ name: 'down' });
+      stdin.emitKey({ name: 'down' });
+      await stdin.sendByChar('\n');
+      // and the second message
+      stdin.emitKey({ name: 'down' });
+      await stdin.sendByChar('\n');
+
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        ? Change type » - Use arrow-keys. Return to submit.
+             Patch      - bug fixes; no API changes.
+        >    Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        ? Change type » - Use arrow-keys. Return to submit.
+             Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+        >    None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  None       - this change does not affect the published package in any way.
+        ? Describe changes (type or choose one) »
+        >   first
+            second
+            third
+        ? Describe changes (type or choose one) »
+            first
+        >   second
+            third
+        √ Describe changes (type or choose one) » second"
+      `);
+
+      const answers = await answerPromise;
+      expect(answers).toEqual({ type: 'none', comment: 'second' });
+    });
+
+    it('filters options while typing', async () => {
+      const recentMessages = ['foo', 'bar', 'baz'];
+      const options = { type: 'minor' } as BeachballOptions;
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
+      expect(questions).toEqual(expectedQuestions.slice(1));
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+
+      // type "ba" and press enter to select "bar"
+      await stdin.sendByChar('ba\n');
+
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        ? Describe changes (type or choose one) » b
+        >   bar
+            baz
+        ? Describe changes (type or choose one) » ba
+        >   bar
+            baz
+        √ Describe changes (type or choose one) » bar"
+      `);
+
+      const answers = await answerPromise;
+      expect(answers).toEqual({ comment: 'bar' });
+    });
+
+    it('handles pressing delete while typing', async () => {
+      const recentMessages = ['foo', 'bar', 'baz'];
+      const options = { type: 'minor' } as BeachballOptions;
+      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
+      expect(questions).toEqual(expectedQuestions.slice(1));
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+
+      // type "b", press backspace to delete it, press enter to select foo
+      await stdin.sendByChar('b');
+      stdin.emitKey({ name: 'backspace' });
+      await stdin.sendByChar('\n');
+
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        ? Describe changes (type or choose one) » b
+        >   bar
+            baz
+        ? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        √ Describe changes (type or choose one) » foo"
+      `);
+
+      const answers = await answerPromise;
+      expect(answers).toEqual({ comment: 'foo' });
+    });
+
+    it('returns no answers if cancelled with ctrl-c', async () => {
+      const questions = _getQuestionsForPackage(defaultQuestionsParams);
+      expect(questions).toEqual(expectedQuestions);
+
+      const answerPromise = _promptForPackageChange(questions!, pkg);
+
+      // answer the first question
+      await stdin.sendByChar('\n');
+      // start typing the second answer then cancel
+      await stdin.sendByChar('a');
+      stdin.emitKey({ name: 'c', ctrl: true });
+
+      const answers = await answerPromise;
+
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+        "Please describe the changes for: foo
+        Cancelled, no change files are written"
+      `);
+
+      expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  Patch      - bug fixes; no API changes.
+        ? Describe changes (type or choose one) »
+        >   message
+        ? Describe changes (type or choose one) » a
+        × Describe changes (type or choose one) » a"
+      `);
+
+      expect(answers).toBeUndefined();
+    });
+  });
+
+  describe('_getChangeFileInfoFromResponse', () => {
+    const logs = initMockLogs();
+    const comment = 'message';
+    const defaultParams = { pkg, options: {} as BeachballOptions, email: null };
+
+    it('works in normal case', () => {
+      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'patch' } });
+      expect<ChangeFileInfo>(change!).toEqual({
+        type: 'patch',
+        comment,
+        packageName: pkg,
+        email: 'email not defined',
+        dependentChangeType: 'patch',
+      });
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    it('uses dependentChangeType none if response.type is none', () => {
+      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'none' } });
+      expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    it('defaults to options.type if response.type is missing', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { comment },
+        options: { type: 'minor' } as BeachballOptions,
+      });
+      expect(change).toMatchObject({ type: 'minor', dependentChangeType: 'patch' });
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    // this is somewhat debatable
+    it('prefers response.type over options.type', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { type: 'patch', comment },
+        options: { type: 'minor' } as BeachballOptions,
+      });
+      expect(change).toMatchObject({ type: 'patch' });
+    });
+
+    it('warns and defaults to none if response.type and options.type are unspecified', () => {
+      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment } });
+      expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+      expect(logs.mocks.log).toHaveBeenCalledTimes(2);
+      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+        "WARN: change type 'none' assumed by default
+        (Not what you intended? Check the repo-level and package-level beachball configs.)"
+      `);
+    });
+
+    it('defaults to options.message if response.comment is missing', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { type: 'patch' },
+        options: { message: comment } as BeachballOptions,
+      });
+      expect(change).toMatchObject({ comment });
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    // this is somewhat debatable
+    it('prefers response.message over options.message', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { type: 'patch', comment: 'response message' },
+        options: { message: comment } as BeachballOptions,
+      });
+      expect(change).toMatchObject({ comment: 'response message' });
+    });
+
+    it('uses options.dependentChangeType if provided', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { type: 'patch', comment },
+        options: { dependentChangeType: 'minor' } as BeachballOptions,
+      });
+      expect(change).toMatchObject({ dependentChangeType: 'minor' });
+    });
+
+    it('returns error if response.type is invalid', () => {
+      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { type: 'invalid' as any } });
+      expect(change).toBeUndefined();
+      expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+      expect(logs.mocks.error).toHaveBeenCalledWith('Prompt response contains invalid change type "invalid"');
+    });
+
+    // This is an important scenario for some people who customize the change prompt
+    it('preserves extra properties on the returned object', () => {
+      const change = _getChangeFileInfoFromResponse({
+        ...defaultParams,
+        response: { comment, type: 'patch', extra: 'extra' } as any,
+      });
+      expect(change).toMatchObject({ extra: 'extra' });
+    });
+  });
+
+  // These combined tests mainly cover various early bail-out cases
+  describe('promptForChange', () => {
+    const logs = initMockLogs();
+
+    /**
+     * Default: packages foo, bar, baz; changes in foo, bar
+     * (this is a function so stdin/stdout will be the latest values)
+     */
+    const defaultParams = (): Parameters<typeof promptForChange>[0] => ({
+      changedPackages: ['foo', 'bar'],
+      packageInfos: makePackageInfos({ foo: {}, bar: {}, baz: {} }),
+      packageGroups: {},
+      options: {} as BeachballOptions,
+      recentMessages: ['commit 2', 'commit 1'],
+      email: null,
+    });
+
+    beforeEach(() => {
+      stdin = new MockStdin();
+      stdout = new MockStdout();
+    });
+
+    afterEach(() => {
+      stdin.destroy();
+      stdout.destroy();
+    });
+
+    it('does not create change files when there are no changes', async () => {
+      const changeFiles = await promptForChange({ ...defaultParams(), changedPackages: [] });
+      expect(changeFiles).toBeUndefined();
+    });
+
+    it('does not prompt if options.type and options.message are provided', async () => {
+      const changeFiles = await promptForChange({
+        ...defaultParams(),
+        options: { type: 'minor', message: 'message' } as BeachballOptions,
+      });
+      expect(changeFiles).toEqual([
+        expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'foo' }),
+        expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'bar' }),
+      ]);
+    });
+
+    // Do one "normal" end-to-end case (the details are covered by helper function tests)
+    it('prompts for change for multiple packages', async () => {
+      const changeFilesPromise = promptForChange(defaultParams());
+      await waitForPrompt();
+
+      // verify asking for first package
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+      // choose custom options for this package
+      stdin.emitKey({ name: 'down' });
+      await stdin.sendByChar('\n');
+      stdin.emitKey({ name: 'down' });
+      await stdin.sendByChar('\n');
+
+      // verify asking for second package
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
+      // choose defaults
+      await stdin.sendByChar('\n\n');
+
+      expect(await changeFilesPromise).toEqual([
+        expect.objectContaining({ comment: 'commit 1', packageName: 'foo', type: 'minor' }),
+        expect.objectContaining({ comment: 'commit 2', packageName: 'bar', type: 'patch' }),
+      ]);
+    });
+
+    it('stops before asking questions if one package has invalid options', async () => {
+      const changeFiles = await promptForChange({
+        ...defaultParams(),
+        packageInfos: makePackageInfos({
+          foo: {},
+          bar: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+        }),
+      });
+
+      expect(changeFiles).toBeUndefined();
+      expect(logs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "bar"');
+      expect(logs.mocks.log).not.toHaveBeenCalled();
+    });
+
+    it('stops partway through if the user cancels', async () => {
+      const changeFilesPromise = promptForChange(defaultParams());
+      await waitForPrompt();
+
+      // use defaults for first package
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+      await stdin.sendByChar('\n\n');
+
+      // cancel for second package
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
+      stdin.emitKey({ name: 'c', ctrl: true });
+
+      // nothing is returned
+      expect(await changeFilesPromise).toBeUndefined();
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Cancelled, no change files are written');
+    });
+
+    it('stops partway through if a response is invalid', async () => {
+      // this can only happen with custom prompts
+      const changeFilePrompt: ChangeFilePromptOptions = {
+        changePrompt: () => [{ type: 'text', name: 'type', message: 'enter any type' }],
+      };
+      const changeFilesPromise = promptForChange({
+        ...defaultParams(),
+        changedPackages: ['foo', 'bar'],
+        packageInfos: makePackageInfos({
+          foo: { combinedOptions: { changeFilePrompt } },
+          bar: { combinedOptions: { changeFilePrompt } },
+        }),
+      });
+      await waitForPrompt();
+
+      // enter a valid type for foo
+      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+      expect(stdout.getOutput()).toMatch(/enter any type/);
+      await stdin.sendByChar('patch\n');
+
+      // enter an invalid type for bar
+      expect(logs.mocks.log).toHaveBeenCalledWith('Please describe the changes for: bar');
+      await stdin.sendByChar('invalid\n');
+
+      expect(await changeFilesPromise).toBeUndefined();
+      expect(logs.mocks.error).toHaveBeenLastCalledWith('Prompt response contains invalid change type "invalid"');
+    });
+  });
+});

--- a/src/__tests__/changefile/promptForChange.test.ts
+++ b/src/__tests__/changefile/promptForChange.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../../changefile/promptForChange';
 import { BeachballOptions } from '../../types/BeachballOptions';
 import { ChangeFilePromptOptions } from '../../types/ChangeFilePrompt';
-import { ChangeFileInfo } from '../../types/ChangeInfo';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { MockStdin } from '../../__fixtures__/mockStdin';
 import { MockStdout } from '../../__fixtures__/mockStdout';
@@ -28,691 +27,136 @@ jest.mock(
     }) as typeof prompts
 );
 
-/** Package name used in the tests */
-const pkg = 'foo';
-
-/** Basic params for `_getQuestionsForPackage`, for a package named `foo` */
-const defaultQuestionsParams: Parameters<typeof _getQuestionsForPackage>[0] = {
-  pkg,
-  packageInfos: makePackageInfos({ [pkg]: {} }),
-  packageGroups: {},
-  options: {} as BeachballOptions,
-  recentMessages: ['message'],
-};
-/** Make `prompts.Choice` objects from a list of messages */
-const makeChoices = (messages: string[]): prompts.Choice[] => messages.map(message => ({ title: message }));
-
-/** Wait for the prompt to finish rendering (simulates real user input) */
-const waitForPrompt = () => new Promise(resolve => process.nextTick(resolve));
-
 /**
- * These tests cover the logic within `promptForChange` that does *not* require filesystem operations.
- * `promptForChange` itself is covered by `__e2e__/change.test.ts`.
+ * These combined tests mainly cover various early bail-out cases (the only meaningful logic in
+ * `promptForChange` itself), plus one basic case.
+ * More detailed scenarios are covered by the tests for the helper functions.
  */
 describe('promptForChange', () => {
-  describe('_getQuestionsForPackage', () => {
-    /**
-     * Mock console logs. NOTE: Initialization is only done in before/after all (not cleared every test
-     * since only a few tests use logs), so tests should use `toHaveBeenLastCalledWith`.
-     */
-    const sharedLogs = initMockLogs({ onlyInitOnce: true });
+  /** Wait for the prompt to finish rendering (simulates real user input) */
+  const waitForPrompt = () => new Promise(resolve => process.nextTick(resolve));
 
-    it('works in basic case', () => {
-      const questions = _getQuestionsForPackage(defaultQuestionsParams);
-      expect(questions).toEqual([
-        {
-          choices: [
-            { title: expect.stringContaining('Patch'), value: 'patch' },
-            { title: expect.stringContaining('Minor'), value: 'minor' },
-            { title: expect.stringContaining('None'), value: 'none' },
-            { title: expect.stringContaining('Major'), value: 'major' },
-          ],
-          message: 'Change type',
-          name: 'type',
-          type: 'select',
-        },
-        {
-          choices: [{ title: 'message' }],
-          message: 'Describe changes (type or choose one)',
-          name: 'comment',
-          onState: expect.any(Function),
-          suggest: expect.any(Function),
-          type: 'autocomplete',
-        },
-      ]);
-    });
+  const logs = initMockLogs();
 
-    // it's somewhat debatable if this is correct (maybe --type should be the override for disallowedChangeTypes?)
-    it('errors if options.type is disallowed', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
-        options: { type: 'major' } as BeachballOptions,
-      });
-      expect(questions).toBeUndefined();
-      expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('Change type "major" is not allowed for package "foo"');
-    });
-
-    it('errors if there are no valid change types for package', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({
-          [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
-        }),
-      });
-      expect(questions).toBeUndefined();
-      expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "foo"');
-    });
-
-    it('respects disallowedChangeTypes', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
-      });
-      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
-      expect(choices).toEqual(['patch', 'minor', 'none']);
-    });
-
-    it('allows prerelease change for package with prerelease version', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({ [pkg]: { version: '1.0.0-beta.1' } }),
-      });
-      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
-      expect(choices).toEqual(['prerelease', 'patch', 'minor', 'none', 'major']);
-    });
-
-    // this is a bit weird as well, but documenting current behavior
-    it('excludes prerelease if disallowed', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({
-          [pkg]: { version: '1.0.0-beta.1', combinedOptions: { disallowedChangeTypes: ['prerelease'] } },
-        }),
-      });
-      const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
-      expect(choices).toEqual(['patch', 'minor', 'none', 'major']);
-    });
-
-    it('excludes the change type question when options.type is specified', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        options: { type: 'patch' } as BeachballOptions,
-      });
-      expect(questions).toHaveLength(1);
-      expect(questions![0].name).toBe('comment');
-    });
-
-    it('excludes the change type question with only one valid option', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({
-          [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
-        }),
-      });
-      expect(questions).toHaveLength(1);
-      expect(questions![0].name).toBe('comment');
-    });
-
-    it('excludes the change type question when prerelease is implicitly the only valid option', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({
-          [pkg]: {
-            version: '1.0.0-beta.1',
-            combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
-          },
-        }),
-      });
-      expect(questions).toHaveLength(1);
-      expect(questions![0].name).toBe('comment');
-    });
-
-    it('excludes the comment question when options.message is set', () => {
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        options: { message: 'message' } as BeachballOptions,
-      });
-      expect(questions).toHaveLength(1);
-      expect(questions![0].name).toBe('type');
-    });
-
-    it('uses options.changeFilePrompt if set', () => {
-      const customQuestions: prompts.PromptObject[] = [{ name: 'custom', message: 'custom prompt', type: 'text' }];
-      const changePrompt: ChangeFilePromptOptions['changePrompt'] = jest.fn(() => customQuestions);
-
-      const questions = _getQuestionsForPackage({
-        ...defaultQuestionsParams,
-        packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { changeFilePrompt: { changePrompt } } } }),
-      });
-
-      expect(questions).toEqual(customQuestions);
-      // includes the original prompts as parameters
-      expect(changePrompt).toHaveBeenLastCalledWith(
-        {
-          changeType: expect.objectContaining({ name: 'type' }),
-          description: expect.objectContaining({ name: 'comment' }),
-        },
-        pkg
-      );
-    });
-
-    it('does case-insensitive filtering on description suggestions', async () => {
-      const recentMessages = ['Foo', 'Bar', 'Baz'];
-      const recentMessageChoices = makeChoices(recentMessages);
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
-      expect(questions).toEqual([
-        expect.anything(),
-        expect.objectContaining({
-          name: 'comment',
-          choices: recentMessageChoices,
-          suggest: expect.any(Function),
-        }),
-      ]);
-
-      const suggestions = await questions![1].suggest!('ba', recentMessageChoices);
-      expect(suggestions).toEqual(makeChoices(['Bar', 'Baz']));
-    });
+  /**
+   * Default: packages foo, bar, baz; changes in foo, bar
+   * (this is a function so stdin/stdout will be the latest values)
+   */
+  const defaultParams = (): Parameters<typeof promptForChange>[0] => ({
+    changedPackages: ['foo', 'bar'],
+    packageInfos: makePackageInfos({ foo: {}, bar: {}, baz: {} }),
+    packageGroups: {},
+    options: {} as BeachballOptions,
+    recentMessages: ['commit 2', 'commit 1'],
+    email: null,
   });
 
-  describe('_promptForPackageChange', () => {
-    const expectedQuestions = [
-      expect.objectContaining({ name: 'type', type: 'select' }),
-      expect.objectContaining({ name: 'comment', type: 'autocomplete' }),
-    ];
-    const logs = initMockLogs();
-
-    beforeEach(() => {
-      stdin = new MockStdin();
-      // prompts writes a near-duplicate chunk with ... while it's processing input, so ignore that.
-      // Also replace
-      stdout = new MockStdout({ ignoreChunks: [/ (…|\.\.\.)( |$)/m], replace: 'prompts' });
-    });
-
-    afterEach(() => {
-      stdin.destroy();
-      stdout.destroy();
-    });
-
-    it('returns an empty object and logs nothing if there are no questions', async () => {
-      const answers = await _promptForPackageChange([], pkg);
-      expect(answers).toEqual({});
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    it('prompts for change type and description', async () => {
-      const questions = _getQuestionsForPackage(defaultQuestionsParams);
-      expect(questions).toEqual(expectedQuestions);
-
-      const answersPromise = _promptForPackageChange(questions!, pkg);
-
-      // input: press enter twice to use defaults (with a pause in between to simulate real user input)
-      await stdin.sendByChar('\n\n');
-      const answers = await answersPromise;
-
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  Patch      - bug fixes; no API changes.
-        ? Describe changes (type or choose one) »
-        >   message
-        √ Describe changes (type or choose one) » message"
-      `);
-      expect(answers).toEqual({ type: 'patch', comment: 'message' });
-    });
-
-    it('accepts custom description typed by character', async () => {
-      // For this one we provide a type in options and only ask for the description
-      const options = { type: 'minor' } as BeachballOptions;
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
-      expect(questions).toEqual(expectedQuestions.slice(1));
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-      await waitForPrompt();
-      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) »
-        >   message"
-      `);
-      stdout.clearOutput();
-
-      // input: a message which isn't included in the recent commits, sent by individual characters
-      // (as if it was typed)
-      await stdin.sendByChar('abc\n');
-      const answers = await answerPromise;
-
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) » a
-        ? Describe changes (type or choose one) » ab
-        ? Describe changes (type or choose one) » abc
-        √ Describe changes (type or choose one) » abc"
-      `);
-      expect(answers).toEqual({ comment: 'abc' });
-    });
-
-    it('accepts custom description pasted', async () => {
-      // For this one we provide a type in options and only ask for the description
-      const options = { type: 'minor' } as BeachballOptions;
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
-      expect(questions).toEqual(expectedQuestions.slice(1));
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-      await waitForPrompt();
-      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) »
-        >   message"
-      `);
-      stdout.clearOutput();
-
-      // input: a message which isn't included in the recent commits, sent all at once
-      // (as if it was pasted)
-      stdin.send('abc');
-      await stdin.sendByChar('\n');
-      const answers = await answerPromise;
-
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) » abc
-        √ Describe changes (type or choose one) » abc"
-      `);
-      expect(answers).toEqual({ comment: 'abc' });
-    });
-
-    it('accepts custom description pasted with newline', async () => {
-      // For this one we provide a type in options and only ask for the description
-      const options = { type: 'minor' } as BeachballOptions;
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
-      expect(questions).toEqual(expectedQuestions.slice(1));
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-      await waitForPrompt();
-      expect(stdout.lastOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) »
-        >   message"
-      `);
-      stdout.clearOutput();
-
-      // input: a message which isn't included in the recent commits, sent all at once
-      // (as if it was pasted)
-      stdin.send('abc\n');
-      const answers = await answerPromise;
-
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`""`);
-      expect(answers).toEqual({ comment: 'abc' });
-    });
-
-    it('uses options selected with arrow keys', async () => {
-      const recentMessages = ['first', 'second', 'third'];
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
-      expect(questions).toEqual(expectedQuestions);
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-
-      // arrow down to select the third type
-      stdin.emitKey({ name: 'down' });
-      stdin.emitKey({ name: 'down' });
-      await stdin.sendByChar('\n');
-      // and the second message
-      stdin.emitKey({ name: 'down' });
-      await stdin.sendByChar('\n');
-
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        ? Change type » - Use arrow-keys. Return to submit.
-             Patch      - bug fixes; no API changes.
-        >    Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        ? Change type » - Use arrow-keys. Return to submit.
-             Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-        >    None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  None       - this change does not affect the published package in any way.
-        ? Describe changes (type or choose one) »
-        >   first
-            second
-            third
-        ? Describe changes (type or choose one) »
-            first
-        >   second
-            third
-        √ Describe changes (type or choose one) » second"
-      `);
-
-      const answers = await answerPromise;
-      expect(answers).toEqual({ type: 'none', comment: 'second' });
-    });
-
-    it('filters options while typing', async () => {
-      const recentMessages = ['foo', 'bar', 'baz'];
-      const options = { type: 'minor' } as BeachballOptions;
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
-      expect(questions).toEqual(expectedQuestions.slice(1));
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-
-      // type "ba" and press enter to select "bar"
-      await stdin.sendByChar('ba\n');
-
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) »
-        >   foo
-            bar
-            baz
-        ? Describe changes (type or choose one) » b
-        >   bar
-            baz
-        ? Describe changes (type or choose one) » ba
-        >   bar
-            baz
-        √ Describe changes (type or choose one) » bar"
-      `);
-
-      const answers = await answerPromise;
-      expect(answers).toEqual({ comment: 'bar' });
-    });
-
-    it('handles pressing delete while typing', async () => {
-      const recentMessages = ['foo', 'bar', 'baz'];
-      const options = { type: 'minor' } as BeachballOptions;
-      const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
-      expect(questions).toEqual(expectedQuestions.slice(1));
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-
-      // type "b", press backspace to delete it, press enter to select foo
-      await stdin.sendByChar('b');
-      stdin.emitKey({ name: 'backspace' });
-      await stdin.sendByChar('\n');
-
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Describe changes (type or choose one) »
-        >   foo
-            bar
-            baz
-        ? Describe changes (type or choose one) » b
-        >   bar
-            baz
-        ? Describe changes (type or choose one) »
-        >   foo
-            bar
-            baz
-        √ Describe changes (type or choose one) » foo"
-      `);
-
-      const answers = await answerPromise;
-      expect(answers).toEqual({ comment: 'foo' });
-    });
-
-    it('returns no answers if cancelled with ctrl-c', async () => {
-      const questions = _getQuestionsForPackage(defaultQuestionsParams);
-      expect(questions).toEqual(expectedQuestions);
-
-      const answerPromise = _promptForPackageChange(questions!, pkg);
-
-      // answer the first question
-      await stdin.sendByChar('\n');
-      // start typing the second answer then cancel
-      await stdin.sendByChar('a');
-      stdin.emitKey({ name: 'c', ctrl: true });
-
-      const answers = await answerPromise;
-
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
-        "Please describe the changes for: foo
-        Cancelled, no change files are written"
-      `);
-
-      expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  Patch      - bug fixes; no API changes.
-        ? Describe changes (type or choose one) »
-        >   message
-        ? Describe changes (type or choose one) » a
-        × Describe changes (type or choose one) » a"
-      `);
-
-      expect(answers).toBeUndefined();
-    });
+  beforeEach(() => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
   });
 
-  describe('_getChangeFileInfoFromResponse', () => {
-    const logs = initMockLogs();
-    const comment = 'message';
-    const defaultParams = { pkg, options: {} as BeachballOptions, email: null };
-
-    it('works in normal case', () => {
-      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'patch' } });
-      expect<ChangeFileInfo>(change!).toEqual({
-        type: 'patch',
-        comment,
-        packageName: pkg,
-        email: 'email not defined',
-        dependentChangeType: 'patch',
-      });
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    it('uses dependentChangeType none if response.type is none', () => {
-      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'none' } });
-      expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    it('defaults to options.type if response.type is missing', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { comment },
-        options: { type: 'minor' } as BeachballOptions,
-      });
-      expect(change).toMatchObject({ type: 'minor', dependentChangeType: 'patch' });
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    // this is somewhat debatable
-    it('prefers response.type over options.type', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { type: 'patch', comment },
-        options: { type: 'minor' } as BeachballOptions,
-      });
-      expect(change).toMatchObject({ type: 'patch' });
-    });
-
-    it('warns and defaults to none if response.type and options.type are unspecified', () => {
-      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment } });
-      expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
-      expect(logs.mocks.log).toHaveBeenCalledTimes(2);
-      expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
-        "WARN: change type 'none' assumed by default
-        (Not what you intended? Check the repo-level and package-level beachball configs.)"
-      `);
-    });
-
-    it('defaults to options.message if response.comment is missing', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { type: 'patch' },
-        options: { message: comment } as BeachballOptions,
-      });
-      expect(change).toMatchObject({ comment });
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    // this is somewhat debatable
-    it('prefers response.message over options.message', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { type: 'patch', comment: 'response message' },
-        options: { message: comment } as BeachballOptions,
-      });
-      expect(change).toMatchObject({ comment: 'response message' });
-    });
-
-    it('uses options.dependentChangeType if provided', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { type: 'patch', comment },
-        options: { dependentChangeType: 'minor' } as BeachballOptions,
-      });
-      expect(change).toMatchObject({ dependentChangeType: 'minor' });
-    });
-
-    it('returns error if response.type is invalid', () => {
-      const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { type: 'invalid' as any } });
-      expect(change).toBeUndefined();
-      expect(logs.mocks.error).toHaveBeenCalledTimes(1);
-      expect(logs.mocks.error).toHaveBeenCalledWith('Prompt response contains invalid change type "invalid"');
-    });
-
-    // This is an important scenario for some people who customize the change prompt
-    it('preserves extra properties on the returned object', () => {
-      const change = _getChangeFileInfoFromResponse({
-        ...defaultParams,
-        response: { comment, type: 'patch', extra: 'extra' } as any,
-      });
-      expect(change).toMatchObject({ extra: 'extra' });
-    });
+  afterEach(() => {
+    stdin.destroy();
+    stdout.destroy();
   });
 
-  // These combined tests mainly cover various early bail-out cases
-  describe('promptForChange', () => {
-    const logs = initMockLogs();
+  it('does not create change files when there are no changes', async () => {
+    const changeFiles = await promptForChange({ ...defaultParams(), changedPackages: [] });
+    expect(changeFiles).toBeUndefined();
+  });
 
-    /**
-     * Default: packages foo, bar, baz; changes in foo, bar
-     * (this is a function so stdin/stdout will be the latest values)
-     */
-    const defaultParams = (): Parameters<typeof promptForChange>[0] => ({
+  it('does not prompt if options.type and options.message are provided', async () => {
+    const changeFiles = await promptForChange({
+      ...defaultParams(),
+      options: { type: 'minor', message: 'message' } as BeachballOptions,
+    });
+    expect(changeFiles).toEqual([
+      expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'foo' }),
+      expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'bar' }),
+    ]);
+  });
+
+  // Do one "normal" end-to-end case (the details are covered by helper function tests)
+  it('prompts for change for multiple packages', async () => {
+    const changeFilesPromise = promptForChange(defaultParams());
+    await waitForPrompt();
+
+    // verify asking for first package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    // choose custom options for this package
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+
+    // verify asking for second package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
+    // choose defaults
+    await stdin.sendByChar('\n\n');
+
+    expect(await changeFilesPromise).toEqual([
+      expect.objectContaining({ comment: 'commit 1', packageName: 'foo', type: 'minor' }),
+      expect.objectContaining({ comment: 'commit 2', packageName: 'bar', type: 'patch' }),
+    ]);
+  });
+
+  it('stops before asking questions if one package has invalid options', async () => {
+    const changeFiles = await promptForChange({
+      ...defaultParams(),
+      packageInfos: makePackageInfos({
+        foo: {},
+        bar: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+      }),
+    });
+
+    expect(changeFiles).toBeUndefined();
+    expect(logs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "bar"');
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('stops partway through if the user cancels', async () => {
+    const changeFilesPromise = promptForChange(defaultParams());
+    await waitForPrompt();
+
+    // use defaults for first package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    await stdin.sendByChar('\n\n');
+
+    // cancel for second package
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
+    stdin.emitKey({ name: 'c', ctrl: true });
+
+    // nothing is returned
+    expect(await changeFilesPromise).toBeUndefined();
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Cancelled, no change files are written');
+  });
+
+  it('stops partway through if a response is invalid', async () => {
+    // this can only happen with custom prompts
+    const changeFilePrompt: ChangeFilePromptOptions = {
+      changePrompt: () => [{ type: 'text', name: 'type', message: 'enter any type' }],
+    };
+    const changeFilesPromise = promptForChange({
+      ...defaultParams(),
       changedPackages: ['foo', 'bar'],
-      packageInfos: makePackageInfos({ foo: {}, bar: {}, baz: {} }),
-      packageGroups: {},
-      options: {} as BeachballOptions,
-      recentMessages: ['commit 2', 'commit 1'],
-      email: null,
+      packageInfos: makePackageInfos({
+        foo: { combinedOptions: { changeFilePrompt } },
+        bar: { combinedOptions: { changeFilePrompt } },
+      }),
     });
+    await waitForPrompt();
 
-    beforeEach(() => {
-      stdin = new MockStdin();
-      stdout = new MockStdout();
-    });
+    // enter a valid type for foo
+    expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
+    expect(stdout.getOutput()).toMatch(/enter any type/);
+    await stdin.sendByChar('patch\n');
 
-    afterEach(() => {
-      stdin.destroy();
-      stdout.destroy();
-    });
+    // enter an invalid type for bar
+    expect(logs.mocks.log).toHaveBeenCalledWith('Please describe the changes for: bar');
+    await stdin.sendByChar('invalid\n');
 
-    it('does not create change files when there are no changes', async () => {
-      const changeFiles = await promptForChange({ ...defaultParams(), changedPackages: [] });
-      expect(changeFiles).toBeUndefined();
-    });
-
-    it('does not prompt if options.type and options.message are provided', async () => {
-      const changeFiles = await promptForChange({
-        ...defaultParams(),
-        options: { type: 'minor', message: 'message' } as BeachballOptions,
-      });
-      expect(changeFiles).toEqual([
-        expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'foo' }),
-        expect.objectContaining({ type: 'minor', comment: 'message', packageName: 'bar' }),
-      ]);
-    });
-
-    // Do one "normal" end-to-end case (the details are covered by helper function tests)
-    it('prompts for change for multiple packages', async () => {
-      const changeFilesPromise = promptForChange(defaultParams());
-      await waitForPrompt();
-
-      // verify asking for first package
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
-      // choose custom options for this package
-      stdin.emitKey({ name: 'down' });
-      await stdin.sendByChar('\n');
-      stdin.emitKey({ name: 'down' });
-      await stdin.sendByChar('\n');
-
-      // verify asking for second package
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
-      // choose defaults
-      await stdin.sendByChar('\n\n');
-
-      expect(await changeFilesPromise).toEqual([
-        expect.objectContaining({ comment: 'commit 1', packageName: 'foo', type: 'minor' }),
-        expect.objectContaining({ comment: 'commit 2', packageName: 'bar', type: 'patch' }),
-      ]);
-    });
-
-    it('stops before asking questions if one package has invalid options', async () => {
-      const changeFiles = await promptForChange({
-        ...defaultParams(),
-        packageInfos: makePackageInfos({
-          foo: {},
-          bar: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
-        }),
-      });
-
-      expect(changeFiles).toBeUndefined();
-      expect(logs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "bar"');
-      expect(logs.mocks.log).not.toHaveBeenCalled();
-    });
-
-    it('stops partway through if the user cancels', async () => {
-      const changeFilesPromise = promptForChange(defaultParams());
-      await waitForPrompt();
-
-      // use defaults for first package
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
-      await stdin.sendByChar('\n\n');
-
-      // cancel for second package
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: bar');
-      stdin.emitKey({ name: 'c', ctrl: true });
-
-      // nothing is returned
-      expect(await changeFilesPromise).toBeUndefined();
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Cancelled, no change files are written');
-    });
-
-    it('stops partway through if a response is invalid', async () => {
-      // this can only happen with custom prompts
-      const changeFilePrompt: ChangeFilePromptOptions = {
-        changePrompt: () => [{ type: 'text', name: 'type', message: 'enter any type' }],
-      };
-      const changeFilesPromise = promptForChange({
-        ...defaultParams(),
-        changedPackages: ['foo', 'bar'],
-        packageInfos: makePackageInfos({
-          foo: { combinedOptions: { changeFilePrompt } },
-          bar: { combinedOptions: { changeFilePrompt } },
-        }),
-      });
-      await waitForPrompt();
-
-      // enter a valid type for foo
-      expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
-      expect(stdout.getOutput()).toMatch(/enter any type/);
-      await stdin.sendByChar('patch\n');
-
-      // enter an invalid type for bar
-      expect(logs.mocks.log).toHaveBeenCalledWith('Please describe the changes for: bar');
-      await stdin.sendByChar('invalid\n');
-
-      expect(await changeFilesPromise).toBeUndefined();
-      expect(logs.mocks.error).toHaveBeenLastCalledWith('Prompt response contains invalid change type "invalid"');
-    });
+    expect(await changeFilesPromise).toBeUndefined();
+    expect(logs.mocks.error).toHaveBeenLastCalledWith('Prompt response contains invalid change type "invalid"');
   });
 });

--- a/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
+++ b/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from '@jest/globals';
+import { _getChangeFileInfoFromResponse } from '../../changefile/promptForChange';
+import { BeachballOptions } from '../../types/BeachballOptions';
+import { ChangeFileInfo } from '../../types/ChangeInfo';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+
+/**
+ * This covers the last part of `promptForChange`: translating the user's responses into a `ChangeFileInfo`.
+ */
+describe('promptForChange _getChangeFileInfoFromResponse', () => {
+  /** Package name used in the tests */
+  const pkg = 'foo';
+  const comment = 'message';
+  const defaultParams = { pkg, options: {} as BeachballOptions, email: null };
+
+  const logs = initMockLogs();
+
+  it('works in normal case', () => {
+    const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'patch' } });
+    expect<ChangeFileInfo>(change!).toEqual({
+      type: 'patch',
+      comment,
+      packageName: pkg,
+      email: 'email not defined',
+      dependentChangeType: 'patch',
+    });
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('uses dependentChangeType none if response.type is none', () => {
+    const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'none' } });
+    expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('defaults to options.type if response.type is missing', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { comment },
+      options: { type: 'minor' } as BeachballOptions,
+    });
+    expect(change).toMatchObject({ type: 'minor', dependentChangeType: 'patch' });
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  // this is somewhat debatable
+  it('prefers response.type over options.type', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { type: 'patch', comment },
+      options: { type: 'minor' } as BeachballOptions,
+    });
+    expect(change).toMatchObject({ type: 'patch' });
+  });
+
+  it('warns and defaults to none if response.type and options.type are unspecified', () => {
+    const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment } });
+    expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+    expect(logs.mocks.log).toHaveBeenCalledTimes(2);
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+        "WARN: change type 'none' assumed by default
+        (Not what you intended? Check the repo-level and package-level beachball configs.)"
+      `);
+  });
+
+  it('defaults to options.message if response.comment is missing', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { type: 'patch' },
+      options: { message: comment } as BeachballOptions,
+    });
+    expect(change).toMatchObject({ comment });
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  // this is somewhat debatable
+  it('prefers response.message over options.message', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { type: 'patch', comment: 'response message' },
+      options: { message: comment } as BeachballOptions,
+    });
+    expect(change).toMatchObject({ comment: 'response message' });
+  });
+
+  it('uses options.dependentChangeType if provided', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { type: 'patch', comment },
+      options: { dependentChangeType: 'minor' } as BeachballOptions,
+    });
+    expect(change).toMatchObject({ dependentChangeType: 'minor' });
+  });
+
+  it('returns error if response.type is invalid', () => {
+    const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { type: 'invalid' as any } });
+    expect(change).toBeUndefined();
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error).toHaveBeenCalledWith('Prompt response contains invalid change type "invalid"');
+  });
+
+  // This is an important scenario for some people who customize the change prompt
+  it('preserves extra properties on the returned object', () => {
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { comment, type: 'patch', extra: 'extra' } as any,
+    });
+    expect(change).toMatchObject({ extra: 'extra' });
+  });
+});

--- a/src/__tests__/changefile/promptForChange_getQuestionsForPackage.test.ts
+++ b/src/__tests__/changefile/promptForChange_getQuestionsForPackage.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import prompts from 'prompts';
+import { _getQuestionsForPackage } from '../../changefile/promptForChange';
+import { BeachballOptions } from '../../types/BeachballOptions';
+import { ChangeFilePromptOptions } from '../../types/ChangeFilePrompt';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+/**
+ * This covers the first part of `promptForChange`: determining what questions to ask for each package.
+ */
+describe('promptForChange _getQuestionsForPackage', () => {
+  /** Package name used in the tests */
+  const pkg = 'foo';
+
+  /** Basic params for `_getQuestionsForPackage`, for a package named `foo` */
+  const defaultQuestionsParams: Parameters<typeof _getQuestionsForPackage>[0] = {
+    pkg,
+    packageInfos: makePackageInfos({ [pkg]: {} }),
+    packageGroups: {},
+    options: {} as BeachballOptions,
+    recentMessages: ['message'],
+  };
+
+  /**
+   * Mock console logs. NOTE: Initialization is only done in before/after all (not cleared every test
+   * since only a few tests use logs), so tests should use `toHaveBeenLastCalledWith`.
+   */
+  const sharedLogs = initMockLogs({ onlyInitOnce: true });
+
+  it('works in basic case', () => {
+    const questions = _getQuestionsForPackage(defaultQuestionsParams);
+    expect(questions).toEqual([
+      {
+        choices: [
+          { title: expect.stringContaining('Patch'), value: 'patch' },
+          { title: expect.stringContaining('Minor'), value: 'minor' },
+          { title: expect.stringContaining('None'), value: 'none' },
+          { title: expect.stringContaining('Major'), value: 'major' },
+        ],
+        message: 'Change type',
+        name: 'type',
+        type: 'select',
+      },
+      {
+        choices: [{ title: 'message' }],
+        message: 'Describe changes (type or choose one)',
+        name: 'comment',
+        onState: expect.any(Function),
+        suggest: expect.any(Function),
+        type: 'autocomplete',
+      },
+    ]);
+  });
+
+  // it's somewhat debatable if this is correct (maybe --type should be the override for disallowedChangeTypes?)
+  it('errors if options.type is disallowed', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+      options: { type: 'major' } as BeachballOptions,
+    });
+    expect(questions).toBeUndefined();
+    expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('Change type "major" is not allowed for package "foo"');
+  });
+
+  it('errors if there are no valid change types for package', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({
+        [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+      }),
+    });
+    expect(questions).toBeUndefined();
+    expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "foo"');
+  });
+
+  it('respects disallowedChangeTypes', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+    });
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    expect(choices).toEqual(['patch', 'minor', 'none']);
+  });
+
+  it('allows prerelease change for package with prerelease version', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({ [pkg]: { version: '1.0.0-beta.1' } }),
+    });
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    expect(choices).toEqual(['prerelease', 'patch', 'minor', 'none', 'major']);
+  });
+
+  // this is a bit weird as well, but documenting current behavior
+  it('excludes prerelease if disallowed', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({
+        [pkg]: { version: '1.0.0-beta.1', combinedOptions: { disallowedChangeTypes: ['prerelease'] } },
+      }),
+    });
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    expect(choices).toEqual(['patch', 'minor', 'none', 'major']);
+  });
+
+  it('excludes the change type question when options.type is specified', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      options: { type: 'patch' } as BeachballOptions,
+    });
+    expect(questions).toHaveLength(1);
+    expect(questions![0].name).toBe('comment');
+  });
+
+  it('excludes the change type question with only one valid option', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({
+        [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
+      }),
+    });
+    expect(questions).toHaveLength(1);
+    expect(questions![0].name).toBe('comment');
+  });
+
+  it('excludes the change type question when prerelease is implicitly the only valid option', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({
+        [pkg]: {
+          version: '1.0.0-beta.1',
+          combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
+        },
+      }),
+    });
+    expect(questions).toHaveLength(1);
+    expect(questions![0].name).toBe('comment');
+  });
+
+  it('excludes the comment question when options.message is set', () => {
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      options: { message: 'message' } as BeachballOptions,
+    });
+    expect(questions).toHaveLength(1);
+    expect(questions![0].name).toBe('type');
+  });
+
+  it('uses options.changeFilePrompt if set', () => {
+    const customQuestions: prompts.PromptObject[] = [{ name: 'custom', message: 'custom prompt', type: 'text' }];
+    const changePrompt: ChangeFilePromptOptions['changePrompt'] = jest.fn(() => customQuestions);
+
+    const questions = _getQuestionsForPackage({
+      ...defaultQuestionsParams,
+      packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { changeFilePrompt: { changePrompt } } } }),
+    });
+
+    expect(questions).toEqual(customQuestions);
+    // includes the original prompts as parameters
+    expect(changePrompt).toHaveBeenLastCalledWith(
+      {
+        changeType: expect.objectContaining({ name: 'type' }),
+        description: expect.objectContaining({ name: 'comment' }),
+      },
+      pkg
+    );
+  });
+
+  it('does case-insensitive filtering on description suggestions', async () => {
+    const recentMessages = ['Foo', 'Bar', 'Baz'];
+    const recentMessageChoices = [{ title: 'Foo' }, { title: 'Bar' }, { title: 'Baz' }];
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
+    expect(questions).toEqual([
+      expect.anything(),
+      expect.objectContaining({
+        name: 'comment',
+        choices: recentMessageChoices,
+        suggest: expect.any(Function),
+      }),
+    ]);
+
+    const suggestions = await questions![1].suggest!('ba', recentMessageChoices);
+    expect(suggestions).toEqual([{ title: 'Bar' }, { title: 'Baz' }]);
+  });
+});

--- a/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
+++ b/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import prompts from 'prompts';
+import { _getQuestionsForPackage, _promptForPackageChange } from '../../changefile/promptForChange';
+import { BeachballOptions } from '../../types/BeachballOptions';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { MockStdin } from '../../__fixtures__/mockStdin';
+import { MockStdout } from '../../__fixtures__/mockStdout';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+// prompts writes to stdout (not console) in a way that can't really be mocked with spies,
+// so instead we inject a custom mock stdout stream, as well as stdin for entering answers
+let stdin: MockStdin;
+let stdout: MockStdout;
+jest.mock(
+  'prompts',
+  () =>
+    ((questions, options) => {
+      questions = Array.isArray(questions) ? questions : [questions];
+      questions = questions.map(q => ({ ...q, stdin, stdout }));
+      return (jest.requireActual('prompts') as typeof prompts)(questions, options);
+    }) as typeof prompts
+);
+
+/**
+ * This covers the actual prompting part of `promptForChange`.
+ */
+describe('promptForChange _promptForPackageChange', () => {
+  /** Package name used in the tests */
+  const pkg = 'foo';
+
+  /** Basic params for `_getQuestionsForPackage`, for a package named `foo` */
+  const defaultQuestionsParams: Parameters<typeof _getQuestionsForPackage>[0] = {
+    pkg,
+    packageInfos: makePackageInfos({ [pkg]: {} }),
+    packageGroups: {},
+    options: {} as BeachballOptions,
+    recentMessages: ['message'],
+  };
+  const expectedQuestions = [
+    expect.objectContaining({ name: 'type', type: 'select' }),
+    expect.objectContaining({ name: 'comment', type: 'autocomplete' }),
+  ];
+
+  /** Wait for the prompt to finish rendering (simulates real user input) */
+  const waitForPrompt = () => new Promise(resolve => process.nextTick(resolve));
+
+  const logs = initMockLogs();
+
+  beforeEach(() => {
+    stdin = new MockStdin();
+    // prompts writes a near-duplicate chunk with ... while it's processing input, so ignore that.
+    // Also replace special characters used by `prompts` that will be different between platforms.
+    stdout = new MockStdout({ ignoreChunks: [/ (…|\.\.\.)( |$)/m], replace: 'prompts' });
+  });
+
+  afterEach(() => {
+    stdin.destroy();
+    stdout.destroy();
+  });
+
+  it('returns an empty object and logs nothing if there are no questions', async () => {
+    const answers = await _promptForPackageChange([], pkg);
+    expect(answers).toEqual({});
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('prompts for change type and description', async () => {
+    const questions = _getQuestionsForPackage(defaultQuestionsParams);
+    expect(questions).toEqual(expectedQuestions);
+
+    const answersPromise = _promptForPackageChange(questions!, pkg);
+
+    // input: press enter twice to use defaults (with a pause in between to simulate real user input)
+    await stdin.sendByChar('\n\n');
+    const answers = await answersPromise;
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  Patch      - bug fixes; no API changes.
+        ? Describe changes (type or choose one) »
+        >   message
+        √ Describe changes (type or choose one) » message"
+      `);
+    expect(answers).toEqual({ type: 'patch', comment: 'message' });
+  });
+
+  it('accepts custom description typed by character', async () => {
+    // For this one we provide a type in options and only ask for the description
+    const options = { type: 'minor' } as BeachballOptions;
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+    expect(questions).toEqual(expectedQuestions.slice(1));
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+    await waitForPrompt();
+    expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+    stdout.clearOutput();
+
+    // input: a message which isn't included in the recent commits, sent by individual characters
+    // (as if it was typed)
+    await stdin.sendByChar('abc\n');
+    const answers = await answerPromise;
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) » a
+        ? Describe changes (type or choose one) » ab
+        ? Describe changes (type or choose one) » abc
+        √ Describe changes (type or choose one) » abc"
+      `);
+    expect(answers).toEqual({ comment: 'abc' });
+  });
+
+  it('accepts custom description pasted', async () => {
+    // For this one we provide a type in options and only ask for the description
+    const options = { type: 'minor' } as BeachballOptions;
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+    expect(questions).toEqual(expectedQuestions.slice(1));
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+    await waitForPrompt();
+    expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+    stdout.clearOutput();
+
+    // input: a message which isn't included in the recent commits, sent all at once
+    // (as if it was pasted)
+    stdin.send('abc');
+    await stdin.sendByChar('\n');
+    const answers = await answerPromise;
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) » abc
+        √ Describe changes (type or choose one) » abc"
+      `);
+    expect(answers).toEqual({ comment: 'abc' });
+  });
+
+  it('accepts custom description pasted with newline', async () => {
+    // For this one we provide a type in options and only ask for the description
+    const options = { type: 'minor' } as BeachballOptions;
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, options });
+    expect(questions).toEqual(expectedQuestions.slice(1));
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+    await waitForPrompt();
+    expect(stdout.lastOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   message"
+      `);
+    stdout.clearOutput();
+
+    // input: a message which isn't included in the recent commits, sent all at once
+    // (as if it was pasted)
+    stdin.send('abc\n');
+    const answers = await answerPromise;
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`""`);
+    expect(answers).toEqual({ comment: 'abc' });
+  });
+
+  it('uses options selected with arrow keys', async () => {
+    const recentMessages = ['first', 'second', 'third'];
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages });
+    expect(questions).toEqual(expectedQuestions);
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+
+    // arrow down to select the third type
+    stdin.emitKey({ name: 'down' });
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+    // and the second message
+    stdin.emitKey({ name: 'down' });
+    await stdin.sendByChar('\n');
+
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        ? Change type » - Use arrow-keys. Return to submit.
+             Patch      - bug fixes; no API changes.
+        >    Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        ? Change type » - Use arrow-keys. Return to submit.
+             Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+        >    None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  None       - this change does not affect the published package in any way.
+        ? Describe changes (type or choose one) »
+        >   first
+            second
+            third
+        ? Describe changes (type or choose one) »
+            first
+        >   second
+            third
+        √ Describe changes (type or choose one) » second"
+      `);
+
+    const answers = await answerPromise;
+    expect(answers).toEqual({ type: 'none', comment: 'second' });
+  });
+
+  it('filters options while typing', async () => {
+    const recentMessages = ['foo', 'bar', 'baz'];
+    const options = { type: 'minor' } as BeachballOptions;
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
+    expect(questions).toEqual(expectedQuestions.slice(1));
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+
+    // type "ba" and press enter to select "bar"
+    await stdin.sendByChar('ba\n');
+
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        ? Describe changes (type or choose one) » b
+        >   bar
+            baz
+        ? Describe changes (type or choose one) » ba
+        >   bar
+            baz
+        √ Describe changes (type or choose one) » bar"
+      `);
+
+    const answers = await answerPromise;
+    expect(answers).toEqual({ comment: 'bar' });
+  });
+
+  it('handles pressing delete while typing', async () => {
+    const recentMessages = ['foo', 'bar', 'baz'];
+    const options = { type: 'minor' } as BeachballOptions;
+    const questions = _getQuestionsForPackage({ ...defaultQuestionsParams, recentMessages, options });
+    expect(questions).toEqual(expectedQuestions.slice(1));
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+
+    // type "b", press backspace to delete it, press enter to select foo
+    await stdin.sendByChar('b');
+    stdin.emitKey({ name: 'backspace' });
+    await stdin.sendByChar('\n');
+
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        ? Describe changes (type or choose one) » b
+        >   bar
+            baz
+        ? Describe changes (type or choose one) »
+        >   foo
+            bar
+            baz
+        √ Describe changes (type or choose one) » foo"
+      `);
+
+    const answers = await answerPromise;
+    expect(answers).toEqual({ comment: 'foo' });
+  });
+
+  it('returns no answers if cancelled with ctrl-c', async () => {
+    const questions = _getQuestionsForPackage(defaultQuestionsParams);
+    expect(questions).toEqual(expectedQuestions);
+
+    const answerPromise = _promptForPackageChange(questions!, pkg);
+
+    // answer the first question
+    await stdin.sendByChar('\n');
+    // start typing the second answer then cancel
+    await stdin.sendByChar('a');
+    stdin.emitKey({ name: 'c', ctrl: true });
+
+    const answers = await answerPromise;
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+        "Please describe the changes for: foo
+        Cancelled, no change files are written"
+      `);
+
+    expect(stdout.getOutput()).toMatchInlineSnapshot(`
+        "? Change type » - Use arrow-keys. Return to submit.
+        >    Patch      - bug fixes; no API changes.
+             Minor      - small feature; backwards compatible API changes.
+             None       - this change does not affect the published package in any way.
+             Major      - major feature; breaking changes.
+        √ Change type »  Patch      - bug fixes; no API changes.
+        ? Describe changes (type or choose one) »
+        >   message
+        ? Describe changes (type or choose one) » a
+        × Describe changes (type or choose one) » a"
+      `);
+
+    expect(answers).toBeUndefined();
+  });
+});

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -1,158 +1,218 @@
-import { ChangeFileInfo, ChangeType } from '../types/ChangeInfo';
-import { getChangedPackages } from './getChangedPackages';
-import { getRecentCommitMessages, getUserEmail } from 'workspace-tools';
 import prompts from 'prompts';
-import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { prerelease } from 'semver';
+import { ChangeFileInfo, ChangeType } from '../types/ChangeInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { getPackageGroups } from '../monorepo/getPackageGroups';
 import { isValidChangeType } from '../validation/isValidChangeType';
 import { DefaultPrompt } from '../types/ChangeFilePrompt';
 import { getDisallowedChangeTypes } from './getDisallowedChangeTypes';
+import { PackageGroups, PackageInfos } from '../types/PackageInfo';
+
+type ChangePromptResponse = { type?: ChangeType; comment?: string };
 
 /**
- * Uses `prompts` package to prompt for change type and description, fills in git user.email and scope
+ * Uses `prompts` package to prompt for change type and description.
+ * (For easier testing, this function does not handle filesystem access.)
  */
-export async function promptForChange(options: BeachballOptions): Promise<ChangeFileInfo[] | undefined> {
-  const { branch, path: cwd } = options;
-  let { package: specificPackage } = options;
-
-  if (specificPackage && !Array.isArray(specificPackage)) {
-    specificPackage = [specificPackage];
-  }
-  const packageInfos = getPackageInfos(cwd);
-  const changedPackages = specificPackage || getChangedPackages(options, packageInfos);
+export async function promptForChange(params: {
+  changedPackages: string[];
+  packageInfos: PackageInfos;
+  packageGroups: PackageGroups;
+  recentMessages: string[];
+  email: string | null;
+  options: BeachballOptions;
+}): Promise<ChangeFileInfo[] | undefined> {
+  const { changedPackages, email, options } = params;
   if (!changedPackages.length) {
     return;
   }
 
-  const recentMessageChoices: prompts.Choice[] = getRecentCommitMessages(branch, cwd).map(msg => ({ title: msg }));
+  // Get the questions for each package first, in case one package has a validation issue
+  const packageQuestions: { [pkg: string]: prompts.PromptObject[] } = {};
+  for (const pkg of changedPackages) {
+    const questions = _getQuestionsForPackage({ pkg, ...params });
+    if (!questions) {
+      return; // validation issue
+    }
+    packageQuestions[pkg] = questions;
+  }
+
+  // Now prompt for each package
   const packageChangeInfo: ChangeFileInfo[] = [];
-
-  const packageGroups = getPackageGroups(packageInfos, options.path, options.groups);
-
   for (let pkg of changedPackages) {
-    console.log('');
-    console.log(`Please describe the changes for: ${pkg}`);
-
-    const disallowedChangeTypes = getDisallowedChangeTypes(pkg, packageInfos, packageGroups);
-    const packageInfo = packageInfos[pkg];
-    const showPrereleaseOption = prerelease(packageInfo.version);
-    const changeTypePrompt: prompts.PromptObject<string> = {
-      type: 'select',
-      name: 'type',
-      message: 'Change type',
-      choices: [
-        ...(showPrereleaseOption ? [{ value: 'prerelease', title: ' [1mPrerelease[22m - bump prerelease version' }] : []),
-        { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no API changes.' },
-        { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible API changes.' },
-        {
-          value: 'none',
-          title: ' [1mNone[22m       - this change does not affect the published package in any way.',
-        },
-        { value: 'major', title: ' [1mMajor[22m      - major feature; breaking changes.' },
-      ].filter(choice => !disallowedChangeTypes?.includes(choice.value as ChangeType)),
-    };
-
-    if (changeTypePrompt.choices!.length === 0) {
-      console.log('No valid changeTypes available, aborting');
-      return;
+    const response = await _promptForPackageChange(packageQuestions[pkg], pkg);
+    if (!response) {
+      return; // user cancelled
     }
 
-    if (options.type && disallowedChangeTypes?.includes(options.type as ChangeType)) {
-      console.log(`${options.type} type is not allowed, aborting`);
-      return;
+    const change = _getChangeFileInfoFromResponse({ response, pkg, email, options });
+    if (!change) {
+      return; // validation issue
     }
-
-    const descriptionPrompt: prompts.PromptObject<string> = {
-      type: 'autocomplete',
-      name: 'comment',
-      message: 'Describe changes (type or choose one)',
-      choices: recentMessageChoices,
-      suggest: (input: string) =>
-        Promise.resolve(
-          input
-            ? // do case-insensitive filtering
-              recentMessageChoices.filter(({ title }) => title.toLowerCase().startsWith(input.toLowerCase()))
-            : recentMessageChoices
-        ),
-      // prompts doesn't have proper support for "freeform" input (value not in the list), and the
-      // previously implemented hack of adding the input to the returned list from `suggest`
-      // no longer works. So this new hack adds the current input as the fallback.
-      // https://github.com/terkelg/prompts/issues/131
-      onState: function (this: any) {
-        this.fallback = { title: this.input };
-
-        // Check to make sure there are no suggestions so we do not override a suggestion
-        if (this.suggestions?.length === 0) {
-          this.value = this.input;
-        }
-      },
-    };
-
-    const showChangeTypePrompt = !options.type && changeTypePrompt.choices!.length > 1;
-
-    const defaultPrompt: DefaultPrompt = {
-      changeType: showChangeTypePrompt ? changeTypePrompt : undefined,
-      description: !options.message ? descriptionPrompt : undefined,
-    };
-    const defaultPrompts = [defaultPrompt.changeType, defaultPrompt.description];
-
-    const questions = (
-      packageInfo.combinedOptions.changeFilePrompt?.changePrompt?.(defaultPrompt, pkg) || defaultPrompts
-    ).filter((q): q is prompts.PromptObject => !!q);
-
-    let response: { comment: string; type: ChangeType } = {
-      type: options.type || 'none',
-      comment: options.message || '',
-    };
-
-    if (questions.length > 0) {
-      let isCancelled = false;
-      response = (await prompts(questions, {
-        onCancel: () => {
-          isCancelled = true;
-        },
-      })) as typeof response;
-
-      if (isCancelled) {
-        console.log('Cancelled, no change files are written');
-        return;
-      }
-
-      // if type is absent in the user input, there are two possiblities for
-      // proceeding next:
-      // 1) if options.type is defined, use that
-      // 2) otherwise, we hit the edge case when options.type is undefined
-      //    and there was only one possible ChangeType to display, 'none'
-      //    but we didn't display it due to showChangeTypePrompt === false;
-      //    so set the type to 'none'
-      if (!response.type) {
-        if (!options.type) {
-          console.log("WARN: change type 'none' assumed by default");
-          console.log('(Not what you intended? Check the repo-level and package-level beachball configs.)');
-        }
-        response = { ...response, type: options.type || 'none' };
-      }
-
-      // fallback to the options.message if message is absent in the user input
-      if (!response.comment && options.message) {
-        response = { ...response, comment: options.message };
-      }
-
-      if (!isValidChangeType(response.type)) {
-        console.error('Prompt response contains invalid change type.');
-        return;
-      }
-    }
-
-    packageChangeInfo.push({
-      ...response,
-      packageName: pkg,
-      email: getUserEmail(cwd) || 'email not defined',
-      dependentChangeType: options.dependentChangeType || (response.type === 'none' ? 'none' : 'patch'),
-    });
+    packageChangeInfo.push(change);
   }
 
   return packageChangeInfo;
+}
+
+/**
+ * Build the list of questions to ask the user for this package.
+ * @internal exported for testing
+ */
+export function _getQuestionsForPackage(params: {
+  pkg: string;
+  packageInfos: PackageInfos;
+  packageGroups: PackageGroups;
+  options: BeachballOptions;
+  recentMessages: string[];
+}): prompts.PromptObject[] | undefined {
+  const { pkg, packageInfos, packageGroups, options, recentMessages } = params;
+
+  const disallowedChangeTypes = getDisallowedChangeTypes(pkg, packageInfos, packageGroups);
+
+  if (options.type && disallowedChangeTypes?.includes(options.type as ChangeType)) {
+    console.error(`Change type "${options.type}" is not allowed for package "${pkg}"`);
+    return;
+  }
+
+  const packageInfo = packageInfos[pkg];
+  const showPrereleaseOption = !!prerelease(packageInfo.version);
+  const changeTypeChoices: prompts.Choice[] = [
+    ...(showPrereleaseOption ? [{ value: 'prerelease', title: ' [1mPrerelease[22m - bump prerelease version' }] : []),
+    { value: 'patch', title: ' [1mPatch[22m      - bug fixes; no API changes.' },
+    { value: 'minor', title: ' [1mMinor[22m      - small feature; backwards compatible API changes.' },
+    {
+      value: 'none',
+      title: ' [1mNone[22m       - this change does not affect the published package in any way.',
+    },
+    { value: 'major', title: ' [1mMajor[22m      - major feature; breaking changes.' },
+  ].filter(choice => !disallowedChangeTypes?.includes(choice.value as ChangeType));
+
+  if (!changeTypeChoices.length) {
+    console.error(`No valid change types available for package "${pkg}"`);
+    return;
+  }
+
+  const changeTypePrompt: prompts.PromptObject<string> = {
+    type: 'select',
+    name: 'type',
+    message: 'Change type',
+    choices: changeTypeChoices,
+  };
+
+  // Do case-insensitive filtering of recent commit messages
+  const recentMessageChoices: prompts.Choice[] = recentMessages.map(msg => ({ title: msg }));
+  const getSuggestions = (input: string) =>
+    input
+      ? recentMessageChoices.filter(({ title }) => title.toLowerCase().startsWith(input.toLowerCase()))
+      : recentMessageChoices;
+
+  const descriptionPrompt: prompts.PromptObject<string> = {
+    type: 'autocomplete',
+    name: 'comment',
+    message: 'Describe changes (type or choose one)',
+    choices: recentMessageChoices,
+    suggest: (input: string) => Promise.resolve(getSuggestions(input)),
+    // prompts doesn't have proper support for "freeform" input (value not in the list), and the
+    // previously implemented hack of adding the input to the returned list from `suggest`
+    // no longer works. So this new hack adds the current input as the fallback.
+    // https://github.com/terkelg/prompts/issues/131
+    onState: function (this: any, state: any) {
+      // If there are no suggestions, update the value to match the input, and unset the fallback
+      // (this.suggestions may be out of date if the user pasted text ending with a newline, so re-calculate)
+      if (!getSuggestions(this.input).length) {
+        this.value = this.input;
+        this.fallback = '';
+      }
+    },
+  };
+
+  const showChangeTypePrompt = !options.type && changeTypePrompt.choices!.length > 1;
+
+  const defaultPrompt: DefaultPrompt = {
+    changeType: showChangeTypePrompt ? changeTypePrompt : undefined,
+    description: !options.message ? descriptionPrompt : undefined,
+  };
+  const defaultPrompts = [defaultPrompt.changeType, defaultPrompt.description];
+
+  return (packageInfo.combinedOptions.changeFilePrompt?.changePrompt?.(defaultPrompt, pkg) || defaultPrompts).filter(
+    (q): q is prompts.PromptObject => !!q
+  );
+}
+
+/**
+ * Do the actual prompting.
+ * @internal exported for testing
+ */
+export async function _promptForPackageChange(
+  questions: prompts.PromptObject[],
+  pkg: string
+): Promise<ChangePromptResponse | undefined> {
+  if (!questions.length) {
+    // This MUST return an empty object rather than nothing, because returning nothing means the
+    // prompt was cancelled and the whole change prompt process should end
+    return {};
+  }
+
+  console.log('');
+  console.log(`Please describe the changes for: ${pkg}`);
+
+  let isCancelled = false;
+  const onCancel = () => {
+    isCancelled = true;
+  };
+  // onCancel is missing from the typings
+  const response: ChangePromptResponse = await prompts(questions, { onCancel } as any);
+
+  if (isCancelled) {
+    console.log('Cancelled, no change files are written');
+  } else {
+    return response;
+  }
+}
+
+/**
+ * Validate/update the response from the user and return the full change file info.
+ * @internal exported for testing
+ */
+export function _getChangeFileInfoFromResponse(params: {
+  response: ChangePromptResponse;
+  pkg: string;
+  email: string | null;
+  options: BeachballOptions;
+}): ChangeFileInfo | undefined {
+  const { pkg, email, options } = params;
+  let response = params.response;
+
+  // if type is absent in the user input, there are two possiblities for
+  // proceeding next:
+  // 1) if options.type is defined, use that
+  // 2) otherwise, we hit the edge case when options.type is undefined
+  //    and there was only one possible ChangeType to display, 'none'
+  //    but we didn't display it due to showChangeTypePrompt === false;
+  //    so set the type to 'none'
+  if (!response.type) {
+    if (!options.type) {
+      console.log("WARN: change type 'none' assumed by default");
+      console.log('(Not what you intended? Check the repo-level and package-level beachball configs.)');
+    }
+    response = { ...response, type: options.type || 'none' };
+  }
+
+  // fallback to the options.message if message is absent in the user input
+  if (!response.comment && options.message) {
+    response = { ...response, comment: options.message };
+  }
+
+  // prevent invalid change types from being entered via custom prompts
+  if (!isValidChangeType(response.type!)) {
+    console.error(`Prompt response contains invalid change type "${response.type}"`);
+    return;
+  }
+
+  return {
+    ...(response as Required<ChangePromptResponse>),
+    packageName: pkg,
+    email: email || 'email not defined',
+    dependentChangeType: options.dependentChangeType || (response.type === 'none' ? 'none' : 'patch'),
+  };
 }

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -1,9 +1,39 @@
 import { BeachballOptions } from '../types/BeachballOptions';
 import { promptForChange } from '../changefile/promptForChange';
 import { writeChangeFiles } from '../changefile/writeChangeFiles';
+import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { getRecentCommitMessages, getUserEmail } from 'workspace-tools';
+import { getChangedPackages } from '../changefile/getChangedPackages';
+import { getPackageGroups } from '../monorepo/getPackageGroups';
 
 export async function change(options: BeachballOptions) {
-  const changes = await promptForChange(options);
+  const { branch, path: cwd } = options;
+  const { package: specificPackage } = options;
+
+  const packageInfos = getPackageInfos(cwd);
+  const packageGroups = getPackageGroups(packageInfos, cwd, options.groups);
+
+  const changedPackages =
+    typeof specificPackage === 'string'
+      ? [specificPackage]
+      : Array.isArray(specificPackage)
+      ? specificPackage
+      : getChangedPackages(options, packageInfos);
+  if (!changedPackages.length) {
+    return;
+  }
+
+  const recentMessages = getRecentCommitMessages(branch, cwd);
+  const email = getUserEmail(cwd);
+
+  const changes = await promptForChange({
+    changedPackages,
+    packageInfos,
+    packageGroups,
+    recentMessages,
+    email,
+    options,
+  });
 
   if (changes) {
     writeChangeFiles({

--- a/yarn.lock
+++ b/yarn.lock
@@ -10270,6 +10270,13 @@ string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -10283,13 +10290,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-bom-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds unit and E2E tests for the `change` command. To add unit tests, it was necessary to split the `promptForChange` helper into several parts, and I moved all the pieces that read from the filesystem into the `change` command function.

One of the motivations for this was to ensure that the autocomplete freeform input hack doesn't break with new `prompts` versions, so it was important to test the actual input part in a realistic manner. Thankfully `prompts` provides options for custom `stdin`/`stdout` streams, and I used a variant of [`mock-stdin`](https://www.npmjs.com/package/mock-stdin) plus a custom writable stream that just saves chunks written to it. 

One thing to note about input mocking is that to simulate the user typing (where characters are entered and processed individually), it's necessary to add a pause such as `process.nextTick` between characters so that `prompts` can finish processing updates. Sending all the characters at once is the equivalent of pasting.

Adding the tests also prompted some improvements to the prompting logic: 
- Get the questions for each package first, in case one package has a validation issue (like no valid change types). This reduces the chances of an issue partway through that will cause the user to lose their work.
- Improve the autocomplete freeform hack to handle pasted input