### PR TITLE
Publish config type updates, and performPublishConfig tests

### DIFF
--- a/change/beachball-b0d4d413-19f2-4277-8fe3-4a6a80933ad2.json
+++ b/change/beachball-b0d4d413-19f2-4277-8fe3-4a6a80933ad2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add type for PublishConfig",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/packageInfos.ts
+++ b/src/__fixtures__/packageInfos.ts
@@ -1,22 +1,33 @@
+import _ from 'lodash';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { PackageInfo, PackageInfos } from '../types/PackageInfo';
 
 /**
- * Makes a properly typed PackageInfos object from a partial object, filling in the `name`,
- * `version` 1.0.0, and an empty `combinedOptions` object. (Other properties are not set, but this
- * at least makes the fixture code a bit more concise and ensures that any properties provided in
- * the override object are valid.)
+ * Makes a properly typed PackageInfos object from a partial object, filling in defaults:
+ * ```
+ * {
+ *   name: '<key>',
+ *   version: '1.0.0',
+ *   private: false,
+ *   combinedOptions: {},
+ *   packageOptions: {},
+ *   packageJsonPath: ''
+ * }
+ * ```
  */
 export function makePackageInfos(packageInfos: {
   [name: string]: Partial<Omit<PackageInfo, 'combinedOptions'>> & { combinedOptions?: Partial<BeachballOptions> };
 }): PackageInfos {
-  const result: PackageInfos = {};
-  for (const [name, info] of Object.entries(packageInfos)) {
-    result[name] = {
+  return _.mapValues(packageInfos, (info, name): PackageInfo => {
+    const { combinedOptions, ...rest } = info;
+    return {
       name,
-      combinedOptions: {} as BeachballOptions,
-      ...info,
-    } as PackageInfo;
-  }
-  return result;
+      version: '1.0.0',
+      private: false,
+      combinedOptions: { ...combinedOptions } as BeachballOptions,
+      packageOptions: {},
+      packageJsonPath: '',
+      ...rest,
+    };
+  });
 }

--- a/src/publish/performPublishOverrides.ts
+++ b/src/publish/performPublishOverrides.ts
@@ -1,7 +1,7 @@
-import { PackageInfos, PackageJson } from '../types/PackageInfo';
+import { PackageInfos, PackageJson, PublishConfig } from '../types/PackageInfo';
 import * as fs from 'fs-extra';
 
-const acceptedKeys = [
+const acceptedKeys: (keyof PublishConfig)[] = [
   'types',
   'typings',
   'main',
@@ -11,7 +11,7 @@ const acceptedKeys = [
   'bin',
   'browser',
   'files',
-] as const;
+];
 const workspacePrefix = 'workspace:';
 
 export function performPublishOverrides(packagesToPublish: string[], packageInfos: PackageInfos): void {

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -5,6 +5,15 @@ export interface PackageDeps {
   [dep: string]: string;
 }
 
+/**
+ * The `publishConfig` field in package.json.
+ * (If modifying this, be sure to update `acceptedKeys` in src/publish/performPublishOverrides.ts.)
+ */
+export type PublishConfig = Pick<
+  PackageJson,
+  'types' | 'typings' | 'main' | 'module' | 'exports' | 'repository' | 'bin' | 'browser' | 'files'
+>;
+
 export interface PackageJson {
   name: string;
   version: string;
@@ -24,10 +33,7 @@ export interface PackageJson {
   scripts?: Record<string, string>;
   beachball?: BeachballOptions;
   /** Overrides applied during publishing */
-  publishConfig?: Pick<
-    PackageJson,
-    'types' | 'typings' | 'main' | 'module' | 'exports' | 'repository' | 'bin' | 'browser' | 'files'
-  >;
+  publishConfig?: PublishConfig;
 }
 
 export interface PackageInfo {


### PR DESCRIPTION
Extract the types of `PackageJson.publishConfig` into a separate `PublishConfig` type.

Fix the `performPublishConfig` tests to not write to the filesystem, and add more coverage.