### PR TITLE
Add --dry-run option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
       "args": ["--", "--runInBand", "--watch", "--testTimeout=1000000", "${fileBasenameNoExtension}"],
       "sourceMaps": true,
       "outputCapture": "std",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      "runtimeVersion": "14.20.0"
     },
     {
       "type": "node",

--- a/change/beachball-8d4c287a-d12c-44c1-867c-47032836dde4.json
+++ b/change/beachball-8d4c287a-d12c-44c1-867c-47032836dde4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add --dry-run option",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -26,18 +26,19 @@ See the [`change` page](./change).
 
 These options are applicable for the `publish` command, as well as `bump` and/or `canary` in some cases.
 
-| Option                        | Alias | Default                        | Description                                                                                                                                |
-| ----------------------------- | ----- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--authType`                  | `-a`  | `'authtoken'`                  | type of token argument, affecting how it is applied to npm commands.                                                                       |
-| `--message`                   | `-m`  | `'applying package updates'`   | custom message for the checkin                                                                                                             |
-| `--git-tags`, `--no-git-tags` |       | `true` (`--git-tags`)          | whether to create git tags for published packages                                                                                          |
-| `--publish`, `--no-publish`   |       | `true` (`--publish`)           | whether to publish to the npm registry                                                                                                     |
-| `--push`, `--no-push`         |       | `true` (`--push`)              | whether to push changes back to git remote origin                                                                                          |
-| `--prerelease-prefix`         |       |                                | prerelease prefix for packages that are specified to receive a prerelease bump (`--prerelease-prefix beta` makes the `x.y.z-beta` version) |
-| `--registry`                  | `-r`  | `'https://registry.npmjs.org'` | npm registry for publishing                                                                                                                |
-| `--retries`                   |       | `3`                            | number of retries for a package publish before failing                                                                                     |
-| `--tag`                       | `-t`  | `'latest'`                     | dist-tag for npm publishes                                                                                                                 |
-| `--token`                     | `-n`  |                                | credential to use with npm commands. its type is specified with the `--authType` argument                                                  |
-| `--verbose`                   |       | `false`                        | prints additional information to the console                                                                                               |
-| `--yes`                       | `-y`  | if CI detected, `true`         | skips the prompts for publish                                                                                                              |
-| `--new`                       |       | `false`                        | publishes new packages if not in registry                                                                                                  |
+| Option                        | Alias | Default                        | Description                                                                                                                      |
+| ----------------------------- | ----- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--authType`                  | `-a`  | `'authtoken'`                  | type of token argument, affecting how it is applied to npm commands.                                                             |
+| `--message`                   | `-m`  | `'applying package updates'`   | custom message for the checkin                                                                                                   |
+| `--git-tags`, `--no-git-tags` |       | `true` (`--git-tags`)          | whether to create git tags for published packages                                                                                |
+| `--publish`, `--no-publish`   |       | `true` (`--publish`)           | whether to publish to the npm registry                                                                                           |
+| `--push`, `--no-push`         |       | `true` (`--push`)              | whether to push changes back to git remote origin                                                                                |
+| `--dry-run`                   |       |                                | do a dry run of publishing: locally make all changes, run `npm publish --dry-run`, and commit (no tags), but don't push          |
+| `--prerelease-prefix`         |       |                                | prerelease prefix for packages that should receive a prerelease bump (`--prerelease-prefix beta` makes the `x.y.z-beta` version) |
+| `--registry`                  | `-r`  | `'https://registry.npmjs.org'` | npm registry for publishing                                                                                                      |
+| `--retries`                   |       | `3`                            | number of retries for a package publish before failing                                                                           |
+| `--tag`                       | `-t`  | `'latest'`                     | dist-tag for npm publishes                                                                                                       |
+| `--token`                     | `-n`  |                                | credential to use with npm commands. its type is specified with the `--authType` argument                                        |
+| `--verbose`                   |       | `false`                        | prints additional information to the console                                                                                     |
+| `--yes`                       | `-y`  | if CI detected, `true`         | skips the prompts for publish                                                                                                    |
+| `--new`                       |       | `false`                        | publishes new packages if not in registry                                                                                        |

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -37,6 +37,15 @@ The `publish` command is designed to run steps in an order that minimizes the ch
 
 It might be surprising that `beachball publish` does so many steps, especially the step about reverting changes! In most version bumping systems that automate syncing the git repo and npm registry, they assume that the source code is still fresh once it's time to push changes back to the git repository. This is rarely the case for large repos with many developers. So, `beachball` fetches the latest changes before pushing back to the target branch to avoid merge conflicts.
 
+### Dry run
+
+If you'd like to do a dry run of publishing, the `--dry-run` option works as follows:
+
+1. Makes all changes locally
+2. Runs `npm publish --dry-run` (skipped if the `publish` option is disabled)
+3. Commits the changes locally and merges them into the target branch, but does _not_ tag or push (skipped if the `bump` or `push` option is disabled)
+4. Stays on the current branch (and doesn't delete the publish branch) so you can inspect changes
+
 ### Example CI workflow
 
 See the [CI integration page](../concepts/ci-integration) details and examples for how to run `beachball publish` in CI.

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -1,6 +1,8 @@
+//
 // The npm test fixture got complicated enough to need tests...
 // But this added complexity greatly speeds up the other npm-related tests by removing the
 // dependency on actual npm CLI calls and a fake registry (which are very slow).
+//
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs-extra';
@@ -270,6 +272,17 @@ describe('_mockNpmPublish', () => {
         '2.0.0': packageJson,
       },
     });
+  });
+
+  it('does a dry run', () => {
+    const data = _makeRegistryData({});
+    packageJson = { name: 'foo', version: '1.0.0', main: 'index.js' };
+
+    const result = _mockNpmPublish(data, ['--dry-run'], { cwd: 'fake' });
+    // logs like it published
+    expect(result).toEqual(getPublishResult({ tag: 'latest' }));
+    // doesn't actually publish
+    expect(data).toEqual({});
   });
 });
 

--- a/src/__fixtures__/registry.ts
+++ b/src/__fixtures__/registry.ts
@@ -101,7 +101,7 @@ export class Registry {
 
       this.server.stderr.on('data', data => {
         const dataStr = String(data);
-        if (!dataStr.includes('Debugger attached')) {
+        if (!dataStr.toLowerCase().includes('debugger')) {
           reject(new Error(dataStr));
         }
       });

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -99,6 +99,28 @@ describe('packagePublish', () => {
     });
   });
 
+  it('does not publish if dryRun is specified', async () => {
+    // This might be redundant to test, but we want to be very sure we're passing the right option
+    // to npm here to avoid accidental publishing.
+    await registry.reset();
+    const testPackageInfo = getTestPackageInfo();
+    const publishResult = await packagePublish(testPackageInfo, {
+      dryRun: true,
+      registry: registry.getUrl(),
+      retries: 2,
+    });
+    expect(publishResult).toEqual(successResult);
+    expect(npmSpy).toHaveBeenCalledTimes(1);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Publishing - ${testSpec} with tag ${testTag}`);
+    expect(allLogs).toMatch('publish command:');
+    expect(allLogs).toMatch(`[log] Published!`);
+
+    // version shouldn't exist
+    await npmShow(testName, { registry, shouldFail: true });
+  });
+
   it('errors and does not retry on republish', async () => {
     // Use real npm for this because the republish detection relies on the real error message
     await registry.reset();

--- a/src/__tests__/packageManager/npmArgs.test.ts
+++ b/src/__tests__/packageManager/npmArgs.test.ts
@@ -77,4 +77,9 @@ describe('getNpmPublishArgs', () => {
     const args = getNpmPublishArgs(packageInfos.basic, { ...options, token: 'testToken' }).join(' ');
     expect(args).toMatch('--//testRegistry:_authToken=testToken');
   });
+
+  it('does dry run if specified', () => {
+    const args = getNpmPublishArgs(packageInfos.basic, { ...options, dryRun: true }).join(' ');
+    expect(args).toMatch('--dry-run');
+  });
 });

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -6,6 +6,7 @@ import { tagPackages } from '../../publish/tagPackages';
 import { generateTag } from '../../git/generateTag';
 import { BumpInfo } from '../../types/BumpInfo';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { BeachballOptions } from '../../types/BeachballOptions';
 
 jest.mock('workspace-tools', () => ({
   gitFailFast: jest.fn(),
@@ -15,42 +16,26 @@ const createTagParameters = (tag: string, cwd: string) => {
   return [['tag', '-a', '-f', tag, '-m', tag], { cwd }];
 };
 
-const noTagBumpInfo: Partial<BumpInfo> = {
-  calculatedChangeTypes: {
-    foo: 'minor',
-    bar: 'major',
-  },
-  packageInfos: makePackageInfos({
-    foo: {
-      version: '1.0.0',
-      combinedOptions: { gitTags: false },
+const makeBumpInfo = (packageOptions: Record<'foo' | 'bar', Partial<BeachballOptions>>): BumpInfo => {
+  const bumpInfo: Partial<BumpInfo> = {
+    calculatedChangeTypes: {
+      foo: 'minor',
+      bar: 'major',
     },
-    bar: {
-      version: '1.0.1',
-      combinedOptions: { gitTags: false },
-    },
-  }),
-  modifiedPackages: new Set(['foo', 'bar']),
-  newPackages: new Set(),
-};
-
-const oneTagBumpInfo: Partial<BumpInfo> = {
-  calculatedChangeTypes: {
-    foo: 'minor',
-    bar: 'major',
-  },
-  packageInfos: makePackageInfos({
-    foo: {
-      version: '1.0.0',
-      combinedOptions: { gitTags: true },
-    },
-    bar: {
-      version: '1.0.1',
-      combinedOptions: { gitTags: false },
-    },
-  }),
-  modifiedPackages: new Set(['foo', 'bar']),
-  newPackages: new Set(),
+    packageInfos: makePackageInfos({
+      foo: {
+        version: '1.0.0',
+        combinedOptions: packageOptions.foo,
+      },
+      bar: {
+        version: '1.0.1',
+        combinedOptions: packageOptions.bar,
+      },
+    }),
+    modifiedPackages: new Set(['foo', 'bar']),
+    newPackages: new Set(),
+  };
+  return bumpInfo as BumpInfo;
 };
 
 const emptyBumpInfo: Partial<BumpInfo> = {
@@ -61,7 +46,7 @@ const emptyBumpInfo: Partial<BumpInfo> = {
 };
 
 describe('tagPackages', () => {
-  initMockLogs();
+  const logs = initMockLogs();
 
   beforeEach(() => {
     (gitFailFast as Mock).mockReset();
@@ -72,17 +57,19 @@ describe('tagPackages', () => {
   });
 
   it('does not create tag for packages with gitTags=false', () => {
+    const bumpInfo = makeBumpInfo({ foo: { gitTags: false }, bar: { gitTags: false } });
     // Also verifies that if `gitTags` is false overall, it doesn't create a git tag for the dist tag (`tag`)
-    tagPackages(noTagBumpInfo as BumpInfo, { path: '', gitTags: false, tag: '' });
+    tagPackages(bumpInfo, { path: '', gitTags: false, tag: '' });
     expect(gitFailFast).not.toHaveBeenCalled();
   });
 
   it('creates tag for packages with gitTags=true', () => {
-    tagPackages(oneTagBumpInfo as BumpInfo, { path: '', gitTags: false, tag: '' });
+    const bumpInfo = makeBumpInfo({ foo: { gitTags: true }, bar: { gitTags: false } });
+    tagPackages(bumpInfo, { path: '', gitTags: false, tag: '' });
     expect(gitFailFast).toHaveBeenCalledTimes(1);
 
-    // verify git is being called to create new auto tag for foo and bar
-    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos!['foo'].version);
+    // verify git is being called to create new auto tag for foo
+    const newFooTag = generateTag('foo', bumpInfo.packageInfos!['foo'].version);
     expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters(newFooTag, ''));
   });
 
@@ -100,5 +87,17 @@ describe('tagPackages', () => {
     tagPackages(emptyBumpInfo as BumpInfo, { path: '', gitTags: true, tag: 'abc' });
     expect(gitFailFast).toBeCalledTimes(1);
     expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters('abc', ''));
+  });
+
+  it('does not create tags with dryRun=true', () => {
+    // In dry run mode, it just logs the tags that would be created
+    const bumpInfo = makeBumpInfo({ foo: { gitTags: true }, bar: { gitTags: true } });
+    tagPackages(bumpInfo, { path: '', dryRun: true, gitTags: true, tag: 'foo' });
+    expect(gitFailFast).not.toHaveBeenCalled();
+    expect(logs.getMockLines('log').split('\n')).toEqual([
+      'Would tag - foo@1.0.0',
+      'Would tag - bar@1.0.1',
+      'Would tag - foo',
+    ]);
   });
 });

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -10,6 +10,7 @@ const booleanOptions = [
   'bump',
   'bumpDeps',
   'commit',
+  'dryRun',
   'disallowDeletedChangeFiles',
   'fetch',
   'forceVersions',

--- a/src/packageManager/npmArgs.ts
+++ b/src/packageManager/npmArgs.ts
@@ -3,10 +3,11 @@ import { NpmOptions } from '../types/NpmOptions';
 import { PackageInfo } from '../types/PackageInfo';
 
 export function getNpmPublishArgs(packageInfo: PackageInfo, options: NpmOptions): string[] {
-  const { registry, token, authType, access } = options;
+  const { registry, token, authType, access, dryRun } = options;
   const pkgCombinedOptions = packageInfo.combinedOptions;
   const args = [
     'publish',
+    ...(dryRun ? ['--dry-run'] : []),
     '--registry',
     registry,
     '--tag',

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -63,13 +63,19 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     console.log('\nCreating git tags for new versions...');
     tagPackages(bumpInfo, options);
 
+    // prepare to push (skip for dry run)
+    const pushArgs = ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`];
+    if (options.dryRun) {
+      console.log(`Skipping pushing to ${branch} for dry run`);
+      console.log(`Would have run: git ${pushArgs.join(' ')}`);
+      completed = true;
+      continue;
+    }
+
     // push
     console.log(`\nPushing to ${branch}...`);
 
-    const pushResult = await gitAsync(
-      ['push', '--no-verify', '--follow-tags', '--verbose', remote, `HEAD:${remoteBranch}`],
-      { cwd, verbose, timeout: gitTimeout }
-    );
+    const pushResult = await gitAsync(pushArgs, { cwd, verbose, timeout: gitTimeout });
     if (pushResult.success) {
       completed = true;
     } else if (pushResult.timedOut) {

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -12,9 +12,13 @@ function createTag(tag: string, cwd: string): void {
  * Also, if git tags aren't disabled for the repo and the overall dist-tag (`options.tag`) has a
  * non-default value (not "latest"), create a git tag for the dist-tag.
  */
-export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 'gitTags' | 'path' | 'tag'>): void {
-  const { gitTags, tag: distTag, path: cwd } = options;
+export function tagPackages(
+  bumpInfo: BumpInfo,
+  options: Pick<BeachballOptions, 'gitTags' | 'path' | 'tag' | 'dryRun'>
+): void {
+  const { gitTags, tag: distTag, path: cwd, dryRun } = options;
   const { modifiedPackages, newPackages } = bumpInfo;
+  const tagVerb = dryRun ? 'Would tag' : 'Tagging';
 
   for (const pkg of [...modifiedPackages, ...newPackages]) {
     const packageInfo = bumpInfo.packageInfos[pkg];
@@ -23,13 +27,17 @@ export function tagPackages(bumpInfo: BumpInfo, options: Pick<BeachballOptions, 
     if (changeType === 'none' || packageInfo.private || !packageInfo.combinedOptions.gitTags) {
       continue;
     }
-    console.log(`Tagging - ${packageInfo.name}@${packageInfo.version}`);
-    const generatedTag = generateTag(packageInfo.name, packageInfo.version);
-    createTag(generatedTag, cwd);
+    console.log(`${tagVerb} - ${packageInfo.name}@${packageInfo.version}`);
+    if (!dryRun) {
+      const generatedTag = generateTag(packageInfo.name, packageInfo.version);
+      createTag(generatedTag, cwd);
+    }
   }
 
   if (gitTags && distTag && distTag !== 'latest') {
-    console.log(`Tagging - ${distTag}`);
-    createTag(distTag, cwd);
+    console.log(`${tagVerb} - ${distTag}`);
+    if (!dryRun) {
+      createTag(distTag, cwd);
+    }
   }
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -39,6 +39,7 @@ export interface CliOptions
   forceVersions?: boolean;
   fromRef?: string;
   help?: boolean;
+  dryRun?: boolean;
   keepChangeFiles?: boolean;
   /**
    * For publish: If true, publish all newly added packages in addition to modified packages.

--- a/src/types/NpmOptions.ts
+++ b/src/types/NpmOptions.ts
@@ -1,4 +1,4 @@
 import { BeachballOptions } from './BeachballOptions';
 
 export type NpmOptions = Required<Pick<BeachballOptions, 'registry'>> &
-  Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout' | 'verbose'>>;
+  Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout' | 'verbose' | 'dryRun'>>;


### PR DESCRIPTION
Add a `--dry-run` option (intended for the CLI only) which does the following:

1. Makes all changes locally
2. Runs `npm publish --dry-run` (skipped if the `publish` option is disabled)
3. Commits the changes locally and merges them into the target branch, but does _not_ tag or push (skipped if the `bump` or `push` option is disabled)
4. Stays on the current branch (and doesn't delete the publish branch) so you can inspect changes

Fixes #503