### PR TITLE
Ensure it bumps premajor, preminor and prepatch with a prereleasePrefix

### DIFF
--- a/change/beachball-f4d4d8d6-7911-4657-87f3-f552ce6eed0f.json
+++ b/change/beachball-f4d4d8d6-7911-4657-87f3-f552ce6eed0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure we can bump premajor, preminor and prepatch with a prereleasePrefix",
+  "packageName": "beachball",
+  "email": "kjell.knapen@craftzing.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -17,10 +17,16 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
   } else if (info.private) {
     console.log(`Skipping bumping private package "${pkgName}"`);
   } else {
+    // Ensure we can bump the correct versions
+    let bumpAsPrerelease = false;
+    if (options.prereleasePrefix && ! ["premajor", "preminor", "prepatch"].includes(changeType)) {
+      bumbAsPrerelease = true;
+    }
+
     // Version should be updated
     info.version = semver.inc(
       info.version,
-      options.prereleasePrefix ? 'prerelease' : changeType,
+      bumbAsPrerelease ? 'prerelease' : changeType,
       options.prereleasePrefix || undefined,
       options.identifierBase
     ) as string;

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -20,13 +20,13 @@ export function bumpPackageInfoVersion(pkgName: string, bumpInfo: BumpInfo, opti
     // Ensure we can bump the correct versions
     let bumpAsPrerelease = false;
     if (options.prereleasePrefix && ! ["premajor", "preminor", "prepatch"].includes(changeType)) {
-      bumbAsPrerelease = true;
+      bumpAsPrerelease = true;
     }
 
     // Version should be updated
     info.version = semver.inc(
       info.version,
-      bumbAsPrerelease ? 'prerelease' : changeType,
+      bumpAsPrerelease ? 'prerelease' : changeType,
       options.prereleasePrefix || undefined,
       options.identifierBase
     ) as string;


### PR DESCRIPTION
My last PR allowed us to add the options for new PrereleaseTypes: Premajor, preminor and prepatch. But the if statement in the current code overruled these types when the prereleasePrefix is checked.

In my opinion this check should change since having this means you can't add the prerelease prefix to the config cause it would handle every change as a prerelease. But since changing that would be a breaking change I added a different if check that should keep working in the current use cases