### PR TITLE
Add context on current running command for change file transforms

### DIFF
--- a/change/beachball-a311609d-38f8-420d-8cd7-a5a98e5876ba.json
+++ b/change/beachball-a311609d-38f8-420d-8cd7-a5a98e5876ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add context on the current running command for changeFiles transform",
+  "packageName": "beachball",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/beachball-a311609d-38f8-420d-8cd7-a5a98e5876ba.json
+++ b/change/beachball-a311609d-38f8-420d-8cd7-a5a98e5876ba.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add context on the current running command for changeFiles transform",
   "packageName": "beachball",
   "email": "1581488+christiango@users.noreply.github.com",

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -266,11 +266,13 @@ describe('writeChangelog', () => {
 
     const beachballOptions: Partial<BeachballOptions> = {
       path: monoRepo.rootPath,
+      command: 'change',
       transform: {
-        changeFiles: (changeFile, changeFilePath) => {
+        changeFiles: (changeFile, changeFilePath, { command }) => {
           // For test, we will be changing the comment based on the package name
           if ((changeFile as ChangeInfo).packageName === 'foo') {
             (changeFile as ChangeInfo).comment = editedComment;
+            (changeFile as ChangeInfo).command = command;
           }
           return changeFile as ChangeInfo;
         },
@@ -293,6 +295,7 @@ describe('writeChangelog', () => {
     for (const { change, changeFile } of changes) {
       if (changeFile.startsWith('foo')) {
         expect(change.comment).toBe(editedComment);
+        expect(change.command).toEqual('change');
       } else {
         expect(change.comment).toBe('comment 2');
       }

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -19,7 +19,7 @@ import { PackageInfos } from '../types/PackageInfo';
  * (so it's possible that multiple entries will have the same filename).
  */
 export function readChangeFiles(options: BeachballOptions, packageInfos: PackageInfos): ChangeSet {
-  const { path: cwd, fromRef } = options;
+  const { path: cwd, fromRef, command } = options;
   const scopedPackages = getScopedPackages(options, packageInfos);
   const changePath = getChangePath(cwd);
 
@@ -72,7 +72,9 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
     // Transform the change files, if the option is provided
     if (options.transform?.changeFiles) {
       try {
-        changeInfo = options.transform?.changeFiles(changeInfo, changeFilePath);
+        changeInfo = options.transform?.changeFiles(changeInfo, changeFilePath, {
+          command,
+        });
       } catch (e) {
         console.warn(`Error transforming ${changeFilePath}: ${e}`);
         continue;

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -273,5 +273,12 @@ export interface TransformOptions {
    * This allows for adding or editing information to the change files
    * without having to modify anything on the disk.
    */
-  changeFiles?: (changeInfo: ChangeInfo | ChangeInfoMultiple, changeFilePath: string) => ChangeInfo;
+  changeFiles?: (
+    changeInfo: ChangeInfo | ChangeInfoMultiple,
+    changeFilePath: string,
+    context: {
+      /** The beachball command that is being run when this transform is invoked. Can be used to selectively run the transform on a specific beachball command like "beachball change" */
+      command: string;
+    }
+  ) => ChangeInfo;
 }


### PR DESCRIPTION
Beachball has a nice feature that lets you run custom transformations on change files. Our team is using them today to augment beachball changelogs with links to the ADO PRs corresponding to the release.

That being said, in the current implementation we are having a negative impact on local beachball change times. This is because beachball runs this transform during commands like change and publish. For our particular transform, we don't want to run it during yarn change, since that runs before we have a merged PR.

With this change, the custom beachball change file transform can decide to skip the expensive step to compute the PR URL if we are not running in the context of a beachball publish