### PR TITLE
Combine and add comments for git tag methods, and move tag helper

### DIFF
--- a/change/beachball-9cd18eea-64c8-4889-ba02-9e881acdabd9.json
+++ b/change/beachball-9cd18eea-64c8-4889-ba02-9e881acdabd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combine and add comments for git tag methods, and move tag helper",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { PackageInfo } from '../types/PackageInfo';
 import { PackageChangelog } from '../types/ChangeLog';
-import { generateTag } from '../tag';
+import { generateTag } from '../git/generateTag';
 import { BumpInfo } from '../types/BumpInfo';
 import { getChangePath } from '../paths';
 import { getCurrentHash, getFileAddedHash } from 'workspace-tools';

--- a/src/changelog/mergeChangelogs.ts
+++ b/src/changelog/mergeChangelogs.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { PackageChangelog } from '../types/ChangeLog';
 import { PackageInfo } from '../types/PackageInfo';
-import { generateTag } from '../tag';
+import { generateTag } from '../git/generateTag';
 import { ChangeType } from '../types/ChangeInfo';
 
 /**

--- a/src/changelog/renderJsonChangelog.ts
+++ b/src/changelog/renderJsonChangelog.ts
@@ -1,4 +1,4 @@
-import { generateTag } from '../tag';
+import { generateTag } from '../git/generateTag';
 import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/ChangeLog';
 
 export function renderJsonChangelog(changelog: PackageChangelog, previousChangelog: ChangelogJson | undefined) {

--- a/src/git/generateTag.ts
+++ b/src/git/generateTag.ts
@@ -1,3 +1,4 @@
+/** Get a standardized package version git tag: `${name}_v${version}` */
 export function generateTag(name: string, version: string) {
   return `${name}_v${version}`;
 }

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -2,14 +2,14 @@ import { performBump } from '../bump/performBump';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { git, revertLocalChanges, parseRemoteBranch } from 'workspace-tools';
-import { tagDistTag, tagPackages } from './tagPackages';
+import { tagPackages } from './tagPackages';
 import { mergePublishBranch } from './mergePublishBranch';
 import { displayManualRecovery } from './displayManualRecovery';
 
 const BUMP_PUSH_RETRIES = 5;
 
 export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
-  const { path: cwd, branch, tag, depth, message, gitTimeout } = options;
+  const { path: cwd, branch, depth, message, gitTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
 
   let completed = false;
@@ -50,10 +50,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     }
 
     // Tag & Push to remote
-    tagPackages(bumpInfo, cwd);
-    if (options.gitTags) {
-      tagDistTag(tag, cwd);
-    }
+    tagPackages(bumpInfo, options);
 
     console.log(`pushing to ${branch}, running the following command for git push:`);
     const pushArgs = ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`];

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -1,15 +1,22 @@
 import { BumpInfo } from '../types/BumpInfo';
-import { generateTag } from '../tag';
+import { generateTag } from '../git/generateTag';
 import { gitFailFast } from 'workspace-tools';
+import { BeachballOptions } from '../types/BeachballOptions';
 
 function createTag(tag: string, cwd: string) {
   gitFailFast(['tag', '-a', '-f', tag, '-m', tag], { cwd });
 }
 
-export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
+/**
+ * Create git tags for each changed package, unless the package or repo has opted out of git tags.
+ * Also, if git tags aren't disabled for the repo and the overall dist-tag (`options.tag`) has a
+ * non-default value (not "latest"), create a git tag for the dist-tag.
+ */
+export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 'gitTags' | 'path' | 'tag'>) {
+  const { gitTags, tag: distTag, path: cwd } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
-  [...modifiedPackages, ...newPackages].forEach(pkg => {
+  for (const pkg of [...modifiedPackages, ...newPackages]) {
     const packageInfo = bumpInfo.packageInfos[pkg];
     const changeType = bumpInfo.calculatedChangeTypes[pkg];
     // Do not tag change type of "none", private packages, or packages opting out of tagging
@@ -19,11 +26,9 @@ export function tagPackages(bumpInfo: BumpInfo, cwd: string) {
     console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
     const generatedTag = generateTag(packageInfo.name, packageInfo.version);
     createTag(generatedTag, cwd);
-  });
-}
+  }
 
-export function tagDistTag(tag: string, cwd: string) {
-  if (tag && tag !== 'latest') {
-    createTag(tag, cwd);
+  if (gitTags && distTag && distTag !== 'latest') {
+    createTag(distTag, cwd);
   }
 }


### PR DESCRIPTION
Make the code for git tag creation during publish less confusing by combining the two related functions and adding comments.

Also move the git tag name helper from the `src` root to a folder `src/git`.