### PR TITLE
Include pre* changes in changelog

### DIFF
--- a/change/beachball-fc33dd32-5877-497d-9032-836787d0c08d.json
+++ b/change/beachball-fc33dd32-5877-497d-9032-836787d0c08d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Include pre* changes in changelog",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -297,6 +297,29 @@ describe('writeChangelog', () => {
     expect(readChangelogMd(repo.pathTo('packages/foo'))).toMatchSnapshot();
   });
 
+  it('includes pre* changes', async () => {
+    repo = repositoryFactory.cloneRepository();
+    const options = getOptions();
+
+    generateChangeFiles(
+      [
+        { packageName: 'foo', comment: 'comment 1', type: 'premajor' },
+        { packageName: 'foo', comment: 'comment 2', type: 'preminor' },
+        { packageName: 'foo', comment: 'comment 3', type: 'prepatch' },
+      ],
+      options
+    );
+
+    const packageInfos = getPackageInfos(repo.rootPath);
+    const changes = readChangeFiles(options, packageInfos);
+    await writeChangelog(options, changes, {}, {}, packageInfos);
+
+    const changelogMd = readChangelogMd(repo.rootPath);
+    expect(changelogMd).toContain('### Major changes (pre-release)\n\n- comment 1');
+    expect(changelogMd).toContain('### Minor changes (pre-release)\n\n- comment 2');
+    expect(changelogMd).toContain('### Patches (pre-release)\n\n- comment 3');
+  });
+
   it('writes only CHANGELOG.md if generateChangelog is "md"', async () => {
     repo = repositoryFactory.cloneRepository();
     const options = getOptions({ generateChangelog: 'md' });

--- a/src/__tests__/changelog/__snapshots__/renderPackageChangelog.test.ts.snap
+++ b/src/__tests__/changelog/__snapshots__/renderPackageChangelog.test.ts.snap
@@ -84,6 +84,40 @@ Thu, 22 Aug 2019 21:20:40 GMT
 - stuff (user2@example.com)"
 `;
 
+exports[`changelog renderers - renderPackageChangelog includes all change types 1`] = `
+"## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Major changes
+
+- major change (user1@example.com)
+
+### Major changes (pre-release)
+
+- premajor change (user1@example.com)
+
+### Minor changes
+
+- minor change (user1@example.com)
+
+### Minor changes (pre-release)
+
+- preminor change (user1@example.com)
+
+### Patches
+
+- patch change (user1@example.com)
+
+### Patches (pre-release)
+
+- prepatch change (user1@example.com)
+
+### Changes
+
+- prerelease change (user1@example.com)"
+`;
+
 exports[`changelog renderers - renderPackageChangelog uses custom renderChangeTypeHeader 1`] = `
 "## 1.2.3
 


### PR DESCRIPTION
#944 added change types premajor/preminor/prepatch, but they weren't being included in the changelog.