### PR TITLE
Some test cleanup

### DIFF
--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -557,7 +557,7 @@ describe('version bumping', () => {
       },
     } as BeachballOptions);
 
-    expect(bumpResult).rejects.toThrow();
+    await expect(bumpResult).rejects.toThrow('Foo');
   });
 
   it('calls sync postbump hook before packages are bumped', async () => {
@@ -648,6 +648,6 @@ describe('version bumping', () => {
       },
     } as BeachballOptions);
 
-    expect(bumpResult).rejects.toThrow();
+    await expect(bumpResult).rejects.toThrow('Foo');
   });
 });

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -18,7 +18,7 @@ describe('publish command (e2e)', () => {
   let repositoryFactory: RepositoryFactory | undefined;
 
   // show error logs for these tests
-  initMockLogs(['error']);
+  initMockLogs({ alsoLog: ['error'] });
 
   function getOptions(repo: Repository, overrides?: Partial<BeachballOptions>): BeachballOptions {
     return {

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -345,12 +345,11 @@ describe('publish command (e2e)', () => {
 
     repo.push();
 
-    // Adds a step that injects a race condition
-    let depthString: string = '';
+    let fetchCommand: string = '';
 
     addGitObserver((args, output) => {
       if (args[0] === 'fetch') {
-        depthString = args[3];
+        fetchCommand = args.join(' ');
       }
     });
 
@@ -363,8 +362,7 @@ describe('publish command (e2e)', () => {
     };
     expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
 
-    // no fetch when flag set to false
-    expect(depthString).toEqual('--depth=10');
+    expect(fetchCommand).toMatch('--depth=10');
   });
 
   it('calls precommit hook before committing changes', async () => {

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -176,7 +176,9 @@ describe('publish command (registry)', () => {
       })
     );
 
-    await expect(publishPromise).rejects.toThrow();
+    await expect(publishPromise).rejects.toThrow(
+      'Error publishing! Refer to the previous logs for recovery instructions.'
+    );
     expect(
       logs.mocks.log.mock.calls.some(([arg0]) => typeof arg0 === 'string' && arg0.includes('Retrying... (3/3)'))
     ).toBeTruthy();

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -15,7 +15,7 @@ describe('publish command (registry)', () => {
   let repositoryFactory: RepositoryFactory | undefined;
 
   // show error logs for these tests
-  const logs = initMockLogs(['error']);
+  const logs = initMockLogs({ alsoLog: ['error'] });
 
   function getOptions(repo: Repository, overrides: Partial<BeachballOptions>): BeachballOptions {
     return {
@@ -159,7 +159,7 @@ describe('publish command (registry)', () => {
     registry.stop();
 
     // hide the errors for this test--it's supposed to have errors, and showing them is misleading
-    logs.init(false);
+    logs.setOverrideOptions({ alsoLog: false });
 
     repositoryFactory = new RepositoryFactory('single');
     const repo = repositoryFactory.cloneRepository();

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,66 +1,47 @@
-import { jest, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
+import { jest, afterEach, beforeAll, afterAll } from '@jest/globals';
 import type { SpyInstance } from 'jest-mock';
+import realConsole from 'console';
 
 /** Methods that will be mocked. More could be added later if needed. */
-export type MockLogMethod = 'log' | 'warn' | 'error';
+type MockLogMethod = 'log' | 'warn' | 'error';
 const mockedMethods: MockLogMethod[] = ['log', 'warn', 'error'];
 
-export type MockLogsOptions = {
+type MockLogsOptions = {
   /**
    * Whether to also log to the real console (or subset of methods to log to the console).
    * All logging can be enabled by setting the VERBOSE env var.
    */
   alsoLog?: boolean | MockLogMethod[];
-
-  /**
-   * If true, init and teardown in beforeAll/afterAll instead of beforeEach/afterEach.
-   */
-  onlyInitOnce?: boolean;
 };
 
 export type MockLogs = {
   /** Mocked methods (to access calls etc) */
   mocks: { [k in MockLogMethod]: SpyInstance<typeof console.log> };
+
   /** Actual console methods */
-  realConsole: typeof console;
-  /** Re-init the mocks for the current test (to use different options for this test) */
-  init: (alsoLog?: boolean | MockLogMethod[]) => void;
-  /** Restore mock implementations */
-  restore: () => void;
-  /** Get the lines logged to a particular method */
+  realConsole: typeof realConsole;
+
+  /** Set override options for one test only */
+  setOverrideOptions: (options: MockLogsOptions) => void;
+
+  /** Get the lines logged to a particular method) */
   getMockLines: (method: MockLogMethod) => string;
 };
 
 /**
  * Initialize console log mocks, which will be reset after each test. This should be called **outside**
- * of any lifecycle hooks or tests because it calls `beforeEach` and `afterEach` for setup and teardown.
+ * of any lifecycle hooks or tests because it calls lifecycle hooks internally for setup and teardown.
  */
-export function initMockLogs(options?: MockLogsOptions): MockLogs;
-/** @deprecated use object param version */
-export function initMockLogs(alsoLog: boolean | MockLogMethod[]): MockLogs;
-export function initMockLogs(opts?: MockLogsOptions | boolean | MockLogMethod[]): MockLogs {
-  const options = typeof opts === 'boolean' || Array.isArray(opts) ? { alsoLog: opts } : opts || {};
-  const { alsoLog, onlyInitOnce } = options;
+export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
+  const { alsoLog } = options;
+  let overrideOptions: MockLogsOptions | undefined;
 
   const logs: MockLogs = {
     mocks: {} as MockLogs['mocks'],
-    realConsole: { ...console },
-    init: (shouldLog = alsoLog) => {
-      logs.restore(); // clear any previous mocks
-      mockedMethods.forEach(method => {
-        const shouldLogMethod = typeof shouldLog === 'boolean' ? shouldLog : shouldLog?.includes(method);
-        logs.mocks[method] = jest
-          .spyOn(console, method)
-          .mockImplementation((...args) =>
-            shouldLogMethod || process.env.VERBOSE ? logs.realConsole[method](...args) : undefined
-          );
-      });
+    realConsole,
+    setOverrideOptions: options => {
+      overrideOptions = options;
     },
-    restore: () =>
-      Object.entries(logs.mocks).forEach(([name, mock]) => {
-        mock.mockRestore();
-        delete (logs.mocks as any)[name];
-      }),
     getMockLines: method =>
       logs.mocks[method].mock.calls
         .map(args => args.join(' '))
@@ -68,13 +49,32 @@ export function initMockLogs(opts?: MockLogsOptions | boolean | MockLogMethod[])
         .trim(),
   };
 
-  (onlyInitOnce ? beforeAll : beforeEach)(() => {
-    logs.init(alsoLog);
+  beforeAll(() => {
+    for (const method of mockedMethods) {
+      const mainShouldLog = shouldLog(method, alsoLog);
+
+      logs.mocks[method] = jest.spyOn(console, method).mockImplementation((...args) => {
+        const currentShouldLog =
+          overrideOptions === undefined ? mainShouldLog : shouldLog(method, overrideOptions.alsoLog);
+        if (process.env.VERBOSE || currentShouldLog) {
+          logs.realConsole[method](...args);
+        }
+      });
+    }
   });
 
-  (onlyInitOnce ? afterAll : afterEach)(() => {
-    logs.restore();
+  afterEach(() => {
+    overrideOptions = undefined;
+    Object.values(logs.mocks).forEach(mock => mock.mockClear());
+  });
+
+  afterAll(() => {
+    Object.values(logs.mocks).forEach(mock => mock.mockRestore());
   });
 
   return logs;
+}
+
+function shouldLog(method: MockLogMethod, alsoLog: boolean | MockLogMethod[] | undefined) {
+  return typeof alsoLog === 'boolean' ? alsoLog : alsoLog?.includes(method);
 }

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -262,6 +262,8 @@ describe('getPackageInfos', () => {
     const repo = multiWorkspaceFactory.cloneRepository();
     repo.updateJsonFile('workspace-a/packages/foo/package.json', { name: 'foo' });
     repo.updateJsonFile('workspace-b/packages/foo/package.json', { name: 'foo' });
-    expect(() => getPackageInfos(repo.rootPath)).toThrow();
+    expect(() => getPackageInfos(repo.rootPath)).toThrow(
+      /Two packages in different workspaces have the same name. Please rename one of these packages:/
+    );
   });
 });

--- a/src/__functional__/validation/isChangeFileNeeded.test.ts
+++ b/src/__functional__/validation/isChangeFileNeeded.test.ts
@@ -69,7 +69,7 @@ describe('isChangeFileNeeded', () => {
     const repo = repositoryFactory.cloneRepository();
     repo.git(['remote', 'set-url', defaultRemoteName, 'file:///__nonexistent']);
     repo.checkout('-b', 'feature-0');
-    repo.commitChange('CHANGELOG.md');
+    repo.commitChange('fake.js');
 
     expect(() => {
       isChangeFileNeeded(
@@ -80,6 +80,6 @@ describe('isChangeFileNeeded', () => {
         } as BeachballOptions,
         getPackageInfos(repo.rootPath)
       );
-    }).toThrow();
+    }).toThrow('Cannot fetch branch "master" from remote "origin"');
   });
 });

--- a/src/__tests__/changefile/promptForChange_getQuestionsForPackage.test.ts
+++ b/src/__tests__/changefile/promptForChange_getQuestionsForPackage.test.ts
@@ -22,11 +22,7 @@ describe('promptForChange _getQuestionsForPackage', () => {
     recentMessages: ['message'],
   };
 
-  /**
-   * Mock console logs. NOTE: Initialization is only done in before/after all (not cleared every test
-   * since only a few tests use logs), so tests should use `toHaveBeenLastCalledWith`.
-   */
-  const sharedLogs = initMockLogs({ onlyInitOnce: true });
+  const logs = initMockLogs();
 
   it('works in basic case', () => {
     const questions = _getQuestionsForPackage(defaultQuestionsParams);
@@ -61,7 +57,7 @@ describe('promptForChange _getQuestionsForPackage', () => {
       options: { type: 'major' } as BeachballOptions,
     });
     expect(questions).toBeUndefined();
-    expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('Change type "major" is not allowed for package "foo"');
+    expect(logs.mocks.error).toHaveBeenCalledWith('Change type "major" is not allowed for package "foo"');
   });
 
   it('errors if there are no valid change types for package', () => {
@@ -72,7 +68,7 @@ describe('promptForChange _getQuestionsForPackage', () => {
       }),
     });
     expect(questions).toBeUndefined();
-    expect(sharedLogs.mocks.error).toHaveBeenLastCalledWith('No valid change types available for package "foo"');
+    expect(logs.mocks.error).toHaveBeenCalledWith('No valid change types available for package "foo"');
   });
 
   it('respects disallowedChangeTypes', () => {

--- a/src/__tests__/publish/performPublishOverrides.test.ts
+++ b/src/__tests__/publish/performPublishOverrides.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, afterEach } from '@jest/globals';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { tmpdir } from '../../__fixtures__/tmpdir';
-import { acceptedKeys, performPublishOverrides } from '../../publish/performPublishOverrides';
+import { performPublishOverrides } from '../../publish/performPublishOverrides';
 import { PackageInfos } from '../../types/PackageInfo';
 
 describe('perform publishConfig overrides', () => {
@@ -90,12 +90,6 @@ describe('perform publishConfig overrides', () => {
     expect(modified.publishConfig.main).toBeUndefined();
     expect(modified.publishConfig.bin).toBeUndefined();
     expect(modified.publishConfig.files).toBeUndefined();
-  });
-
-  it('should always at least accept types, main, and module', () => {
-    expect(acceptedKeys).toContain('main');
-    expect(acceptedKeys).toContain('module');
-    expect(acceptedKeys).toContain('types');
   });
 });
 

--- a/src/__tests__/publish/toposortPackages.test.ts
+++ b/src/__tests__/publish/toposortPackages.test.ts
@@ -51,7 +51,7 @@ describe('toposortPackages', () => {
 
     expect(() => {
       toposortPackages(['foo', 'bar'], packageInfos);
-    }).toThrow();
+    }).toThrow(/Cyclic dependency.*?foo/);
   });
 
   it('throws if package info is missing', () => {
@@ -59,6 +59,6 @@ describe('toposortPackages', () => {
 
     expect(() => {
       toposortPackages(['foo'], packageInfos);
-    }).toThrow();
+    }).toThrow('Package info is missing for foo.');
   });
 });


### PR DESCRIPTION
Tests using `expect(...).toThrow()` should always check for a specific error message to avoid hiding unexpected errors.

Simplify the mock log setup.

And a few other small fixes.