### PR TITLE
feat: Enable override to NPM_CONCURRENCY defaults through env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ show help message
 
 skips the prompts for publish
 
+## Overriding Concurrency
+
+In large monorepos, the Beachball sync process can be time-consuming due to the high number of packages. To optimize performance, you can override the default concurrency (typically set to 2 or 5) by setting the NPM_CONCURRENCY environment variable to a value that best suits your needs
+
 ## Examples
 
 ```

--- a/change/beachball-3a1535e5-d3c6-4f91-a673-17f6e527edb3.json
+++ b/change/beachball-3a1535e5-d3c6-4f91-a673-17f6e527edb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "override NPM_CONCURRENCY defaults through env variable",
+  "packageName": "beachball",
+  "email": "nickykalu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,4 +17,6 @@ export const env = Object.freeze({
   // These are borrowed from workspace-tools
   workspaceToolsGitDebug: !!process.env.GIT_DEBUG,
   workspaceToolsGitMaxBuffer: (process.env.GIT_MAX_BUFFER && parseInt(process.env.GIT_MAX_BUFFER, 10)) || undefined,
+  // Override default NPM_CONCURRENCY
+  npmConcurrency: (process.env.NPM_CONCURRENCY && parseInt(process.env.NPM_CONCURRENCY)) || undefined
 });

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -18,7 +18,7 @@ export type NpmShowResult = PackageJson & {
 
 let packageVersionsCache: { [pkgName: string]: NpmShowResult | false } = {};
 
-const NPM_CONCURRENCY = env.isJest ? 2 : 5;
+const NPM_CONCURRENCY = env.npmConcurrency ?? (env.isJest ? 2 : 5);
 
 export function _clearPackageVersionsCache(): void {
   packageVersionsCache = {};


### PR DESCRIPTION
**Description:** 
This update introduces the ability to specify the NPM_CONCURRENCY environment variable, which controls the concurrency level when listing package versions from NPM. The current default settings are either 2 or 5.

**Usage:**
To adjust the concurrency, set the NPM_CONCURRENCY environment variable to the desired value. This change enables users and CI/CD pipelines to override the default concurrency levels when running the beachball sync command.

**Why This Is Necessary:**
For large monorepos, the beachball sync process can take an excessive amount of time due to the high volume of packages. By allowing a higher concurrency setting, this update can help improve performance and reduce the overall sync time.

**Considerations when overriding this value:**

- Network Latency
- Registry Throttling: When interacting with private or public npm registries, excessive concurrency may trigger rate limits.
- Local Resources: High concurrency can increase CPU and memory usage. 

We do not provide a specific recommendation for the ideal NPM_CONCURRENCY value, as this will vary based on your network and system conditions and registry rate limits. We suggest conducting benchmarks to determine the optimal setting for your environment.