### PR TITLE
Adding support for identifier base

### DIFF
--- a/change/beachball-f8eb13a7-d410-4a2e-92e3-0e95346da8c5.json
+++ b/change/beachball-f8eb13a7-d410-4a2e-92e3-0e95346da8c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding support for identifier base when bumping with a pre-release prefix",
+  "packageName": "beachball",
+  "email": "jdesalliers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -21,7 +21,8 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
     info.version = semver.inc(
       info.version,
       options.prereleasePrefix ? 'prerelease' : changeType,
-      options.prereleasePrefix || undefined
+      options.prereleasePrefix || undefined,
+      options.identifierBase
     ) as string;
     modifiedPackages.add(pkgName);
   }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -3,6 +3,7 @@ import { ChangeInfo, ChangeInfoMultiple, ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
 import { PackageInfos } from './PackageInfo';
+import type { inc } from 'semver';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -127,6 +128,11 @@ export interface RepoOptions {
   path: string;
   /** Prerelease prefix for packages that are specified to receive a prerelease bump */
   prereleasePrefix?: string | null;
+  /** This is for prerelease. Set it to "0" for zero-based or "1" for one-based.
+   *  Set it to false to omit the prerelease number.
+   *  @default "0"
+   */
+  identifierBase?: inc.IdentifierBase | false;
   /**
    * Whether to publish to the npm registry
    * @default true

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -3,7 +3,6 @@ import { ChangeInfo, ChangeInfoMultiple, ChangeType } from './ChangeInfo';
 import { ChangeFilePromptOptions } from './ChangeFilePrompt';
 import { ChangelogOptions } from './ChangelogOptions';
 import { PackageInfos } from './PackageInfo';
-import type { inc } from 'semver';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
@@ -132,7 +131,7 @@ export interface RepoOptions {
    *  Set it to false to omit the prerelease number.
    *  @default "0"
    */
-  identifierBase?: inc.IdentifierBase | false;
+  identifierBase?: '0' | '1' | false;
   /**
    * Whether to publish to the npm registry
    * @default true


### PR DESCRIPTION
[Pre-release identifier](https://docs.npmjs.com/cli/v6/using-npm/semver#prerelease-identifiers) in semver allows to control the identifier base when bumping a pre-release package.

With beachball, the identifier base is always set to zero; the goal of this PR is to support zero-based, one-based and no identifier base.

The options for the identifier base are "0", "1" and false.

Here is how it works with semver: 
![image](https://github.com/microsoft/beachball/assets/36003332/dfeb79d6-8231-48c5-9431-99737a02ebac)