### PR TITLE
Pass packageInfos into prepublish, postpublish, and postbump hooks

### DIFF
--- a/change/beachball-b16e6b4f-dc7c-47e6-bd0f-3722b5c2c112.json
+++ b/change/beachball-b16e6b4f-dc7c-47e6-bd0f-3722b5c2c112.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Beachball passes bumpVersions as 4th param of prepublish, postpublish, and postbump hooks",
+  "comment": "Beachball passes packageInfos as 4th param of prepublish, postpublish, and postbump hooks",
   "packageName": "beachball",
   "email": "tronguye@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/beachball-b16e6b4f-dc7c-47e6-bd0f-3722b5c2c112.json
+++ b/change/beachball-b16e6b4f-dc7c-47e6-bd0f-3722b5c2c112.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Beachball passes bumpVersions as 4th param of prepublish, postpublish, and postbump hooks",
+  "packageName": "beachball",
+  "email": "tronguye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/callHook.ts
+++ b/src/bump/callHook.ts
@@ -14,15 +14,10 @@ export async function callHook(
     return;
   }
 
-  const bumpVersions = Object.keys(packageInfos).reduce((accumulator, pkgName) => {
-    accumulator[pkgName] = packageInfos[pkgName].version;
-    return accumulator;
-  }, {} as Record<string, string>);
-
   for (const pkg of affectedPackages) {
     const packageInfo = packageInfos[pkg];
     const packagePath = path.dirname(packageInfo.packageJsonPath);
 
-    await hook(packagePath, packageInfo.name, packageInfo.version, bumpVersions);
+    await hook(packagePath, packageInfo.name, packageInfo.version, packageInfos);
   }
 }

--- a/src/bump/callHook.ts
+++ b/src/bump/callHook.ts
@@ -14,8 +14,15 @@ export async function callHook(
     return;
   }
 
+  const bumpVersions = Object.keys(packageInfos).reduce((accumulator, pkgName) => {
+    accumulator[pkgName] = packageInfos[pkgName].version;
+    return accumulator;
+  }, {} as Record<string, string>);
+
   for (const pkg of affectedPackages) {
     const packageInfo = packageInfos[pkg];
-    await hook(path.dirname(packageInfo.packageJsonPath), packageInfo.name, packageInfo.version);
+    const packagePath = path.dirname(packageInfo.packageJsonPath);
+
+    await hook(packagePath, packageInfo.name, packageInfo.version, bumpVersions);
   }
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -2,6 +2,7 @@ import { AuthType } from './Auth';
 import { ChangeInfo, ChangeInfoMultiple, ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
+import { PackageInfos } from './PackageInfo';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -198,13 +199,13 @@ export interface HooksOptions {
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
    */
-  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
    */
-  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
@@ -216,7 +217,7 @@ export interface HooksOptions {
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
    */
-  postbump?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  postbump?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
 
   /**
    * Runs once after all bumps to all packages before committing changes

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -198,24 +198,43 @@ export interface HooksOptions {
    *
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
+   *
+   * @param packagePath The path to the package directory
+   * @param name The name of the package as defined in package.json
+   * @param version The post-bump version of the package to be published
+   * @param packageInfos Metadata about other packages processed by Beachball. Computed post-bump. Readonly.
    */
   prepublish?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
+   *
+   * @param packagePath The path to the package directory
+   * @param name The name of the package as defined in package.json
+   * @param version The post-bump version of the package to be published
+   * @param packageInfos Metadata about other packages processed by Beachball. Computed post-bump. Readonly.
    */
   postpublish?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
+   *
+   * @param packagePath The path to the package directory
+   * @param name The name of the package as defined in package.json
+   * @param version The pre-bump version of the package to be published
    */
   prebump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
 
   /**
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
+   *
+   * @param packagePath The path to the package directory
+   * @param name The name of the package as defined in package.json
+   * @param version The post-bump version of the package to be published
+   * @param packageInfos Metadata about other packages processed by Beachball. Computed post-bump. Readonly.
    */
   postbump?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -190,6 +190,8 @@ export interface VersionGroupOptions {
   name: string;
 }
 
+type BackCompatHooksType = (packagePath: string, name: string, version: string) => void | Promise<void>;
+
 export interface HooksOptions {
   /**
    * Runs for each package after version bumps have been processed and committed to git, but before the actual
@@ -198,13 +200,13 @@ export interface HooksOptions {
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
    */
-  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  prepublish?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
    */
-  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  postpublish?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
@@ -216,7 +218,7 @@ export interface HooksOptions {
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
    */
-  postbump?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
+  postbump?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
 
   /**
    * Runs once after all bumps to all packages before committing changes

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -198,13 +198,13 @@ export interface HooksOptions {
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
    */
-  prepublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
    */
-  postpublish?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
@@ -216,7 +216,7 @@ export interface HooksOptions {
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
    */
-  postbump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
+  postbump?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs once after all bumps to all packages before committing changes

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -199,13 +199,13 @@ export interface HooksOptions {
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
    */
-  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
+  prepublish?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
    */
-  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
+  postpublish?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
@@ -217,7 +217,7 @@ export interface HooksOptions {
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
    */
-  postbump?: (packagePath: string, name: string, version: string, bumpVersions: PackageInfos) => void | Promise<void>;
+  postbump?: (packagePath: string, name: string, version: string, packageInfos: Readonly<PackageInfos>) => void | Promise<void>;
 
   /**
    * Runs once after all bumps to all packages before committing changes

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -190,8 +190,6 @@ export interface VersionGroupOptions {
   name: string;
 }
 
-type BackCompatHooksType = (packagePath: string, name: string, version: string) => void | Promise<void>;
-
 export interface HooksOptions {
   /**
    * Runs for each package after version bumps have been processed and committed to git, but before the actual
@@ -200,13 +198,13 @@ export interface HooksOptions {
    * This allows for file modifications which will be reflected in the published package but not be reflected in the
    * repository.
    */
-  prepublish?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
+  prepublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs for each package after the publish command.
    * Any file changes made in this step will **not** be committed automatically.
    */
-  postpublish?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
+  postpublish?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs for each package, before writing changelog and package.json updates
@@ -218,7 +216,7 @@ export interface HooksOptions {
    * Runs for each package, after writing changelog and package.json updates
    * to the filesystem. May be called multiple times during publish.
    */
-  postbump?: ((packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>) | BackCompatHooksType;
+  postbump?: (packagePath: string, name: string, version: string, bumpVersions: Record<string, string>) => void | Promise<void>;
 
   /**
    * Runs once after all bumps to all packages before committing changes


### PR DESCRIPTION
Same end goal as #896 

We are trying to have our yarn 1 repo be able to:

Locally, refer to local workspace package version using the * version
At publish time, change to ^x.y.z, where x.y.z is the post-bump version

To accomplish this, we are hoping to use the prepublish hook to change the internal packages to ^x.y.z. Passing the post-bump versions to the prepublish hook would allow for this to happen without file i/o on our end