### PR TITLE
Fix always-fail-validation bug in src/validation/isValidGroupOptions.ts: return true for valid group options

### DIFF
--- a/change/beachball-13772bcd-6adf-4eec-8c1f-5322db44c332.json
+++ b/change/beachball-13772bcd-6adf-4eec-8c1f-5322db44c332.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "return true for valid group options",
+  "packageName": "beachball",
+  "email": "aeun@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -19,6 +19,8 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]) {
     );
     return false;
   }
+
+  return true;
 }
 
 /** Validate per-package beachball options are valid for packages in groups */


### PR DESCRIPTION
Last week, this change in `src/validation/validate.ts` below was checked in through [PR 878](https://github.com/microsoft/beachball/pull/878):

```
// validate.ts
if (options.groups && !isValidGroupOptions(options.groups)) {
    hasError = true; // the helper logs this
  }
```

`!isValidGroupOptions(options.groups)` in the condition being checked always returns true, because currently `isValidGroupOptions(options.groups)` only returns false or undefined.

```
// isValidGroupOptions.ts
export function isValidGroupOptions(groups: VersionGroupOptions[]) {
  // Values that violate types could happen in a user-provided object
  if (!Array.isArray(groups)) {
    console.error(
      'ERROR: Expected "groups" configuration setting to be an array. Received:\n' + JSON.stringify(groups)
    );
    return false;
  }

  for (const group of groups) {
    if (!group.include || !group.name) {
      return false;
    }
  const badGroups = groups.filter(group => !group.include || !group.name);
  if (badGroups.length) {
    console.error(
      'ERROR: "groups" configuration entries must define "include" and "name". Found invalid groups:\n' +
        badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
    );
    return false;
  }
}
```

You can also see this through the method signature in isValidGroupOptions.d.ts when being used through node_modules.
```
export declare function isValidGroupOptions(groups: VersionGroupOptions[]): false | undefined;
```

As a result any groups in the config will fail silently, regardless of if the group is valid or not.
```
// example failure in a pipeline
Validating options and change files...
##[debug]Exit code: 1
##[debug]Leaving Invoke-VstsTool.
##[error]Cmd.exe exited with code '1'.
```

Suggested fix:
I think you can just add "returns true" if y'all don't have any conditions you want to check for that would make it a failure.