### PR TITLE
Improve logging during publishing

### DIFF
--- a/change/beachball-8a3c9880-68c8-497f-94e2-c49747393de6.json
+++ b/change/beachball-8a3c9880-68c8-497f-94e2-c49747393de6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve logging during publishing",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -9,6 +9,8 @@ import { getNewPackages } from '../publish/getNewPackages';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 
 export async function publish(options: BeachballOptions) {
+  console.log('\nPreparing to publish');
+
   const { path: cwd, branch, registry, tag } = options;
   // First, validate that we have changes to publish
   const oldPackageInfos = getPackageInfos(cwd);
@@ -21,7 +23,8 @@ export async function publish(options: BeachballOptions) {
   // Collate the changes per package
   const currentBranch = getBranchName(cwd);
   const currentHash = getCurrentHash(cwd);
-  console.log(`Publishing with the following configuration:
+
+  console.log(`\nPublishing with the following configuration:
 
   registry: ${registry}
 
@@ -35,6 +38,7 @@ export async function publish(options: BeachballOptions) {
   pushes to remote git repo: ${options.bump && options.push && options.branch ? 'yes' : 'no'}
 
 `);
+
   if (!options.yes) {
     const response = await prompts({
       type: 'confirm',
@@ -45,18 +49,15 @@ export async function publish(options: BeachballOptions) {
       return;
     }
   }
+
   // checkout publish branch
   const publishBranch = 'publish_' + String(new Date().getTime());
 
-  console.log(`creating temporary publish branch ${publishBranch}`);
+  console.log(`Creating temporary publish branch ${publishBranch}`);
   gitFailFast(['checkout', '-b', publishBranch], { cwd });
 
-  if (options.bump) {
-    console.log('Bumping version for npm publish');
-  }
-
+  console.log(`\nGathering info ${options.bump ? 'to bump versions' : 'about versions and changes'}`);
   const bumpInfo = gatherBumpInfo(options, oldPackageInfos);
-
   if (options.new) {
     // Publish newly created packages even if they don't have change files
     // (this is unlikely unless the packages were pushed without a PR that runs "beachball check")
@@ -66,7 +67,9 @@ export async function publish(options: BeachballOptions) {
   // Step 1. Bump + npm publish
   // npm / yarn publish
   if (options.publish) {
+    console.log('\nBumping versions and publishing to npm');
     await publishToRegistry(bumpInfo, options);
+    console.log();
   } else {
     console.log('Skipping publish');
   }
@@ -74,6 +77,7 @@ export async function publish(options: BeachballOptions) {
   // Step 2.
   // - reset, fetch latest from origin/master (to ensure less chance of conflict), then bump again + commit
   if (options.bump && branch && options.push) {
+    // this does its own section logging
     await bumpAndPush(bumpInfo, publishBranch, options);
   } else {
     console.log('Skipping git push and tagging');
@@ -81,11 +85,12 @@ export async function publish(options: BeachballOptions) {
 
   // Step 3.
   // Clean up: switch back to current branch, delete publish branch
+  console.log('\nCleaning up');
 
   const revParseSuccessful = currentBranch || currentHash;
   if (currentBranch && currentBranch !== 'HEAD') {
     console.log(`git checkout ${currentBranch}`);
-    gitFailFast(['checkout', currentBranch!], { cwd });
+    gitFailFast(['checkout', currentBranch], { cwd });
   } else if (currentHash) {
     console.log(`Looks like the repo was detached from a branch`);
     console.log(`git checkout ${currentHash}`);

--- a/src/logging/format.ts
+++ b/src/logging/format.ts
@@ -1,0 +1,3 @@
+export function formatList(items: string[]) {
+  return items.map(item => `- ${item}`).join('\n');
+}

--- a/src/publish/shouldPublishPackage.ts
+++ b/src/publish/shouldPublishPackage.ts
@@ -13,20 +13,20 @@ export function shouldPublishPackage(
   if (changeType === 'none') {
     return {
       publish: false,
-      reasonToSkip: `package ${pkgName} has change type as none`,
+      reasonToSkip: `${pkgName} has change type none`,
     };
   }
 
   if (packageInfo.private) {
     return {
       publish: false,
-      reasonToSkip: `package ${pkgName} is private`,
+      reasonToSkip: `${pkgName} is private`,
     };
   }
   if (!bumpInfo.scopedPackages.has(pkgName)) {
     return {
       publish: false,
-      reasonToSkip: `package ${pkgName} is out-of-scope`,
+      reasonToSkip: `${pkgName} is out-of-scope`,
     };
   }
 

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -5,10 +5,10 @@ import { shouldPublishPackage } from './shouldPublishPackage';
  * Validate no private package is listed as package dependency for packages which will be published.
  */
 export function validatePackageDependencies(bumpInfo: BumpInfo): boolean {
-  let hasErrors: boolean = false;
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
   const packagesToValidate = [...modifiedPackages, ...newPackages];
+
   /** Mapping from dep to all validated packages that depend on it */
   const allDeps: { [dep: string]: string[] } = {};
   for (const pkg of packagesToValidate) {
@@ -18,29 +18,22 @@ export function validatePackageDependencies(bumpInfo: BumpInfo): boolean {
       continue;
     }
 
-    const packageInfo = packageInfos[pkg];
-    if (packageInfo.dependencies) {
-      for (const dep of Object.keys(packageInfo.dependencies)) {
-        if (!allDeps[dep]) {
-          allDeps[dep] = [];
-        }
-        allDeps[dep].push(pkg);
-      }
+    for (const dep of Object.keys(packageInfos[pkg].dependencies || {})) {
+      allDeps[dep] ??= [];
+      allDeps[dep].push(pkg);
     }
   }
 
   console.log(`Validating no private package among package dependencies`);
-  for (const [dep, usedBy] of Object.entries(allDeps)) {
-    if (packageInfos[dep] && packageInfos[dep].private === true) {
-      console.error(
-        `\nERROR: Private package ${dep} should not be a dependency of published package(s) ${usedBy.join(', ')}.`
-      );
-      hasErrors = true;
-    }
+  const errorDeps = Object.keys(allDeps).filter(dep => packageInfos[dep]?.private);
+  if (errorDeps.length) {
+    console.error(
+      `ERROR: Found private packages among published package dependencies:\n` +
+        errorDeps.map(dep => `- ${dep}: used by ${allDeps[dep].join(', ')}`).join('\n')
+    );
+    return false;
   }
 
-  if (!hasErrors) {
-    console.log(' OK!\n');
-  }
-  return !hasErrors;
+  console.log('  OK!\n');
+  return true;
 }


### PR DESCRIPTION
Add more logs (and more line breaks) and reformat/group some existing logs for improved readability. Specifically for various package validation steps, it's easier to read the logs if the successful and error or skipped packages are grouped together as a list under a heading rather than interleaved or printed with lots of repeated text.