### PR TITLE
Add --all option for change command

### DIFF
--- a/change/beachball-9bdf704a-61ed-4b77-8dfa-26bc583976fa.json
+++ b/change/beachball-9bdf704a-61ed-4b77-8dfa-26bc583976fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add --all option for `change` command",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/cli/change.md
+++ b/docs/cli/change.md
@@ -16,7 +16,15 @@ $ beachball change
 
 ### Options
 
-See the [options page](./options).
+Some [general options](./options) including `--branch` also apply for this command.
+
+| Option        | Alias | Default              | Description                                                                       |
+| ------------- | ----- | -------------------- | --------------------------------------------------------------------------------- |
+| `--all`       |       | false                | Generate change files for all packages                                            |
+| `--message`   | `-m`  | (interactive prompt) | Description for all change files                                                  |
+| `--no-commit` |       | false                | Stage the change file rather than committing                                      |
+| `--package`   |       | (changed packages)   | Generate change files for these packages (option can be specified multiple times) |
+| `--type`      |       | (interactive prompt) | Type for all the change files (must be valid for each package)                    |
 
 ### Walkthrough
 
@@ -31,28 +39,34 @@ There are uncommitted changes in your repository. Please commit these files firs
 
 Make sure to commit _all_ changes before proceeding with the `change` command.
 
-Now we'll commit the changes we made and run `beachball change` again:
+After committing, run `beachball change`:
 
 ```
 $ beachball change
-Defaults to "origin/master"
-Checking for changes against "origin/master"
 
-Please describe the changes for: single
-? Describe changes (type or choose one) ›
-adding a new file
+Validating options and change files...
+Checking for changes against "origin/main"
+Found changes in the following packages:
+  some-pkg
 ```
 
-First, it will ask for a **description** of the change. You can enter any text, but `beachball` will also provide a list of recent commit messages to choose from.
+For each package, the prompt will start by asking for a **change type**. If this change has no impact on the published package (e.g. fixing a typo in a comment or updating a test), choose "none."
+
+```
+Please describe the changes for: some-pkg
+? Change type › - Use arrow-keys. Return to submit.
+❯ Patch - bug fixes; no backwards incompatible changes.
+  Minor - small feature; backwards compatible changes.
+  None - this change does not affect the published package in any way.
+  Major - major feature; breaking changes.
+```
+
+Next, it asks for a **description** of the change. You can type any text or choose from a list of recent commit messages.
 
 > Tip: These descriptions will be collated into a changelog when the change is published by `beachball publish`, so think about how to describe your change in a way that's helpful and relevant for consumers of the package.
 
-Next, the form will ask for a change **type**. This should be chosen based on [semantic versioning rules](https://semver.org/) because it determines how to update the package version. If the change doesn't affect the published package at all (e.g. you just updated some comments), choose `none`.
-
-```bash
-? Change type › - Use arrow-keys. Return to submit.
-❯  Patch - bug fixes; no backwards incompatible changes.
-   Minor - small feature; backwards compatible changes.
-   None - this change does not affect the published package in any way.
-   Major - major feature; breaking changes.
+```
+Please describe the changes for: some-pkg
+? Describe changes (type or choose one) ›
+adding a new file
 ```

--- a/docs/cli/change.md
+++ b/docs/cli/change.md
@@ -16,17 +16,43 @@ $ beachball change
 
 ### Options
 
-Some [general options](./options) including `--branch` also apply for this command.
+Some [general options](./options) including `--branch` and `--scope` also apply for this command.
 
 | Option        | Alias | Default              | Description                                                                       |
 | ------------- | ----- | -------------------- | --------------------------------------------------------------------------------- |
 | `--all`       |       | false                | Generate change files for all packages                                            |
 | `--message`   | `-m`  | (interactive prompt) | Description for all change files                                                  |
-| `--no-commit` |       | false                | Stage the change file rather than committing                                      |
+| `--no-commit` |       | false                | Stage the change files rather than committing                                     |
 | `--package`   |       | (changed packages)   | Generate change files for these packages (option can be specified multiple times) |
 | `--type`      |       | (interactive prompt) | Type for all the change files (must be valid for each package)                    |
 
-### Walkthrough
+### Examples
+
+Basic interactive prompt (see [walkthrough](#prompt-walkthrough) for details):
+
+```
+beachball change
+```
+
+Skip the interactive prompt by specifying a message and type for all changed packages:
+
+```
+beachball change --type patch --message 'some message'
+```
+
+Generate change file for specific package(s), regardless of changes, and even if a change file already exists for the package in this branch. Each package must be specified with a separate `--package` option. (You can also use the `--message` and `--type` options here.)
+
+```
+beachball change --package foo --package bar
+```
+
+Generate change files for all packages, regardless of changes. This would most often be used for build config updates which only touch a shared config file, but actually impact the output of all packages.
+
+```
+beachball change --all --type patch --message 'update build output settings'
+```
+
+### Prompt walkthrough
 
 If you have changes that are not committed yet (i.e. `git status` reports changes), then `beachball change` will warn you about these:
 
@@ -50,7 +76,7 @@ Found changes in the following packages:
   some-pkg
 ```
 
-For each package, the prompt will start by asking for a **change type**. If this change has no impact on the published package (e.g. fixing a typo in a comment or updating a test), choose "none."
+For each package, the prompt will start by asking for a change **type**. This should be chosen based on [semantic versioning rules](https://semver.org/) because it determines how to update the package version. If the change doesn't affect the published package at all (e.g. you just updated some comments), choose `none`.
 
 ```
 Please describe the changes for: some-pkg

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -13,19 +13,14 @@ For the latest full list of supported options, see `CliOptions` [in this file](h
 
 These apply to most CLI commands.
 
-| Option     | Alias      | Default           | Description               |
-| ---------- | ---------- | ----------------- | ------------------------- |
-| `--branch` | `-b`       | `'origin/master'` | target branch from origin |
-| `--help`   | `-?`, `-h` |                   | show help message         |
+| Option       | Alias | Default                                                                      | Description               |
+| ------------ | ----- | ---------------------------------------------------------------------------- | ------------------------- |
+| `--branch`   | `-b`  | Detected default branch in default remote, falling back to `'origin/master'` | target branch from origin |
+| `--no-fetch` |       |                                                                              | Disable fetching          |
 
-## Change options
+## `change` options
 
-These options are applicable to the `change` command.
-
-| Option      | Alias | Default              | Description                                                    |
-| ----------- | ----- | -------------------- | -------------------------------------------------------------- |
-| `--message` | `-m`  | (interactive prompt) | Description for all change files                               |
-| `--type`    |       | (interactive prompt) | Type for all the change files (must be valid for each package) |
+See the [`change` page](./change).
 
 ## Bumping and publishing options
 

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -192,4 +192,13 @@ describe('getChangedPackages', () => {
     expect(changedPackagesB).toStrictEqual([]);
     expect(changedPackagesRoot).toStrictEqual(['@workspace-a/foo']);
   });
+
+  it('returns all packages with --all option', () => {
+    repositoryFactory = new RepositoryFactory('monorepo');
+    const repo = repositoryFactory.cloneRepository();
+    const options = { all: true, fetch: false, path: repo.rootPath, branch: defaultBranchName } as BeachballOptions;
+    const packageInfos = getPackageInfos(repo.rootPath);
+
+    expect(getChangedPackages(options, packageInfos).sort()).toStrictEqual(['a', 'b', 'bar', 'baz', 'foo']);
+  });
 });

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -7,8 +7,7 @@ import { getChangedPackages } from '../changefile/getChangedPackages';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
 
 export async function change(options: BeachballOptions): Promise<void> {
-  const { branch, path: cwd } = options;
-  const { package: specificPackage } = options;
+  const { branch, path: cwd, package: specificPackage } = options;
 
   const packageInfos = getPackageInfos(cwd);
   const packageGroups = getPackageGroups(packageInfos, cwd, options.groups);

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -41,16 +41,19 @@ export async function listPackageVersionsByTag(
   packageInfos: PackageInfo[],
   tag: string | undefined,
   options: NpmOptions
-): Promise<{ [pkg: string]: string | undefined }> {
+): Promise<{ [pkg: string]: string }> {
   const limit = pLimit(NPM_CONCURRENCY);
-  const versions: { [pkg: string]: string | undefined } = {};
+  const versions: { [pkg: string]: string } = {};
 
   await Promise.all(
     packageInfos.map(pkg =>
       limit(async () => {
         const info = await getNpmPackageInfo(pkg.name, options);
         const npmTag = tag || pkg.combinedOptions.tag || pkg.combinedOptions.defaultNpmTag;
-        versions[pkg.name] = (npmTag && info['dist-tags']?.[npmTag]) || undefined;
+        const version = npmTag && info['dist-tags']?.[npmTag];
+        if (version) {
+          versions[pkg.name] = version;
+        }
       })
     )
   );

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -60,7 +60,9 @@ export function validate(
 
   const packageInfos = getPackageInfos(options.path);
 
-  if (typeof options.package === 'string' && !packageInfos[options.package]) {
+  if (options.all && options.package) {
+    logValidationError('Cannot specify both "all" and "package" options');
+  } else if (typeof options.package === 'string' && !packageInfos[options.package]) {
     logValidationError(`package "${options.package}" was not found`);
   } else {
     const invalidPackages = Array.isArray(options.package)


### PR DESCRIPTION
Add an `--all` option for the `change` command to generate change files for all packages (or all in-scope packages, if `scope` is specified).