### PR TITLE
Add option to include private packages for changefile and bump

### DIFF
--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -55,32 +55,33 @@ It's also common to have a repo-level `beachball.config.js` and any individual p
 
 For the latest full list of supported options, see `RepoOptions` [in this file](https://github.com/microsoft/beachball/blob/master/src/types/BeachballOptions.ts).
 
-| Option                  | Type                                     | Default           | Option Type          | Description                                                                                     |
-| ----------------------- | ---------------------------------------- | ----------------- | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `access`                | `'public'` or `'restricted'`             | `'restricted'`    | repo                 | publishes private packages access level                                                         |
-| `branch`                | string                                   | `'origin/master'` | repo                 | the target branch (with remote)                                                                 |
-| `bumpDeps`              | bool                                     | `true`            | repo                 | bump dependent packages during publish (bump A if A depends on B)                               |
-| `changeFilePrompt`      | `ChangeFilePromptOptions` ([details][1]) |                   | repo                 | customize the prompt for change files (can be used to add custom fields)                        |
-| `changehint`            | string                                   |                   | repo                 | hint message for when change files are not detected but required                                |
-| `changelog`             | `ChangelogOptions` ([details][2])        |                   | repo                 | changelog rendering and grouping options                                                        |
-| `defaultNpmTag`         | string                                   | `'latest'`        | package              | the default dist-tag used for NPM publish                                                       |
-| `disallowedChangeTypes` | string[]                                 |                   | repo, group, package | what change types are disallowed                                                                |
-| `fetch`                 | bool                                     | `true`            | repo                 | fetch from remote before doing diff comparisons                                                 |
-| `generateChangelog`     | bool                                     | `true`            | repo                 | whether to generate changelog files                                                             |
-| `gitTags`               | bool                                     | `true`            | repo, package        | whether to create git tags for published packages (eg: foo_v1.0.1)                              |
-| `groups`                | `VersionGroupOptions[]` ([details][3])   |                   | repo                 | specifies groups of packages that need to be version bumped at the same time                    |
-| `groupChanges`          | bool                                     | `false`           | repo                 | will write multiple changes to a single changefile                                              |
-| `hooks`                 | `HooksOptions` ([details][4])            |                   | repo                 | hooks for custom pre/post publish actions                                                       |
-| `ignorePatterns`        | string[]                                 |                   | repo                 | ignore changes in these files (minimatch patterns; negations not supported)                     |
-| `package`               | string                                   |                   | repo                 | specifies which package the command relates to (overrides change detection based on `git diff`) |
-| `prereleasePrefix`      | string                                   |                   | repo                 | prerelease prefix for packages that are specified to receive a prerelease bump                  |
-| `publish`               | bool                                     | `true`            | repo                 | whether to publish to npm registry                                                              |
-| `push`                  | bool                                     | `true`            | repo                 | whether to push to the remote git branch                                                        |
-| `registry`              | string                                   |                   | repo                 | target NPM registry to publish                                                                  |
-| `retries`               | number                                   | `3`               | repo                 | number of retries for a package publish before failing                                          |
-| `shouldPublish`         | false \| undefined                       |                   | package              | manually disable publishing of a package by beachball (does not work to force publishing)       |
-| `tag`                   | string                                   | `'latest'`        | repo, package        | dist-tag for npm when published                                                                 |
-| `transform`             | `TransformOptions` ([details][4])        |                   | repo                 | transformations for change files                                                                |
+| Option                   | Type                                     | Default           | Option Type          | Description                                                                                     |
+|--------------------------|------------------------------------------|-------------------| -------------------- |-------------------------------------------------------------------------------------------------|
+| `access`                 | `'public'` or `'restricted'`             | `'restricted'`    | repo                 | publishes private packages access level                                                         |
+| `branch`                 | string                                   | `'origin/master'` | repo                 | the target branch (with remote)                                                                 |
+| `bumpDeps`               | bool                                     | `true`            | repo                 | bump dependent packages during publish (bump A if A depends on B)                               |
+| `changeFilePrompt`       | `ChangeFilePromptOptions` ([details][1]) |                   | repo                 | customize the prompt for change files (can be used to add custom fields)                        |
+| `changehint`             | string                                   |                   | repo                 | hint message for when change files are not detected but required                                |
+| `changelog`              | `ChangelogOptions` ([details][2])        |                   | repo                 | changelog rendering and grouping options                                                        |
+| `defaultNpmTag`          | string                                   | `'latest'`        | package              | the default dist-tag used for NPM publish                                                       |
+| `disallowedChangeTypes`  | string[]                                 |                   | repo, group, package | what change types are disallowed                                                                |
+| `fetch`                  | bool                                     | `true`            | repo                 | fetch from remote before doing diff comparisons                                                 |
+| `generateChangelog`      | bool                                     | `true`            | repo                 | whether to generate changelog files                                                             |
+| `gitTags`                | bool                                     | `true`            | repo, package        | whether to create git tags for published packages (eg: foo_v1.0.1)                              |
+| `groups`                 | `VersionGroupOptions[]` ([details][3])   |                   | repo                 | specifies groups of packages that need to be version bumped at the same time                    |
+| `groupChanges`           | bool                                     | `false`           | repo                 | will write multiple changes to a single changefile                                              |
+| `hooks`                  | `HooksOptions` ([details][4])            |                   | repo                 | hooks for custom pre/post publish actions                                                       |
+| `ignorePatterns`         | string[]                                 |                   | repo                 | ignore changes in these files (minimatch patterns; negations not supported)                     |
+| `includePrivatePackages` | bool                                     | `false`           | repo                 | include private packages in changefiles and bump (they won't be published)                      |
+| `package`                | string                                   |                   | repo                 | specifies which package the command relates to (overrides change detection based on `git diff`) |
+| `prereleasePrefix`       | string                                   |                   | repo                 | prerelease prefix for packages that are specified to receive a prerelease bump                  |
+| `publish`                | bool                                     | `true`            | repo                 | whether to publish to npm registry                                                              |
+| `push`                   | bool                                     | `true`            | repo                 | whether to push to the remote git branch                                                        |
+| `registry`               | string                                   |                   | repo                 | target NPM registry to publish                                                                  |
+| `retries`                | number                                   | `3`               | repo                 | number of retries for a package publish before failing                                          |
+| `shouldPublish`          | false \| undefined                       |                   | package              | manually disable publishing of a package by beachball (does not work to force publishing)       |
+| `tag`                    | string                                   | `'latest'`        | repo, package        | dist-tag for npm when published                                                                 |
+| `transform`              | `TransformOptions` ([details][4])        |                   | repo                 | transformations for change files                                                                |
 
 [1]: https://github.com/microsoft/beachball/blob/master/src/types/ChangeFilePrompt.ts
 [2]: https://github.com/microsoft/beachball/blob/master/src/types/ChangelogOptions.ts

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -19,7 +19,7 @@ import { PackageInfos } from '../types/PackageInfo';
  * (so it's possible that multiple entries will have the same filename).
  */
 export function readChangeFiles(options: BeachballOptions, packageInfos: PackageInfos): ChangeSet {
-  const { path: cwd, fromRef } = options;
+  const { path: cwd, fromRef, includePrivatePackages } = options;
   const scopedPackages = getScopedPackages(options, packageInfos);
   const changePath = getChangePath(cwd);
 
@@ -87,9 +87,10 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
       // (This may happen if a package is renamed or its private flag is changed.)
       const warningType = !packageInfos[change.packageName]
         ? 'nonexistent'
-        : packageInfos[change.packageName].private
+        : (packageInfos[change.packageName].private && !includePrivatePackages)
         ? 'private'
         : undefined;
+
       if (warningType) {
         const resolution = options.groupChanges ? 'remove the entry from this file' : 'delete this file';
         console.warn(

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -7,6 +7,7 @@ import { env } from '../env';
 const arrayOptions = ['disallowedChangeTypes', 'package', 'scope'] as const;
 const booleanOptions = [
   'all',
+  'includePrivatePackages',
   'bump',
   'bumpDeps',
   'commit',

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -9,6 +9,7 @@ export function getDefaultOptions(): BeachballOptions {
   return {
     access: 'restricted',
     all: false,
+    includePrivatePackages: false,
     authType: 'authtoken',
     branch: 'origin/master',
     bump: true,

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -28,6 +28,7 @@ export interface CliOptions
     | 'tag'
   > {
   all: boolean;
+  includePrivatePackages: boolean;
   authType: AuthType;
   bump: boolean;
   canaryName?: string | undefined;


### PR DESCRIPTION
For some of our monorepo projects we currently version our packages with lerna version. We are making a switch to microsoft beachball for more control. Some of our packages are non JS based but do have a package.json. These packages need to bumped to the correct version but don't have to be published.

Their package.json contains `"private": true`. As of right now beachball didn't contain an option to allow the bumping of private packages so with this PR I added the config option to allow just that.

the new option ìncludePrivatePackages` defaults to false and is only used during the changeset/bump commands. This is hopefully something other people can benefit from.