### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,10 +40,12 @@ jobs:
           node-version-file: .nvmrc
 
       # Guarantee a predictable version of npm for the first round of tests
-      - name: Install package managers
-        run: npm install --global npm@${{ matrix.npm }} yarn@1
+      - name: Install npm@${{ matrix.npm }}
+        run: npm install --global npm@${{ matrix.npm }}
 
-      - run: yarn --frozen-lockfile
+      # Use midgard-yarn in CI because it's faster (especially on slow Windows CI machines)
+      - name: yarn
+        run: npx midgard-yarn install --frozen-lockfile
 
       - run: yarn build
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,15 +37,14 @@ jobs:
       - name: Install Node.js from .nvmrc
         uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .nvmrc
 
       # Guarantee a predictable version of npm for the first round of tests
       - name: Install npm@${{ matrix.npm }}
         run: npm install --global npm@${{ matrix.npm }}
 
-      # Use midgard-yarn in CI because it's faster (especially on slow Windows CI machines)
-      - name: yarn
-        run: npx midgard-yarn install --frozen-lockfile
+      - run: yarn --frozen-lockfile
 
       - run: yarn build
 


### PR DESCRIPTION
~~`yarn install` is super slow on Windows CI machines, so try using midgard-yarn to speed it up.~~

That didn't help...trying using [`actions/setup-node`](https://github.com/actions/setup-node)'s `cache` option instead?