### PR TITLE
Minor cleanup and tests for listPackageVersions

### DIFF
--- a/change/beachball-352b1a99-a2ae-4ba6-b8c1-7d3ed1a2e44d.json
+++ b/change/beachball-352b1a99-a2ae-4ba6-b8c1-7d3ed1a2e44d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor cleanup of listPackageVersions",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/beachball-352b1a99-a2ae-4ba6-b8c1-7d3ed1a2e44d.json
+++ b/change/beachball-352b1a99-a2ae-4ba6-b8c1-7d3ed1a2e44d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Minor cleanup of listPackageVersions",
+  "comment": "Minor cleanup of listPackageVersions and getNewPackages",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -1,0 +1,52 @@
+import { afterAll, afterEach, beforeAll, jest } from '@jest/globals';
+import { npmAsync } from '../packageManager/npm';
+
+type NpmShowResult = {
+  versions?: string[];
+  'dist-tags'?: Record<string, string>;
+};
+
+/** Mapping from package name to value to return from npm show */
+type NpmShowMockData = Record<string, NpmShowResult>;
+
+/**
+ * Mock the `npm show` command for `npmAsync` calls.
+ * Other commands could potentially be mocked in the future.
+ */
+export function initNpmAsyncMock() {
+  const npmSpy = npmAsync as jest.MockedFunction<typeof npmAsync>;
+  if (!npmSpy.mock) {
+    throw new Error('npmAsync() is not currently mocked');
+  }
+
+  let showData: NpmShowMockData | undefined;
+
+  beforeAll(() => {
+    npmSpy.mockImplementation(args => {
+      if (args[0] !== 'show') throw new Error('unrecognized npm command: ' + args.join(' '));
+      if (!showData) throw new Error('npm show called before npmMock.setShowData()');
+
+      const packageName = args.slice(-1)[0];
+      const data = showData[packageName];
+      const stdout = data ? JSON.stringify(data) : '';
+
+      return Promise.resolve({ stdout, success: !!data }) as ReturnType<typeof npmAsync>;
+    });
+  });
+
+  afterEach(() => {
+    showData = undefined;
+    npmSpy.mockClear();
+  });
+
+  afterAll(() => {
+    npmSpy.mockRestore();
+  });
+
+  return {
+    spy: npmSpy,
+    setShowData: (data: NpmShowMockData) => {
+      showData = data;
+    },
+  };
+}

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -10,6 +10,7 @@ export type NpmShowResult = {
   versions: string[];
   main?: string;
   'dist-tags': Record<string, string>;
+  dependencies?: Record<string, string>;
 };
 
 /**
@@ -23,11 +24,11 @@ export function npmShow(
   shouldFail: boolean = false
 ): NpmShowResult | undefined {
   const timeout = env.isCI && os.platform() === 'win32' ? 4500 : 1500;
-  const start = Date.now();
+  // const start = Date.now();
   const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json'], { timeout });
-  if (Date.now() - start > timeout) {
-    throw new Error(`npm show ${packageName} took more than ${timeout}ms`);
-  }
+  // if (Date.now() - start > timeout) {
+  //   throw new Error(`npm show ${packageName} took more than ${timeout}ms`);
+  // }
   expect(showResult.failed).toBe(shouldFail);
   return shouldFail ? undefined : JSON.parse(showResult.stdout);
 }

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
-import _ from 'lodash';
 
 import { generateChangeFiles } from '../../__fixtures__/changeFiles';
 import { initMockLogs } from '../../__fixtures__/mockLogs';

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import _ from 'lodash';
+import {
+  listPackageVersions,
+  listPackageVersionsByTag,
+  _clearPackageVersionsCache,
+} from '../../packageManager/listPackageVersions';
+import { NpmOptions } from '../../types/NpmOptions';
+import { initNpmAsyncMock } from '../../__fixtures__/mockNpm';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+// unfortunately it appears this has to be done in the test file, not by mockNpm
+jest.mock('../../packageManager/npm', () => {
+  const npm = jest.requireActual<typeof import('../../packageManager/npm')>('../../packageManager/npm');
+  return { ...npm, npm: jest.fn(), npmAsync: jest.fn() };
+});
+
+describe('list npm versions', () => {
+  /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
+  const npmMock = initNpmAsyncMock();
+  const npmOptions: NpmOptions = { registry: 'https://fake' };
+
+  afterEach(() => {
+    _clearPackageVersionsCache();
+  });
+
+  describe('listPackageVersions', () => {
+    it('succeeds with nothing to do', async () => {
+      expect(await listPackageVersions([], npmOptions)).toEqual({});
+      expect(npmMock.spy).not.toHaveBeenCalled();
+    });
+
+    it('returns versions for one package', async () => {
+      npmMock.setShowData({ foo: { versions: ['1.0.0', '1.0.1'] } });
+      expect(await listPackageVersions(['foo'], npmOptions)).toEqual({ foo: ['1.0.0', '1.0.1'] });
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.spy).toHaveBeenCalledWith(
+        ['show', '--registry', 'https://fake', '--json', 'foo'],
+        expect.anything()
+      );
+    });
+
+    it('returns empty versions array for missing package', async () => {
+      npmMock.setShowData({});
+      expect(await listPackageVersions(['foo'], npmOptions)).toEqual({ foo: [] });
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.spy).toHaveBeenCalledWith(
+        ['show', '--registry', 'https://fake', '--json', 'foo'],
+        expect.anything()
+      );
+    });
+
+    it('returns versions for multiple packages', async () => {
+      const packages = 'abcdefghij'.split('');
+      const showData = Object.fromEntries(packages.map((x, i) => [x, { versions: [`${i}.0.0`, `${i}.0.1`] }]));
+      npmMock.setShowData(showData);
+
+      expect(await listPackageVersions(packages, npmOptions)).toEqual(_.mapValues(showData, x => x.versions));
+      expect(npmMock.spy).toHaveBeenCalledTimes(packages.length);
+    });
+
+    it('returns versions for multiple packages with some missing', async () => {
+      npmMock.setShowData({ foo: { versions: ['1.0.0', '1.0.1'] } });
+      expect(await listPackageVersions(['foo', 'bar'], npmOptions)).toEqual({ foo: ['1.0.0', '1.0.1'], bar: [] });
+      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('respects password auth args', async () => {
+      npmMock.setShowData({});
+      await listPackageVersions(['foo'], { ...npmOptions, authType: 'password', token: 'pass' });
+      expect(npmMock.spy).toHaveBeenCalledWith(
+        ['show', '--registry', 'https://fake', '--json', 'foo', '--//fake:_password=pass'],
+        expect.anything()
+      );
+    });
+
+    it('respects token auth args', async () => {
+      npmMock.setShowData({});
+      await listPackageVersions(['foo'], { ...npmOptions, authType: 'authtoken', token: 'pass' });
+      expect(npmMock.spy).toHaveBeenCalledWith(
+        ['show', '--registry', 'https://fake', '--json', 'foo', '--//fake:_authToken=pass'],
+        expect.anything()
+      );
+    });
+  });
+
+  describe('listPackageVersionsByTag', () => {
+    it('succeeds with nothing to do', async () => {
+      expect(await listPackageVersionsByTag([], undefined, npmOptions)).toEqual({});
+      expect(await listPackageVersionsByTag([], 'beta', npmOptions)).toEqual({});
+      expect(npmMock.spy).not.toHaveBeenCalled();
+    });
+
+    it('returns requested tag for one package', async () => {
+      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      const packageInfos = Object.values(
+        makePackageInfos({ foo: { combinedOptions: { tag: 'latest', defaultNpmTag: 'latest' } } })
+      );
+
+      const versions = await listPackageVersionsByTag(packageInfos, 'beta', npmOptions);
+      expect(versions).toEqual({ foo: '2.0.0-beta' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.spy).toHaveBeenCalledWith(
+        ['show', '--registry', 'https://fake', '--json', 'foo'],
+        expect.anything()
+      );
+    });
+
+    it('returns requested tag for multiple packages', async () => {
+      npmMock.setShowData({
+        foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
+        bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
+      });
+      const packageInfos = Object.values(
+        makePackageInfos({
+          foo: { combinedOptions: { tag: 'latest' } },
+          bar: { combinedOptions: { tag: 'latest' } },
+        })
+      );
+
+      const versions = await listPackageVersionsByTag(packageInfos, 'beta', npmOptions);
+      expect(versions).toEqual({ foo: '2.0.0-beta', bar: '3.0.0-beta' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns versions for many packages', async () => {
+      const packages = 'abcdefghij'.split('');
+      const showData = Object.fromEntries(packages.map((x, i) => [x, { 'dist-tags': { latest: `${i}.0.0` } }]));
+      npmMock.setShowData(showData);
+      const packageInfos = Object.values(makePackageInfos(_.mapValues(showData, () => ({}))));
+
+      expect(await listPackageVersionsByTag(packageInfos, 'latest', npmOptions)).toEqual(
+        _.mapValues(showData, x => x['dist-tags']?.latest)
+      );
+      expect(npmMock.spy).toHaveBeenCalledTimes(packages.length);
+    });
+
+    it('falls back to combinedOptions.tag', async () => {
+      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      const packageInfos = Object.values(
+        makePackageInfos({ foo: { combinedOptions: { tag: 'beta', defaultNpmTag: 'latest' } } })
+      );
+
+      const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
+      expect(versions).toEqual({ foo: '2.0.0-beta' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to combinedOptions.defaultNpmTag if combinedOptions.tag is unset', async () => {
+      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      const packageInfos = Object.values(makePackageInfos({ foo: { combinedOptions: { defaultNpmTag: 'beta' } } }));
+
+      const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
+      expect(versions).toEqual({ foo: '2.0.0-beta' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty if no dist-tags available', async () => {
+      npmMock.setShowData({});
+      const packageInfos = Object.values(makePackageInfos({ foo: {} }));
+
+      const versions = await listPackageVersionsByTag(packageInfos, 'latest', npmOptions);
+      expect(versions).toEqual({});
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty if no matching dist-tags available', async () => {
+      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      const packageInfos = Object.values(makePackageInfos({ foo: {} }));
+
+      const versions = await listPackageVersionsByTag(packageInfos, 'missing', npmOptions);
+      expect(versions).toEqual({});
+      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to different tag option for different packages', async () => {
+      npmMock.setShowData({
+        foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
+        bar: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
+      });
+      const packageInfos = Object.values(
+        makePackageInfos({
+          foo: { combinedOptions: { defaultNpmTag: 'latest' } },
+          bar: { combinedOptions: { tag: 'beta', defaultNpmTag: 'latest' } },
+        })
+      );
+
+      const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
+      expect(versions).toEqual({ foo: '1.0.0', bar: '2.0.0-beta' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns versions for multiple packages with some missing', async () => {
+      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0' } } });
+      const packageInfos = Object.values(makePackageInfos({ foo: {}, bar: {} }));
+
+      const versions = await listPackageVersionsByTag(packageInfos, 'latest', npmOptions);
+      expect(versions).toEqual({ foo: '1.0.0' });
+      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import _ from 'lodash';
+import { _clearPackageVersionsCache } from '../../packageManager/listPackageVersions';
+import { getNewPackages } from '../../publish/getNewPackages';
+import { NpmOptions } from '../../types/NpmOptions';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { initNpmAsyncMock } from '../../__fixtures__/mockNpm';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+
+// unfortunately it appears this has to be done in the test file, not by mockNpm
+jest.mock('../../packageManager/npm', () => {
+  const npm = jest.requireActual<typeof import('../../packageManager/npm')>('../../packageManager/npm');
+  return { ...npm, npm: jest.fn(), npmAsync: jest.fn() };
+});
+
+describe('getNewPackages', () => {
+  const logs = initMockLogs();
+  /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
+  const npmMock = initNpmAsyncMock();
+  const npmOptions = {} as NpmOptions;
+
+  afterEach(() => {
+    _clearPackageVersionsCache();
+  });
+
+  it('returns empty if no packages exist', async () => {
+    const newPackages = await getNewPackages({ modifiedPackages: new Set(), packageInfos: {} }, npmOptions);
+    expect(newPackages).toEqual([]);
+    expect(npmMock.spy).not.toHaveBeenCalled();
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('returns empty if all packages are modified not new', async () => {
+    const modifiedPackages = new Set(['foo', 'bar']);
+    const packageInfos = makePackageInfos({ foo: {}, bar: {} });
+
+    const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
+    expect(newPackages).toEqual([]);
+    expect(npmMock.spy).not.toHaveBeenCalled();
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('returns empty if no packages are new', async () => {
+    // foo and bar aren't modified locally but already exist in the registry
+    npmMock.setShowData({ foo: { versions: ['1.0.0'] }, bar: { versions: ['1.0.0'] } });
+    const modifiedPackages = new Set<string>();
+    const packageInfos = makePackageInfos({ foo: {}, bar: {} });
+
+    const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
+    expect(newPackages).toEqual([]);
+    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('returns new packages with no modified packagess', async () => {
+    npmMock.setShowData({});
+    const modifiedPackages = new Set<string>();
+    const packageInfos = makePackageInfos({ foo: {}, bar: {} });
+
+    const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
+    expect(newPackages).toEqual(['foo', 'bar']);
+    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: foo');
+    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: bar');
+  });
+
+  it('returns only new package with mix of new, old, and modified', async () => {
+    npmMock.setShowData({ foo: { versions: ['1.0.0'] } });
+    const modifiedPackages = new Set<string>(['bar']);
+    const packageInfos = makePackageInfos({ foo: {}, bar: {}, baz: {} });
+
+    const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
+    expect(newPackages).toEqual(['baz']);
+    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: baz');
+  });
+});

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -58,6 +58,8 @@ export async function publish(options: BeachballOptions) {
   const bumpInfo = gatherBumpInfo(options, oldPackageInfos);
 
   if (options.new) {
+    // Publish newly created packages even if they don't have change files
+    // (this is unlikely unless the packages were pushed without a PR that runs "beachball check")
     bumpInfo.newPackages = new Set<string>(await getNewPackages(bumpInfo, options));
   }
 

--- a/src/publish/getNewPackages.ts
+++ b/src/publish/getNewPackages.ts
@@ -2,15 +2,18 @@ import { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
 import { NpmOptions } from '../types/NpmOptions';
 
-export async function getNewPackages(bumpInfo: BumpInfo, options: NpmOptions) {
+export async function getNewPackages(
+  bumpInfo: Pick<BumpInfo, 'modifiedPackages' | 'packageInfos'>,
+  options: NpmOptions
+) {
   const { modifiedPackages, packageInfos } = bumpInfo;
 
-  const newPackages = Object.keys(packageInfos).filter(pkg => !modifiedPackages.has(pkg));
+  const newPackages = Object.keys(packageInfos).filter(pkg => !modifiedPackages.has(pkg) && !packageInfos[pkg].private);
 
   const publishedVersions = await listPackageVersions(newPackages, options);
 
   return newPackages.filter(pkg => {
-    if (!packageInfos[pkg].private && !publishedVersions[pkg]?.length) {
+    if (!publishedVersions[pkg]?.length) {
       console.log(`New package detected: ${pkg}`);
       return true;
     }

--- a/src/publish/getNewPackages.ts
+++ b/src/publish/getNewPackages.ts
@@ -10,15 +10,10 @@ export async function getNewPackages(bumpInfo: BumpInfo, options: NpmOptions) {
   const publishedVersions = await listPackageVersions(newPackages, options);
 
   return newPackages.filter(pkg => {
-    const packageInfo = packageInfos[pkg];
-    // Ignore private packages or change type "none" packages
-    if (packageInfo.private) {
-      return false;
-    }
-
-    if (!publishedVersions[pkg] || publishedVersions[pkg].length === 0) {
+    if (!packageInfos[pkg].private && !publishedVersions[pkg]?.length) {
       console.log(`New package detected: ${pkg}`);
       return true;
     }
+    return false;
   });
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -41,8 +41,11 @@ export interface CliOptions
   keepChangeFiles?: boolean;
   /**
    * For publish: If true, publish all newly added packages in addition to modified packages.
-   * (This likely has limited use with the current implementation since new packages also
-   * require change files if `beachball check` is run before check-in.)
+   * New packages *with change files* will always be published regardless of this option.
+   *
+   * (This has limited use unless you pushed new packages directly to the main branch, or
+   * your PR build doesn't run `beachball check`. Otherwise, `beachball check` will require
+   * change files to be created for the missing packages.)
    */
   new: boolean;
   package?: string | string[];

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -39,6 +39,11 @@ export interface CliOptions
   fromRef?: string;
   help?: boolean;
   keepChangeFiles?: boolean;
+  /**
+   * For publish: If true, publish all newly added packages in addition to modified packages.
+   * (This likely has limited use with the current implementation since new packages also
+   * require change files if `beachball check` is run before check-in.)
+   */
   new: boolean;
   package?: string | string[];
   /** Timeout for npm operations (other than install, which is expected to take longer) */


### PR DESCRIPTION
Add types and simplify a couple things in `listPackageVersions`, ad add a test. This is a basic enough function that it's possible to mock npm return values for speed, rather than using the fake registry.

Also simplify things and add a test for `getNewPackages`.

Finally, I noticed there was a lack of publish E2E coverage for basic monorepo scenarios, so I added tests for the following:
- Publish only the changed packages in a monorepo
- Publish dependents of changed packages in a monorepo
- Publish new non-modified packages in a monorepo (test `new` option)