### PR TITLE
Changelog options render main header

### DIFF
--- a/change/beachball-e6b4755a-c316-496c-8094-19d6ec7f7201.json
+++ b/change/beachball-e6b4755a-c316-496c-8094-19d6ec7f7201.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add renderMainHeader changelog option",
+  "packageName": "beachball",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/changelog/__snapshots__/writeChangelog.test.ts.snap
+++ b/src/__functional__/changelog/__snapshots__/writeChangelog.test.ts.snap
@@ -26,7 +26,7 @@ exports[`writeChangelog generates correct changelog in monorepo with groupChange
 exports[`writeChangelog generates correct changelog in monorepo with groupChanges (grouped change FILES): bar CHANGELOG.md 1`] = `
 "# Change Log - bar
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -84,7 +84,7 @@ exports[`writeChangelog generates correct changelog in monorepo with groupChange
 exports[`writeChangelog generates correct changelog in monorepo with groupChanges (grouped change FILES): foo CHANGELOG.md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -145,7 +145,7 @@ exports[`writeChangelog generates correct changelog with changeDir set: changelo
 exports[`writeChangelog generates correct changelog with changeDir set: changelog md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -206,7 +206,7 @@ exports[`writeChangelog generates correct changelog: changelog json 1`] = `
 exports[`writeChangelog generates correct changelog: changelog md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -226,7 +226,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates correct grouped changelog in monorepo: bar CHANGELOG.md 1`] = `
 "# Change Log - bar
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -244,7 +244,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates correct grouped changelog in monorepo: foo CHANGELOG.md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -261,7 +261,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates correct grouped changelog in monorepo: grouped CHANGELOG.md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -282,7 +282,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog 1`] = `
 "# Change Log - bar
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -299,7 +299,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates correct grouped changelog when grouped change log is saved to the same dir as a regular changelog 2`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -319,7 +319,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes: bar CHANGELOG.md 1`] = `
 "# Change Log - bar
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -337,7 +337,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes: baz CHANGELOG.md 1`] = `
 "# Change Log - baz
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -354,7 +354,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries where packages have normal changes and dependency changes: grouped CHANGELOG.md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -374,7 +374,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries: bar CHANGELOG.md 1`] = `
 "# Change Log - bar
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -391,7 +391,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries: baz CHANGELOG.md 1`] = `
 "# Change Log - baz
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -408,7 +408,7 @@ This log was last generated on (date) and should not be manually modified.
 exports[`writeChangelog generates grouped changelog without dependent change entries: grouped CHANGELOG.md 1`] = `
 "# Change Log - foo
 
-This log was last generated on (date) and should not be manually modified.
+<!-- This log was last generated on (date) and should not be manually modified. -->
 
 <!-- Start content -->
 

--- a/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
+++ b/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renderChangelog handles no previous content 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -26,7 +26,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 exports[`renderChangelog keeps previous content if no marker or h2 is found 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -53,7 +53,7 @@ This log was last generated on Wed, 21 Aug 2019 21:20:40 GMT and should not be m
 exports[`renderChangelog merges default and custom renderers 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -80,7 +80,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 exports[`renderChangelog merges with previous content using h2 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -107,7 +107,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 exports[`renderChangelog merges with previous content using marker 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
@@ -134,7 +134,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 exports[`renderChangelog uses full custom renderer 1`] = `
 "# Change Log - foo
 
-This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 

--- a/src/__tests__/changelog/renderChangelog.test.ts
+++ b/src/__tests__/changelog/renderChangelog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { MarkdownChangelogRenderOptions, renderChangelog, markerComment } from '../../changelog/renderChangelog';
-import { ChangelogEntry } from '../../types/ChangeLog';
+import { ChangelogEntry, PackageChangelog } from '../../types/ChangeLog';
 
 const previousHeader = `# Change Log - foo
 
@@ -124,9 +124,14 @@ describe('renderChangelog', () => {
     options.changelogOptions.customRenderers = {
       renderEntry: jest.fn(async (entry: ChangelogEntry) => `- ${entry.comment} ${entry.extra})`),
     };
+    options.changelogOptions.renderMainHeader = jest.fn(
+      async (packageChangelog: PackageChangelog) => `Custom main header ${packageChangelog.name}`
+    );
 
     const result = await renderChangelog(options);
     expect(result).toContain('Awesome change custom');
+    expect(result).toContain('Custom main header foo');
+    expect(result).not.toContain('# Change Log -');
     expect(options.changelogOptions.customRenderers.renderEntry).toHaveBeenCalledWith(
       expect.objectContaining({ extra: 'custom' }),
       expect.anything()

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -46,7 +46,7 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
     return (
       [
         `# Change Log - ${newVersionChangelog.name}`,
-        `This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified.`,
+        `<!-- This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified. -->`,
         markerComment,
         await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
         previousLogEntries,

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -1,4 +1,5 @@
 import { renderPackageChangelog, defaultRenderers } from './renderPackageChangelog';
+import { renderMainHeader } from './renderMainHeader';
 import { ChangelogOptions, PackageChangelogRenderInfo } from '../types/ChangelogOptions';
 
 export interface MarkdownChangelogRenderOptions extends Omit<PackageChangelogRenderInfo, 'renderers'> {
@@ -14,7 +15,11 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
     previousContent = '',
     newVersionChangelog,
     isGrouped,
-    changelogOptions: { renderPackageChangelog: customRenderPackageChangelog, customRenderers },
+    changelogOptions: {
+      renderPackageChangelog: customRenderPackageChangelog,
+      customRenderers,
+      renderMainHeader: customRenderMainHeader,
+    },
   } = renderOptions;
 
   let previousLogEntries: string;
@@ -45,7 +50,7 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
 
     return (
       [
-        `# Change Log - ${newVersionChangelog.name}`,
+        await (customRenderMainHeader || renderMainHeader)(newVersionChangelog),
         `<!-- This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified. -->`,
         markerComment,
         await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),

--- a/src/changelog/renderMainHeader.ts
+++ b/src/changelog/renderMainHeader.ts
@@ -1,0 +1,5 @@
+import { PackageChangelog } from '../types/ChangeLog';
+
+export async function renderMainHeader(newVersionChangelog: PackageChangelog) {
+  return `# Change Log - ${newVersionChangelog.name}`;
+}

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -24,6 +24,15 @@ export interface ChangelogOptions {
    * If using a custom `renderPackageChangelog`, these will not be called automatically.
    */
   customRenderers?: ChangelogRenderers;
+  /**
+   * Custom renderer for the header for the entire changelog.
+   *
+   * Default is like this (no leading or trailing newlines):
+   * ```txt
+   * # Change Log - @scope/package-name
+   * ```
+   */
+  renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
 }
 
 /**


### PR DESCRIPTION
Implements the changes discussed in #975 including:

- Comments out the  `<!-- This log was last generated ... -->` part of the changelog by default, since it's mostly intended for someone who's trying to edit the markdown source.
- Supports changing the default `<h1>` content `# Changelog - <@package-name>` via a `renderMainHeader` changelog option.