### PR TITLE
Improve mock npm and support mock publishing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ const config = {
   projects: [
     {
       displayName: 'unit',
-      testMatch: ['**/__tests__/**/*.test.ts'],
+      testMatch: ['**/__(tests|fixtures)__/**/*.test.ts'],
       ...commonOptions,
     },
     {

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -1,0 +1,342 @@
+// The npm test fixture got complicated enough to need tests...
+// But this added complexity greatly speeds up the other npm-related tests by removing the
+// dependency on actual npm CLI calls and a fake registry (which are very slow).
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs-extra';
+import { NpmResult, npm } from '../packageManager/npm';
+import { PackageJson } from '../types/PackageInfo';
+import { initNpmMock, _makeRegistryData, _mockNpmPublish, _mockNpmShow } from './mockNpm';
+
+jest.mock('fs-extra');
+jest.mock('../packageManager/npm');
+
+describe('_makeRegistryData', () => {
+  it('returns empty data', () => {
+    expect(_makeRegistryData({})).toEqual({});
+  });
+
+  it('uses provided dist-tags and versions, and fills in other data', () => {
+    const data = _makeRegistryData({
+      foo: {
+        versions: ['1.0.0', '1.0.1', '2.0.0-beta'],
+        'dist-tags': { latest: '1.0.1', beta: '2.0.0-beta' },
+      },
+      bar: {
+        versions: ['1.0.0'],
+        'dist-tags': { latest: '1.0.0' },
+      },
+    });
+    expect(data).toEqual({
+      foo: {
+        'dist-tags': { latest: '1.0.1', beta: '2.0.0-beta' },
+        versions: ['1.0.0', '1.0.1', '2.0.0-beta'],
+        versionData: {
+          '1.0.0': { name: 'foo', version: '1.0.0' },
+          '1.0.1': { name: 'foo', version: '1.0.1' },
+          '2.0.0-beta': { name: 'foo', version: '2.0.0-beta' },
+        },
+      },
+      bar: {
+        'dist-tags': { latest: '1.0.0' },
+        versions: ['1.0.0'],
+        versionData: {
+          '1.0.0': { name: 'bar', version: '1.0.0' },
+        },
+      },
+    });
+  });
+
+  it('fills in missing dist-tags from versions', () => {
+    const data = _makeRegistryData({
+      foo: { versions: ['1.0.0', '1.0.1'] },
+    });
+    expect(data.foo['dist-tags']).toEqual({ latest: '1.0.1' });
+  });
+
+  it('sorts versions when determining latest dist-tag', () => {
+    const data = _makeRegistryData({
+      foo: { versions: ['1.0.1', '2.0.0', '0.1.0'] },
+    });
+    expect(data.foo['dist-tags']).toEqual({ latest: '2.0.0' });
+  });
+
+  it('fills in missing latest dist-tag from versions', () => {
+    const data = _makeRegistryData({
+      foo: { versions: ['1.0.0', '1.0.1', '1.0.0-beta'], 'dist-tags': { beta: '1.0.0-beta' } },
+    });
+    expect(data.foo['dist-tags']).toEqual({ latest: '1.0.1', beta: '1.0.0-beta' });
+  });
+
+  it('fills in missing versions from dist-tags', () => {
+    const data = _makeRegistryData({
+      foo: { 'dist-tags': { beta: '2.0.0-beta', latest: '1.0.1' } },
+    });
+    expect(data.foo.versions).toEqual(['1.0.1', '2.0.0-beta']);
+  });
+
+  it('throws if a package provides neither versions nor dist-tags', () => {
+    expect(() => _makeRegistryData({ foo: {} })).toThrow(/must include either versions or dist-tags for foo/);
+  });
+});
+
+describe('_mockNpmShow', () => {
+  function getShowResult(
+    params: { error: string } | { data: ReturnType<typeof _makeRegistryData>; name: string; version: string }
+  ) {
+    let output: string;
+    let isError: boolean;
+    if ('error' in params) {
+      output = params.error;
+      isError = true;
+    } else {
+      const { data, name, version } = params;
+      output = JSON.stringify({
+        // NOTE: this is sensitive to the order of keys used in _mockNpmShow
+        ...data[name].versionData[version],
+        'dist-tags': data[name]['dist-tags'],
+        versions: data[name].versions,
+      });
+      isError = false;
+    }
+
+    return {
+      stdout: isError ? '' : output,
+      stderr: isError ? output : '',
+      all: output,
+      success: !isError,
+      failed: isError,
+    } as NpmResult;
+  }
+
+  const data = _makeRegistryData({
+    foo: {
+      versions: ['1.0.0-beta', '1.0.0', '1.0.1'],
+      'dist-tags': { latest: '1.0.1', beta: '1.0.0-beta' },
+    },
+    '@foo/bar': {
+      versions: ['2.0.0-beta', '2.0.0', '2.0.1'],
+      'dist-tags': { latest: '2.0.1', beta: '2.0.0-beta' },
+    },
+  });
+
+  it("errors if package doesn't exist", () => {
+    const emptyData = _makeRegistryData({});
+    const result = _mockNpmShow(emptyData, ['foo'], {});
+    expect(result).toEqual(getShowResult({ error: '[fake] code E404 - foo - not found' }));
+  });
+
+  it('returns requested version plus dist-tags and version list', () => {
+    const result = _mockNpmShow(data, ['foo@1.0.0'], {});
+    expect(result).toEqual(getShowResult({ data: data, name: 'foo', version: '1.0.0' }));
+  });
+
+  it('returns requested version of scoped package', () => {
+    const result = _mockNpmShow(data, ['@foo/bar@2.0.0'], {});
+    expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.0' }));
+  });
+
+  it('returns requested tag', () => {
+    const result = _mockNpmShow(data, ['foo@beta'], {});
+    expect(result).toEqual(getShowResult({ data, name: 'foo', version: '1.0.0-beta' }));
+  });
+
+  it('returns requested tag of scoped package', () => {
+    const result = _mockNpmShow(data, ['@foo/bar@beta'], {});
+    expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.0-beta' }));
+  });
+
+  it('returns latest version if no version requested', () => {
+    const result = _mockNpmShow(data, ['foo'], {});
+    expect(result).toEqual(getShowResult({ data, name: 'foo', version: '1.0.1' }));
+  });
+
+  it('returns latest version of scoped package if no version requested', () => {
+    const result = _mockNpmShow(data, ['@foo/bar'], {});
+    expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.1' }));
+  });
+
+  it("errors if requested version doesn't exist", () => {
+    const result = _mockNpmShow(data, ['foo@2.0.0'], {});
+    expect(result).toEqual(getShowResult({ error: '[fake] code E404 - foo@2.0.0 - not found' }));
+  });
+
+  // support for this could be added later
+  it('currently throws if requested version is a range', () => {
+    expect(() => _mockNpmShow(data, ['foo@^1.0.0'], {})).toThrow(/not currently supported/);
+  });
+});
+
+describe('_mockNpmPublish', () => {
+  function getPublishResult(params: { error?: string; tag?: string }) {
+    const { error, tag } = params;
+    if (!error && !packageJson) throw new Error('packageJson not set');
+    const stdout = error ? '' : `[fake] published ${packageJson?.name}@${packageJson?.version} with tag ${tag}`;
+    return {
+      stdout,
+      stderr: error || '',
+      all: stdout || error,
+      success: !error,
+      failed: !!error,
+    } as NpmResult;
+  }
+
+  let packageJson: PackageJson | undefined;
+
+  beforeAll(() => {
+    (fs.readJsonSync as jest.MockedFunction<typeof fs.readJsonSync>).mockImplementation(() => {
+      if (!packageJson) throw new Error('packageJson not set');
+      return packageJson;
+    });
+  });
+
+  afterEach(() => {
+    packageJson = undefined;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws if cwd is not specified', () => {
+    expect(() => _mockNpmPublish({}, [], {})).toThrow('cwd is required for mock npm publish');
+  });
+
+  it('errors if reading package.json fails', () => {
+    // this error is from the fs.readJsonSync mock, but it's the same code path as if reading the file fails
+    expect(() => _mockNpmPublish({}, [], { cwd: 'fake' })).toThrow('packageJson not set');
+  });
+
+  it('errors on re-publish', () => {
+    const data = _makeRegistryData({ foo: { versions: ['1.0.0'] } });
+    packageJson = { name: 'foo', version: '1.0.0', main: 'nope.js' };
+    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    expect(result).toEqual(
+      getPublishResult({
+        error: '[fake] EPUBLISHCONFLICT foo@1.0.0 already exists in registry',
+      })
+    );
+    // verify that the package didn't get updated in the fake registry
+    // (the "main" field specified above won't exist on the default version)
+    expect(data.foo.versionData['1.0.0'].main).toBeUndefined();
+  });
+
+  it('publishes to empty registry with default tag latest', () => {
+    const data = _makeRegistryData({});
+    packageJson = { name: 'foo', version: '1.0.0', main: 'index.js' };
+
+    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    expect(result).toEqual(getPublishResult({ tag: 'latest' }));
+    expect(data.foo).toEqual({
+      versions: ['1.0.0'],
+      'dist-tags': { latest: '1.0.0' },
+      versionData: { '1.0.0': packageJson },
+    });
+  });
+
+  it('publishes package and updates latest tag', () => {
+    const data = _makeRegistryData({
+      foo: { versions: ['1.0.0'], 'dist-tags': { latest: '1.0.0' } },
+    });
+    packageJson = { name: 'foo', version: '2.0.0', main: 'index.js' };
+
+    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    expect(result).toEqual(getPublishResult({ tag: 'latest' }));
+    expect(data.foo).toEqual({
+      versions: ['1.0.0', '2.0.0'],
+      // latest tag is updated
+      'dist-tags': { latest: '2.0.0' },
+      versionData: {
+        '1.0.0': { name: 'foo', version: '1.0.0' },
+        '2.0.0': packageJson,
+      },
+    });
+  });
+
+  it('publishes requested tag and does not update latest', () => {
+    const data = _makeRegistryData({
+      foo: { versions: ['1.0.0'], 'dist-tags': { latest: '1.0.0', beta: '1.0.0' } },
+    });
+    packageJson = { name: 'foo', version: '2.0.0', main: 'index.js' };
+
+    const result = _mockNpmPublish(data, ['--tag', 'beta'], { cwd: 'fake' });
+    expect(result).toEqual(getPublishResult({ tag: 'beta' }));
+    expect(data.foo).toEqual({
+      versions: ['1.0.0', '2.0.0'],
+      // beta tag updated, latest not updated
+      'dist-tags': { beta: '2.0.0', latest: '1.0.0' },
+      versionData: {
+        '1.0.0': { name: 'foo', version: '1.0.0' },
+        '2.0.0': packageJson,
+      },
+    });
+  });
+});
+
+describe('mockNpm', () => {
+  const npmMock = initNpmMock();
+  let packageJson: PackageJson | undefined;
+
+  beforeAll(() => {
+    (fs.readJsonSync as jest.MockedFunction<typeof fs.readJsonSync>).mockImplementation(() => {
+      if (!packageJson) throw new Error('packageJson not set');
+      return packageJson;
+    });
+  });
+
+  afterEach(() => {
+    packageJson = undefined;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('mocks npm show', async () => {
+    npmMock.setRegistryData({ foo: { versions: ['1.0.0'] } });
+    const result = await npm(['show', 'foo']);
+    expect(result).toMatchObject({
+      success: true,
+      stdout: expect.stringContaining('"name":"foo"'),
+    });
+  });
+
+  it('resets calls and registry after each test', async () => {
+    expect(npmMock.mock).not.toHaveBeenCalled();
+    // registry data for foo was set in the previous test but should have been cleared
+    const result = await npm(['show', 'foo']);
+    expect(result).toMatchObject({
+      success: false,
+      stderr: expect.stringContaining('not found'),
+    });
+  });
+
+  it('mocks npm publish', async () => {
+    packageJson = { name: 'foo', version: '1.0.0' };
+    const result = await npm(['publish'], { cwd: 'fake' });
+    expect(result).toMatchObject({
+      success: true,
+      stdout: expect.stringContaining('published foo'),
+    });
+  });
+
+  it('throws on unsupported command', async () => {
+    await expect(() => npm(['pack'])).rejects.toThrow('Command not supported by mock npm: pack');
+  });
+
+  it('respects mocked command', async () => {
+    const mockShow = jest.fn(() => 'hi');
+    npmMock.setCommandOverride('show', mockShow as any);
+    const result = await npm(['show', 'foo']);
+    expect(result).toEqual('hi');
+    expect(mockShow).toHaveBeenCalledWith(expect.any(Object), ['foo'], undefined);
+  });
+
+  it("respects extra mocked command that's not normally supported", async () => {
+    const mockPack = jest.fn(() => 'hi');
+    npmMock.setCommandOverride('pack', mockPack as any);
+    const result = await npm(['pack']);
+    expect(result).toEqual('hi');
+    expect(mockPack).toHaveBeenCalledWith(expect.any(Object), [], undefined);
+  });
+});

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -1,53 +1,212 @@
 import { afterAll, afterEach, beforeAll, jest } from '@jest/globals';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import path from 'path';
+import semver from 'semver';
 import { NpmShowResult } from '../packageManager/listPackageVersions';
 import { npm, NpmResult } from '../packageManager/npm';
+import { PackageJson } from '../types/PackageInfo';
 
-/** Mapping from package name to value to return from npm show */
-type NpmShowMockData = Record<string, Partial<NpmShowResult>>;
+/** Published versions and dist-tags for a package */
+type NpmPackageVersionsData = Pick<NpmShowResult, 'versions' | 'dist-tags'>;
+
+type MockNpmRegistryPackage = NpmPackageVersionsData & {
+  /** Mapping from version to full package data */
+  versionData: Record<string, PackageJson>;
+};
+
+/** Mapping from package name to registry data */
+type MockNpmRegistry = Record<string, MockNpmRegistryPackage>;
+
+/** Mapping from package name to partial registry data (easier to specify in tests) */
+type PartialRegistryData = Record<string, Partial<NpmPackageVersionsData>>;
 
 /**
- * Mock the `npm show` command for `npm` calls.
+ * Mock implementation of an npm command.
+ * @param registryData Fake registry data to operate on
+ * @param args Command line args, *excluding* the command name
+ * @param opts Command line options, notably `cwd` for publish
+ */
+type MockNpmCommand = (registryData: MockNpmRegistry, args: string[], opts: Parameters<typeof npm>[1]) => NpmResult;
+
+export type NpmMock = {
+  /**
+   * Mocked `npm()` function.
+   */
+  mock: jest.MockedFunction<typeof npm>;
+  /**
+   * Set a temporary override for a specific mock npm command.
+   * This will be reset after each test.
+   */
+  setCommandOverride: (command: string, override: MockNpmCommand) => void;
+  /**
+   * Set registry data as a mapping from package name to package data.
+   *
+   * This should be used for tests covering only the `show` command.
+   * For tests also covering `publish`, it's better to call the mocked npm publish command
+   * to add package versions to ensure all relevant data is included.
+   */
+  setRegistryData: (registryData: PartialRegistryData) => void;
+};
+
+/**
+ * Mock the `npm show` and `npm publish` commands for `npm()` calls.
  * Other commands could potentially be mocked in the future.
  *
- * This should be called at the top level of tests because it handles its own setup/teardown
- * (and resetting between tests) using lifecycle functions.
+ * These mocks operate on a fake registry data object, which can be set using `setRegistryData()`
+ * and is reset after each test.
+ *
+ * This setup helper must be called at the top level of a `describe()` block because it handles
+ * its own setup/teardown (and resetting between tests) using lifecycle functions.
  */
-export function initNpmMock() {
-  const npmSpy = npm as jest.MockedFunction<typeof npm>;
-  if (!npmSpy.mock) {
+export function initNpmMock(): NpmMock {
+  const npmMock = npm as jest.MockedFunction<typeof npm>;
+  if (!npmMock.mock) {
     throw new Error(
-      'npm() is not currently mocked (you must call jest.mock() for <pathTo>/packageManager/npm in your test)'
+      "npm() is not currently mocked. You must call jest.mock('<relativePathTo>/packageManager/npm') at the top of your test."
     );
   }
 
-  let showData: NpmShowMockData | undefined;
+  const defaultMocks: Record<string, MockNpmCommand> = {
+    show: _mockNpmShow,
+    publish: _mockNpmPublish,
+  };
+  let overrideMocks: Record<string, MockNpmCommand> = {};
+  let registryData: MockNpmRegistry = {};
 
   beforeAll(() => {
-    npmSpy.mockImplementation(args => {
-      if (args[0] !== 'show') throw new Error('unrecognized npm command: ' + args.join(' '));
-      if (!showData) throw new Error('npm show called before npmMock.setShowData()');
-
-      const packageName = args.slice(-1)[0];
-      const data = showData[packageName];
-      const stdout = data ? JSON.stringify(data) : '';
-
-      return Promise.resolve({ stdout, success: !!data } as NpmResult);
+    npmMock.mockImplementation(async ([command, ...args], opts) => {
+      const func = overrideMocks[command] || defaultMocks[command];
+      if (!func) {
+        throw new Error(`Command not supported by mock npm: ${command}`);
+      }
+      return func(registryData, args, opts);
     });
   });
 
   afterEach(() => {
-    showData = undefined;
-    npmSpy.mockClear();
+    registryData = {};
+    overrideMocks = {};
+    npmMock.mockClear();
   });
 
   afterAll(() => {
-    npmSpy.mockRestore();
+    npmMock.mockRestore();
   });
 
   return {
-    spy: npmSpy,
-    setShowData: (data: NpmShowMockData) => {
-      showData = data;
+    mock: npmMock,
+    setCommandOverride: (command, override) => {
+      overrideMocks[command] = override;
+    },
+    setRegistryData: data => {
+      registryData = _makeRegistryData(data);
     },
   };
 }
+
+/** (exported for testing) Make full registry data from partial data */
+export function _makeRegistryData(data: PartialRegistryData): MockNpmRegistry {
+  return _.mapValues(data, (pkg, name): MockNpmRegistryPackage => {
+    let versions = pkg.versions;
+    let distTags = pkg['dist-tags'];
+    if (!versions && !distTags) {
+      throw new Error(`setRegistryData() must include either versions or dist-tags for ${name}`);
+    }
+
+    // Include all versions from either `versions` or `dist-tags`, deduped and sorted
+    distTags ??= {};
+    const versionsSet = new Set([...(versions || []), ...Object.values(distTags)]);
+    versions = semver.sort([...versionsSet]);
+    // Ensure "latest" is set
+    distTags.latest ??= versions.slice(-1)[0];
+
+    return {
+      versions,
+      'dist-tags': distTags,
+      // Fill in basic package.json data for each version
+      versionData: Object.fromEntries(versions.map(version => [version, { name, version }])),
+    };
+  });
+}
+
+/** (exported for testing) Mock npm show based on the registry data */
+export const _mockNpmShow: MockNpmCommand = (registryData, args) => {
+  // Assumption: all beachball callers to "npm show" list the package name last
+  const packageSpec = args.slice(-1)[0];
+
+  // The requested package may be only a name, or may include a version (either tag or semver).
+  // Split at any @ later in the string (@ at the start is a scope) to see if there's a version,
+  // or default to latest if no version is specified.
+  const [name, version = 'latest'] = packageSpec.split(/(?!^)@/);
+  const pkgData = registryData[name];
+
+  if (!pkgData) {
+    const stderr = `[fake] code E404 - ${name} - not found`;
+    return { stdout: '', stderr, all: stderr, success: false, failed: true } as NpmResult;
+  }
+
+  let finalVersion: string | undefined;
+  if (semver.valid(version)) {
+    // syntactically valid single version
+    finalVersion = version;
+  } else if (semver.validRange(version)) {
+    // syntactically valid range: could be implemented but no test is using it
+    throw new Error('Ranges are not currently supported by mock npm');
+  } else {
+    // try it as a dist-tag
+    finalVersion = pkgData['dist-tags'][version];
+  }
+
+  const versionData = finalVersion ? pkgData.versionData[finalVersion] : undefined;
+  if (!versionData) {
+    // Some versions for this package exist, but the specified version or tag doesn't
+    // (note that "E404" matches the actual npm output, but the rest of the message is different)
+    const stderr = `[fake] code E404 - ${name}@${version} - not found`;
+    return { stdout: '', stderr, all: stderr, success: false, failed: true } as NpmResult;
+  }
+
+  const stdout = JSON.stringify({
+    // NOTE: if key order changes here, the test must be updated
+    ...versionData,
+    'dist-tags': pkgData['dist-tags'],
+    versions: pkgData.versions,
+  });
+  return { stdout, stderr: '', all: stdout, success: true, failed: false } as NpmResult;
+};
+
+/** (exported for testing) Mock npm publish to the registry data */
+export const _mockNpmPublish: MockNpmCommand = (registryData, args: string[], opts: Parameters<typeof npm>[1]) => {
+  if (!opts?.cwd) {
+    throw new Error('cwd is required for mock npm publish');
+  }
+
+  // Read package.json from cwd to find the published package name and version.
+  // (If this fails, let the exception propagate for easier debugging.)
+  const packageJson = fs.readJsonSync(path.join(opts.cwd, 'package.json')) as PackageJson;
+  const { name, version } = packageJson;
+
+  if (registryData[name]?.versions?.includes(version)) {
+    // note that EPUBLISHCONFLICT matches the actual npm output, but the rest of the message is different
+    const stderr = `[fake] EPUBLISHCONFLICT ${name}@${version} already exists in registry`;
+    return { stdout: '', stderr, all: stderr, success: false, failed: true } as NpmResult;
+  }
+
+  let tag = '';
+  for (let i = 0; !tag && i < args.length; i++) {
+    if (args[i] === '--tag' && i < args.length - 1) {
+      tag = args[i + 1];
+    } else if (args[i].startsWith('--tag=')) {
+      tag = args[i].replace(/^--tag=/, '');
+    }
+  }
+  tag ||= 'latest';
+
+  registryData[name] ??= { versions: [], 'dist-tags': {}, versionData: {} };
+  registryData[name].versions.push(version);
+  registryData[name]['dist-tags'][tag] = version;
+  registryData[name].versionData[version] = packageJson;
+
+  const stdout = `[fake] published ${name}@${version} with tag ${tag}`;
+  return { stdout, stderr: '', all: stdout, success: true, failed: false } as NpmResult;
+};

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -23,24 +23,24 @@ describe('list npm versions', () => {
   describe('listPackageVersions', () => {
     it('succeeds with nothing to do', async () => {
       expect(await listPackageVersions([], npmOptions)).toEqual({});
-      expect(npmMock.spy).not.toHaveBeenCalled();
+      expect(npmMock.mock).not.toHaveBeenCalled();
     });
 
     it('returns versions for one package', async () => {
-      npmMock.setShowData({ foo: { versions: ['1.0.0', '1.0.1'] } });
+      npmMock.setRegistryData({ foo: { versions: ['1.0.0', '1.0.1'] } });
       expect(await listPackageVersions(['foo'], npmOptions)).toEqual({ foo: ['1.0.0', '1.0.1'] });
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
-      expect(npmMock.spy).toHaveBeenCalledWith(
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledWith(
         ['show', '--registry', 'https://fake', '--json', 'foo'],
         expect.anything()
       );
     });
 
     it('returns empty versions array for missing package', async () => {
-      npmMock.setShowData({});
+      npmMock.setRegistryData({});
       expect(await listPackageVersions(['foo'], npmOptions)).toEqual({ foo: [] });
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
-      expect(npmMock.spy).toHaveBeenCalledWith(
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledWith(
         ['show', '--registry', 'https://fake', '--json', 'foo'],
         expect.anything()
       );
@@ -49,31 +49,31 @@ describe('list npm versions', () => {
     it('returns versions for multiple packages', async () => {
       const packages = 'abcdefghij'.split('');
       const showData = Object.fromEntries(packages.map((x, i) => [x, { versions: [`${i}.0.0`, `${i}.0.1`] }]));
-      npmMock.setShowData(showData);
+      npmMock.setRegistryData(showData);
 
       expect(await listPackageVersions(packages, npmOptions)).toEqual(_.mapValues(showData, x => x.versions));
-      expect(npmMock.spy).toHaveBeenCalledTimes(packages.length);
+      expect(npmMock.mock).toHaveBeenCalledTimes(packages.length);
     });
 
     it('returns versions for multiple packages with some missing', async () => {
-      npmMock.setShowData({ foo: { versions: ['1.0.0', '1.0.1'] } });
+      npmMock.setRegistryData({ foo: { versions: ['1.0.0', '1.0.1'] } });
       expect(await listPackageVersions(['foo', 'bar'], npmOptions)).toEqual({ foo: ['1.0.0', '1.0.1'], bar: [] });
-      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+      expect(npmMock.mock).toHaveBeenCalledTimes(2);
     });
 
     it('respects password auth args', async () => {
-      npmMock.setShowData({});
+      npmMock.setRegistryData({});
       await listPackageVersions(['foo'], { ...npmOptions, authType: 'password', token: 'pass' });
-      expect(npmMock.spy).toHaveBeenCalledWith(
+      expect(npmMock.mock).toHaveBeenCalledWith(
         ['show', '--registry', 'https://fake', '--json', 'foo', '--//fake:_password=pass'],
         expect.anything()
       );
     });
 
     it('respects token auth args', async () => {
-      npmMock.setShowData({});
+      npmMock.setRegistryData({});
       await listPackageVersions(['foo'], { ...npmOptions, authType: 'authtoken', token: 'pass' });
-      expect(npmMock.spy).toHaveBeenCalledWith(
+      expect(npmMock.mock).toHaveBeenCalledWith(
         ['show', '--registry', 'https://fake', '--json', 'foo', '--//fake:_authToken=pass'],
         expect.anything()
       );
@@ -84,26 +84,26 @@ describe('list npm versions', () => {
     it('succeeds with nothing to do', async () => {
       expect(await listPackageVersionsByTag([], undefined, npmOptions)).toEqual({});
       expect(await listPackageVersionsByTag([], 'beta', npmOptions)).toEqual({});
-      expect(npmMock.spy).not.toHaveBeenCalled();
+      expect(npmMock.mock).not.toHaveBeenCalled();
     });
 
     it('returns requested tag for one package', async () => {
-      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(
         makePackageInfos({ foo: { combinedOptions: { tag: 'latest', defaultNpmTag: 'latest' } } })
       );
 
       const versions = await listPackageVersionsByTag(packageInfos, 'beta', npmOptions);
       expect(versions).toEqual({ foo: '2.0.0-beta' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
-      expect(npmMock.spy).toHaveBeenCalledWith(
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledWith(
         ['show', '--registry', 'https://fake', '--json', 'foo'],
         expect.anything()
       );
     });
 
     it('returns requested tag for multiple packages', async () => {
-      npmMock.setShowData({
+      npmMock.setRegistryData({
         foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
         bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
       });
@@ -116,61 +116,61 @@ describe('list npm versions', () => {
 
       const versions = await listPackageVersionsByTag(packageInfos, 'beta', npmOptions);
       expect(versions).toEqual({ foo: '2.0.0-beta', bar: '3.0.0-beta' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+      expect(npmMock.mock).toHaveBeenCalledTimes(2);
     });
 
     it('returns versions for many packages', async () => {
       const packages = 'abcdefghij'.split('');
       const showData = Object.fromEntries(packages.map((x, i) => [x, { 'dist-tags': { latest: `${i}.0.0` } }]));
-      npmMock.setShowData(showData);
+      npmMock.setRegistryData(showData);
       const packageInfos = Object.values(makePackageInfos(_.mapValues(showData, () => ({}))));
 
       expect(await listPackageVersionsByTag(packageInfos, 'latest', npmOptions)).toEqual(
         _.mapValues(showData, x => x['dist-tags']?.latest)
       );
-      expect(npmMock.spy).toHaveBeenCalledTimes(packages.length);
+      expect(npmMock.mock).toHaveBeenCalledTimes(packages.length);
     });
 
     it('falls back to combinedOptions.tag', async () => {
-      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(
         makePackageInfos({ foo: { combinedOptions: { tag: 'beta', defaultNpmTag: 'latest' } } })
       );
 
       const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
       expect(versions).toEqual({ foo: '2.0.0-beta' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to combinedOptions.defaultNpmTag if combinedOptions.tag is unset', async () => {
-      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(makePackageInfos({ foo: { combinedOptions: { defaultNpmTag: 'beta' } } }));
 
       const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
       expect(versions).toEqual({ foo: '2.0.0-beta' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
     });
 
     it('returns empty if no dist-tags available', async () => {
-      npmMock.setShowData({});
+      npmMock.setRegistryData({});
       const packageInfos = Object.values(makePackageInfos({ foo: {} }));
 
       const versions = await listPackageVersionsByTag(packageInfos, 'latest', npmOptions);
       expect(versions).toEqual({});
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
     });
 
     it('returns empty if no matching dist-tags available', async () => {
-      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
+      npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(makePackageInfos({ foo: {} }));
 
       const versions = await listPackageVersionsByTag(packageInfos, 'missing', npmOptions);
       expect(versions).toEqual({});
-      expect(npmMock.spy).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to different tag option for different packages', async () => {
-      npmMock.setShowData({
+      npmMock.setRegistryData({
         foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
         bar: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
       });
@@ -183,16 +183,16 @@ describe('list npm versions', () => {
 
       const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
       expect(versions).toEqual({ foo: '1.0.0', bar: '2.0.0-beta' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+      expect(npmMock.mock).toHaveBeenCalledTimes(2);
     });
 
     it('returns versions for multiple packages with some missing', async () => {
-      npmMock.setShowData({ foo: { 'dist-tags': { latest: '1.0.0' } } });
+      npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0' } } });
       const packageInfos = Object.values(makePackageInfos({ foo: {}, bar: {} }));
 
       const versions = await listPackageVersionsByTag(packageInfos, 'latest', npmOptions);
       expect(versions).toEqual({ foo: '1.0.0' });
-      expect(npmMock.spy).toHaveBeenCalledTimes(2);
+      expect(npmMock.mock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -22,7 +22,7 @@ describe('getNewPackages', () => {
   it('returns empty if no packages exist', async () => {
     const newPackages = await getNewPackages({ modifiedPackages: new Set(), packageInfos: {} }, npmOptions);
     expect(newPackages).toEqual([]);
-    expect(npmMock.spy).not.toHaveBeenCalled();
+    expect(npmMock.mock).not.toHaveBeenCalled();
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
@@ -32,43 +32,43 @@ describe('getNewPackages', () => {
 
     const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
     expect(newPackages).toEqual([]);
-    expect(npmMock.spy).not.toHaveBeenCalled();
+    expect(npmMock.mock).not.toHaveBeenCalled();
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
   it('returns empty if no packages are new', async () => {
     // foo and bar aren't modified locally but already exist in the registry
-    npmMock.setShowData({ foo: { versions: ['1.0.0'] }, bar: { versions: ['1.0.0'] } });
+    npmMock.setRegistryData({ foo: { versions: ['1.0.0'] }, bar: { versions: ['1.0.0'] } });
     const modifiedPackages = new Set<string>();
     const packageInfos = makePackageInfos({ foo: {}, bar: {} });
 
     const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
     expect(newPackages).toEqual([]);
-    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(npmMock.mock).toHaveBeenCalledTimes(2);
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
   it('returns new packages with no modified packagess', async () => {
-    npmMock.setShowData({});
+    npmMock.setRegistryData({});
     const modifiedPackages = new Set<string>();
     const packageInfos = makePackageInfos({ foo: {}, bar: {} });
 
     const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
     expect(newPackages).toEqual(['foo', 'bar']);
-    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(npmMock.mock).toHaveBeenCalledTimes(2);
     expect(logs.mocks.log).toHaveBeenCalledTimes(2);
     expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: foo');
     expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: bar');
   });
 
   it('returns only new package with mix of new, old, and modified', async () => {
-    npmMock.setShowData({ foo: { versions: ['1.0.0'] } });
+    npmMock.setRegistryData({ foo: { versions: ['1.0.0'] } });
     const modifiedPackages = new Set<string>(['bar']);
     const packageInfos = makePackageInfos({ foo: {}, bar: {}, baz: {} });
 
     const newPackages = await getNewPackages({ modifiedPackages, packageInfos }, npmOptions);
     expect(newPackages).toEqual(['baz']);
-    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(npmMock.mock).toHaveBeenCalledTimes(2);
     expect(logs.mocks.log).toHaveBeenCalledTimes(1);
     expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: baz');
   });

--- a/src/__tests__/publish/validatePackageVersions.test.ts
+++ b/src/__tests__/publish/validatePackageVersions.test.ts
@@ -23,11 +23,11 @@ describe('validatePackageVersions', () => {
   });
 
   it('succeeds with a valid new version', async () => {
-    npmMock.setShowData({ foo: { versions: ['0.1.0', '1.0.0', '2.0.0'] } });
+    npmMock.setRegistryData({ foo: { versions: ['0.1.0', '1.0.0', '2.0.0'] } });
     const packageInfos = makePackageInfos({ foo: { version: '1.0.1' } });
 
     expect(await validatePackageVersions(['foo'], packageInfos, npmOptions)).toBe(true);
-    expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[log]
       Validating new package versions...
@@ -38,11 +38,11 @@ describe('validatePackageVersions', () => {
   });
 
   it('succeeds if package has no versions in the registry', async () => {
-    npmMock.setShowData({});
+    npmMock.setRegistryData({});
     const packageInfos = makePackageInfos({ foo: { version: '1.0.0' } });
 
     expect(await validatePackageVersions(['foo'], packageInfos, npmOptions)).toBe(true);
-    expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[log]
       Validating new package versions...
@@ -53,11 +53,11 @@ describe('validatePackageVersions', () => {
   });
 
   it('fails with a duplicate version', async () => {
-    npmMock.setShowData({ foo: { versions: ['0.1.0', '1.0.0'] } });
+    npmMock.setRegistryData({ foo: { versions: ['0.1.0', '1.0.0'] } });
     const packageInfos = makePackageInfos({ foo: { version: '1.0.0' } });
 
     expect(await validatePackageVersions(['foo'], packageInfos, npmOptions)).toBe(false);
-    expect(npmMock.spy).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "ERROR: Attempting to publish package versions that already exist in the registry:
       - foo@1.0.0"
@@ -65,11 +65,11 @@ describe('validatePackageVersions', () => {
   });
 
   it('fails with useful output if both valid and invalid versions are present', async () => {
-    npmMock.setShowData({ foo: { versions: ['1.0.0'] }, bar: { versions: ['1.0.0'] } });
+    npmMock.setRegistryData({ foo: { versions: ['1.0.0'] }, bar: { versions: ['1.0.0'] } });
     const packageInfos = makePackageInfos({ foo: { version: '1.0.0' }, bar: { version: '1.0.1' } });
 
     expect(await validatePackageVersions(['foo', 'bar'], packageInfos, npmOptions)).toBe(false);
-    expect(npmMock.spy).toHaveBeenCalledTimes(2);
+    expect(npmMock.mock).toHaveBeenCalledTimes(2);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[log]
       Validating new package versions...


### PR DESCRIPTION
Update the mock npm helper to support `npm publish` in addition to `npm show`, and add more customization ability and comments.

This is to support a future change to make most of the publishing-related tests use this npm mock rather than interacting with a verdaccio registry via the npm CLI, which is extremely slow and limits the number of tests that can reasonably be added.