### PR TITLE
Add optional extra logging for npm publish

### DIFF
--- a/change/beachball-5e9f9693-7595-4b5c-8280-540a1d87c1ef.json
+++ b/change/beachball-5e9f9693-7595-4b5c-8280-540a1d87c1ef.json
@@ -1,0 +1,7 @@
+{
+  "comment": "--verbose now enables \"notice\" level logging for npm publish to show the list of files, and pipes output to the console",
+  "type": "patch",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/packageManager/npm.ts
+++ b/src/packageManager/npm.ts
@@ -21,10 +21,16 @@ export function npm(
 
 export async function npmAsync(
   args: string[],
-  options: execa.Options = {}
+  options: execa.Options & { pipe?: boolean } = {}
 ): Promise<execa.ExecaReturnValue & { success: boolean }> {
+  const { pipe, ...execaOptions } = options;
   try {
-    const result = await execa('npm', args, { ...options });
+    const npmProcess = execa('npm', args, { ...execaOptions });
+    if (pipe) {
+      npmProcess.stdout?.pipe(process.stdout);
+      npmProcess.stderr?.pipe(process.stderr);
+    }
+    const result = await npmProcess;
     return {
       ...result,
       success: !result.failed,

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -10,7 +10,7 @@ export function packagePublish(
   access: string,
   authType?: AuthType,
   timeout?: number | undefined,
-  gitTimeout?: number | undefined
+  verbose?: boolean
 ) {
   const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);
@@ -21,7 +21,9 @@ export function packagePublish(
     '--tag',
     packageOptions.tag || packageOptions.defaultNpmTag,
     '--loglevel',
-    'warn',
+    // With the verbose option, restore default level of logs (including list of files published).
+    // A more specific npm log level option could be added in the future if needed.
+    verbose ? 'notice' : 'warn',
     ...getNpmAuthArgs(registry, token, authType),
   ];
 
@@ -30,5 +32,5 @@ export function packagePublish(
     args.push(access);
   }
   console.log(`publish command: ${args.join(' ')}`);
-  return npmAsync(args, { cwd: packagePath, timeout, all: true });
+  return npmAsync(args, { cwd: packagePath, timeout, all: true, pipe: verbose });
 }

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -14,7 +14,7 @@ import { performPublishOverrides } from './performPublishOverrides';
 type Unpromisify<T> = T extends Promise<infer U> ? U : never;
 
 export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions) {
-  const { registry, token, access, timeout, authType } = options;
+  const { registry, token, access, timeout, authType, verbose } = options;
   const bumpInfo = _.cloneDeep(originalBumpInfo);
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
@@ -80,7 +80,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     let retries = 0;
 
     do {
-      result = await packagePublish(packageInfo, registry, token, access, authType, timeout);
+      result = await packagePublish(packageInfo, registry, token, access, authType, timeout, verbose);
 
       if (result.success) {
         console.log('Published!');
@@ -89,7 +89,10 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
         retries++;
 
         hasAuthError = result.all!.includes('ENEEDAUTH');
-        const failedMessage = `Publishing "${pkg}" failed${hasAuthError ? ' due to auth error' : ''}:\n\n` + result.all;
+        const failedMessage =
+          `Publishing "${pkg}" failed${hasAuthError ? ' due to auth error' : ''}` +
+          // With verbose logs, the output should have already been piped to the console
+          (verbose ? '' : ':\n\n' + result.all);
 
         if (hasAuthError) {
           console.error(failedMessage);


### PR DESCRIPTION
Currently there's no way to make beachball show the actual list of files published with `npm publish` due to the `--loglevel warn` arg (the list of files uses `notice` level).

This PR makes Beachball's `--verbose` option enable `--loglevel notice` for `npm publish` and pipe output to the console, rather than only showing output if there's an error.

(If someone needs even more detailed `npm publish` logs in the future, we could add a separate option for more detailed control of npm loglevel, but I think enabling basic output under `--verbose` should be good enough for most situations.)