### PR TITLE
Remove newPackages from main BumpInfo

### DIFF
--- a/change/beachball-848fed39-4933-483a-a038-1470bebe299b.json
+++ b/change/beachball-848fed39-4933-483a-a038-1470bebe299b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove newPackages from main BumpInfo",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -26,7 +26,6 @@ describe('updateRelatedChangeType', () => {
           baz: { combinedOptions: { disallowedChangeTypes: [], defaultNpmTag: 'latest' } },
         }),
         modifiedPackages: new Set(),
-        newPackages: new Set(),
         packageGroups: {},
         scopedPackages: new Set(),
         dependentChangedBy: {},

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -28,7 +28,6 @@ export function gatherBumpInfo(options: BeachballOptions, packageInfos: PackageI
     packageGroups: getPackageGroups(packageInfos, options.path, options.groups),
     changeFileChangeInfos: changes,
     modifiedPackages: new Set<string>(),
-    newPackages: new Set<string>(),
     scopedPackages: new Set(getScopedPackages(options, packageInfos)),
     dependentChangedBy: {},
   };

--- a/src/bump/getDependentsForPackages.ts
+++ b/src/bump/getDependentsForPackages.ts
@@ -12,7 +12,7 @@ export function getDependentsForPackages(
 ): PackageDependents {
   const { packageInfos, scopedPackages } = bumpInfo;
 
-  const dependents: PackageDependents = {};
+  const dependents: { [pkgName: string]: string[] } = {};
 
   for (const [pkgName, info] of Object.entries(packageInfos)) {
     if (!scopedPackages.has(pkgName)) {

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -1,5 +1,5 @@
 import { formatList } from '../logging/format';
-import { BumpInfo } from '../types/BumpInfo';
+import { PublishBumpInfo } from '../types/BumpInfo';
 import { toposortPackages } from './toposortPackages';
 
 /**
@@ -10,10 +10,10 @@ import { toposortPackages } from './toposortPackages';
  * based on the dependency graph to ensure they're published in the correct order, and any
  * new/modified packages that will be skipped (and why) are logged to the console.
  */
-export function getPackagesToPublish(bumpInfo: BumpInfo, validationMode?: boolean): string[] {
-  const { modifiedPackages, newPackages, packageInfos } = bumpInfo;
+export function getPackagesToPublish(bumpInfo: PublishBumpInfo, validationMode?: boolean): string[] {
+  const { modifiedPackages, newPackages, packageInfos, calculatedChangeTypes, scopedPackages } = bumpInfo;
 
-  let packages = [...modifiedPackages, ...newPackages];
+  let packages = [...modifiedPackages, ...(newPackages || [])];
   if (!validationMode) {
     // skip this step when called from `validate` since it's not needed and might be slow
     packages = toposortPackages(packages, packageInfos);
@@ -22,15 +22,15 @@ export function getPackagesToPublish(bumpInfo: BumpInfo, validationMode?: boolea
   const skippedPackageReasons: string[] = [];
 
   for (const pkg of packages) {
-    const packageInfo = bumpInfo.packageInfos[pkg];
-    const changeType = bumpInfo.calculatedChangeTypes[pkg];
+    const packageInfo = packageInfos[pkg];
+    const changeType = calculatedChangeTypes[pkg];
 
     let skipReason = '';
     if (changeType === 'none') {
       skipReason = 'has change type none';
     } else if (packageInfo.private) {
       skipReason = 'is private';
-    } else if (!bumpInfo.scopedPackages.has(pkg)) {
+    } else if (!scopedPackages.has(pkg)) {
       skipReason = 'is out-of-scope';
     }
 

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { performBump } from '../bump/performBump';
-import { BumpInfo } from '../types/BumpInfo';
+import { PublishBumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
 import { packagePublish } from '../packageManager/packagePublish';
 import { validatePackageVersions } from './validatePackageVersions';
@@ -14,7 +14,7 @@ import { callHook } from '../bump/callHook';
  * Publish all the bumped packages to the registry.
  * This will bump packages on the filesystem first if `options.bump` is true.
  */
-export async function publishToRegistry(originalBumpInfo: BumpInfo, options: BeachballOptions): Promise<void> {
+export async function publishToRegistry(originalBumpInfo: PublishBumpInfo, options: BeachballOptions): Promise<void> {
   const bumpInfo = _.cloneDeep(originalBumpInfo);
 
   if (options.bump) {
@@ -37,7 +37,8 @@ export async function publishToRegistry(originalBumpInfo: BumpInfo, options: Bea
     process.exit(1);
   }
 
-  // performing publishConfig and workspace version overrides requires this procedure to ONLY be run right before npm publish, but NOT in the git push
+  // performing publishConfig and workspace version overrides requires this procedure to
+  // ONLY be run right before npm publish, but NOT in the git push
   performPublishOverrides(packagesToPublish, bumpInfo.packageInfos);
 
   // if there is a prepublish hook perform a prepublish pass, calling the routine on each package

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -21,9 +21,6 @@ export type BumpInfo = {
   /** Set of packages that had been modified */
   modifiedPackages: Set<string>;
 
-  /** Set of new packages detected in this info */
-  newPackages: Set<string>;
-
   /** Map from package name to its internal dependency names that were bumped. */
   dependentChangedBy: { [pkgName: string]: Set<string> };
 
@@ -32,4 +29,16 @@ export type BumpInfo = {
 };
 
 /** Dependents cache (child points to parents): if A depends on B, then `{ B: [A] }` */
-export type PackageDependents = { [pkgName: string]: string[] };
+export type PackageDependents = { readonly [pkgName: string]: ReadonlyArray<string> };
+
+/**
+ * Bump info with additional property set/used only during publishing (not while calculating
+ * packages to bump).
+ */
+export type PublishBumpInfo = BumpInfo & {
+  /**
+   * Set of packages detected in this info which weren't previously published and didn't have
+   * change files. (Only populated if `options.new` is set.)
+   */
+  newPackages?: ReadonlyArray<string>;
+};


### PR DESCRIPTION
`BumpInfo.newPackages` is only set and used during the actual steps of bumping on disk and publishing, not the initial bumping in-memory. Move it to a separate type `PublishBumpInfo` (not a great name...) and update the relevant functions to clarify where it's used.

I also added a console log before the operation starts with a warning against using it, because it's usually unnecessary and potentially pretty expensive (fetch *every unmodified package* from npm).

(It's unclear if determining the new packages strictly *needs* to be done only during publish, but it is potentially pretty expensive, and it's always been part of only the publish command since it was added in #234.) 