### PR TITLE
ensure that all packages bumped get a new entry in the changelog.json…

### DIFF
--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -24,7 +24,7 @@ export function setDependentVersions(
           if (packageInfo) {
             const existingVersionRange = deps[dep];
             const bumpedVersionRange = bumpMinSemverRange(packageInfo.version, existingVersionRange);
-            if (existingVersionRange !== bumpedVersionRange) {
+            if (bumpedVersionRange === "*" || existingVersionRange !== bumpedVersionRange) {
               deps[dep] = bumpedVersionRange;
 
               dependentChangedBy[pkgName] = dependentChangedBy[pkgName] || new Set<string>();


### PR DESCRIPTION
This PR fixes an issue in beachball where, If package **_foo_** depends on package **_bar_** with an entry in it's _package.json_:
``
"bar":"*"
``
If you update **_bar_**. both packages should be bumped but only **_bar_** is getting a new entry in it's _changelog.json_ file.

Each package, should get a new entry in it's _changelog.json_ file.