### PR TITLE
Use normalized-tmpdir in tests

### DIFF
--- a/change/beachball-1c33a622-edd0-4089-bfef-1010b43a585a.json
+++ b/change/beachball-1c33a622-edd0-4089-bfef-1010b43a585a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use normalized-tmpdir in tests",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "gh-pages": "4.0.0",
     "jest": "28.1.3",
     "jest-mock": "28.1.3",
+    "normalized-tmpdir": "1.0.1",
     "prettier": "2.8.2",
     "strip-ansi": "6.0.1",
     "tmp": "0.2.1",

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -1,6 +1,5 @@
 import * as tmp from 'tmp';
-import fs from 'fs-extra';
-import os from 'os';
+import { normalizedTmpdir } from 'normalized-tmpdir';
 // import console to ensure that warnings are always logged if needed (no mocking)
 import realConsole from 'console';
 
@@ -12,46 +11,17 @@ tmp.setGracefulCleanup();
 
 /**
  * Create a temporary directory and return the normalized real path to the directory.
- * This includes workarounds for both Mac and Windows quirks which cause path comparison problems.
  *
  * @param options See {@link tmp.DirOptions}. The default for `prefix` is `beachball-`, and
  * `unsafeCleanup` (try to delete on exit even if the dir contains files) is always enabled.
  */
 export function tmpdir(options?: tmp.DirOptions): string {
-  // Get the real path because on Mac, tmp will return /var/... which is actually a symlink to /private/var/...
-  // (and mixing the symlink path and the real path causes issues in functions that use relative paths)
-  let dir = fs.realpathSync(
-    tmp.dirSync({
-      prefix: 'beachball-',
-      ...options,
-      // "Unsafe" means delete on exit even if it still contains files...which actually is safe.
-      unsafeCleanup: true,
-    }).name
-  );
-
-  if (os.platform() === 'win32' && dir.includes('~')) {
-    // On Windows, if the user directory is more than 8 characters, os.tmpdir() (used by tmp)
-    // apparently returns a path with the user directory segment as a short (8.3) name, such as
-    // C:\Users\RUNNER~1\AppData\Local\Temp on the github actions runner. This messes up path
-    // comparisons against anything based on process.cwd() which uses long names.
-    //
-    // There's no official way to convert between short and long names in Node, so try a string
-    // replacement of the short user segment with the home directory.
-    const windowsShortUserDir = dir.match(/^[a-z]:\\Users\\[^\\]+/i)?.[0];
-    const homedir = os.homedir();
-    // replace if the drive letter is the same
-    if (windowsShortUserDir && homedir[0].toLowerCase() === windowsShortUserDir[0].toLowerCase()) {
-      dir = dir.replace(windowsShortUserDir, homedir);
-    }
-    if (dir.includes('~')) {
-      // This could happen if the ~ was somewhere else besides the user directory, or if the
-      // temp directory is not under the home directory.
-      realConsole.warn(
-        `⚠️⚠️⚠️\nWARNING: temp directory "${dir}" contains a short (8.3) path segment which could not be expanded ` +
-          'by available heuristics. This will likely cause test failures due to comparisons with long paths.\n⚠️⚠️⚠️'
-      );
-    }
-  }
-
-  return dir;
+  return tmp.dirSync({
+    prefix: 'beachball-',
+    ...options,
+    // "Unsafe" means delete on exit even if it still contains files...which actually is safe.
+    unsafeCleanup: true,
+    // Create a directory starting with this normalized path
+    tmpdir: normalizedTmpdir({ console: realConsole }),
+  }).name;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8277,6 +8277,11 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
+normalized-tmpdir@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalized-tmpdir/-/normalized-tmpdir-1.0.1.tgz#9ae5b920b8c50fb0c1cdb98017077f586f3136f0"
+  integrity sha512-QO2UWkgkgLYzu+5f2IXHrsg4RJn2Wa9fsvCSbgh8gcjMHt41NuN0qjFqk4L3wHnKRtwKNWEvmqrlv3tl0QmfWg==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
I moved the `os.tmpdir()` normalization logic to a [new package](https://www.npmjs.com/package/normalized-tmpdir), so use that in beachball.