### PR TITLE
Move post-bump package updating utils to separate file

### DIFF
--- a/change/beachball-68aac7dd-5676-4f86-af7f-4c2ee46d08f7.json
+++ b/change/beachball-68aac7dd-5676-4f86-af7f-4c2ee46d08f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor post-bump updating utilities",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -1,99 +1,22 @@
-import fs from 'fs-extra';
-import path from 'path';
 import { unlinkChangeFiles } from '../changefile/unlinkChangeFiles';
 import { writeChangelog } from '../changelog/writeChangelog';
 import { BumpInfo } from '../types/BumpInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { PackageInfos, PackageJson, consideredDependencies } from '../types/PackageInfo';
-import { findProjectRoot } from 'workspace-tools';
-import { npm } from '../packageManager/npm';
-import { packageManager } from '../packageManager/packageManager';
 import { callHook } from './callHook';
-
-export function writePackageJson(modifiedPackages: Set<string>, packageInfos: PackageInfos): void {
-  for (const pkgName of modifiedPackages) {
-    const info = packageInfos[pkgName];
-    if (!fs.existsSync(info.packageJsonPath)) {
-      console.warn(`Skipping ${pkgName} since package.json does not exist`);
-      continue;
-    }
-    const packageJson: PackageJson = fs.readJSONSync(info.packageJsonPath);
-
-    if (!info.private) {
-      packageJson.version = info.version;
-    }
-
-    for (const depKind of consideredDependencies) {
-      // updatedDeps contains all of the dependencies in the bump info since the beginning of a build job
-      const updatedDeps = info[depKind] || {};
-
-      // to be cautious, only update internal && modifiedPackages, since some other dependency
-      // changes could have occurred since the beginning of the build job and the next merge step
-      // would overwrite those incorrectly!
-      for (const [dep, updatedVersion] of Object.entries(updatedDeps)) {
-        if (modifiedPackages.has(dep) && packageJson[depKind]?.[dep]) {
-          packageJson[depKind]![dep] = updatedVersion;
-        }
-      }
-    }
-
-    fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
-  }
-}
+import { updatePackageJsons } from './updatePackageJsons';
+import { updateLockFile } from './updateLockFile';
 
 /**
- * Detects lockfile for npm, pnpm, or yarn and runs the appropriate command to update it
- */
-export async function updatePackageLock(cwd: string): Promise<void> {
-  const root = findProjectRoot(cwd);
-  if (root && fs.existsSync(path.join(root, 'package-lock.json'))) {
-    console.log('Updating package-lock.json after bumping packages');
-    const res = await npm(['install', '--package-lock-only', '--ignore-scripts'], { stdio: 'inherit', cwd: root });
-    if (!res.success) {
-      console.warn('Updating package-lock.json failed. Continuing...');
-    }
-  } else if (root && fs.existsSync(path.join(root, 'pnpm-lock.yaml'))) {
-    console.log('Updating pnpm-lock.yaml after bumping packages');
-    const res = await packageManager('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], {
-      stdio: 'inherit',
-      cwd: root,
-    });
-    if (!res.success) {
-      console.warn('Updating pnpm-lock.yaml failed. Continuing...');
-    }
-  } else if (root && fs.existsSync(path.join(root, 'yarn.lock'))) {
-    console.log('Updating yarn.lock after bumping packages');
-    const version = await packageManager('yarn', ['--version'], { cwd: root });
-    if (!version.success) {
-      console.warn('Failed to get yarn version. Continuing...');
-      return;
-    }
-
-    if (version.stdout.startsWith('1.')) {
-      console.log('Yarn v1 detected, skipping update lockfile since it is not needed');
-      return;
-    }
-
-    // for yarn v2+
-    const res = await packageManager('yarn', ['install', '--mode', 'update-lockfile'], { stdio: 'inherit', cwd: root });
-    if (!res.success) {
-      console.warn('Updating yarn.lock failed. Continuing...');
-    }
-  }
-}
-
-/**
- * Performs the bump, writes to the file system
- *
- * deletes change files, update package.json, and changelogs
+ * Performs the bump and writes to the filesystem:
+ * update package.json files, update lock file, write changelogs, and delete change files.
  */
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions): Promise<BumpInfo> {
   const { modifiedPackages, packageInfos, changeFileChangeInfos } = bumpInfo;
 
   await callHook(options.hooks?.prebump, modifiedPackages, bumpInfo.packageInfos);
 
-  writePackageJson(modifiedPackages, packageInfos);
-  await updatePackageLock(options.path);
+  updatePackageJsons(modifiedPackages, packageInfos);
+  await updateLockFile(options.path);
 
   if (options.generateChangelog) {
     // Generate changelog

--- a/src/bump/updateLockFile.ts
+++ b/src/bump/updateLockFile.ts
@@ -1,0 +1,47 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { findProjectRoot } from 'workspace-tools';
+import { packageManager } from '../packageManager/packageManager';
+
+/**
+ * Detects lockfile for npm, pnpm, or yarn and runs the appropriate command to update it
+ */
+export async function updateLockFile(cwd: string): Promise<void> {
+  const root = findProjectRoot(cwd);
+  if (!root) {
+    return;
+  }
+
+  let updateFile: string | undefined;
+  let updateCommand: ['npm' | 'pnpm' | 'yarn', ...string[]] | undefined;
+
+  if (fs.existsSync(path.join(root, 'package-lock.json'))) {
+    updateFile = 'package-lock.json';
+    updateCommand = ['npm', 'install', '--package-lock-only', '--ignore-scripts'];
+  } else if (fs.existsSync(path.join(root, 'pnpm-lock.yaml'))) {
+    updateFile = 'pnpm-lock.yaml';
+    updateCommand = ['pnpm', 'install', '--lockfile-only', '--ignore-scripts'];
+  } else if (fs.existsSync(path.join(root, 'yarn.lock'))) {
+    const version = await packageManager('yarn', ['--version'], { cwd: root });
+    if (version.success) {
+      // For yarn v1, local versions aren't recorded in the lock file, so we don't need an update.
+      // yarn v2+ records these versions and may require an update.
+      if (!version.stdout.startsWith('1.')) {
+        updateFile = 'yarn.lock';
+        updateCommand = ['yarn', 'install', '--mode', 'update-lockfile'];
+      }
+    } else {
+      console.warn('Failed to get yarn version. Continuing...');
+    }
+  }
+
+  if (updateFile && updateCommand) {
+    console.log(`Updating ${updateFile} after bumping packages`);
+
+    const res = await packageManager(updateCommand[0], updateCommand.slice(1), { stdio: 'inherit', cwd: root });
+
+    if (!res.success) {
+      console.warn(`Updating ${updateFile} failed. Continuing...`);
+    }
+  }
+}

--- a/src/bump/updatePackageJsons.ts
+++ b/src/bump/updatePackageJsons.ts
@@ -1,0 +1,37 @@
+import fs from 'fs-extra';
+import { PackageInfos, PackageJson, consideredDependencies } from '../types/PackageInfo';
+
+/**
+ * Update package.json files for modified packages after bumping.
+ */
+export function updatePackageJsons(modifiedPackages: Set<string>, packageInfos: PackageInfos): void {
+  for (const pkgName of modifiedPackages) {
+    const info = packageInfos[pkgName];
+    if (!fs.existsSync(info.packageJsonPath)) {
+      // rare case in highly active monorepos where a package might have been deleted in main
+      console.warn(`Skipping ${pkgName} since package.json does not exist`);
+      continue;
+    }
+    const packageJson: PackageJson = fs.readJSONSync(info.packageJsonPath);
+
+    if (!info.private) {
+      packageJson.version = info.version;
+    }
+
+    for (const depKind of consideredDependencies) {
+      // updatedDeps contains all of the dependencies in the bump info since the beginning of a build job
+      const updatedDeps = info[depKind] || {};
+
+      // to be cautious, only update internal && modifiedPackages, since some other dependency
+      // changes could have occurred since the beginning of the build job and the next merge step
+      // would overwrite those incorrectly!
+      for (const [dep, updatedVersion] of Object.entries(updatedDeps)) {
+        if (modifiedPackages.has(dep) && packageJson[depKind]?.[dep]) {
+          packageJson[depKind]![dep] = updatedVersion;
+        }
+      }
+    }
+
+    fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
+  }
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,7 +4,8 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { listPackageVersionsByTag } from '../packageManager/listPackageVersions';
 import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
-import { writePackageJson, updatePackageLock } from '../bump/performBump';
+import { updateLockFile } from '../bump/updateLockFile';
+import { updatePackageJsons } from '../bump/updatePackageJsons';
 
 export async function sync(options: BeachballOptions): Promise<void> {
   const packageInfos = getPackageInfos(options.path);
@@ -33,6 +34,6 @@ export async function sync(options: BeachballOptions): Promise<void> {
   const dependentModifiedPackages = setDependentVersions(packageInfos, scopedPackages, options);
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
-  writePackageJson(modifiedPackages, packageInfos);
-  await updatePackageLock(options.path);
+  updatePackageJsons(modifiedPackages, packageInfos);
+  await updateLockFile(options.path);
 }


### PR DESCRIPTION
Move the utilities for updating package.jsons and the lock file after bumping into their own files. This makes the code easier to read.