### PR TITLE
CLI options: improve handling of booleans and other cases

### DIFF
--- a/change/beachball-349b5c41-3054-4f34-b30d-1413216f67e9.json
+++ b/change/beachball-349b5c41-3054-4f34-b30d-1413216f67e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure getCliOptions properly handles all boolean and numeric options",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/options/getCliOptions.test.ts
+++ b/src/__functional__/options/getCliOptions.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, afterEach, describe, expect, it, jest } from '@jest/globals';
+import { getCliOptions } from '../../options/getCliOptions';
+import { findProjectRoot, getDefaultRemoteBranch } from 'workspace-tools';
+
+jest.mock('workspace-tools', () => {
+  return {
+    getDefaultRemoteBranch: jest.fn((options: { branch?: string }) => `origin/${options.branch || 'main'}`),
+    findProjectRoot: jest.fn(() => 'fake-root'),
+  };
+});
+
+/** test wrapper for `getCliOptions` which adds common args */
+function getCliOptionsTest(args: string[]) {
+  return getCliOptions(['node', 'beachball', ...args], true /*disableCache*/);
+}
+
+//
+// These tests cover a mix of built-in parser behavior, provided options, and custom overrides.
+// It's worth having tests for relevant built-in behaviors in case we change parsers in the future
+// (likely to commander), to ensure there are no undocumented breaking changes from the beachball
+// "end user" perspective.
+//
+describe('getCliOptions', () => {
+  // This is the same mocked value as above (can't be shared in a const because jest.mock() is
+  // not allowed to access the surrounding context)
+  const projectRoot = 'fake-root';
+  const mockFindProjectRoot = findProjectRoot as jest.MockedFunction<typeof findProjectRoot>;
+  const defaults = { command: 'change', path: projectRoot };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  // start by making sure nothing went wrong with the mock
+  it('uses fake project root', () => {
+    expect(findProjectRoot(process.cwd())).toEqual(projectRoot);
+  });
+
+  it('parses no args (adds path to result)', () => {
+    const options = getCliOptionsTest([]);
+    expect(options).toEqual(defaults);
+  });
+
+  it('parses command', () => {
+    const options = getCliOptionsTest(['check']);
+    expect(options).toEqual({ ...defaults, command: 'check' });
+  });
+
+  it('parses options', () => {
+    // use a basic option of each value type (except arrays, tested later)
+    const options = getCliOptionsTest(['--type', 'patch', '--access=public', '--fetch', '--depth', '1']);
+    expect(options).toEqual({ ...defaults, type: 'patch', access: 'public', fetch: true, depth: 1 });
+  });
+
+  it('parses command and options', () => {
+    const options = getCliOptionsTest(['publish', '--tag', 'foo']);
+    expect(options).toEqual({ ...defaults, command: 'publish', tag: 'foo' });
+  });
+
+  it('parses array options with multiple values', () => {
+    const options = getCliOptionsTest(['--scope', 'foo', 'bar']);
+    expect(options).toEqual({ ...defaults, scope: ['foo', 'bar'] });
+  });
+
+  it('parses array option specified multiple times', () => {
+    const options = getCliOptionsTest(['--scope', 'foo', '--scope', 'bar']);
+    expect(options).toEqual({ ...defaults, scope: ['foo', 'bar'] });
+  });
+
+  // documenting that this is not currently supported (could change in the future if desired)
+  it('does not parse values with commas as separate array entries', () => {
+    const options = getCliOptionsTest(['--scope', 'a,b', '--scope=c,d']);
+    expect(options).toEqual({ ...defaults, scope: ['a,b', 'c,d'] });
+  });
+
+  it('throws if non-array option is specified multiple times', () => {
+    expect(() => getCliOptionsTest(['--tag', 'foo', '--tag', 'baz'])).toThrow();
+  });
+
+  it('parses negated boolean option', () => {
+    const options = getCliOptionsTest(['--no-fetch']);
+    expect(options).toEqual({ ...defaults, fetch: false });
+  });
+
+  it('parses valid boolean option values', () => {
+    const falseOptions = getCliOptionsTest(['--fetch=false', '--yes', 'false']);
+    expect(falseOptions).toEqual({ ...defaults, fetch: false, yes: false });
+
+    const trueOptions = getCliOptionsTest(['--fetch=true', '--yes', 'true']);
+    expect(trueOptions).toEqual({ ...defaults, fetch: true, yes: true });
+  });
+
+  it('parses boolean flag with valid value', () => {
+    const falseOptions = getCliOptionsTest(['-y', 'false']);
+    expect(falseOptions).toEqual({ ...defaults, yes: false });
+
+    const trueOptions = getCliOptionsTest(['-y', 'true']);
+    expect(trueOptions).toEqual({ ...defaults, yes: true });
+  });
+
+  it('throws on invalid numeric value', () => {
+    expect(() => getCliOptionsTest(['--depth', 'foo'])).toThrow();
+  });
+
+  it('converts hyphenated options to camel case', () => {
+    const options = getCliOptionsTest(['--git-tags', '--dependent-change-type', 'patch']);
+    expect(options).toEqual({ ...defaults, gitTags: true, dependentChangeType: 'patch' });
+  });
+
+  it('supports camel case for options defined as hyphenated', () => {
+    const options = getCliOptionsTest([
+      '--gitTags',
+      '--dependentChangeType',
+      'patch',
+      '--disallowed-change-types',
+      'major',
+      'minor',
+    ]);
+    expect(options).toEqual({
+      ...defaults,
+      gitTags: true,
+      dependentChangeType: 'patch',
+      disallowedChangeTypes: ['major', 'minor'],
+    });
+  });
+
+  it('parses short option aliases', () => {
+    const options = getCliOptionsTest(['publish', '-t', 'test', '-r', 'http://whatever', '-y']);
+    expect(options).toEqual({ ...defaults, command: 'publish', tag: 'test', registry: 'http://whatever', yes: true });
+  });
+
+  it('parses long option aliases', () => {
+    const options = getCliOptionsTest(['--config', 'path/to/config.json', '--force', '--since', 'main']);
+    expect(options).toEqual({ ...defaults, configPath: 'path/to/config.json', forceVersions: true, fromRef: 'main' });
+  });
+
+  it('for canary command, adds canary tag and ignores regular tag', () => {
+    const options = getCliOptionsTest(['canary', '--tag', 'bar']);
+    expect(options).toEqual({ ...defaults, command: 'canary', tag: 'canary' });
+  });
+
+  it('for canary command, uses canaryName as tag and ignores regular tag', () => {
+    const options = getCliOptionsTest(['canary', '--canary-name', 'foo', '--tag', 'bar']);
+    expect(options).toEqual({ ...defaults, command: 'canary', canaryName: 'foo', tag: 'foo' });
+  });
+
+  it('does not set tag to canaryName for non-canary command', () => {
+    const options = getCliOptionsTest(['publish', '--canary-name', 'foo', '--tag', 'bar']);
+    expect(options).toEqual({ ...defaults, command: 'publish', canaryName: 'foo', tag: 'bar' });
+  });
+
+  it('falls back to process.cwd as path if findProjectRoot fails', () => {
+    mockFindProjectRoot.mockImplementationOnce(() => {
+      throw new Error('nope');
+    });
+    const options = getCliOptionsTest([]);
+    expect(options).toEqual({ ...defaults, path: process.cwd() });
+  });
+
+  it('uses provided branch if it contains a slash', () => {
+    const options = getCliOptionsTest(['--branch', 'someremote/foo']);
+    expect(options).toEqual({ ...defaults, branch: 'someremote/foo' });
+    // this is mocked at the top of the file
+    expect(getDefaultRemoteBranch).not.toHaveBeenCalled();
+  });
+
+  it('adds default remote to branch without slash', () => {
+    const options = getCliOptionsTest(['--branch', 'foo']);
+    expect(options).toEqual({ ...defaults, branch: 'origin/foo' });
+    expect(getDefaultRemoteBranch).toHaveBeenCalledWith({ branch: 'foo', verbose: undefined, cwd: projectRoot });
+  });
+
+  it('preserves additional string options', () => {
+    const options = getCliOptionsTest(['--foo', 'bar', '--baz=qux']);
+    expect(options).toEqual({ ...defaults, foo: 'bar', baz: 'qux' });
+  });
+
+  it('handles additional boolean flags as booleans', () => {
+    const options = getCliOptionsTest(['--foo', '--no-bar']);
+    expect(options).toEqual({ ...defaults, foo: true, bar: false });
+  });
+
+  it('handles additional boolean text values as booleans', () => {
+    const options = getCliOptionsTest(['--foo', 'true', '--bar=false']);
+    expect(options).toEqual({ ...defaults, foo: true, bar: false });
+  });
+
+  it('handles additional numeric values as numbers', () => {
+    const options = getCliOptionsTest(['--foo', '1', '--bar=2']);
+    expect(options).toEqual({ ...defaults, foo: 1, bar: 2 });
+  });
+
+  it('handles additional option specified multiple times as array', () => {
+    const options = getCliOptionsTest(['--foo', 'bar', '--foo', 'baz']);
+    expect(options).toEqual({ ...defaults, foo: ['bar', 'baz'] });
+  });
+
+  // documenting current behavior (doesn't have to stay this way)
+  it('for additional options, does not handle multiple values as part of array', () => {
+    // in this case the trailing value "baz" would be treated as the command since it's the first
+    // positional option
+    const options = getCliOptionsTest(['--foo', 'bar', 'baz']);
+    expect(options).toEqual({ ...defaults, foo: 'bar', command: 'baz' });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ import { validate } from './validation/validate';
       await sync(options);
       break;
 
-    default:
+    case 'change':
       const { isChangeNeeded } = validate(options, { allowMissingChangeFiles: true });
 
       if (!isChangeNeeded && !options.package) {
@@ -66,6 +66,9 @@ import { validate } from './validation/validate';
       await change(options);
 
       break;
+
+    default:
+      throw new Error('Invalid command: ' + options.command);
   }
 })().catch(e => {
   showVersion();

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -3,12 +3,112 @@ import { CliOptions } from '../types/BeachballOptions';
 import { getDefaultRemoteBranch, findProjectRoot } from 'workspace-tools';
 import { env } from '../env';
 
+// For camelCased options, yargs will automatically accept them with-dashes too.
+const arrayOptions = ['disallowedChangeTypes', 'package', 'scope'] as const;
+const booleanOptions = [
+  'all',
+  'bump',
+  'bumpDeps',
+  'commit',
+  'disallowDeletedChangeFiles',
+  'fetch',
+  'forceVersions',
+  'gitTags',
+  'help',
+  'keepChangeFiles',
+  'new',
+  'publish',
+  'push',
+  'verbose',
+  'version',
+  'yes',
+] as const;
+const numberOptions = ['depth', 'gitTimeout', 'retries', 'timeout'] as const;
+const stringOptions = [
+  'access',
+  'authType',
+  'branch',
+  'canaryName',
+  'changehint',
+  'configPath',
+  'dependentChangeType',
+  'fromRef',
+  'message',
+  'prereleasePrefix',
+  'registry',
+  'tag',
+  'token',
+  'type',
+] as const;
+
+type AtLeastOne<T> = [T, ...T[]];
+/** Type hack to verify that an array includes all keys of a type */
+const allKeysOfType =
+  <T extends string>() =>
+  <L extends AtLeastOne<T>>(
+    ...x: L extends any ? (Exclude<T, L[number]> extends never ? L : Exclude<T, L[number]>[]) : never
+  ) =>
+    x;
+
+// Verify that all the known CLI options have types specified, to ensure correct parsing.
+//
+// NOTE: If a prop is missing, this will have a somewhat misleading error:
+//   Argument of type '"disallowedChangeTypes"' is not assignable to parameter of type '"tag" | "version"'
+//
+// To fix, add the missing names after "parameter of type" ("tag" and "version" in this example)
+// to the appropriate array above.
+const knownOptions = allKeysOfType<keyof CliOptions>()(
+  ...arrayOptions,
+  ...booleanOptions,
+  ...numberOptions,
+  ...stringOptions,
+  // these options are filled in below, not respected from the command line
+  'path',
+  'command'
+);
+
+const parserOptions: parser.Options = {
+  configuration: {
+    'boolean-negation': true,
+    'camel-case-expansion': true,
+    'dot-notation': false,
+    'duplicate-arguments-array': true,
+    'flatten-duplicate-arrays': true,
+    'greedy-arrays': true, // for now; we might want to change this to false in the future
+    'parse-numbers': true,
+    'parse-positional-numbers': false,
+    'short-option-groups': false,
+    'strip-aliased': true,
+    'strip-dashed': true,
+  },
+  // spread to get rid of readonly...
+  array: [...arrayOptions],
+  boolean: [...booleanOptions],
+  number: [...numberOptions],
+  string: [...stringOptions],
+  alias: {
+    authType: ['a'],
+    branch: ['b'],
+    configPath: ['c', 'config'],
+    forceVersions: ['force'],
+    fromRef: ['since'],
+    help: ['h', '?'],
+    message: ['m'],
+    package: ['p'],
+    registry: ['r'],
+    tag: ['t'],
+    token: ['n'],
+    version: ['v'],
+    yes: ['y'],
+  },
+};
+
 let cachedCliOptions: CliOptions;
 
-export function getCliOptions(argv: string[]): CliOptions {
+export function getCliOptions(argv: string[], disableCache?: boolean): CliOptions {
   // Special case caching to process.argv which should be immutable
   if (argv === process.argv) {
-    if (env.beachballDisableCache || !cachedCliOptions) {
+    if (disableCache || env.beachballDisableCache || !cachedCliOptions) {
       cachedCliOptions = getCliOptionsUncached(process.argv);
     }
     return cachedCliOptions;
@@ -19,52 +119,32 @@ export function getCliOptions(argv: string[]): CliOptions {
 
 function getCliOptionsUncached(argv: string[]): CliOptions {
   // Be careful not to mutate the input argv
-  const trimmedArgv = [...argv].splice(2);
+  const trimmedArgv = argv.slice(2);
 
-  const args = parser(trimmedArgv, {
-    string: ['branch', 'tag', 'message', 'package', 'since', 'dependent-change-type', 'config'],
-    array: ['scope', 'disallowed-change-types'],
-    boolean: ['git-tags', 'keep-change-files', 'force', 'disallow-deleted-change-files', 'no-commit', 'fetch'],
-    number: ['depth'],
-    alias: {
-      authType: ['a'],
-      branch: ['b'],
-      config: ['c'],
-      tag: ['t'],
-      registry: ['r'],
-      message: ['m'],
-      token: ['n'],
-      help: ['h', '?'],
-      yes: ['y'],
-      package: ['p'],
-      version: ['v'],
-    },
-  });
+  const args = parser(trimmedArgv, parserOptions);
 
-  const { _, ...restArgs } = args;
+  const { _: positionalArgs, ...options } = args;
   let cwd: string;
   try {
     cwd = findProjectRoot(process.cwd());
   } catch (err) {
     cwd = process.cwd();
   }
-  const cliOptions = {
-    ...(_.length > 0 && { command: _[0] }),
-    ...(restArgs as any),
-    path: cwd,
-    fromRef: args.since,
-    keepChangeFiles: args['keep-change-files'],
-    disallowDeletedChangeFiles: args['disallow-deleted-change-files'],
-    forceVersions: args.force,
-    configPath: args.config,
-  } as CliOptions;
 
-  const disallowedChangeTypesArgs = args['disallowed-change-types'];
-  if (disallowedChangeTypesArgs) {
-    cliOptions.disallowedChangeTypes = disallowedChangeTypesArgs;
+  if (positionalArgs.length > 1) {
+    throw new Error(`Only one positional argument (the command) is allowed. Received: ${positionalArgs.join(' ')}`);
   }
 
+  const cliOptions = {
+    ...(options as CliOptions),
+    command: positionalArgs.length ? String(positionalArgs[0]) : 'change',
+    path: cwd,
+  };
+
   if (args.branch) {
+    // TODO: This logic assumes the first segment of any branch name with a slash must be the remote,
+    // which is not necessarily accurate. Ideally we should check if a remote with that name exists,
+    // and if not, perform the default remote lookup.
     cliOptions.branch =
       args.branch.indexOf('/') > -1
         ? args.branch
@@ -73,6 +153,25 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
 
   if (cliOptions.command === 'canary') {
     cliOptions.tag = cliOptions.canaryName || 'canary';
+  }
+
+  for (const key of Object.keys(cliOptions) as (keyof CliOptions)[]) {
+    const value = cliOptions[key];
+    if (value === undefined) {
+      delete cliOptions[key];
+    } else if (typeof value === 'number' && isNaN(value)) {
+      throw new Error(`Non-numeric value passed for numeric option "${key}"`);
+    } else if (knownOptions.includes(key)) {
+      if (Array.isArray(value) && !arrayOptions.includes(key as any)) {
+        throw new Error(`Option "${key}" only accepts a single value. Received: ${value.join(' ')}`);
+      }
+    } else if (value === 'true') {
+      // For unknown arguments like --foo=true or --bar=false, yargs will handle the value as a string.
+      // Convert it to a boolean to avoid subtle bugs.
+      (cliOptions as any)[key] = true;
+    } else if (value === 'false') {
+      (cliOptions as any)[key] = false;
+    }
   }
 
   return cliOptions;

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -13,6 +13,7 @@ export interface CliOptions
     | 'branch'
     | 'bumpDeps'
     | 'changehint'
+    | 'depth'
     | 'disallowedChangeTypes'
     | 'fetch'
     | 'gitTags'
@@ -25,7 +26,6 @@ export interface CliOptions
     | 'retries'
     | 'scope'
     | 'tag'
-    | 'depth'
   > {
   all: boolean;
   authType: AuthType;


### PR DESCRIPTION
- Ensure that that text values `true` and `false` are handled as booleans
- Add explicit expected option types for all known CLI options
- Refine the returned value to not include camel case or aliased keys
- Add tests for `getCliOptions` (this will help ensure predictable behavior with future `yargs-parser` upgrades or if we change to another parser like `commander`)