### PR TITLE
Run npm with shell: true

### DIFF
--- a/change/beachball-777e7bf0-8855-48ac-9337-c6578415bc13.json
+++ b/change/beachball-777e7bf0-8855-48ac-9337-c6578415bc13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set shell: true when spawning npm commands. This is required for Windows after a [Node security fix](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2).",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/packageManager/npm.ts
+++ b/src/packageManager/npm.ts
@@ -10,7 +10,7 @@ export async function npm(
   options: execa.Options = {}
 ): Promise<execa.ExecaReturnValue & { success: boolean }> {
   try {
-    const result = await execa('npm', args, { ...options });
+    const result = await execa('npm', args, { ...options, shell: true });
     return {
       ...result,
       success: !result.failed,


### PR DESCRIPTION
Set shell: true when spawning npm commands. This is required for Windows after a [Node security fix](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2).