### PR TITLE
New timeout flag for git push

### DIFF
--- a/change/beachball-9dd923c9-890e-453f-8aa5-ef4f324cd61a.json
+++ b/change/beachball-9dd923c9-890e-453f-8aa5-ef4f324cd61a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "New flag for git push timeout",
+  "packageName": "beachball",
+  "email": "viditmathur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -25,7 +25,7 @@ export function getDefaultOptions() {
     scope: null,
     retries: 3,
     timeout: undefined,
-    pushTimeout: undefined,
+    gitTimeout: undefined,
     bump: true,
     canaryName: undefined,
     generateChangelog: true,

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -25,6 +25,7 @@ export function getDefaultOptions() {
     scope: null,
     retries: 3,
     timeout: undefined,
+    pushTimeout: undefined,
     bump: true,
     canaryName: undefined,
     generateChangelog: true,

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -9,7 +9,8 @@ export function packagePublish(
   token: string,
   access: string,
   authType?: AuthType,
-  timeout?: number | undefined
+  timeout?: number | undefined,
+  pushTimeout?: number | undefined
 ) {
   const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -10,7 +10,7 @@ export function packagePublish(
   access: string,
   authType?: AuthType,
   timeout?: number | undefined,
-  pushTimeout?: number | undefined
+  gitTimeout?: number | undefined
 ) {
   const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -9,7 +9,7 @@ import { displayManualRecovery } from './displayManualRecovery';
 const BUMP_PUSH_RETRIES = 5;
 
 export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
-  const { path: cwd, branch, tag, message, pushTimeout } = options;
+  const { path: cwd, branch, tag, message, gitTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
 
   let completed = false;
@@ -66,7 +66,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     console.log('git ' + pushArgs.join(' '));
 
     try {
-      const pushResult = git(pushArgs, { cwd, pushTimeout });
+      const pushResult = git(pushArgs, { cwd, timeout: gitTimeout });
 
       if (!pushResult.success) {
         console.warn(`[WARN ${tryNumber}/${BUMP_PUSH_RETRIES}]: push to ${branch} has failed!\n${pushResult.stderr}`);

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -9,7 +9,7 @@ import { displayManualRecovery } from './displayManualRecovery';
 const BUMP_PUSH_RETRIES = 5;
 
 export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
-  const { path: cwd, branch, tag, message, timeout } = options;
+  const { path: cwd, branch, tag, message, pushTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
 
   let completed = false;
@@ -66,7 +66,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     console.log('git ' + pushArgs.join(' '));
 
     try {
-      const pushResult = git(pushArgs, { cwd, timeout });
+      const pushResult = git(pushArgs, { cwd, pushTimeout });
 
       if (!pushResult.success) {
         console.warn(`[WARN ${tryNumber}/${BUMP_PUSH_RETRIES}]: push to ${branch} has failed!\n${pushResult.stderr}`);

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -42,6 +42,7 @@ export interface CliOptions
   new: boolean;
   package?: string | string[];
   timeout?: number;
+  pushTimeout?: number;
   token: string;
   type?: ChangeType | null;
   verbose?: boolean;

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -42,7 +42,7 @@ export interface CliOptions
   new: boolean;
   package?: string | string[];
   timeout?: number;
-  pushTimeout?: number;
+  gitTimeout?: number;
   token: string;
   type?: ChangeType | null;
   verbose?: boolean;


### PR DESCRIPTION
Building on top of using timeouts for git operations, here this PR introduced a new flag `gitTimeout` to decouple the publish and git timeout. 