### PR TITLE
Use proper options and timeout on all npm operations

### DIFF
--- a/change/beachball-448aabe5-7a1f-4d03-8156-c08ec0087dcc.json
+++ b/change/beachball-448aabe5-7a1f-4d03-8156-c08ec0087dcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use proper options and timeout on all npm operations",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -93,14 +93,18 @@ describe('sync command (e2e)', () => {
 
     const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
 
-    expect((await packagePublish(packageInfosBeforeSync['foopkg'], registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(packageInfosBeforeSync['barpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
+    expect(
+      (await packagePublish(packageInfosBeforeSync['foopkg'], { registry: registry.getUrl() })).success
+    ).toBeTruthy();
+    expect(
+      (await packagePublish(packageInfosBeforeSync['barpkg'], { registry: registry.getUrl() })).success
+    ).toBeTruthy();
 
     const newFooInfo = createTempPackage('foopkg', '1.2.0');
     const newBarInfo = createTempPackage('barpkg', '3.0.0');
 
-    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, { registry: registry.getUrl() })).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, { registry: registry.getUrl() })).success).toBeTruthy();
 
     await sync(getOptions(repo, { tag: '' }));
 
@@ -125,14 +129,18 @@ describe('sync command (e2e)', () => {
 
     const packageInfosBeforeSync = getPackageInfos(repo.rootPath);
 
-    expect((await packagePublish(packageInfosBeforeSync['apkg'], registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(packageInfosBeforeSync['bpkg'], registry.getUrl(), '', '')).success).toBeTruthy();
+    expect(
+      (await packagePublish(packageInfosBeforeSync['apkg'], { registry: registry.getUrl() })).success
+    ).toBeTruthy();
+    expect(
+      (await packagePublish(packageInfosBeforeSync['bpkg'], { registry: registry.getUrl() })).success
+    ).toBeTruthy();
 
     const newFooInfo = createTempPackage('apkg', '2.0.0', 'beta');
     const newBarInfo = createTempPackage('bpkg', '3.0.0', 'latest');
 
-    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, { registry: registry.getUrl() })).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, { registry: registry.getUrl() })).success).toBeTruthy();
 
     await sync(getOptions(repo, { tag: 'beta' }));
 
@@ -163,8 +171,8 @@ describe('sync command (e2e)', () => {
     epkg.combinedOptions.tag = 'latest';
     fpkg.combinedOptions.tag = 'latest';
 
-    expect((await packagePublish(epkg, registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(fpkg, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(epkg, { registry: registry.getUrl() })).success).toBeTruthy();
+    expect((await packagePublish(fpkg, { registry: registry.getUrl() })).success).toBeTruthy();
 
     const newFooInfo = createTempPackage('epkg', '1.0.0-1');
     const newBarInfo = createTempPackage('fpkg', '3.0.0');
@@ -172,8 +180,8 @@ describe('sync command (e2e)', () => {
     newFooInfo.combinedOptions.tag = 'prerelease';
     newBarInfo.combinedOptions.tag = 'latest';
 
-    expect((await packagePublish(newFooInfo, registry.getUrl(), '', '')).success).toBeTruthy();
-    expect((await packagePublish(newBarInfo, registry.getUrl(), '', '')).success).toBeTruthy();
+    expect((await packagePublish(newFooInfo, { registry: registry.getUrl() })).success).toBeTruthy();
+    expect((await packagePublish(newBarInfo, { registry: registry.getUrl() })).success).toBeTruthy();
 
     await sync(getOptions(repo, { tag: 'prerelease', forceVersions: true }));
 

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -20,7 +20,7 @@ export function npmShow(
   packageName: string,
   shouldFail: boolean = false
 ): NpmShowResult | undefined {
-  const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json']);
+  const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json'], { timeout: 1000 });
   expect(showResult.failed).toBe(shouldFail);
   return shouldFail ? undefined : JSON.parse(showResult.stdout);
 }

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -61,7 +61,7 @@ describe('packagePublish', () => {
 
   it('can publish', async () => {
     const testPackageInfo = getTestPackageInfo(testTag);
-    const publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    const publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
     // Check the result like this so any output will show up in the logs if there are errors
     // (hard to debug otherwise)
     expect(publishResult).toEqual(expect.objectContaining({ success: true }));
@@ -77,16 +77,16 @@ describe('packagePublish', () => {
 
   it('errors on republish', async () => {
     const testPackageInfo = getTestPackageInfo(testTag);
-    let publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    let publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
-    publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
     expect(publishResult.success).toBeFalsy();
   });
 
   it('publish with no tag publishes latest', async () => {
     const testPackageInfo = getTestPackageInfo(null);
-    const publishResult = await packagePublish(testPackageInfo, registry.getUrl(), '', '');
+    const publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
     const expectedNpmResult: NpmShowResult = {
@@ -99,7 +99,7 @@ describe('packagePublish', () => {
 
   it('publish package with defaultNpmTag publishes as defaultNpmTag', async () => {
     const testPackageInfoWithDefaultNpmTag = getTestPackageInfo(null, testTag);
-    const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
+    const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, { registry: registry.getUrl() });
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
     const expectedNpmResult: NpmShowResult = {
@@ -112,7 +112,7 @@ describe('packagePublish', () => {
 
   it('publish with specified tag overrides defaultNpmTag', async () => {
     const testPackageInfoWithDefaultNpmTag = getTestPackageInfo(testTag, 'thisShouldNotBeUsed');
-    const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, registry.getUrl(), '', '');
+    const publishResult = await packagePublish(testPackageInfoWithDefaultNpmTag, { registry: registry.getUrl() });
     expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
 
     const expectedNpmResult: NpmShowResult = {

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -21,7 +21,7 @@ export async function canary(options: BeachballOptions) {
     }
   }
 
-  const packageVersions = await listPackageVersions([...bumpInfo.modifiedPackages], options.registry);
+  const packageVersions = await listPackageVersions([...bumpInfo.modifiedPackages], options);
 
   for (const pkg of bumpInfo.modifiedPackages) {
     let newVersion = oldPackageInfo[pkg].version;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -59,7 +59,7 @@ export async function publish(options: BeachballOptions) {
   const bumpInfo = gatherBumpInfo(options, oldPackageInfos);
 
   if (options.new) {
-    bumpInfo.newPackages = new Set<string>(await getNewPackages(bumpInfo, options.registry));
+    bumpInfo.newPackages = new Set<string>(await getNewPackages(bumpInfo, options));
   }
 
   // Step 1. Bump + npm publish

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -11,13 +11,7 @@ export async function sync(options: BeachballOptions) {
   const scopedPackages = new Set(getScopedPackages(options, packageInfos));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));
-  const publishedVersions = await listPackageVersionsByTag(
-    [...infos.values()],
-    options.registry,
-    options.tag,
-    options.token,
-    options.authType
-  );
+  const publishedVersions = await listPackageVersionsByTag([...infos.values()], options.tag, options);
 
   const modifiedPackages = new Set<string>();
 

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -7,7 +7,7 @@ let cachedCliOptions: CliOptions;
 export function getCliOptions(argv: string[]): CliOptions {
   // Special case caching to process.argv which should be immutable
   if (argv === process.argv) {
-    if (!cachedCliOptions) {
+    if (process.env.BEACHBALL_DISABLE_CACHE || !cachedCliOptions) {
       cachedCliOptions = getCliOptionsUncached(process.argv);
     }
     return cachedCliOptions;

--- a/src/options/getRepoOptions.ts
+++ b/src/options/getRepoOptions.ts
@@ -6,7 +6,7 @@ let cachedRepoOptions = new Map<CliOptions, RepoOptions>();
 
 export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
   const { configPath, path: cwd, branch } = cliOptions;
-  if (cachedRepoOptions.has(cliOptions)) {
+  if (!process.env.BEACHBALL_DISABLE_CACHE && cachedRepoOptions.has(cliOptions)) {
     return cachedRepoOptions.get(cliOptions)!;
   }
 

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -1,17 +1,10 @@
 import { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
 import { getNpmAuthArgs, npmAsync } from './npm';
-import { AuthType } from '../types/Auth';
+import { NpmOptions } from '../types/NpmOptions';
 
-export function packagePublish(
-  packageInfo: PackageInfo,
-  registry: string,
-  token: string,
-  access: string,
-  authType?: AuthType,
-  timeout?: number | undefined,
-  gitTimeout?: number | undefined
-) {
+export function packagePublish(packageInfo: PackageInfo, options: NpmOptions) {
+  const { registry, token, authType, access, timeout } = options;
   const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);
   const args = [

--- a/src/publish/getNewPackages.ts
+++ b/src/publish/getNewPackages.ts
@@ -1,12 +1,13 @@
 import { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
+import { NpmOptions } from '../types/NpmOptions';
 
-export async function getNewPackages(bumpInfo: BumpInfo, registry: string) {
+export async function getNewPackages(bumpInfo: BumpInfo, options: NpmOptions) {
   const { modifiedPackages, packageInfos } = bumpInfo;
 
   const newPackages = Object.keys(packageInfos).filter(pkg => !modifiedPackages.has(pkg));
 
-  const publishedVersions = await listPackageVersions(newPackages, registry);
+  const publishedVersions = await listPackageVersions(newPackages, options);
 
   return newPackages.filter(pkg => {
     const packageInfo = packageInfos[pkg];

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -14,7 +14,6 @@ import { performPublishOverrides } from './performPublishOverrides';
 type Unpromisify<T> = T extends Promise<infer U> ? U : never;
 
 export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions) {
-  const { registry, token, access, timeout, authType } = options;
   const bumpInfo = _.cloneDeep(originalBumpInfo);
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
@@ -25,7 +24,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
   const succeededPackages = new Set<string>();
 
   let invalid = false;
-  if (!(await validatePackageVersions(bumpInfo, registry))) {
+  if (!(await validatePackageVersions(bumpInfo, options))) {
     displayManualRecovery(bumpInfo, succeededPackages);
     invalid = true;
   } else if (!validatePackageDependencies(bumpInfo)) {
@@ -80,7 +79,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     let retries = 0;
 
     do {
-      result = await packagePublish(packageInfo, registry, token, access, authType, timeout);
+      result = await packagePublish(packageInfo, options);
 
       if (result.success) {
         console.log('Published!');

--- a/src/publish/validatePackageVersions.ts
+++ b/src/publish/validatePackageVersions.ts
@@ -1,11 +1,12 @@
 import { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
 import { shouldPublishPackage } from './shouldPublishPackage';
+import { NpmOptions } from '../types/NpmOptions';
 
 /**
  * Validate a package being published is not already published.
  */
-export async function validatePackageVersions(bumpInfo: BumpInfo, registry: string): Promise<boolean> {
+export async function validatePackageVersions(bumpInfo: BumpInfo, options: NpmOptions): Promise<boolean> {
   let hasErrors: boolean = false;
 
   const packages = [...bumpInfo.modifiedPackages].filter(pkg => {
@@ -18,7 +19,7 @@ export async function validatePackageVersions(bumpInfo: BumpInfo, registry: stri
     return true;
   });
 
-  const publishedVersions = await listPackageVersions(packages, registry);
+  const publishedVersions = await listPackageVersions(packages, options);
 
   for (const pkg of packages) {
     const packageInfo = bumpInfo.packageInfos[pkg];

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -41,7 +41,9 @@ export interface CliOptions
   keepChangeFiles?: boolean;
   new: boolean;
   package?: string | string[];
+  /** Timeout for npm operations (other than install, which is expected to take longer) */
   timeout?: number;
+  /** Timeout for `git push` operations */
   gitTimeout?: number;
   token: string;
   type?: ChangeType | null;

--- a/src/types/NpmOptions.ts
+++ b/src/types/NpmOptions.ts
@@ -1,0 +1,4 @@
+import { BeachballOptions } from './BeachballOptions';
+
+export type NpmOptions = Required<Pick<BeachballOptions, 'registry'>> &
+  Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout'>>;


### PR DESCRIPTION
Some npm operations weren't respecting the timeout, and npm options were being passed around in infinitely-expanding named parameter lists.

This PR updates npm operations to use a unified options type and respect the timeout.