### PR TITLE
Centralize handling of environment variables

### DIFF
--- a/change/beachball-6aa96220-94df-4c01-9f39-bef7a7b27685.json
+++ b/change/beachball-6aa96220-94df-4c01-9f39-bef7a7b27685.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Centralize handling of environment variables",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -1,5 +1,6 @@
 import { expect } from '@jest/globals';
 import os from 'os';
+import { env } from '../env';
 import { npm } from '../packageManager/npm';
 import { Registry } from './registry';
 
@@ -21,7 +22,7 @@ export function npmShow(
   packageName: string,
   shouldFail: boolean = false
 ): NpmShowResult | undefined {
-  const timeout = process.env.CI && os.platform() === 'win32' ? 4500 : 1500;
+  const timeout = env.isCI && os.platform() === 'win32' ? 4500 : 1500;
   const start = Date.now();
   const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json'], { timeout });
   if (Date.now() - start > timeout) {

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import { tmpdir } from './tmpdir';
 import { git } from 'workspace-tools';
 import { defaultBranchName, defaultRemoteName, optsWithLang, setDefaultBranchName } from './gitDefaults';
+import { env } from '../env';
 
 /**
  * Clone options. See the docs for details on behavior and interaction of these options.
@@ -212,7 +213,7 @@ ${gitResult.stderr.toString()}`);
   cleanUp() {
     try {
       // This occasionally throws on Windows with "resource busy"
-      if (this.root && !process.env.CI) {
+      if (this.root && !env.isCI) {
         fs.removeSync(this.root);
       }
     } catch (err) {

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -6,6 +6,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { tmpdir } from './tmpdir';
 import { gitFailFast } from 'workspace-tools';
 import { setDefaultBranchName } from './gitDefaults';
+import { env } from '../env';
 
 /**
  * Standard fixture options. See {@link getSinglePackageFixture}, {@link getMonorepoFixture} and
@@ -236,7 +237,7 @@ export class RepositoryFactory {
 
     try {
       // This occasionally throws on Windows with "resource busy"
-      if (this.root && !process.env.CI) {
+      if (this.root && !env.isCI) {
         fs.removeSync(this.root);
       }
     } catch (err) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,20 @@
+const isAzurePipelines = !!process.env.TF_BUILD;
+
+export const env = Object.freeze({
+  // most everything but ADO sets process.env.CI by default
+  isCI: !!process.env.CI || isAzurePipelines,
+
+  isJest: !!process.env.JEST_WORKER_ID,
+
+  /**
+   * @deprecated This should likely be replaced with a different strategy (it's never set)
+   * but actually disabling all the caching e.g. whenever running in jest would cause major
+   * test perf issues due to various methods being called too many times. Leaving it for now
+   * because it makes it easy to find the places that are doing cachine.
+   */
+  beachballDisableCache: !!process.env.BEACHBALL_DISABLE_CACHE,
+
+  // These are borrowed from workspace-tools
+  workspaceToolsGitDebug: !!process.env.GIT_DEBUG,
+  workspaceToolsGitMaxBuffer: (process.env.GIT_MAX_BUFFER && parseInt(process.env.GIT_MAX_BUFFER, 10)) || undefined,
+});

--- a/src/git/gitAsync.ts
+++ b/src/git/gitAsync.ts
@@ -1,4 +1,5 @@
 import execa from 'execa';
+import { env } from '../env';
 
 // cwd is required here
 // stdio behavior is overridden
@@ -80,12 +81,8 @@ export function getGitEnv(verbose: boolean | undefined): {
   /** Max buffer for git operations, copied from workspace-tools implementation */
   maxBuffer: number;
 } {
-  verbose = verbose || !!process.env.GIT_DEBUG;
-  const isJest = !!process.env.JEST_WORKER_ID;
-  const maxBuffer = process.env.GIT_MAX_BUFFER && parseInt(process.env.GIT_MAX_BUFFER, 10);
   return {
-    shouldLog: verbose ? (isJest ? 'end' : 'live') : false,
-    // isVerbose: verbose || !!process.env.GIT_DEBUG,
-    maxBuffer: maxBuffer || 500 * 1024 * 1024,
+    shouldLog: verbose || env.workspaceToolsGitDebug ? (env.isJest ? 'end' : 'live') : false,
+    maxBuffer: env.workspaceToolsGitMaxBuffer || 500 * 1024 * 1024,
   };
 }

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -1,13 +1,14 @@
 import parser from 'yargs-parser';
 import { CliOptions } from '../types/BeachballOptions';
 import { getDefaultRemoteBranch, findProjectRoot } from 'workspace-tools';
+import { env } from '../env';
 
 let cachedCliOptions: CliOptions;
 
 export function getCliOptions(argv: string[]): CliOptions {
   // Special case caching to process.argv which should be immutable
   if (argv === process.argv) {
-    if (process.env.BEACHBALL_DISABLE_CACHE || !cachedCliOptions) {
+    if (env.beachballDisableCache || !cachedCliOptions) {
       cachedCliOptions = getCliOptionsUncached(process.argv);
     }
     return cachedCliOptions;

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -1,3 +1,4 @@
+import { env } from '../env';
 import { BeachballOptions } from '../types/BeachballOptions';
 
 export function getDefaultOptions() {
@@ -14,7 +15,7 @@ export function getDefaultOptions() {
     token: '',
     gitTags: true,
     tag: '',
-    yes: !!(process.env.CI || process.env.TF_BUILD),
+    yes: env.isCI,
     access: 'restricted',
     changehint: 'Run "beachball change" to create a change file',
     type: null,

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -4,6 +4,7 @@ import { getCliOptions } from './getCliOptions';
 import { getRepoOptions } from './getRepoOptions';
 import { getDefaultOptions } from './getDefaultOptions';
 import path from 'path';
+import { env } from '../env';
 
 /**
  * Gets all package level options (default + root options + package options + cli options)
@@ -12,7 +13,7 @@ import path from 'path';
 export function getCombinedPackageOptions(actualPackageOptions: Partial<PackageOptions>): PackageOptions {
   const defaultOptions = getDefaultOptions();
   // Don't use options from process.argv or the beachball repo in tests
-  const cliOptions = process.env.NODE_ENV !== 'test' && getCliOptions(process.argv);
+  const cliOptions = !env.isJest && getCliOptions(process.argv);
   const repoOptions = cliOptions && getRepoOptions(cliOptions);
   return {
     ...defaultOptions,

--- a/src/options/getRepoOptions.ts
+++ b/src/options/getRepoOptions.ts
@@ -1,12 +1,13 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import { getDefaultRemoteBranch } from 'workspace-tools';
+import { env } from '../env';
 import { RepoOptions, CliOptions, BeachballOptions } from '../types/BeachballOptions';
 
 let cachedRepoOptions = new Map<CliOptions, RepoOptions>();
 
 export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
   const { configPath, path: cwd, branch } = cliOptions;
-  if (!process.env.BEACHBALL_DISABLE_CACHE && cachedRepoOptions.has(cliOptions)) {
+  if (!env.beachballDisableCache && cachedRepoOptions.has(cliOptions)) {
     return cachedRepoOptions.get(cliOptions)!;
   }
 

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -2,6 +2,7 @@ import { getNpmAuthArgs, npmAsync } from './npm';
 import pLimit from 'p-limit';
 import { PackageInfo } from '../types/PackageInfo';
 import { NpmOptions } from '../types/NpmOptions';
+import { env } from '../env';
 
 const packageVersionsCache: { [pkgName: string]: any } = {};
 
@@ -10,7 +11,7 @@ const NPM_CONCURRENCY = 5;
 async function getNpmPackageInfo(packageName: string, options: NpmOptions) {
   const { registry, token, authType, timeout } = options;
 
-  if (process.env.BEACHBALL_DISABLE_CACHE || !packageVersionsCache[packageName]) {
+  if (env.beachballDisableCache || !packageVersionsCache[packageName]) {
     const args = ['show', '--registry', registry, '--json', packageName, ...getNpmAuthArgs(registry, token, authType)];
 
     const showResult = await npmAsync(args, { timeout });


### PR DESCRIPTION
Move most environment variable access to a file `env.ts`. This allows type checking (prevents typos in names), fallbacks, and compound variables like `isCI` which take into account multiple platforms' variables.