### PR TITLE
Move workspace publish overrides after prepublish hook execution

### DIFF
--- a/change/beachball-dcfa4985-8bb6-49b8-85db-365302dd9325.json
+++ b/change/beachball-dcfa4985-8bb6-49b8-85db-365302dd9325.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move workspace publish overrides after prepublish hook execution",
+  "packageName": "beachball",
+  "email": "tronguye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -34,9 +34,6 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     process.exit(1);
   }
 
-  // performing publishConfig and workspace version overrides requires this procedure to ONLY be run right before npm publish, but NOT in the git push
-  performPublishOverrides(packagesToPublish, bumpInfo.packageInfos);
-
   // if there is a prepublish hook perform a prepublish pass, calling the routine on each package
   const prepublishHook = options.hooks?.prepublish;
   if (prepublishHook) {
@@ -45,6 +42,9 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
       await prepublishHook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
     }
   }
+
+  // performing publishConfig and workspace version overrides requires this procedure to ONLY be run right before npm publish, but NOT in the git push
+  performPublishOverrides(packagesToPublish, bumpInfo.packageInfos);
 
   // finally pass through doing the actual npm publish command
   const succeededPackages = new Set<string>();


### PR DESCRIPTION
We are trying to have our yarn 1 repo be able to:
1. Locally, refer to local workspace package version
2. At publish time, change to ^x.y.z, where x.y.z is the post-bump version

To accomplish this, we are hoping to use the prepublish hook to change the internal packages to workspace:^ version, which Beachball already has logic to replace with ^x.y.z. Locally, we'd keep a specific version such as * to resolve to local workspace version.

We attempted this with the postbump hook, but postbump hook is also executed in the git commit/push route and thus pushed workspace:^ versions to our upstream (which yarn 1 can't resolve). As such, we propose that we can execute the prepublish hook before the workspace range overrides. This will allow us to hook into the publish, change to workspace:^ for internal dependencies, which is then handed back off to Beachball to override to the right version to publish