### PR TITLE
Update to typescript 4.5

### DIFF
--- a/change/beachball-47472917-5374-4d55-a134-51a4ddbefa85.json
+++ b/change/beachball-47472917-5374-4d55-a134-51a4ddbefa85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update to typescript 4.5",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "strip-ansi": "^6.0.1",
     "tmp": "^0.2.1",
     "ts-jest": "^29.0.0",
-    "typescript": "~4.3.5",
+    "typescript": "~4.5.0",
     "verdaccio": "^4.13.2",
     "verdaccio-auth-memory": "^10.2.0",
     "verdaccio-memory": "^10.3.0",

--- a/src/publish/toposortPackages.ts
+++ b/src/publish/toposortPackages.ts
@@ -34,6 +34,6 @@ export function toposortPackages(packages: string[], packageInfos: PackageInfos)
   try {
     return toposort(dependencyGraph).filter((pkg): pkg is string => !!pkg);
   } catch (err) {
-    throw new Error(`Failed to topologically sort packages: ${err?.message}`);
+    throw new Error(`Failed to topologically sort packages: ${(err as Error)?.message}`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10880,10 +10880,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@~4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@~4.5.0:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Typescript 4.5 has been out for quite awhile now, and the API surface of beachball types is pretty minimal, so it's probably safe to update. 

(It would likely be okay to go even newer than this, but I specifically wanted `Awaited` which is in 4.5.)