### PR TITLE
Exit with an error on invalid change files

### DIFF
--- a/change/beachball-d1d64636-b7a3-490c-80a1-af0e305a05ca.json
+++ b/change/beachball-d1d64636-b7a3-490c-80a1-af0e305a05ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exit with an error on invalid change files",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -113,29 +113,6 @@ export function validate(
     hasError = true; // the helper logs this
   }
 
-  if (hasError) {
-    // If any of the above basic checks failed, it doesn't make sense to check if change files are needed
-    process.exit(1);
-  }
-
-  let isChangeNeeded = false;
-
-  if (allowFetching) {
-    // This has the side effect of fetching, so call it even if !allowMissingChangeFiles for now
-    isChangeNeeded = isChangeFileNeeded(options, packageInfos);
-
-    if (isChangeNeeded && !allowMissingChangeFiles) {
-      logValidationError('Change files are needed!');
-      console.log(options.changehint);
-      process.exit(1); // exit here (this is the main poin)
-    }
-
-    if (options.disallowDeletedChangeFiles && areChangeFilesDeleted(options)) {
-      logValidationError('Change files must not be deleted!');
-      process.exit(1);
-    }
-  }
-
   const changeSet = readChangeFiles(options, packageInfos);
 
   for (const { changeFile, change } of changeSet) {
@@ -158,6 +135,29 @@ export function validate(
     } else if (!isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
       logValidationError(`Invalid dependentChangeType detected in ${changeFile}: "${change.dependentChangeType}"`);
       hasError = true;
+    }
+  }
+
+  if (hasError) {
+    // If any of the above basic checks failed, it doesn't make sense to check if change files are needed
+    process.exit(1);
+  }
+
+  let isChangeNeeded = false;
+
+  if (allowFetching) {
+    // This has the side effect of fetching, so call it even if !allowMissingChangeFiles for now
+    isChangeNeeded = isChangeFileNeeded(options, packageInfos);
+
+    if (isChangeNeeded && !allowMissingChangeFiles) {
+      logValidationError('Change files are needed!');
+      console.log(options.changehint);
+      process.exit(1); // exit here (this is the main poin)
+    }
+
+    if (options.disallowDeletedChangeFiles && areChangeFilesDeleted(options)) {
+      logValidationError('Change files must not be deleted!');
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
#878 introduced a bug where beachball would no longer exit with an error if there were invalid change files (though it would log messages). 

This PR changes the ordering of some checks so that `if (hasError) process.exit(1)` comes *after* all the other checks that set `hasError`.