### PR TITLE
Report all package/group validation errors instead of short circuiting

### DIFF
--- a/change/beachball-d7948994-9dad-4ef4-b9a9-2d705d933810.json
+++ b/change/beachball-d7948994-9dad-4ef4-b9a9-2d705d933810.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Report all package/group validation errors instead of short circuiting",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -1,6 +1,12 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { getWorkspaces, listAllTrackedFiles, findPackageRoot, findProjectRoot } from 'workspace-tools';
+import {
+  getWorkspaces as getWorkspacePackages,
+  listAllTrackedFiles,
+  findPackageRoot,
+  findProjectRoot,
+  WorkspaceInfo,
+} from 'workspace-tools';
 import { PackageInfos } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 
@@ -21,63 +27,70 @@ export function getPackageInfos(cwd: string): PackageInfos {
 }
 
 function getPackageInfosFromWorkspace(projectRoot: string) {
+  let workspacePackages: WorkspaceInfo | undefined;
   try {
-    const packageInfos: PackageInfos = {};
-
     // first try using the workspace provided packages (if available)
-    const workspaceInfo = getWorkspaces(projectRoot);
-
-    if (workspaceInfo && workspaceInfo.length > 0) {
-      workspaceInfo.forEach(info => {
-        const { path: packagePath, packageJson } = info;
-        const packageJsonPath = path.join(packagePath, 'package.json');
-
-        try {
-          packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
-        } catch (e) {
-          // Pass, the package.json is invalid
-          console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
-        }
-      });
-
-      return packageInfos;
-    }
+    workspacePackages = getWorkspacePackages(projectRoot);
   } catch (e) {
     // not a recognized workspace from workspace-tools
   }
+
+  if (!workspacePackages?.length) {
+    return;
+  }
+
+  const packageInfos: PackageInfos = {};
+
+  for (const { path: packagePath, packageJson } of workspacePackages) {
+    const packageJsonPath = path.join(packagePath, 'package.json');
+
+    try {
+      packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
+    } catch (e) {
+      // Pass, the package.json is invalid
+      console.warn(`Problem processing ${packageJsonPath}: ${e}`);
+    }
+  }
+
+  return packageInfos;
 }
 
 function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string) {
   const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], projectRoot);
+  if (!packageJsonFiles.length) {
+    return;
+  }
 
   const packageInfos: PackageInfos = {};
 
-  if (packageJsonFiles && packageJsonFiles.length > 0) {
-    packageJsonFiles.forEach(packageJsonPath => {
-      let hasDuplicatePackage = false;
-      try {
-        const packageJsonFullPath = path.join(projectRoot, packageJsonPath);
-        const packageJson = fs.readJSONSync(packageJsonFullPath);
-        if (packageInfos[packageJson.name]) {
-          hasDuplicatePackage = true;
-          throw new Error(
-            `Two packages in different workspaces have the same name. Please rename one of these packages:\n- ${
-              packageInfos[packageJson.name].packageJsonPath
-            }\n- ${packageJsonPath}`
-          );
-        }
-        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
-      } catch (e) {
-        if (hasDuplicatePackage) {
-          throw e; // duplicate package error should propagate
-        }
-        // Pass, the package.json is invalid
-        console.warn(`Invalid package.json file detected ${packageJsonPath}: `, e);
-      }
-    });
+  let hasError = false;
 
-    return packageInfos;
+  for (const packageJsonPath of packageJsonFiles) {
+    try {
+      const packageJsonFullPath = path.join(projectRoot, packageJsonPath);
+      const packageJson = fs.readJSONSync(packageJsonFullPath);
+      if (!packageInfos[packageJson.name]) {
+        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
+      } else {
+        console.error(
+          `ERROR: Two packages have the same name "${packageJson.name}". Please rename one of these packages:\n` +
+            `- ${path.relative(projectRoot, packageInfos[packageJson.name].packageJsonPath)}\n` +
+            `- ${packageJsonPath}`
+        );
+        // Keep going so we can log all the errors
+        hasError = true;
+      }
+    } catch (e) {
+      // Pass, the package.json is invalid
+      console.warn(`Problem processing ${packageJsonPath}: ${e}`);
+    }
   }
+
+  if (hasError) {
+    throw new Error('Duplicate package names found (see above for details)');
+  }
+
+  return packageInfos;
 }
 
 function getPackageInfosFromSingleRepo(packageRoot: string) {


### PR DESCRIPTION
Previously, `getPackageGroups` and some of the `getPackageInfos` helpers would throw or exit on the first detected error, which could hide later errors and require more overall time spent debugging.

This PR updates those functions to check for and report all errors before exiting. I also added early bailouts for "base cases" of those functions to reduce nesting and increase readability.