### PR TITLE
Validation improvements

### DIFF
--- a/change/beachball-7aca6811-7db0-44c1-810b-1f4a16006014.json
+++ b/change/beachball-7aca6811-7db0-44c1-810b-1f4a16006014.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve validation logging and performance",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/bumpMinSemverRange.ts
+++ b/src/bump/bumpMinSemverRange.ts
@@ -4,24 +4,28 @@ export function bumpMinSemverRange(minVersion: string, semverRange: string) {
   if (semverRange === '*') {
     return semverRange;
   }
-
-  if (new Set(['workspace:*', 'workspace:~', 'workspace:^']).has(semverRange)) {
+  if (['workspace:*', 'workspace:~', 'workspace:^'].includes(semverRange)) {
     // For basic workspace ranges we can just preserve current value and replace during publish
     // https://pnpm.io/workspaces#workspace-protocol-workspace
     return semverRange;
-  } else if (semverRange.startsWith('~') || semverRange.startsWith('^')) {
+  }
+  if (semverRange[0] === '~' || semverRange[0] === '^') {
     // ~1.0.0
     // ^1.0.0
     return semverRange[0] + minVersion;
-  } else if (semverRange.startsWith('workspace:~') || semverRange.startsWith('workspace:^')) {
+  }
+  if (semverRange.startsWith('workspace:~') || semverRange.startsWith('workspace:^')) {
     // workspace:~1.0.0
     // workspace:^1.0.0
     return `workspace:${semverRange[10]}${minVersion}`;
-  } else if (semverRange.includes('>')) {
-    // Less frequently used, but we treat any of these kinds of ranges to be within a minor band for now: more complex understand of the semver range utility is needed to do more
+  }
+  if (semverRange.includes('>')) {
+    // Less frequently used, but we treat any of these kinds of ranges to be within a minor band for now:
+    // more complex understanding of the semver range utility is needed to do more
     // >=1.0.0 <2.0.0
     return `>=${minVersion} <${semver.inc(minVersion, 'major')}`;
-  } else if (semverRange.includes(' - ')) {
+  }
+  if (semverRange.includes(' - ')) {
     // 1.0.0 - 2.0.0
     return `${minVersion} - ${semver.inc(minVersion, 'major')}`;
   }

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -9,19 +9,15 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
   const { calculatedChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
   const changeType = calculatedChangeTypes[pkgName];
+
   if (!info) {
     console.log(`Unknown package named "${pkgName}" detected from change files, skipping!`);
-    return;
-  }
-  if (changeType === 'none') {
+  } else if (changeType === 'none') {
     console.log(`"${pkgName}" has a "none" change type, no version bump is required.`);
-    return;
-  }
-  if (info.private) {
+  } else if (info.private) {
     console.log(`Skipping bumping private package "${pkgName}"`);
-    return;
-  }
-  if (!info.private) {
+  } else {
+    // Version should be updated
     info.version = semver.inc(
       info.version,
       options.prereleasePrefix ? 'prerelease' : changeType,

--- a/src/bump/setGroupsInBumpInfo.ts
+++ b/src/bump/setGroupsInBumpInfo.ts
@@ -3,9 +3,9 @@ import { BumpInfo } from '../types/BumpInfo';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 
 export function setGroupsInBumpInfo(bumpInfo: BumpInfo, options: BeachballOptions) {
-  bumpInfo.packageGroups = getPackageGroups(bumpInfo.packageInfos, options.path, options.groups);
-
   if (options.groups) {
+    bumpInfo.packageGroups = getPackageGroups(bumpInfo.packageInfos, options.path, options.groups);
+
     for (const grpName of Object.keys(bumpInfo.packageGroups)) {
       const grpOptions = options.groups.find(groupItem => groupItem.name === grpName)!;
       bumpInfo.groupOptions[grpName] = grpOptions;

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -21,11 +21,6 @@ import { ChangeType } from '../types/ChangeInfo';
  * - bumpInfo.calculatedChangeTypes: will not mutate the entryPoint `pkgName` change type
  *
  * Inputs from bumpInfo are listed in the [^1] below in the function body
- *
- * @param entryPointPackageName
- * @param bumpInfo
- * @param bumpDeps
- * @returns
  */
 export function updateRelatedChangeType(changeFile: string, bumpInfo: BumpInfo, bumpDeps: boolean) {
   /** [^1]: all the information needed from `bumpInfo` */

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -129,13 +129,13 @@ async function writeChangelogFiles(
   try {
     previousJson = fs.existsSync(changelogJsonFile) ? fs.readJSONSync(changelogJsonFile) : undefined;
   } catch (e) {
-    console.warn('CHANGELOG.json is invalid:', e);
+    console.warn(`${changelogJsonFile} is invalid: ${e}`);
   }
   try {
     const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
     fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
   } catch (e) {
-    console.warn('Problem writing to CHANGELOG.json:', e);
+    console.warn(`Problem writing to ${changelogJsonFile}: ${e}`);
   }
 
   // Update CHANGELOG.md

--- a/src/logging/format.ts
+++ b/src/logging/format.ts
@@ -1,3 +1,12 @@
+/** Format strings as a bulleted list with line breaks */
 export function formatList(items: string[]) {
   return items.map(item => `- ${item}`).join('\n');
+}
+
+/**
+ * Format an object on a single line with spaces between the properties and brackets
+ * (similar to `JSON.stringify(obj, null, 2)` but without the line breaks).
+ */
+export function singleLineStringify(obj: any) {
+  return JSON.stringify(obj, null, 2).replace(/\n\s*/g, ' ');
 }

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -11,6 +11,9 @@ const BUMP_PUSH_RETRIES = 5;
 /** Use verbose logging for these steps to make it easier to debug if something goes wrong */
 const verbose = true;
 
+/**
+ * Bump versions locally, commit, optionally tag, and push to git.
+ */
 export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
   const { path: cwd, branch, depth, gitTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
@@ -25,7 +28,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
   while (tryNumber < BUMP_PUSH_RETRIES && !completed) {
     tryNumber++;
     console.log('-'.repeat(80));
-    console.log(`Trying to push to git. Attempt ${tryNumber}/${BUMP_PUSH_RETRIES}`);
+    console.log(`Bumping versions and pushing to git (attempt ${tryNumber}/${BUMP_PUSH_RETRIES})`);
     console.log('Reverting');
     revertLocalChanges(cwd);
 
@@ -47,7 +50,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     }
 
     // bump the version
-    console.log('\nBumping the versions for git push');
+    console.log('\nBumping versions locally (and writing changelogs if requested)');
     await performBump(bumpInfo, options);
 
     // checkin

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -1,7 +1,7 @@
 import { BumpInfo } from '../types/BumpInfo';
 
 export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()) {
-  const errorLines = ['Something went wrong with publishing! Manually update these package and versions:'];
+  const errorLines: string[] = [];
   const succeededLines: string[] = [];
 
   bumpInfo.modifiedPackages.forEach(pkg => {
@@ -14,13 +14,15 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
     }
   });
 
-  console.error(errorLines.join('\n') + '\n');
+  console.error(
+    'Something went wrong with publishing! Manually update these package and versions:\n' + errorLines.sort().join('\n')
+  );
 
   if (succeededLines.length) {
     console.warn(
       'These packages and versions were successfully published, but may be invalid if they depend on ' +
         'package versions for which publishing failed:\n' +
-        succeededLines.join('\n') +
+        succeededLines.sort().join('\n') +
         '\n\nTo recover from this, run "beachball sync" to synchronize local package.json files with the registry. ' +
         'If necessary, unpublish or deprecate any invalid packages from the above list after "beachball sync".'
     );

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -43,7 +43,7 @@ export function getPackagesToPublish(bumpInfo: BumpInfo, validationMode?: boolea
 
   // this log is not helpful when called from `validate`
   if (skippedPackageReasons.length && !validationMode) {
-    console.log(`\nSkipping publishing the following packages:\n${formatList(skippedPackageReasons)}`);
+    console.log(`\nSkipping publishing the following packages:\n${formatList(skippedPackageReasons.sort())}`);
   }
 
   return packagesToPublish;

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -18,7 +18,10 @@ export function validatePackageDependencies(packagesToValidate: string[], packag
   if (errorDeps.length) {
     console.error(
       `ERROR: Found private packages among published package dependencies:\n` +
-        errorDeps.map(dep => `- ${dep}: used by ${allDeps[dep].join(', ')}`).join('\n')
+        errorDeps
+          .map(dep => `- ${dep}: used by ${allDeps[dep].join(', ')}`)
+          .sort()
+          .join('\n')
     );
     return false;
   }

--- a/src/publish/validatePackageVersions.ts
+++ b/src/publish/validatePackageVersions.ts
@@ -29,12 +29,13 @@ export async function validatePackageVersions(
   }
 
   if (okVersions.length) {
+    // keep the original order here to show what order they'll be published in
     console.log(`\nPackage versions are OK to publish:\n${formatList(okVersions)}`);
   }
   if (errorVersions.length) {
     console.error(
       `\nERROR: Attempting to publish package versions that already exist in the registry:\n` +
-        formatList(errorVersions)
+        formatList(errorVersions.sort())
     );
     return false;
   }

--- a/src/validation/areChangeFilesDeleted.ts
+++ b/src/validation/areChangeFilesDeleted.ts
@@ -6,11 +6,6 @@ export function areChangeFilesDeleted(options: BeachballOptions): boolean {
   const { branch, path: cwd } = options;
 
   const root = findProjectRoot(cwd);
-  if (!root) {
-    console.error('Failed to find the project root');
-    process.exit(1);
-  }
-
   const changePath = getChangePath(cwd);
 
   console.log(`Checking for deleted change files against "${branch}"`);
@@ -24,19 +19,11 @@ export function areChangeFilesDeleted(options: BeachballOptions): boolean {
     root
   );
 
-  // if this value is undefined, git has failed to execute the command above.
-  if (!changeFilesDeletedSinceRef) {
-    process.exit(1);
-  }
-
-  const changeFilesDeleted = changeFilesDeletedSinceRef.length > 0;
-
-  if (changeFilesDeleted) {
+  if (changeFilesDeletedSinceRef.length) {
     const changeFiles = changeFilesDeletedSinceRef.map(file => `- ${file}`);
-    const errorMessage = 'The following change files were deleted:';
-
-    console.error(`${errorMessage}\n${changeFiles.join('\n')}\n`);
+    console.error(`ERROR: The following change files were deleted:\n${changeFiles.join('\n')}\n`);
+    return true;
   }
 
-  return changeFilesDeleted;
+  return false;
 }

--- a/src/validation/isChangeFileNeeded.ts
+++ b/src/validation/isChangeFileNeeded.ts
@@ -14,6 +14,7 @@ export function isChangeFileNeeded(options: BeachballOptions, packageInfos: Pack
         .map(pkg => `\n  ${pkg}`)
         .join('')}`
     );
+    return true;
   }
-  return changedPackages.length > 0;
+  return false;
 }

--- a/src/validation/isValidChangeType.ts
+++ b/src/validation/isValidChangeType.ts
@@ -1,3 +1,5 @@
+import { SortedChangeTypes } from '../changefile/changeTypes';
+
 export function isValidChangeType(changeType: string) {
-  return ['patch', 'major', 'minor', 'prerelease', 'none'].includes(changeType);
+  return SortedChangeTypes.includes(changeType as any);
 }

--- a/src/validation/isValidChangelogOptions.ts
+++ b/src/validation/isValidChangelogOptions.ts
@@ -1,30 +1,20 @@
-import { ChangelogOptions, ChangelogGroupOptions } from '../types/ChangelogOptions';
+import { singleLineStringify } from '../logging/format';
+import { ChangelogOptions } from '../types/ChangelogOptions';
 
 export function isValidChangelogOptions(options: ChangelogOptions): boolean {
-  if (options.groups) {
-    if (!isValidChangelogGroupOptions(options.groups)) {
-      return false;
-    }
+  if (!options.groups) {
+    return true;
   }
-  return true;
-}
 
-function isValidChangelogGroupOptions(groupOptions: ChangelogGroupOptions[]): boolean {
-  for (const options of groupOptions) {
-    if (!options.changelogPath) {
-      console.log('changelog group options cannot contain empty changelogPath.');
-      return false;
-    }
+  const badGroups = options.groups.filter(group => !group.changelogPath || !group.masterPackageName || !group.include);
 
-    if (!options.masterPackageName) {
-      console.log('changelog group options cannot contain empty masterPackageName.');
-      return false;
-    }
-
-    if (!options.include) {
-      console.log('changelog group options cannot contain empty include.');
-      return false;
-    }
+  if (badGroups.length) {
+    console.error(
+      'ERROR: "changelog.groups" entries must define "changelogPath", "masterPackageName", and "include". ' +
+        'Found invalid groups:\n' +
+        badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
+    );
+    return false;
   }
 
   return true;

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -1,33 +1,46 @@
+import { formatList, singleLineStringify } from '../logging/format';
 import { VersionGroupOptions } from '../types/BeachballOptions';
-import { getPackageGroups } from '../monorepo/getPackageGroups';
-import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { PackageGroups, PackageInfos } from '../types/PackageInfo';
 
-export function isValidGroupOptions(root: string, groups: VersionGroupOptions[]) {
+export function isValidGroupOptions(groups: VersionGroupOptions[]) {
+  // Values that violate types could happen in a user-provided object
   if (!Array.isArray(groups)) {
+    console.error(
+      'ERROR: Expected "groups" configuration setting to be an array. Received:\n' + JSON.stringify(groups)
+    );
     return false;
   }
 
-  for (const group of groups) {
-    if (!group.include || !group.name) {
-      return false;
+  const badGroups = groups.filter(group => !group.include || !group.name);
+  if (badGroups.length) {
+    console.error(
+      'ERROR: "groups" configuration entries must define "include" and "name". Found invalid groups:\n' +
+        badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
+    );
+    return false;
+  }
+}
+
+/** Validate per-package beachball options are valid for packages in groups */
+export function isValidGroupedPackageOptions(packageInfos: PackageInfos, packageGroups: PackageGroups) {
+  const errorPackages: string[] = [];
+
+  // make sure no disallowed change type options exist inside an individual package
+  for (const [groupName, { packageNames }] of Object.entries(packageGroups)) {
+    for (const pkgName of packageNames) {
+      if (packageInfos[pkgName].packageOptions.disallowedChangeTypes) {
+        errorPackages.push(`${pkgName} in group "${groupName}"`);
+      }
     }
   }
 
-  const packageInfos = getPackageInfos(root);
-  const packageGroups = getPackageGroups(packageInfos, root, groups);
-  // make sure no disallowed changetype options exist inside an individual package
-
-  for (const grp of Object.keys(packageGroups)) {
-    const pkgs = packageGroups[grp].packageNames;
-    for (const pkgName of pkgs) {
-      if (packageInfos[pkgName].packageOptions.disallowedChangeTypes) {
-        console.error(
-          `Cannot have a disallowedChangeType inside a package config (${pkgName}) when there is a group defined; use the groups.disallowedChangeTypes instead.`
-        );
-
-        return false;
-      }
-    }
+  if (errorPackages.length) {
+    console.error(
+      'ERROR: Found package configs that define disallowedChangeTypes and are also part of a group. ' +
+        'Define disallowedChangeTypes in the group instead.\n' +
+        formatList(errorPackages.sort())
+    );
+    return false;
   }
 
   return true;


### PR DESCRIPTION
Previously, a lot of the validation steps would immediately call `process.exit(1)` on failure, which is not helpful because it could hide future errors. Some validation helpers would even short circuit on the first individual package with an error. Also, there were some expensive calculations such as package infos and package groups being run multiple times.

This PR switches around some of the ordering for validation and adds more logging:
- Calculate package infos and groups in the main `validate` method and pass them to helpers
- Modify all validation helpers that iterate over anything to accumulate errors and log them together at the end for readability
- If there's an individual error, continue through validation as far as possible (to show any additional errors) instead of exiting immediately
- For anything that displays lists of packages, sort the output alphabetically (if the original order wasn't significant) so it's easier to process

Also includes some minor improvements (including sorting) for logging in other places.