### PR TITLE
Fix validation bug that caused beachball to always exit with an error

### DIFF
--- a/change/beachball-2548d443-5e21-43ef-ae92-75e7089f7a0b.json
+++ b/change/beachball-2548d443-5e21-43ef-ae92-75e7089f7a0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix validation bug that caused beachball to always exit with an error (and add return types to all functions)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/validate.test.ts
+++ b/src/__e2e__/validate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, afterEach, jest } from '@jest/globals';
+import { defaultBranchName } from '../__fixtures__/gitDefaults';
+import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { initMockLogs } from '../__fixtures__/mockLogs';
+import { validate } from '../validation/validate';
+
+describe('validate', () => {
+  let repositoryFactory: RepositoryFactory | undefined;
+  const logs = initMockLogs();
+  // this is mocked in jestSetup
+  const processExit = process.exit as jest.MockedFunction<typeof process.exit>;
+  const processExitImpl = processExit.getMockImplementation()!;
+
+  afterEach(() => {
+    repositoryFactory?.cleanUp();
+    repositoryFactory = undefined;
+    processExit.mockImplementation(processExitImpl);
+  });
+
+  // Some super basic tests for now to ensure that validate() doesn't get blatantly broken again
+  it('succeeds in a basic scenario', () => {
+    repositoryFactory = new RepositoryFactory('monorepo');
+    const repo = repositoryFactory.cloneRepository();
+    repo.checkout('-b', 'test');
+    const options = { path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
+    const result = validate(options);
+    expect(result.isChangeNeeded).toBe(false);
+    expect(logs.mocks.error).not.toHaveBeenCalled();
+    // the success log for the "change" command is done in the main cli file, not validate()
+  });
+
+  it('fails if change files are needed', () => {
+    // this calls process.exit on failure, so mock it
+    processExit.mockImplementation((() => {
+      /*no-op*/
+    }) as any);
+
+    repositoryFactory = new RepositoryFactory('monorepo');
+    const repo = repositoryFactory.cloneRepository();
+    repo.checkout('-b', 'test');
+    repo.stageChange('packages/foo/test.js');
+    const options = { path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
+    const result = validate(options);
+    expect(result.isChangeNeeded).toBe(true);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files are needed!');
+  });
+});

--- a/src/__e2e__/validate.test.ts
+++ b/src/__e2e__/validate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach, jest } from '@jest/globals';
+import { describe, expect, it, afterAll, jest, beforeAll, afterEach } from '@jest/globals';
 import { defaultBranchName } from '../__fixtures__/gitDefaults';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -6,43 +6,54 @@ import { initMockLogs } from '../__fixtures__/mockLogs';
 import { validate } from '../validation/validate';
 
 describe('validate', () => {
-  let repositoryFactory: RepositoryFactory | undefined;
+  let repositoryFactory: RepositoryFactory;
   const logs = initMockLogs();
   // this is mocked in jestSetup
   const processExit = process.exit as jest.MockedFunction<typeof process.exit>;
-  const processExitImpl = processExit.getMockImplementation()!;
 
-  afterEach(() => {
-    repositoryFactory?.cleanUp();
-    repositoryFactory = undefined;
-    processExit.mockImplementation(processExitImpl);
+  beforeAll(() => {
+    // these tests can reuse a factory because they don't push changes
+    repositoryFactory = new RepositoryFactory('monorepo');
   });
 
-  // Some super basic tests for now to ensure that validate() doesn't get blatantly broken again
-  it('succeeds in a basic scenario', () => {
-    repositoryFactory = new RepositoryFactory('monorepo');
+  afterEach(() => {
+    processExit.mockClear();
+  });
+
+  afterAll(() => {
+    repositoryFactory.cleanUp();
+  });
+
+  it('succeeds with no changes', () => {
     const repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
     const options = { path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
+
     const result = validate(options);
     expect(result.isChangeNeeded).toBe(false);
     expect(logs.mocks.error).not.toHaveBeenCalled();
-    // the success log for the "change" command is done in the main cli file, not validate()
+    // the success log for the "check" command is done in the main cli file, not validate()
   });
 
-  it('fails if change files are needed', () => {
-    // this calls process.exit on failure, so mock it
-    processExit.mockImplementation((() => {
-      /*no-op*/
-    }) as any);
-
-    repositoryFactory = new RepositoryFactory('monorepo');
+  it('exits with error by default if change files are needed', () => {
     const repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
     repo.stageChange('packages/foo/test.js');
     const options = { path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
-    const result = validate(options);
-    expect(result.isChangeNeeded).toBe(true);
+
+    expect(() => validate(options)).toThrowError(/process\.exit/);
+    expect(processExit).toHaveBeenCalledWith(1);
     expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files are needed!');
+  });
+
+  it('returns an error if change files are needed and allowMissingChangeFiles is true', () => {
+    const repo = repositoryFactory.cloneRepository();
+    repo.checkout('-b', 'test');
+    repo.stageChange('packages/foo/test.js');
+    const options = { path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
+
+    const result = validate(options, { allowMissingChangeFiles: true });
+    expect(result.isChangeNeeded).toBe(true);
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 });

--- a/src/__fixtures__/changeFiles.ts
+++ b/src/__fixtures__/changeFiles.ts
@@ -14,7 +14,11 @@ export type PartialChangeFile = { packageName: string } & Partial<ChangeFileInfo
  * @param cwd Working directory
  * @param groupChanges Whether to group all changes into one change file.
  */
-export function generateChangeFiles(changes: (string | PartialChangeFile)[], cwd: string, groupChanges?: boolean) {
+export function generateChangeFiles(
+  changes: (string | PartialChangeFile)[],
+  cwd: string,
+  groupChanges?: boolean
+): void {
   writeChangeFiles({
     changes: changes.map(change => {
       change = typeof change === 'string' ? { packageName: change } : change;

--- a/src/__fixtures__/changelog.ts
+++ b/src/__fixtures__/changelog.ts
@@ -18,8 +18,11 @@ export function readChangelogJson(packagePath: string, cleanForSnapshot: boolean
   return cleanForSnapshot ? cleanChangelogJson(json) : json;
 }
 
-/** Clean changelog json for a snapshot: replace dates and SHAs with placeholders */
-export function cleanChangelogJson(changelog: ChangelogJson) {
+/**
+ * Clean changelog json for a snapshot: replace dates and SHAs with placeholders.
+ * Note: this clones the changelog object rather than modifying the original.
+ */
+export function cleanChangelogJson(changelog: ChangelogJson): ChangelogJson {
   changelog = _.cloneDeep(changelog);
   // for a better snapshot, make the fake commit match if the real commit did
   const fakeCommits: { [commit: string]: string } = {};

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -11,7 +11,7 @@ import { setDependentVersions } from './setDependentVersions';
  *
  * NOTE: THIS FUNCTION MUTATES STATE!
  */
-export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
+export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions): void {
   const { bumpDeps } = options;
   const { packageInfos, scopedPackages, calculatedChangeTypes, changeFileChangeInfos, modifiedPackages } = bumpInfo;
 
@@ -51,6 +51,4 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions) {
   // step 4: Bump all the dependencies packages
   bumpInfo.dependentChangedBy = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(bumpInfo.dependentChangedBy).forEach(pkg => modifiedPackages.add(pkg));
-
-  return bumpInfo;
 }

--- a/src/bump/bumpMinSemverRange.ts
+++ b/src/bump/bumpMinSemverRange.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export function bumpMinSemverRange(minVersion: string, semverRange: string) {
+export function bumpMinSemverRange(minVersion: string, semverRange: string): string {
   if (semverRange === '*') {
     return semverRange;
   }

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -5,7 +5,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 /**
  * Bumps an individual package version based on the change type
  */
-export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions) {
+export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, options: BeachballOptions): void {
   const { calculatedChangeTypes, packageInfos, modifiedPackages } = bumpInfo;
   const info = packageInfos[pkgName];
   const changeType = calculatedChangeTypes[pkgName];

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -8,7 +8,7 @@ import { PackageInfos, PackageJson } from '../types/PackageInfo';
 import { findProjectRoot } from 'workspace-tools';
 import { npm } from '../packageManager/npm';
 
-export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos) {
+export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos): void {
   for (const pkgName of modifiedPackages) {
     const info = packageInfos[pkgName];
     if (!fs.existsSync(info.packageJsonPath)) {
@@ -43,7 +43,7 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
 /**
  * If `package-lock.json` exists, runs `npm install --package-lock-only` to update it.
  */
-export function updatePackageLock(cwd: string) {
+export function updatePackageLock(cwd: string): void {
   const root = findProjectRoot(cwd);
   if (root && fs.existsSync(path.join(root, 'package-lock.json'))) {
     console.log('Updating package-lock.json after bumping packages');
@@ -59,7 +59,7 @@ export function updatePackageLock(cwd: string) {
  *
  * deletes change files, update package.json, and changelogs
  */
-export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions) {
+export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions): Promise<BumpInfo> {
   const { modifiedPackages, packageInfos, changeFileChangeInfos, dependentChangedBy, calculatedChangeTypes } = bumpInfo;
 
   await callHook('prebump', bumpInfo, options);
@@ -79,13 +79,14 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
 
   await callHook('postbump', bumpInfo, options);
 
+  // This is returned from bump() for testing
   return bumpInfo;
 }
 
 /**
  * Calls a specified hook for each package being bumped
  */
-async function callHook(hookName: keyof HooksOptions, bumpInfo: BumpInfo, options: BeachballOptions) {
+async function callHook(hookName: keyof HooksOptions, bumpInfo: BumpInfo, options: BeachballOptions): Promise<void> {
   const hook = options.hooks?.[hookName];
   if (!hook) {
     return;

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -6,7 +6,7 @@ export function setDependentVersions(
   packageInfos: PackageInfos,
   scopedPackages: Set<string>,
   { verbose }: BeachballOptions
-) {
+): { [dependent: string]: Set<string> } {
   const dependentChangedBy: { [dependent: string]: Set<string> } = {};
 
   for (const [pkgName, info] of Object.entries(packageInfos)) {

--- a/src/bump/setGroupsInBumpInfo.ts
+++ b/src/bump/setGroupsInBumpInfo.ts
@@ -2,7 +2,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { BumpInfo } from '../types/BumpInfo';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 
-export function setGroupsInBumpInfo(bumpInfo: BumpInfo, options: BeachballOptions) {
+export function setGroupsInBumpInfo(bumpInfo: BumpInfo, options: BeachballOptions): void {
   if (options.groups) {
     bumpInfo.packageGroups = getPackageGroups(bumpInfo.packageInfos, options.path, options.groups);
 

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -22,7 +22,7 @@ import { ChangeType } from '../types/ChangeInfo';
  *
  * Inputs from bumpInfo are listed in the [^1] below in the function body
  */
-export function updateRelatedChangeType(changeFile: string, bumpInfo: BumpInfo, bumpDeps: boolean) {
+export function updateRelatedChangeType(changeFile: string, bumpInfo: BumpInfo, bumpDeps: boolean): void {
   /** [^1]: all the information needed from `bumpInfo` */
   const { calculatedChangeTypes, packageGroups, dependents, packageInfos, groupOptions } = bumpInfo;
 
@@ -100,7 +100,7 @@ export function updateRelatedChangeType(changeFile: string, bumpInfo: BumpInfo, 
     }
   }
 
-  function updateChangeType(pkg: string, changeType: ChangeType, disallowedChangeTypes: ChangeType[]) {
+  function updateChangeType(pkg: string, changeType: ChangeType, disallowedChangeTypes: ChangeType[]): ChangeType {
     const newChangeType = getMaxChangeType(calculatedChangeTypes[pkg], changeType, disallowedChangeTypes);
     calculatedChangeTypes[pkg] = newChangeType;
 

--- a/src/changefile/changeTypes.ts
+++ b/src/changefile/changeTypes.ts
@@ -20,7 +20,7 @@ const ChangeTypeWeights = Object.fromEntries(SortedChangeTypes.map((t, i) => [t,
  * Get initial package change types based on the greatest change type set for each package in any
  * change file, accounting for any disallowed change types or nonexistent packages.
  */
-export function initializePackageChangeTypes(changeSet: ChangeSet) {
+export function initializePackageChangeTypes(changeSet: ChangeSet): { [pkgName: string]: ChangeType } {
   const pkgChangeTypes: { [pkgName: string]: ChangeType } = {};
 
   for (const { change } of changeSet) {
@@ -49,7 +49,7 @@ function getAllowedChangeType(changeType: ChangeType, disallowedChangeTypes: Cha
  * e.g. if `a` is "major" and `b` is "patch", and "major" is disallowed, the result will be "minor"
  * (the greatest allowed change type).
  */
-export function getMaxChangeType(a: ChangeType, b: ChangeType, disallowedChangeTypes: ChangeType[] | null) {
+export function getMaxChangeType(a: ChangeType, b: ChangeType, disallowedChangeTypes: ChangeType[] | null): ChangeType {
   if (disallowedChangeTypes) {
     a = getAllowedChangeType(a, disallowedChangeTypes);
     b = getAllowedChangeType(b, disallowedChangeTypes);

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -15,7 +15,7 @@ function getMatchingPackageInfo(
   file: string,
   cwd: string,
   packageInfosByPath: { [packageAbsNormalizedPath: string]: PackageInfo }
-) {
+): PackageInfo | undefined {
   // Normalize all the paths before comparing (the packageInfosByPath entries should also be normalized)
   // to ensure ensure that this doesn't break on Windows if any input paths have forward slashes
   cwd = path.normalize(cwd);
@@ -103,7 +103,7 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
 /**
  * Gets all the changed packages, accounting for change files
  */
-export function getChangedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
+export function getChangedPackages(options: BeachballOptions, packageInfos: PackageInfos): string[] {
   const { path: cwd, branch } = options;
 
   const changePath = getChangePath(cwd);

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -15,7 +15,7 @@ export function unlinkChangeFiles(
     [pkg: string]: PackageInfo;
   },
   cwd: string
-) {
+): void {
   const changePath = getChangePath(cwd);
   if (!changeSet || !changeSet.length) {
     return;

--- a/src/changefile/writeChangeFiles.ts
+++ b/src/changefile/writeChangeFiles.ts
@@ -9,12 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
  * Loops through the `changes` and writes out a list of change files
  * @returns List of changefile paths, mainly for testing purposes.
  */
-export function writeChangeFiles({
-  changes,
-  cwd,
-  commitChangeFiles = true,
-  groupChanges = false,
-}: {
+export function writeChangeFiles(params: {
   changes: ChangeFileInfo[];
   cwd: string;
   /** default true */
@@ -22,6 +17,7 @@ export function writeChangeFiles({
   /** group all changes into one change file (default false) */
   groupChanges?: boolean;
 }): string[] {
+  const { changes, cwd, commitChangeFiles = true, groupChanges = false } = params;
   const changePath = getChangePath(cwd);
   const branchName = getBranchName(cwd);
 

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -15,10 +15,8 @@ export function getPackageChangelogs(
     [pkg: string]: PackageInfo;
   },
   cwd: string
-) {
-  const changelogs: {
-    [pkgName: string]: PackageChangelog;
-  } = {};
+): { [pkgName: string]: PackageChangelog } {
+  const changelogs: { [pkgName: string]: PackageChangelog } = {};
 
   const changeFileCommits: { [changeFile: string]: string } = {};
   const changePath = getChangePath(cwd);
@@ -33,8 +31,8 @@ export function getPackageChangelogs(
       changeFileCommits[changeFile] = getFileAddedHash(path.join(changePath, changeFile), cwd) || 'not available';
     }
 
-    changelogs[packageName].comments = changelogs[packageName].comments || {};
-    changelogs[packageName].comments[changeType] = changelogs[packageName].comments[changeType] || [];
+    changelogs[packageName].comments ??= {};
+    changelogs[packageName].comments[changeType] ??= [];
     changelogs[packageName].comments[changeType]!.push({
       author: change.email,
       package: packageName,
@@ -60,8 +58,8 @@ export function getPackageChangelogs(
 
     const changeType = calculatedChangeTypes[dependent];
 
-    changelogs[dependent].comments = changelogs[dependent].comments || {};
-    changelogs[dependent].comments[changeType] = changelogs[dependent].comments[changeType] || [];
+    changelogs[dependent].comments ??= {};
+    changelogs[dependent].comments[changeType] ??= [];
 
     for (const dep of changedBy) {
       if (dep !== dependent) {
@@ -78,7 +76,7 @@ export function getPackageChangelogs(
   return changelogs;
 }
 
-function createChangeLog(packageInfo: PackageInfo) {
+function createChangeLog(packageInfo: PackageInfo): PackageChangelog {
   const name = packageInfo.name;
   const version = packageInfo.version;
   return {

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -1,4 +1,3 @@
-import { PackageChangelog } from '../types/ChangeLog';
 import { renderPackageChangelog, defaultRenderers } from './renderPackageChangelog';
 import { ChangelogOptions, PackageChangelogRenderInfo } from '../types/ChangelogOptions';
 
@@ -46,7 +45,8 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
 
     return (
       [
-        renderChangelogHeader(newVersionChangelog),
+        `# Change Log - ${newVersionChangelog.name}`,
+        `This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified.`,
         markerComment,
         await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
         previousLogEntries,
@@ -58,11 +58,4 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
     console.log('Error occurred rendering package version changelog:', err);
     return '';
   }
-}
-
-function renderChangelogHeader(changelog: PackageChangelog): string {
-  return (
-    `# Change Log - ${changelog.name}\n\n` +
-    `This log was last generated on ${changelog.date.toUTCString()} and should not be manually modified.`
-  );
 }

--- a/src/changelog/renderJsonChangelog.ts
+++ b/src/changelog/renderJsonChangelog.ts
@@ -1,7 +1,10 @@
 import { generateTag } from '../git/generateTag';
 import { PackageChangelog, ChangelogJson, ChangelogJsonEntry } from '../types/ChangeLog';
 
-export function renderJsonChangelog(changelog: PackageChangelog, previousChangelog: ChangelogJson | undefined) {
+export function renderJsonChangelog(
+  changelog: PackageChangelog,
+  previousChangelog: ChangelogJson | undefined
+): ChangelogJson {
   const result: ChangelogJson = {
     name: changelog.name,
     entries: previousChangelog?.entries ? [...previousChangelog.entries] : [],

--- a/src/changelog/renderPackageChangelog.ts
+++ b/src/changelog/renderPackageChangelog.ts
@@ -49,10 +49,7 @@ async function _renderChangeTypeSection(
     : '';
 }
 
-async function _renderChangeTypeHeader(
-  changeType: ChangeType,
-  renderInfo: PackageChangelogRenderInfo
-): Promise<string> {
+async function _renderChangeTypeHeader(changeType: ChangeType): Promise<string> {
   return `### ${groupNames[changeType]}`;
 }
 

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 import _ from 'lodash';
-import { PackageInfo } from '../types/PackageInfo';
+import { PackageInfo, PackageInfos } from '../types/PackageInfo';
 import { getPackageChangelogs } from './getPackageChangelogs';
 import { renderChangelog } from './renderChangelog';
 import { renderJsonChangelog } from './renderJsonChangelog';
@@ -17,9 +17,7 @@ export async function writeChangelog(
   changeFileChangeInfos: ChangeSet,
   calculatedChangeTypes: BumpInfo['calculatedChangeTypes'],
   dependentChangedBy: BumpInfo['dependentChangedBy'],
-  packageInfos: {
-    [pkg: string]: PackageInfo;
-  }
+  packageInfos: PackageInfos
 ): Promise<void> {
   const groupedChangelogPaths = await writeGroupedChangelog(
     options,
@@ -52,9 +50,7 @@ async function writeGroupedChangelog(
   options: BeachballOptions,
   changeFileChangeInfos: ChangeSet,
   calculatedChangeTypes: BumpInfo['calculatedChangeTypes'],
-  packageInfos: {
-    [pkg: string]: PackageInfo;
-  }
+  packageInfos: PackageInfos
 ): Promise<string[]> {
   if (!options.changelog) {
     return [];
@@ -91,13 +87,10 @@ async function writeGroupedChangelog(
 
       const isInGroup = isPathIncluded(relativePath, group.include, group.exclude);
       if (isInGroup) {
-        if (!groupedChangelogs[changelogPath]) {
-          groupedChangelogs[changelogPath] = {
-            changelogs: [],
-            masterPackage,
-          };
-        }
-
+        groupedChangelogs[changelogPath] ??= {
+          changelogs: [],
+          masterPackage,
+        };
         groupedChangelogs[changelogPath].changelogs.push(changelogs[pkg]);
       }
     }

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -2,8 +2,10 @@ import { gatherBumpInfo } from '../bump/gatherBumpInfo';
 import { performBump } from '../bump/performBump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { BumpInfo } from '../types/BumpInfo';
 
-export async function bump(options: BeachballOptions) {
+export async function bump(options: BeachballOptions): Promise<BumpInfo> {
   const bumpInfo = gatherBumpInfo(options, getPackageInfos(options.path));
-  return await performBump(bumpInfo, options);
+  // The bumpInfo is returned for testing
+  return performBump(bumpInfo, options);
 }

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -7,7 +7,7 @@ import { listPackageVersions } from '../packageManager/listPackageVersions';
 import { publishToRegistry } from '../publish/publishToRegistry';
 import { BeachballOptions } from '../types/BeachballOptions';
 
-export async function canary(options: BeachballOptions) {
+export async function canary(options: BeachballOptions): Promise<void> {
   const oldPackageInfo = getPackageInfos(options.path);
 
   const bumpInfo = gatherBumpInfo(options, oldPackageInfo);

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -6,7 +6,7 @@ import { getRecentCommitMessages, getUserEmail } from 'workspace-tools';
 import { getChangedPackages } from '../changefile/getChangedPackages';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 
-export async function change(options: BeachballOptions) {
+export async function change(options: BeachballOptions): Promise<void> {
   const { branch, path: cwd } = options;
   const { package: specificPackage } = options;
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@ import { findProjectRoot } from 'workspace-tools';
 import { npm } from '../packageManager/npm';
 import { PackageJson } from '../types/PackageInfo';
 
-function errorExit(message: string) {
+function errorExit(message: string): void {
   console.error(message);
   console.log(
     'You can still set up beachball manually by following the instructions here: https://microsoft.github.io/beachball/overview/getting-started.html'
@@ -13,7 +13,7 @@ function errorExit(message: string) {
   process.exit(1);
 }
 
-export async function init(options: BeachballOptions) {
+export async function init(options: BeachballOptions): Promise<void> {
   let root: string;
   try {
     root = findProjectRoot(options.path);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -8,7 +8,7 @@ import { publishToRegistry } from '../publish/publishToRegistry';
 import { getNewPackages } from '../publish/getNewPackages';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 
-export async function publish(options: BeachballOptions) {
+export async function publish(options: BeachballOptions): Promise<void> {
   console.log('\nPreparing to publish');
 
   const { path: cwd, branch, registry, tag } = options;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
 import { writePackageJson, updatePackageLock } from '../bump/performBump';
 
-export async function sync(options: BeachballOptions) {
+export async function sync(options: BeachballOptions): Promise<void> {
   const packageInfos = getPackageInfos(options.path);
   const scopedPackages = new Set(getScopedPackages(options, packageInfos));
 

--- a/src/git/ensureSharedHistory.ts
+++ b/src/git/ensureSharedHistory.ts
@@ -11,7 +11,7 @@ import { gitFetch } from './fetch';
  */
 export function ensureSharedHistory(
   options: Pick<BeachballOptions, 'fetch' | 'path' | 'branch' | 'depth' | 'verbose'>
-) {
+): void {
   const { fetch, path: cwd, branch, depth, verbose } = options;
   // `branch` should *usually* include a remote, but it's not guaranteed (see doc comment).
   // `remote` is the remote name (e.g. "origin") or "" if `branch` was missing a remote.
@@ -101,7 +101,7 @@ function deepenHistory(params: {
   depth: number | undefined;
   cwd: string;
   verbose?: boolean;
-}) {
+}): boolean {
   const { remote, remoteBranch, branch, cwd, verbose } = params;
   const depth = params.depth || 100;
 
@@ -135,7 +135,12 @@ function deepenHistory(params: {
   return hasCommonCommit(branch, cwd);
 }
 
-function logError(error: 'missing-branch' | 'shallow-clone', branch: string, remote: string, remoteBranch: string) {
+function logError(
+  error: 'missing-branch' | 'shallow-clone',
+  branch: string,
+  remote: string,
+  remoteBranch: string
+): void {
   let mainError: string;
   let mitigationSteps: string;
 
@@ -170,15 +175,15 @@ ${mitigationSteps}
 `);
 }
 
-function hasBranchRef(branch: string, cwd: string) {
+function hasBranchRef(branch: string, cwd: string): boolean {
   return git(['rev-parse', '--verify', branch], { cwd }).success;
 }
 
-function isShallowRepository(cwd: string) {
+function isShallowRepository(cwd: string): boolean {
   return git(['rev-parse', '--is-shallow-repository'], { cwd }).stdout.trim() === 'true';
 }
 
 /** Returns whether `branch` and HEAD have a common commit anywhere in their history */
-function hasCommonCommit(branch: string, cwd: string) {
+function hasCommonCommit(branch: string, cwd: string): boolean {
   return git(['merge-base', branch, 'HEAD'], { cwd }).success;
 }

--- a/src/git/generateTag.ts
+++ b/src/git/generateTag.ts
@@ -1,4 +1,4 @@
 /** Get a standardized package version git tag: `${name}_v${version}` */
-export function generateTag(name: string, version: string) {
+export function generateTag(name: string, version: string): string {
   return `${name}_v${version}`;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,9 +1,9 @@
-export function showVersion() {
+export function showVersion(): void {
   const packageJson = require('../package.json');
   console.log(`beachball v${packageJson.version} - the sunniest version bumping tool`);
 }
 
-export function showHelp() {
+export function showHelp(): void {
   showVersion();
 
   console.log(`Prerequisites:

--- a/src/logging/format.ts
+++ b/src/logging/format.ts
@@ -1,5 +1,5 @@
 /** Format strings as a bulleted list with line breaks */
-export function formatList(items: string[]) {
+export function formatList(items: string[]): string {
   return items.map(item => `- ${item}`).join('\n');
 }
 
@@ -7,6 +7,6 @@ export function formatList(items: string[]) {
  * Format an object on a single line with spaces between the properties and brackets
  * (similar to `JSON.stringify(obj, null, 2)` but without the line breaks).
  */
-export function singleLineStringify(obj: any) {
+export function singleLineStringify(obj: any): string {
   return JSON.stringify(obj, null, 2).replace(/\n\s*/g, ' ');
 }

--- a/src/monorepo/getPackageGroups.ts
+++ b/src/monorepo/getPackageGroups.ts
@@ -3,7 +3,11 @@ import path from 'path';
 import { PackageInfos, PackageGroups } from '../types/PackageInfo';
 import { isPathIncluded } from './isPathIncluded';
 
-export function getPackageGroups(packageInfos: PackageInfos, root: string, groups: VersionGroupOptions[] | undefined) {
+export function getPackageGroups(
+  packageInfos: PackageInfos,
+  root: string,
+  groups: VersionGroupOptions[] | undefined
+): PackageGroups {
   if (!groups?.length) {
     return {};
   }

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -26,7 +26,7 @@ export function getPackageInfos(cwd: string): PackageInfos {
   );
 }
 
-function getPackageInfosFromWorkspace(projectRoot: string) {
+function getPackageInfosFromWorkspace(projectRoot: string): PackageInfos | undefined {
   let workspacePackages: WorkspaceInfo | undefined;
   try {
     // first try using the workspace provided packages (if available)
@@ -55,7 +55,7 @@ function getPackageInfosFromWorkspace(projectRoot: string) {
   return packageInfos;
 }
 
-function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string) {
+function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string): PackageInfos | undefined {
   const packageJsonFiles = listAllTrackedFiles(['**/package.json', 'package.json'], projectRoot);
   if (!packageJsonFiles.length) {
     return;
@@ -93,7 +93,7 @@ function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string) {
   return packageInfos;
 }
 
-function getPackageInfosFromSingleRepo(packageRoot: string) {
+function getPackageInfosFromSingleRepo(packageRoot: string): PackageInfos {
   const packageInfos: PackageInfos = {};
   const packageJsonFullPath = path.resolve(packageRoot, 'package.json');
   const packageJson = fs.readJSONSync(packageJsonFullPath);

--- a/src/monorepo/getScopedPackages.ts
+++ b/src/monorepo/getScopedPackages.ts
@@ -3,7 +3,7 @@ import { PackageInfos } from '../types/PackageInfo';
 import path from 'path';
 import { isPathIncluded } from './isPathIncluded';
 
-export function getScopedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
+export function getScopedPackages(options: BeachballOptions, packageInfos: PackageInfos): string[] {
   if (!options.scope) {
     return Object.keys(packageInfos);
   }

--- a/src/monorepo/isPathIncluded.ts
+++ b/src/monorepo/isPathIncluded.ts
@@ -3,7 +3,7 @@ import minimatch from 'minimatch';
 /**
  * Check if a relative path should be included given include and exclude patterns using minimatch.
  */
-export function isPathIncluded(relativePath: string, include: string | string[], exclude?: string | string[]) {
+export function isPathIncluded(relativePath: string, include: string | string[], exclude?: string | string[]): boolean {
   const includePatterns = typeof include === 'string' ? [include] : include;
   let shouldInclude = includePatterns.reduce(
     (included, pattern) => included || minimatch(relativePath, pattern),

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -1,7 +1,11 @@
 import { env } from '../env';
 import { BeachballOptions } from '../types/BeachballOptions';
 
-export function getDefaultOptions() {
+/**
+ * Default options.
+ * Note that as of writing, this does not actually set values for all "required" BeachballOptions.
+ */
+export function getDefaultOptions(): BeachballOptions {
   return {
     access: 'restricted',
     all: false,

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -4,20 +4,21 @@ import { PackageInfo } from '../types/PackageInfo';
 import { NpmOptions } from '../types/NpmOptions';
 import { env } from '../env';
 
-let packageVersionsCache: {
-  [pkgName: string]: {
-    versions?: string[];
-    'dist-tags'?: Record<string, string>;
-  };
-} = {};
+// More properties can be added as needed
+type NpmRegistryPackage = {
+  versions?: string[];
+  'dist-tags'?: Record<string, string>;
+};
+
+let packageVersionsCache: { [pkgName: string]: NpmRegistryPackage } = {};
 
 const NPM_CONCURRENCY = env.isJest ? 2 : 5;
 
-export async function _clearPackageVersionsCache() {
+export function _clearPackageVersionsCache(): void {
   packageVersionsCache = {};
 }
 
-async function getNpmPackageInfo(packageName: string, options: NpmOptions) {
+async function getNpmPackageInfo(packageName: string, options: NpmOptions): Promise<NpmRegistryPackage> {
   const { registry, token, authType, timeout } = options;
 
   if (env.beachballDisableCache || !packageVersionsCache[packageName]) {
@@ -40,7 +41,7 @@ export async function listPackageVersionsByTag(
   packageInfos: PackageInfo[],
   tag: string | undefined,
   options: NpmOptions
-) {
+): Promise<{ [pkg: string]: string | undefined }> {
   const limit = pLimit(NPM_CONCURRENCY);
   const versions: { [pkg: string]: string | undefined } = {};
 
@@ -57,7 +58,10 @@ export async function listPackageVersionsByTag(
   return versions;
 }
 
-export async function listPackageVersions(packageList: string[], options: NpmOptions) {
+export async function listPackageVersions(
+  packageList: string[],
+  options: NpmOptions
+): Promise<{ [pkg: string]: string[] }> {
   const limit = pLimit(NPM_CONCURRENCY);
   const versions: { [pkg: string]: string[] } = {};
 

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { getNpmAuthArgs, npmAsync } from './npm';
 import { NpmOptions } from '../types/NpmOptions';
 
-export function packagePublish(packageInfo: PackageInfo, options: NpmOptions) {
+export function packagePublish(packageInfo: PackageInfo, options: NpmOptions): ReturnType<typeof npmAsync> {
   const { registry, token, authType, access, timeout } = options;
   const packageOptions = packageInfo.combinedOptions;
   const packagePath = path.dirname(packageInfo.packageJsonPath);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -7,7 +7,7 @@ export const changeFolder = 'change';
 /**
  * Get the absolute path to the folder containing beachball change files.
  */
-export function getChangePath(cwd: string) {
+export function getChangePath(cwd: string): string {
   const root = findProjectRoot(cwd);
   return path.join(root, changeFolder);
 }

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -14,7 +14,7 @@ const verbose = true;
 /**
  * Bump versions locally, commit, optionally tag, and push to git.
  */
-export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions) {
+export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, options: BeachballOptions): Promise<void> {
   const { path: cwd, branch, depth, gitTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch(branch);
 
@@ -88,7 +88,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
 async function mergePublishBranch(
   publishBranch: string,
   options: Pick<BeachballOptions, 'branch' | 'hooks' | 'message' | 'path'>
-) {
+): Promise<boolean> {
   await options.hooks?.precommit?.(options.path);
 
   console.log(`\nMerging ${publishBranch} into ${options.branch}...`);

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -1,6 +1,6 @@
 import { BumpInfo } from '../types/BumpInfo';
 
-export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()) {
+export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()): void {
   const errorLines: string[] = [];
   const succeededLines: string[] = [];
 

--- a/src/publish/getNewPackages.ts
+++ b/src/publish/getNewPackages.ts
@@ -5,7 +5,7 @@ import { NpmOptions } from '../types/NpmOptions';
 export async function getNewPackages(
   bumpInfo: Pick<BumpInfo, 'modifiedPackages' | 'packageInfos'>,
   options: NpmOptions
-) {
+): Promise<string[]> {
   const { modifiedPackages, packageInfos } = bumpInfo;
 
   const newPackages = Object.keys(packageInfos).filter(pkg => !modifiedPackages.has(pkg) && !packageInfos[pkg].private);

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -10,7 +10,7 @@ import { toposortPackages } from './toposortPackages';
  * based on the dependency graph to ensure they're published in the correct order, and any
  * new/modified packages that will be skipped (and why) are logged to the console.
  */
-export function getPackagesToPublish(bumpInfo: BumpInfo, validationMode?: boolean) {
+export function getPackagesToPublish(bumpInfo: BumpInfo, validationMode?: boolean): string[] {
   const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
 
   let packages = [...modifiedPackages, ...newPackages];

--- a/src/publish/performPublishOverrides.ts
+++ b/src/publish/performPublishOverrides.ts
@@ -14,7 +14,7 @@ const acceptedKeys = [
 ] as const;
 const workspacePrefix = 'workspace:';
 
-export function performPublishOverrides(packagesToPublish: string[], packageInfos: PackageInfos) {
+export function performPublishOverrides(packagesToPublish: string[], packageInfos: PackageInfos): void {
   for (const pkgName of packagesToPublish) {
     const info = packageInfos[pkgName];
     const packageJson = fs.readJSONSync(info.packageJsonPath);
@@ -26,7 +26,7 @@ export function performPublishOverrides(packagesToPublish: string[], packageInfo
   }
 }
 
-function performPublishConfigOverrides(packageJson: PackageJson) {
+function performPublishConfigOverrides(packageJson: PackageJson): void {
   // Everything in publishConfig in accepted keys here will get overridden & removed from the publishConfig section
   if (packageJson.publishConfig) {
     for (const [k, value] of Object.entries(packageJson.publishConfig)) {
@@ -45,7 +45,7 @@ function performPublishConfigOverrides(packageJson: PackageJson) {
  * handle this replacement for us, but as of this time publishing only happens via npm, which can't do this
  * replacement.
  */
-function performWorkspaceVersionOverrides(packageJson: PackageJson, packageInfos: PackageInfos) {
+function performWorkspaceVersionOverrides(packageJson: PackageJson, packageInfos: PackageInfos): void {
   const { dependencies, devDependencies, peerDependencies } = packageJson;
   for (const deps of [dependencies, devDependencies, peerDependencies]) {
     if (!deps) continue;

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -11,7 +11,7 @@ import { performPublishOverrides } from './performPublishOverrides';
 import { PackageInfo } from '../types/PackageInfo';
 import { getPackagesToPublish } from './getPackagesToPublish';
 
-export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions) {
+export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions): Promise<void> {
   const bumpInfo = _.cloneDeep(originalBumpInfo);
 
   if (options.bump) {
@@ -69,7 +69,7 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
   }
 }
 
-async function tryPublishPackage(packageInfo: PackageInfo, options: BeachballOptions) {
+async function tryPublishPackage(packageInfo: PackageInfo, options: BeachballOptions): Promise<boolean> {
   const pkg = packageInfo.name;
   console.log(`\nPublishing - ${pkg}@${packageInfo.version} with tag ${packageInfo.combinedOptions.tag}.`);
 

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -3,7 +3,7 @@ import { generateTag } from '../git/generateTag';
 import { gitFailFast } from 'workspace-tools';
 import { BeachballOptions } from '../types/BeachballOptions';
 
-function createTag(tag: string, cwd: string) {
+function createTag(tag: string, cwd: string): void {
   gitFailFast(['tag', '-a', '-f', tag, '-m', tag], { cwd });
 }
 
@@ -12,7 +12,7 @@ function createTag(tag: string, cwd: string) {
  * Also, if git tags aren't disabled for the repo and the overall dist-tag (`options.tag`) has a
  * non-default value (not "latest"), create a git tag for the dist-tag.
  */
-export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 'gitTags' | 'path' | 'tag'>) {
+export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 'gitTags' | 'path' | 'tag'>): void {
   const { gitTags, tag: distTag, path: cwd } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
 
@@ -21,7 +21,7 @@ export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 
     const changeType = bumpInfo.calculatedChangeTypes[pkg];
     // Do not tag change type of "none", private packages, or packages opting out of tagging
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
-      return;
+      continue;
     }
     console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
     const generatedTag = generateTag(packageInfo.name, packageInfo.version);

--- a/src/validation/isChangeFileNeeded.ts
+++ b/src/validation/isChangeFileNeeded.ts
@@ -2,7 +2,7 @@ import { getChangedPackages } from '../changefile/getChangedPackages';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { PackageInfos } from '../types/PackageInfo';
 
-export function isChangeFileNeeded(options: BeachballOptions, packageInfos: PackageInfos) {
+export function isChangeFileNeeded(options: BeachballOptions, packageInfos: PackageInfos): boolean {
   const { branch } = options;
 
   console.log(`Checking for changes against "${branch}"`);

--- a/src/validation/isGitAvailable.ts
+++ b/src/validation/isGitAvailable.ts
@@ -1,6 +1,6 @@
 import { git, findGitRoot } from 'workspace-tools';
 
-export function isGitAvailable(cwd: string) {
+export function isGitAvailable(cwd: string): boolean {
   const result = git(['--version']);
   try {
     return result.success && !!findGitRoot(cwd);

--- a/src/validation/isValidChangeType.ts
+++ b/src/validation/isValidChangeType.ts
@@ -1,5 +1,5 @@
 import { SortedChangeTypes } from '../changefile/changeTypes';
 
-export function isValidChangeType(changeType: string) {
+export function isValidChangeType(changeType: string): boolean {
   return SortedChangeTypes.includes(changeType as any);
 }

--- a/src/validation/isValidDependentChangeType.ts
+++ b/src/validation/isValidDependentChangeType.ts
@@ -3,7 +3,7 @@ import { ChangeType } from '../types/ChangeInfo';
 export function isValidDependentChangeType(
   dependentChangeType: ChangeType,
   disallowedChangeTypes: ChangeType[] | null
-) {
+): boolean {
   // patch is always allowed as a dependentChangeType
   const disallowedDependentChangeTypes = (disallowedChangeTypes || []).filter(t => t !== 'patch');
 

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -2,7 +2,7 @@ import { formatList, singleLineStringify } from '../logging/format';
 import { VersionGroupOptions } from '../types/BeachballOptions';
 import { PackageGroups, PackageInfos } from '../types/PackageInfo';
 
-export function isValidGroupOptions(groups: VersionGroupOptions[]) {
+export function isValidGroupOptions(groups: VersionGroupOptions[]): boolean {
   // Values that violate types could happen in a user-provided object
   if (!Array.isArray(groups)) {
     console.error(
@@ -19,10 +19,12 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]) {
     );
     return false;
   }
+
+  return true;
 }
 
 /** Validate per-package beachball options are valid for packages in groups */
-export function isValidGroupedPackageOptions(packageInfos: PackageInfos, packageGroups: PackageGroups) {
+export function isValidGroupedPackageOptions(packageInfos: PackageInfos, packageGroups: PackageGroups): boolean {
   const errorPackages: string[] = [];
 
   // make sure no disallowed change type options exist inside an individual package

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -29,7 +29,10 @@ type ValidationOptions = {
   allowMissingChangeFiles?: boolean;
 };
 
-export function validate(options: BeachballOptions, validateOptions?: Partial<ValidationOptions>) {
+export function validate(
+  options: BeachballOptions,
+  validateOptions?: Partial<ValidationOptions>
+): { isChangeNeeded: boolean } {
   const { allowMissingChangeFiles = false, allowFetching = true } = validateOptions || {};
 
   console.log('\nValidating options and change files...');


### PR DESCRIPTION
I refactored some stuff with validation and forgot to add a final `return true` in one of the modified functions (which didn't declare a return type, so the compiler didn't catch it).

This PR fixes that error, adds some super basic tests for `validate()` (it had no test coverage...), and adds return types to all functions to reduce the chance of similar future errors.