### PR TITLE
Run all npm commands async

### DIFF
--- a/change/beachball-811d2893-9f79-4cf7-a6b0-83cc24615cf6.json
+++ b/change/beachball-811d2893-9f79-4cf7-a6b0-83cc24615cf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Run all npm commands async",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -5,7 +5,7 @@ import { addGitObserver, clearGitObservers } from 'workspace-tools';
 import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { defaultBranchName, defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { initMockLogs } from '../__fixtures__/mockLogs';
-import { npmShow, NpmShowResult } from '../__fixtures__/npmShow';
+import { npmShow } from '../__fixtures__/npmShow';
 import { Registry } from '../__fixtures__/registry';
 import { Repository } from '../__fixtures__/repository';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
@@ -67,12 +67,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -91,12 +90,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { push: false }));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
   });
 
   it('can perform a successful npm publish from a race condition', async () => {
@@ -125,12 +123,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -169,12 +166,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -198,12 +194,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { bump: false }));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.0.0'],
       'dist-tags': { latest: '1.0.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -220,14 +215,13 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    npmShow(registry, 'bar', true /*shouldFail*/);
+    await npmShow('bar', { registry, shouldFail: true });
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -247,24 +241,25 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo));
 
-    const bazResult: NpmShowResult = { name: 'baz', versions: ['1.4.0'], 'dist-tags': { latest: '1.4.0' } };
-    expect(npmShow(registry, 'baz')).toMatchObject(bazResult);
+    expect(await npmShow('baz', { registry })).toMatchObject({
+      name: 'baz',
+      versions: ['1.4.0'],
+      'dist-tags': { latest: '1.4.0' },
+    });
 
-    const barResult: NpmShowResult = {
+    expect(await npmShow('bar', { registry })).toMatchObject({
       name: 'bar',
       versions: ['1.3.5'],
       'dist-tags': { latest: '1.3.5' },
       dependencies: { baz: '^1.4.0' },
-    };
-    expect(npmShow(registry, 'bar')).toMatchObject(barResult);
+    });
 
-    const fooResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.0.1'],
       'dist-tags': { latest: '1.0.1' },
       dependencies: { bar: '^1.3.5' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(fooResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -287,8 +282,8 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { new: true }));
 
-    expect(npmShow(registry, 'foo')).toMatchObject({ name: 'foo', versions: ['1.1.0'] });
-    expect(npmShow(registry, 'bar')).toMatchObject({ name: 'bar', versions: ['1.3.4'] });
+    expect(await npmShow('foo', { registry })).toMatchObject({ name: 'foo', versions: ['1.1.0'] });
+    expect(await npmShow('bar', { registry })).toMatchObject({ name: 'bar', versions: ['1.3.4'] });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -306,16 +301,15 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { scope: ['!packages/foo'] }));
 
-    npmShow(registry, 'foo', true /*shouldFail*/);
+    await npmShow('foo', { registry, shouldFail: true });
 
     expect(repo.getCurrentTags()).toEqual([]);
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('bar', { registry })).toMatchObject({
       name: 'bar',
       versions: ['1.4.0'],
       'dist-tags': { latest: '1.4.0' },
-    };
-    expect(npmShow(registry, 'bar')).toMatchObject(expectedNpmResult);
+    });
 
     repo.checkout(defaultBranchName);
     repo.pull();
@@ -348,7 +342,7 @@ describe('publish command (e2e)', () => {
     );
 
     // Query the information from package.json from the registry to see if it was successfully patched
-    const show = npmShow(registry, 'foo')!;
+    const show = (await npmShow('foo', { registry }))!;
     expect(show.name).toEqual('foo');
     expect(show.main).toEqual('lib/index.js');
     expect(show.hasOwnProperty('onPublish')).toBeFalsy();
@@ -410,12 +404,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { fetch: false }));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     // no fetch when flag set to false
     expect(fetchCount).toBe(0);
@@ -439,12 +432,11 @@ describe('publish command (e2e)', () => {
 
     await publish(getOptions(repo, { depth: 10 }));
 
-    const expectedNpmResult: NpmShowResult = {
+    expect(await npmShow('foo', { registry })).toMatchObject({
       name: 'foo',
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
-    };
-    expect(npmShow(registry, 'foo')).toMatchObject(expectedNpmResult);
+    });
 
     expect(fetchCommand).toMatch('--depth=10');
   });

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -65,9 +65,9 @@ describe('publish command (registry)', () => {
 
     await publish(getOptions(repo, { package: 'foo' }));
 
-    const show = npmShow(registry, 'foo')!;
-    expect(show.name).toEqual('foo');
-    expect(show.versions).toHaveLength(1);
+    const publishedPackage = (await npmShow('foo', { registry }))!;
+    expect(publishedPackage.name).toEqual('foo');
+    expect(publishedPackage.versions).toHaveLength(1);
   });
 
   it('can perform a successful npm publish even with private packages', async () => {
@@ -87,7 +87,7 @@ describe('publish command (registry)', () => {
 
     await publish(getOptions(repo, { package: 'foopkg' }));
 
-    npmShow(registry, 'foopkg', true /*shouldFail*/);
+    await npmShow('foopkg', { registry, shouldFail: true });
   });
 
   it('can perform a successful npm publish when multiple packages changed at same time', async () => {
@@ -107,10 +107,10 @@ describe('publish command (registry)', () => {
 
     await publish(getOptions(repo, { package: 'foopkg' }));
 
-    const showFoo = npmShow(registry, 'foopkg')!;
+    const showFoo = (await npmShow('foopkg', { registry }))!;
     expect(showFoo['dist-tags'].latest).toEqual('1.1.0');
 
-    const showBar = npmShow(registry, 'barpkg')!;
+    const showBar = (await npmShow('barpkg', { registry }))!;
     expect(showBar['dist-tags'].latest).toEqual('1.1.0');
   });
 
@@ -131,7 +131,7 @@ describe('publish command (registry)', () => {
 
     await publish(getOptions(repo, { package: 'foopkg' }));
 
-    npmShow(registry, 'badname', true /*shouldFail*/);
+    await npmShow('badname', { registry, shouldFail: true });
   });
 
   it('should exit publishing early if only invalid change files exist', async () => {
@@ -152,7 +152,7 @@ describe('publish command (registry)', () => {
       expect.stringContaining('Change detected for nonexistent package fake')
     );
 
-    npmShow(registry, 'fake', true /*shouldFail*/);
+    await npmShow('fake', { registry, shouldFail: true });
   });
 
   it('will perform retries', async () => {

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -1,34 +1,28 @@
 import { expect } from '@jest/globals';
 import os from 'os';
 import { env } from '../env';
+import { NpmShowResult } from '../packageManager/listPackageVersions';
 import { npm } from '../packageManager/npm';
 import { Registry } from './registry';
-
-/** Partial JSON returned by registry from running `npm show` */
-export type NpmShowResult = {
-  name: string;
-  versions: string[];
-  main?: string;
-  'dist-tags': Record<string, string>;
-  dependencies?: Record<string, string>;
-};
 
 /**
  * Runs `npm show <packageName>` on the fake registry and returns the result.
  * Also does an `expect()` to verify whether the command was successful
  * (or unsuccessful if `shouldFail` is true).
  */
-export function npmShow(
-  registry: Registry,
+export async function npmShow(
   packageName: string,
-  shouldFail: boolean = false
-): NpmShowResult | undefined {
+  options: { registry: Registry; shouldFail?: boolean }
+): Promise<NpmShowResult | undefined> {
+  const { registry, shouldFail } = options;
+
   const timeout = env.isCI && os.platform() === 'win32' ? 4500 : 1500;
-  // const start = Date.now();
-  const showResult = npm(['--registry', registry.getUrl(), 'show', packageName, '--json'], { timeout });
-  // if (Date.now() - start > timeout) {
-  //   throw new Error(`npm show ${packageName} took more than ${timeout}ms`);
-  // }
-  expect(showResult.failed).toBe(shouldFail);
+  const registryArg = registry ? ['--registry', registry.getUrl()] : [];
+
+  const showResult = await npm([...registryArg, 'show', '--json', packageName], { timeout });
+
+  expect(!!showResult.timedOut).toBe(false);
+  expect(showResult.failed).toBe(!!shouldFail);
+
   return shouldFail ? undefined : JSON.parse(showResult.stdout);
 }

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -6,14 +6,14 @@ import {
   _clearPackageVersionsCache,
 } from '../../packageManager/listPackageVersions';
 import { NpmOptions } from '../../types/NpmOptions';
-import { initNpmAsyncMock } from '../../__fixtures__/mockNpm';
+import { initNpmMock } from '../../__fixtures__/mockNpm';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 jest.mock('../../packageManager/npm');
 
 describe('list npm versions', () => {
   /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
-  const npmMock = initNpmAsyncMock();
+  const npmMock = initNpmMock();
   const npmOptions: NpmOptions = { registry: 'https://fake' };
 
   afterEach(() => {

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -4,7 +4,7 @@ import { _clearPackageVersionsCache } from '../../packageManager/listPackageVers
 import { getNewPackages } from '../../publish/getNewPackages';
 import { NpmOptions } from '../../types/NpmOptions';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
-import { initNpmAsyncMock } from '../../__fixtures__/mockNpm';
+import { initNpmMock } from '../../__fixtures__/mockNpm';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 jest.mock('../../packageManager/npm');
@@ -12,7 +12,7 @@ jest.mock('../../packageManager/npm');
 describe('getNewPackages', () => {
   const logs = initMockLogs();
   /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
-  const npmMock = initNpmAsyncMock();
+  const npmMock = initNpmMock();
   const npmOptions = {} as NpmOptions;
 
   afterEach(() => {

--- a/src/__tests__/publish/validatePackageVersions.test.ts
+++ b/src/__tests__/publish/validatePackageVersions.test.ts
@@ -3,15 +3,15 @@ import { _clearPackageVersionsCache } from '../../packageManager/listPackageVers
 import { validatePackageVersions } from '../../publish/validatePackageVersions';
 import { NpmOptions } from '../../types/NpmOptions';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
-import { initNpmAsyncMock } from '../../__fixtures__/mockNpm';
+import { initNpmMock } from '../../__fixtures__/mockNpm';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 
 jest.mock('../../packageManager/npm');
 
 describe('validatePackageVersions', () => {
   const logs = initMockLogs();
-  /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
-  const npmMock = initNpmAsyncMock();
+  /** Mock the `npm show` command. This also handles cleanup after each test. */
+  const npmMock = initNpmMock();
   const npmOptions = {} as NpmOptions;
 
   afterEach(() => {

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -43,11 +43,11 @@ export function writePackageJson(modifiedPackages: Set<string>, packageInfos: Pa
 /**
  * If `package-lock.json` exists, runs `npm install --package-lock-only` to update it.
  */
-export function updatePackageLock(cwd: string): void {
+export async function updatePackageLock(cwd: string): Promise<void> {
   const root = findProjectRoot(cwd);
   if (root && fs.existsSync(path.join(root, 'package-lock.json'))) {
     console.log('Updating package-lock.json after bumping packages');
-    const res = npm(['install', '--package-lock-only', '--ignore-scripts'], { stdio: 'inherit' });
+    const res = await npm(['install', '--package-lock-only', '--ignore-scripts'], { stdio: 'inherit' });
     if (!res.success) {
       console.warn('Updating package-lock.json failed. Continuing...');
     }
@@ -65,7 +65,7 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
   await callHook('prebump', bumpInfo, options);
 
   writePackageJson(modifiedPackages, packageInfos);
-  updatePackageLock(options.path);
+  await updatePackageLock(options.path);
 
   if (options.generateChangelog) {
     // Generate changelog

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,7 +28,7 @@ export async function init(options: BeachballOptions): Promise<void> {
     errorExit(`Cannot find package.json at ${packageJsonFilePath}`);
   }
 
-  const npmResult = npm(['info', 'beachball', '--json']);
+  const npmResult = await npm(['info', 'beachball', '--json']);
   if (!npmResult.success) {
     errorExit('Failed to retrieve beachball version from npm');
   }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -34,5 +34,5 @@ export async function sync(options: BeachballOptions): Promise<void> {
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
   writePackageJson(modifiedPackages, packageInfos);
-  updatePackageLock(options.path);
+  await updatePackageLock(options.path);
 }

--- a/src/packageManager/npm.ts
+++ b/src/packageManager/npm.ts
@@ -1,30 +1,11 @@
 import execa from 'execa';
 
-/**
- * Run an npm command. Returns the error result instead of throwing on failure.
- */
-export function npm(
-  args: string[],
-  options: execa.SyncOptions = {}
-): execa.ExecaSyncReturnValue & { success: boolean } {
-  try {
-    const result = execa.sync('npm', args, { ...options });
-    return {
-      ...result,
-      success: !result.failed,
-    };
-  } catch (e) {
-    return {
-      ...(e as execa.ExecaSyncError),
-      success: false,
-    };
-  }
-}
+export type NpmResult = Awaited<ReturnType<typeof npm>>;
 
 /**
  * Run an npm command. Returns the error result instead of throwing on failure.
  */
-export async function npmAsync(
+export async function npm(
   args: string[],
   options: execa.Options = {}
 ): Promise<execa.ExecaReturnValue & { success: boolean }> {

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -1,14 +1,14 @@
 import { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
-import { npmAsync } from './npm';
+import { npm, NpmResult } from './npm';
 import { NpmOptions } from '../types/NpmOptions';
 import { getNpmPublishArgs } from './npmArgs';
 
-export function packagePublish(packageInfo: PackageInfo, options: NpmOptions): ReturnType<typeof npmAsync> {
+export function packagePublish(packageInfo: PackageInfo, options: NpmOptions): Promise<NpmResult> {
   const args = getNpmPublishArgs(packageInfo, options);
   console.log(`publish command: ${args.join(' ')}`);
 
-  return npmAsync(args, {
+  return npm(args, {
     cwd: path.dirname(packageInfo.packageJsonPath),
     timeout: options.timeout,
     all: true,


### PR DESCRIPTION
Remove the synchronous `npm` helper, and rename `npmAsync` to just `npm`. This is mainly to simplify some things in future tests.

Also remove some tests in `packagePublish` that were actually just verifying that the correct options were passed to `npm publish`, which is now covered by the `getNpmPublishArgs` tests.

(Most of the extra changes were triggered by updates to the `npmShow` test helper to make it asynchronous and tweak the signature.)