### PR TITLE
Add more logging during publishing

### DIFF
--- a/change/beachball-f146e707-ddd6-42bd-8918-391c07aaeabf.json
+++ b/change/beachball-f146e707-ddd6-42bd-8918-391c07aaeabf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more logging during publishing",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/packageManager/npmArgs.ts
+++ b/src/packageManager/npmArgs.ts
@@ -12,7 +12,7 @@ export function getNpmPublishArgs(packageInfo: PackageInfo, options: NpmOptions)
     '--tag',
     pkgCombinedOptions.tag || pkgCombinedOptions.defaultNpmTag || 'latest',
     '--loglevel',
-    'warn',
+    options.verbose ? 'notice' : 'warn',
     ...getNpmAuthArgs(registry, token, authType),
   ];
 

--- a/src/types/NpmOptions.ts
+++ b/src/types/NpmOptions.ts
@@ -1,4 +1,4 @@
 import { BeachballOptions } from './BeachballOptions';
 
 export type NpmOptions = Required<Pick<BeachballOptions, 'registry'>> &
-  Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout'>>;
+  Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout' | 'verbose'>>;


### PR DESCRIPTION
- Include the package root directory in the pre-publish message
- If `--verbose` is set, increase the npm logging level to `notice`
- Add a specific check (and prevent retries) for E403