### PR TITLE
Better handling of some known publishing issues

### DIFF
--- a/change/beachball-d1b2b2d2-c6cf-4ada-820d-bf5ed03fcce7.json
+++ b/change/beachball-d1b2b2d2-c6cf-4ada-820d-bf5ed03fcce7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent retrying publishing and display a specific helpful error message in case of certain common errors (version exists; auth issue)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -1,28 +1,36 @@
-import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, jest } from '@jest/globals';
+import { describe, expect, it, afterEach, jest } from '@jest/globals';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { npmShow } from '../__fixtures__/npmShow';
-import { Registry } from '../__fixtures__/registry';
 import { Repository } from '../__fixtures__/repository';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { publish } from '../commands/publish';
 import { getDefaultOptions } from '../options/getDefaultOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
+import { initNpmMock } from '../__fixtures__/mockNpm';
+
+// Spawning actual npm to run commands against a fake registry is extremely slow, so mock it for
+// this test (packagePublish covers the more complete npm registry scenario).
+//
+// If an issue is found in the future that could only be caught by this test using real npm,
+// a new test file with a real registry should be created to cover that specific scenario.
+jest.mock('../packageManager/npm');
 
 describe('publish command (registry)', () => {
-  let registry: Registry;
+  initNpmMock();
+
   let repositoryFactory: RepositoryFactory | undefined;
 
   // show error logs for these tests
   const logs = initMockLogs({ alsoLog: ['error'] });
 
-  function getOptions(repo: Repository, overrides: Partial<BeachballOptions>): BeachballOptions {
+  function getOptions(repo: Repository): BeachballOptions {
     return {
       ...getDefaultOptions(),
       branch: defaultRemoteBranchName,
       path: repo.rootPath,
-      registry: registry.getUrl(),
+      registry: 'fake',
       command: 'publish',
       message: 'apply package updates',
       bumpDeps: false,
@@ -31,31 +39,15 @@ describe('publish command (registry)', () => {
       tag: 'latest',
       yes: true,
       access: 'public',
-      ...overrides,
     };
   }
 
-  beforeAll(() => {
-    registry = new Registry(__filename);
-    jest.setTimeout(30000);
-  });
-
-  afterAll(() => {
-    registry.stop();
-  });
-
-  beforeEach(async () => {
-    await registry.reset();
-  });
-
   afterEach(() => {
-    if (repositoryFactory) {
-      repositoryFactory.cleanUp();
-      repositoryFactory = undefined;
-    }
+    repositoryFactory?.cleanUp();
+    repositoryFactory = undefined;
   });
 
-  it('can perform a successful npm publish', async () => {
+  it('publishes single package', async () => {
     repositoryFactory = new RepositoryFactory('single');
     const repo = repositoryFactory.cloneRepository();
 
@@ -63,14 +55,14 @@ describe('publish command (registry)', () => {
 
     repo.push();
 
-    await publish(getOptions(repo, { package: 'foo' }));
+    await publish(getOptions(repo));
 
-    const publishedPackage = (await npmShow('foo', { registry }))!;
+    const publishedPackage = (await npmShow('foo'))!;
     expect(publishedPackage.name).toEqual('foo');
     expect(publishedPackage.versions).toHaveLength(1);
   });
 
-  it('can perform a successful npm publish even with private packages', async () => {
+  it('publishes in monorepo with mixed public and private packages', async () => {
     repositoryFactory = new RepositoryFactory({
       folders: {
         packages: {
@@ -85,12 +77,15 @@ describe('publish command (registry)', () => {
 
     repo.push();
 
-    await publish(getOptions(repo, { package: 'foopkg' }));
+    await publish(getOptions(repo));
 
-    await npmShow('foopkg', { registry, shouldFail: true });
+    expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
+    expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package foopkg'));
+
+    await npmShow('foopkg', { shouldFail: true });
   });
 
-  it('can perform a successful npm publish when multiple packages changed at same time', async () => {
+  it('publishes when multiple packages changed at same time', async () => {
     repositoryFactory = new RepositoryFactory({
       folders: {
         packages: {
@@ -105,16 +100,16 @@ describe('publish command (registry)', () => {
 
     repo.push();
 
-    await publish(getOptions(repo, { package: 'foopkg' }));
+    await publish(getOptions(repo));
 
-    const showFoo = (await npmShow('foopkg', { registry }))!;
+    const showFoo = (await npmShow('foopkg'))!;
     expect(showFoo['dist-tags'].latest).toEqual('1.1.0');
 
-    const showBar = (await npmShow('barpkg', { registry }))!;
+    const showBar = (await npmShow('barpkg'))!;
     expect(showBar['dist-tags'].latest).toEqual('1.1.0');
   });
 
-  it('can perform a successful npm publish even with a non-existent package listed in the change file', async () => {
+  it('succeeds even with a non-existent package listed in a change file', async () => {
     repositoryFactory = new RepositoryFactory({
       folders: {
         packages: {
@@ -129,12 +124,18 @@ describe('publish command (registry)', () => {
 
     repo.push();
 
-    await publish(getOptions(repo, { package: 'foopkg' }));
+    await publish(getOptions(repo));
 
-    await npmShow('badname', { registry, shouldFail: true });
+    expect(logs.mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Change detected for nonexistent package badname')
+    );
+    expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
+
+    // didn't somehow publish a package that doesn't exist
+    await npmShow('badname', { shouldFail: true });
   });
 
-  it('should exit publishing early if only invalid change files exist', async () => {
+  it('exits publishing early if only invalid change files exist', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     const repo = repositoryFactory.cloneRepository();
 
@@ -144,7 +145,7 @@ describe('publish command (registry)', () => {
 
     repo.push();
 
-    await publish(getOptions(repo, { package: 'foopkg' }));
+    await publish(getOptions(repo));
 
     expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package bar'));
@@ -152,33 +153,6 @@ describe('publish command (registry)', () => {
       expect.stringContaining('Change detected for nonexistent package fake')
     );
 
-    await npmShow('fake', { registry, shouldFail: true });
-  });
-
-  it('will perform retries', async () => {
-    registry.stop();
-
-    // hide the errors for this test--it's supposed to have errors, and showing them is misleading
-    logs.setOverrideOptions({ alsoLog: false });
-
-    repositoryFactory = new RepositoryFactory('single');
-    const repo = repositoryFactory.cloneRepository();
-
-    generateChangeFiles(['foo'], repo.rootPath);
-
-    repo.push();
-
-    const publishPromise = publish(
-      getOptions(repo, {
-        registry: 'httppppp://somethingwrong',
-        package: 'foo',
-        timeout: 100,
-      })
-    );
-
-    await expect(publishPromise).rejects.toThrow(
-      'Error publishing! Refer to the previous logs for recovery instructions.'
-    );
-    expect(logs.getMockLines('log')).toMatch('Retrying... (3/3)');
+    await npmShow('fake', { shouldFail: true });
   });
 });

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -311,6 +311,15 @@ describe('mockNpm', () => {
     });
   });
 
+  it('can "publish" a package to registry with helper', async () => {
+    npmMock.publishPackage({ name: 'foo', version: '1.0.0' });
+    const result = await npm(['show', 'foo']);
+    expect(result).toMatchObject({
+      success: true,
+      stdout: expect.stringContaining('"name":"foo"'),
+    });
+  });
+
   it('mocks npm publish', async () => {
     packageJson = { name: 'foo', version: '1.0.0' };
     const result = await npm(['publish'], { cwd: 'fake' });

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -12,7 +12,7 @@ import { Registry } from './registry';
  */
 export async function npmShow(
   packageName: string,
-  options: { registry: Registry; shouldFail?: boolean }
+  options: { registry?: Registry; shouldFail?: boolean } = {}
 ): Promise<NpmShowResult | undefined> {
   const { registry, shouldFail } = options;
 

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -1,42 +1,56 @@
-import { describe, expect, it, beforeAll, afterAll, beforeEach, jest } from '@jest/globals';
+import { describe, expect, it, beforeAll, afterAll, beforeEach, jest, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { npmShow } from '../../__fixtures__/npmShow';
 import { Registry } from '../../__fixtures__/registry';
 import { tmpdir } from '../../__fixtures__/tmpdir';
+import * as npmModule from '../../packageManager/npm';
 import { packagePublish } from '../../packageManager/packagePublish';
 import { PackageInfo } from '../../types/PackageInfo';
+import { npm, NpmResult } from '../../packageManager/npm';
 
 const testTag = 'testbeachballtag';
 const testName = 'testbeachballpackage';
 const testVersion = '0.6.0';
 const testPackage = { name: testName, version: testVersion };
 
+// Some of these tests use an actual local npm registry, so they're slower to run.
+// The rest mock npm calls for efficiency.
+//
+// (If there's ever a bug that could have been caught by testing against a real registry/npm,
+//
 describe('packagePublish', () => {
+  let npmSpy: jest.SpiedFunction<typeof npm>;
+  /**
+   * Actual local npm registry.
+   * NOTE: tests using the registry must call `await registry.reset()` at the start.
+   * (This is not done in beforeEach because it's a bit slow, and not all tests use the registry.)
+   */
   let registry: Registry;
   let tempRoot: string;
   let tempPackageJsonPath: string;
+  /**
+   * Test publish results against this object so that any output will show up in the logs if there
+   * are errors (otherwise it's hard to debug).
+   */
+  const successResult = expect.objectContaining({ success: true });
+  const failedResult = expect.objectContaining({ success: false });
 
-  initMockLogs();
+  const logs = initMockLogs();
 
-  function getTestPackageInfo(tag: string | null, defaultNpmTag = 'latest'): PackageInfo {
+  function getTestPackageInfo(): PackageInfo {
     return {
       ...testPackage,
       packageJsonPath: tempPackageJsonPath,
       private: false,
       combinedOptions: {
         gitTags: true,
-        tag,
-        defaultNpmTag,
+        tag: testTag,
+        defaultNpmTag: 'latest',
         disallowedChangeTypes: [],
       },
-      packageOptions: {
-        gitTags: true,
-        tag,
-        defaultNpmTag,
-        disallowedChangeTypes: [],
-      },
+      packageOptions: {} as any,
     };
   }
 
@@ -50,8 +64,12 @@ describe('packagePublish', () => {
     fs.writeJSONSync(tempPackageJsonPath, testPackage, { spaces: 2 });
   });
 
-  beforeEach(async () => {
-    await registry.reset();
+  beforeEach(() => {
+    npmSpy = jest.spyOn(npmModule, 'npm');
+  });
+
+  afterEach(() => {
+    npmSpy.mockRestore();
   });
 
   afterAll(() => {
@@ -60,11 +78,17 @@ describe('packagePublish', () => {
   });
 
   it('can publish', async () => {
-    const testPackageInfo = getTestPackageInfo(testTag);
-    const publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
-    // Check the result like this so any output will show up in the logs if there are errors
-    // (hard to debug otherwise)
-    expect(publishResult).toEqual(expect.objectContaining({ success: true }));
+    // Do a basic publishing test against the real registry
+    await registry.reset();
+    const testPackageInfo = getTestPackageInfo();
+    const publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl(), retries: 2 });
+    expect(publishResult).toEqual(successResult);
+    expect(npmSpy).toHaveBeenCalledTimes(1);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Publishing - ${testName}@${testVersion} with tag ${testTag}`);
+    expect(allLogs).toMatch('publish command:');
+    expect(allLogs).toMatch(`[log] Published!`);
 
     expect(await npmShow(testName, { registry })).toMatchObject({
       name: testName,
@@ -74,12 +98,88 @@ describe('packagePublish', () => {
     });
   });
 
-  it('errors on republish', async () => {
-    const testPackageInfo = getTestPackageInfo(testTag);
-    let publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
-    expect(publishResult).toEqual(expect.objectContaining({ success: true })); // see comment on first test
+  it('errors and does not retry on republish', async () => {
+    // Use real npm for this because the republish detection relies on the real error message
+    await registry.reset();
+    const testPackageInfo = getTestPackageInfo();
+    let publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl(), retries: 2 });
+    expect(publishResult).toEqual(successResult);
+    expect(npmSpy).toHaveBeenCalledTimes(1);
+    logs.clear();
 
-    publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl() });
-    expect(publishResult.success).toBeFalsy();
+    publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl(), retries: 2 });
+    expect(publishResult).toEqual(failedResult);
+    // `retries` should be ignored if the version already exists
+    expect(npmSpy).toHaveBeenCalledTimes(2);
+
+    const logs2ndTry = logs.getMockLines('all');
+    expect(logs2ndTry).toMatch(`${testName}@${testVersion} already exists in the registry`);
+  });
+
+  it('performs retries', async () => {
+    // It's difficult or not desirable to simulate actual error conditions (such as timeouts or network errors),
+    // so mock all npm calls for this test.
+    const testPackageInfo = getTestPackageInfo();
+    // mock success by default, except for the two mocked failures below
+    npmSpy.mockImplementation(() => Promise.resolve({ success: true } as NpmResult));
+    // first call: arbitrary error
+    npmSpy.mockImplementationOnce(() => Promise.resolve({ success: false, all: 'some errors' } as NpmResult));
+    // second call: timeout
+    npmSpy.mockImplementationOnce(() =>
+      Promise.resolve({ success: false, all: 'sloooow', timedOut: true } as NpmResult)
+    );
+
+    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3 });
+    expect(publishResult).toEqual(successResult);
+    expect(npmSpy).toHaveBeenCalledTimes(3);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`[warn] Publishing ${testName} failed. Output:\n\nsome errors`);
+    expect(allLogs).toMatch('Retrying... (1/3)');
+    expect(allLogs).toMatch(`[warn] Publishing ${testName} failed (timed out). Output:\n\nsloooow`);
+    expect(allLogs).toMatch('Retrying... (2/3)');
+    expect(allLogs).toMatch(`[log] Published!`);
+  });
+
+  it('fails if out of retries', async () => {
+    // Again, mock all npm calls for this test instead of simulating an actual error condition.
+    npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'some errors' } as NpmResult));
+
+    const publishResult = await packagePublish(getTestPackageInfo(), { registry: 'fake', retries: 3 });
+    expect(publishResult).toEqual(failedResult);
+    expect(npmSpy).toHaveBeenCalledTimes(4);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch('Retrying... (1/3)');
+    expect(allLogs).toMatch('Retrying... (2/3)');
+    expect(allLogs).toMatch('Retrying... (3/3)');
+    expect(allLogs).toMatch(`[error] Publishing ${testName} failed. Output:\n\nsome errors`);
+  });
+
+  it('does not retry on auth error', async () => {
+    // Mock an auth error
+    const testPackageInfo = getTestPackageInfo();
+    npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code ENEEDAUTH' } as NpmResult));
+
+    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3 });
+    expect(publishResult).toEqual(failedResult);
+    expect(npmSpy).toHaveBeenCalledTimes(1);
+
+    expect(logs.getMockLines('error')).toMatch(
+      `Publishing ${testName} failed due to an auth error. Output:\n\nERR! code ENEEDAUTH`
+    );
+  });
+
+  it('does not retry on E404', async () => {
+    // E404 most commonly indicates an issue with a token, which is hard to simulate,
+    // so just mock the npm call.
+    const testPackageInfo = getTestPackageInfo();
+    npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code E404' } as NpmResult));
+
+    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3 });
+    expect(publishResult).toEqual(failedResult);
+    expect(npmSpy).toHaveBeenCalledTimes(1);
+
+    expect(logs.getMockLines('error')).toMatch(`Publishing ${testName} returned E404`);
   });
 });

--- a/src/bump/callHook.ts
+++ b/src/bump/callHook.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { HooksOptions } from '../types/BeachballOptions';
+import { PackageInfos } from '../types/PackageInfo';
+
+/**
+ * Call a hook for each affected package. Does nothing if the hook is undefined.
+ */
+export async function callHook(
+  hook: HooksOptions['prebump' | 'postbump' | 'prepublish' | 'postpublish'],
+  affectedPackages: Iterable<string>,
+  packageInfos: PackageInfos
+): Promise<void> {
+  if (!hook) {
+    return;
+  }
+
+  for (const pkg of affectedPackages) {
+    const packageInfo = packageInfos[pkg];
+    await hook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
+  }
+}

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -31,7 +31,6 @@ export function getDefaultOptions(): BeachballOptions {
     scope: null,
     tag: '',
     timeout: undefined,
-    token: '',
     type: null,
     version: false,
     yes: env.isCI,

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -45,18 +45,22 @@ export async function packagePublish(
     const output = `Output:\n\n${result.all}\n`;
 
     // First check for specific cases where retries are unlikely to help
-    if (result.all!.includes('ENEEDAUTH')) {
-      console.error(`Publishing ${pkg} failed due to an auth error. ${output}`);
-      break;
-    }
     if (result.all!.includes('EPUBLISHCONFLICT')) {
       console.error(`${pkg}@${packageInfo.version} already exists in the registry. ${output}`);
       break;
     }
+    if (result.all!.includes('ENEEDAUTH')) {
+      // ENEEDAUTH only happens if no auth was attempted (no token/password provided).
+      console.error(`Publishing ${pkg} failed due to an auth error. ${output}`);
+      break;
+    }
     if (result.all!.includes('code E404')) {
+      // All types of invalid credentials appear to cause E404.
+      // validate() already checks for the most common ways invalid variable names might show up,
+      // so log a slightly more generic message instead of details about the token.
       console.error(
         `Publishing ${pkg} returned E404. Contrary to the output, this usually indicates an issue ` +
-          'with an auth token (expired or improper scopes).'
+          'with an auth token (expired, improper scopes, or incorrect variable name).'
       );
       // demote the output on this one due to the misleading message
       console.log(output);

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -1,16 +1,72 @@
 import { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
 import { npm, NpmResult } from './npm';
-import { NpmOptions } from '../types/NpmOptions';
+import { BeachballOptions } from '../types/BeachballOptions';
 import { getNpmPublishArgs } from './npmArgs';
+import { NpmOptions } from '../types/NpmOptions';
 
-export function packagePublish(packageInfo: PackageInfo, options: NpmOptions): Promise<NpmResult> {
-  const args = getNpmPublishArgs(packageInfo, options);
-  console.log(`publish command: ${args.join(' ')}`);
+/**
+ * Attempt to publish the package with retries. Returns the result of the final npm publish call
+ * (mainly for tests; the real code just checks `result.success`).
+ */
+export async function packagePublish(
+  packageInfo: PackageInfo,
+  options: NpmOptions & Pick<BeachballOptions, 'retries'>
+): Promise<NpmResult> {
+  const publishArgs = getNpmPublishArgs(packageInfo, options);
 
-  return npm(args, {
-    cwd: path.dirname(packageInfo.packageJsonPath),
-    timeout: options.timeout,
-    all: true,
-  });
+  const publishTag = publishArgs[publishArgs.indexOf('--tag') + 1];
+  const pkg = packageInfo.name;
+  console.log(`\nPublishing - ${pkg}@${packageInfo.version} with tag ${publishTag}`);
+
+  console.log(`  publish command: ${publishArgs.join(' ')}`);
+
+  let result: NpmResult;
+
+  // Unclear whether `options.retries` should be interpreted as "X attempts" or "initial attempt + X retries"...
+  // It was previously implemented as the latter, so keep that for now.
+  for (let retries = 0; retries <= options.retries; retries++) {
+    if (retries > 0) {
+      console.log(`Retrying... (${retries}/${options.retries})\n`);
+    }
+
+    result = await npm(publishArgs, {
+      // Run npm publish in the package directory
+      cwd: path.dirname(packageInfo.packageJsonPath),
+      timeout: options.timeout,
+      all: true,
+    });
+
+    if (result.success) {
+      console.log('Published!');
+      return result;
+    }
+
+    const output = `Output:\n\n${result.all}\n`;
+
+    // First check for specific cases where retries are unlikely to help
+    if (result.all!.includes('ENEEDAUTH')) {
+      console.error(`Publishing ${pkg} failed due to an auth error. ${output}`);
+      break;
+    }
+    if (result.all!.includes('EPUBLISHCONFLICT')) {
+      console.error(`${pkg}@${packageInfo.version} already exists in the registry. ${output}`);
+      break;
+    }
+    if (result.all!.includes('code E404')) {
+      console.error(
+        `Publishing ${pkg} returned E404. Contrary to the output, this usually indicates an issue ` +
+          'with an auth token (expired or improper scopes).'
+      );
+      // demote the output on this one due to the misleading message
+      console.log(output);
+      break;
+    }
+
+    const timedOutMessage = result.timedOut ? ' (timed out)' : '';
+    const log = retries < options.retries ? console.warn : console.error;
+    log(`Publishing ${pkg} failed${timedOutMessage}. ${output}`);
+  }
+
+  return result!;
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -53,7 +53,7 @@ export interface CliOptions
   timeout?: number;
   /** Timeout for `git push` operations */
   gitTimeout?: number;
-  token: string;
+  token?: string;
   type?: ChangeType | null;
   verbose?: boolean;
   version?: boolean;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -77,6 +77,19 @@ export function validate(
     logValidationError(`authType "${options.authType}" is not valid`);
   }
 
+  if (options.command === 'publish' && options.token !== undefined) {
+    if (options.token === '') {
+      logValidationError(
+        'token should not be an empty string. This usually indicates an incorrect variable name ' +
+          'or forgetting to pass a secret into a workflow step.'
+      );
+    } else if (options.token.startsWith('$') && options.authType !== 'password') {
+      logValidationError(
+        `token appears to be a variable reference: "${options.token}" -- please check your workflow configuration.`
+      );
+    }
+  }
+
   if (options.dependentChangeType && !isValidChangeType(options.dependentChangeType)) {
     logValidationError(`dependentChangeType "${options.dependentChangeType}" is not valid`);
   }


### PR DESCRIPTION
Display a specific helpful error message and (mostly) prevent retries in the following cases:
- `ENEEDAUTH`: Not logged in/token not provided
- `EPUBLISHCONFLICT`: Version already exists in registry
- `code E404`: Usually indicates an issue with an auth token (expired or improper scopes)
- Also add a specific note if the operation timed out (retries are allowed in this case).

As part of this, I refactored the publish retries and error handling logic to be centralized in `packagePublish` (for easier testing), rather than split between there and `publishToRegistry`. 

(Another common case is that the token variable name in a workflow/pipeline is invalid, which depending on the syntax may either result in the token being an empty string from an unset variable, or a failed variable substitution starting with `$`. I added specific tests for both of those in the earlier validation step, only for the publish command.)

The bulk of the change is updating most publishing-related tests to use a mocked version of the `npm()` helper, rather than using the npm CLI (which is very slow to start up) and a verdaccio registry (also pretty slow). This speeds up the tests `publishE2E`, `publishRegistry`, and `syncE2E` by 2-4x, even with some new test coverage added. A couple of the `packagePublish` tests continue to run with the npm CLI and verdaccio registry to ensure we have some basic coverage for real npm.