### PR TITLE
Improve getChangedPackages logging and add more tests

### DIFF
--- a/change/beachball-41697bc4-654b-469a-a08f-75705c9c34f0.json
+++ b/change/beachball-41697bc4-654b-469a-a08f-75705c9c34f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve getChangedPackages logging",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -315,7 +315,6 @@ describe('publish command (e2e)', () => {
 
     repo.push();
 
-    // Adds a step that injects a race condition
     let fetchCount = 0;
 
     addGitObserver((args, output) => {

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -179,8 +179,6 @@ describe('publish command (registry)', () => {
     await expect(publishPromise).rejects.toThrow(
       'Error publishing! Refer to the previous logs for recovery instructions.'
     );
-    expect(
-      logs.mocks.log.mock.calls.some(([arg0]) => typeof arg0 === 'string' && arg0.includes('Retrying... (3/3)'))
-    ).toBeTruthy();
+    expect(logs.getMockLines('log')).toMatch('Retrying... (3/3)');
   });
 });

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -21,7 +21,7 @@ export function npmShow(
   packageName: string,
   shouldFail: boolean = false
 ): NpmShowResult | undefined {
-  const timeout = process.env.CI && os.platform() === 'win32' ? 3000 : 1000;
+  const timeout = process.env.CI && os.platform() === 'win32' ? 4500 : 1500;
   const start = Date.now();
   const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json'], { timeout });
   if (Date.now() - start > timeout) {

--- a/src/__fixtures__/registry.ts
+++ b/src/__fixtures__/registry.ts
@@ -89,7 +89,7 @@ export class Registry {
       }
 
       if (!this.server || !this.server.stdout || !this.server.stderr) {
-        return reject('server not initialized correctly');
+        return reject(new Error('server not initialized correctly'));
       }
 
       this.server.stdout.on('data', data => {
@@ -100,11 +100,14 @@ export class Registry {
       });
 
       this.server.stderr.on('data', data => {
-        reject(data?.toString());
+        const dataStr = String(data);
+        if (!dataStr.includes('Debugger attached')) {
+          reject(new Error(dataStr));
+        }
       });
 
       this.server.on('error', data => {
-        reject(data);
+        reject(new Error(String(data)));
       });
     });
   }

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -8,6 +8,8 @@ import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { PackageInfos, PackageInfo } from '../types/PackageInfo';
 
+const count = (count: number, str: string) => `${count} ${str}${count === 1 ? '' : 's'}`;
+
 /**
  * Ensure that adequate history is available to check for changes between HEAD and `options.branch`.
  * Otherwise attempting to get changes will fail with an error "no merge base".
@@ -118,7 +120,7 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
   const logIncluded = (file: string) => verboseLog(`  - ${file}`);
 
   const changes = [...(getChanges(branch, cwd) || []), ...(getStagedChanges(cwd) || [])];
-  verboseLog(`Found ${changes.length} changed files in branch "${branch}" (before filtering)`);
+  verboseLog(`Found ${count(changes.length, 'changed file')} in branch "${branch}" (before filtering)`);
 
   if (!changes.length) {
     return [];
@@ -168,7 +170,9 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
     }
   }
 
-  verboseLog(`Found ${fileCount} files in ${includedPackages.size} packages that should be published`);
+  verboseLog(
+    `Found ${count(fileCount, 'file')} in ${count(includedPackages.size, 'package')} that should be published`
+  );
 
   return [...includedPackages];
 }


### PR DESCRIPTION
Use correct singular/plural with numbers in `getChangedPackages` logging and add a lot more tests for basic cases that were missing coverage.