### PR TITLE
Add option to use hash in changelog filenames

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,10 @@
       "args": ["--", "--runInBand", "--watch", "--testTimeout=1000000", "${fileBasenameNoExtension}"],
       "sourceMaps": true,
       "outputCapture": "std",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      // Debug with Node 14 via nvm.
+      // On Windows, you might have to change this to a specific version.
+      "runtimeVersion": "14"
     },
     {
       "type": "node",

--- a/change/beachball-ba7bb90f-ba01-4c9b-84ac-e054aa4db235.json
+++ b/change/beachball-ba7bb90f-ba01-4c9b-84ac-e054aa4db235.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace usage of uuid library with built-in crypto.randomUUID()",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
+++ b/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add option changelog.hashFilenames",
+  "comment": "Add option changelog.uniqueFilenames",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
+++ b/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add option changelog.uniqueFilenames",
+  "comment": "Add option `changelog.uniqueFilenames` for adding a hash to the changelog filename based on the package name",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
+++ b/change/beachball-c1b55758-27ac-4dc8-b073-8380c991c183.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option changelog.hashFilenames",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,11 @@ const commonOptions = {
   roots: ['<rootDir>/src'],
   setupFilesAfterEnv: ['<rootDir>/scripts/jestSetup.js'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      // in ts-jest, this means skip type checking (we already type check in the build step)
+      { isolatedModules: true },
+    ],
   },
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "semver": "^7.0.0",
     "toposort": "^2.0.2",
     "p-graph": "^1.1.2",
-    "uuid": "^9.0.0",
     "workspace-tools": "^0.38.0",
     "yargs-parser": "^21.0.0"
   },
@@ -65,7 +64,6 @@
     "@types/semver": "^7.3.13",
     "@types/tmp": "^0.2.3",
     "@types/toposort": "^2.0.3",
-    "@types/uuid": "^9.0.0",
     "@types/yargs-parser": "^21.0.0",
     "find-free-port": "^2.0.0",
     "gh-pages": "^5.0.0",

--- a/src/__fixtures__/createTestFileStructure.ts
+++ b/src/__fixtures__/createTestFileStructure.ts
@@ -1,0 +1,20 @@
+import fs from 'fs-extra';
+import { tmpdir } from './tmpdir';
+import path from 'path';
+
+/**
+ * For each key in `files`, create a test folder and write a file of that filename, where the
+ * content is the value (and create any intermediate folders).
+ * @returns path to the test folder with **forward slashes**
+ */
+export function createTestFileStructure(files: Record<string, string | object>): string {
+  const testFolderPath = tmpdir();
+
+  for (const [filename, content] of Object.entries(files)) {
+    const filePath = path.join(testFolderPath, filename);
+    fs.ensureDirSync(path.dirname(filePath));
+    fs.writeFileSync(filePath, typeof content === 'string' ? content : JSON.stringify(content));
+  }
+
+  return testFolderPath.replace(/\\/g, '/');
+}

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs-extra';
 import * as tmp from 'tmp';
 import { normalizedTmpdir } from 'normalized-tmpdir';
 // import console to ensure that warnings are always logged if needed (no mocking)
@@ -24,4 +25,13 @@ export function tmpdir(options?: tmp.DirOptions): string {
     // Create a directory starting with this normalized path
     tmpdir: normalizedTmpdir({ console: realConsole }),
   }).name;
+}
+
+/** Remove the temp directory, ignoring errors */
+export function removeTempDir(dir: string) {
+  try {
+    fs.rmSync(dir, { force: true });
+  } catch {
+    // ignore
+  }
 }

--- a/src/__functional__/changelog/prepareChangelogPaths.test.ts
+++ b/src/__functional__/changelog/prepareChangelogPaths.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { removeTempDir } from '../../__fixtures__/tmpdir';
+import { prepareChangelogPaths } from '../../changelog/prepareChangelogPaths';
+import { createTestFileStructure } from '../../__fixtures__/createTestFileStructure';
+
+describe('prepareChangelogPaths', () => {
+  let consoleLogMock: jest.SpiedFunction<typeof console.log>;
+  let consoleWarnMock: jest.SpiedFunction<typeof console.warn>;
+  let tempDir: string | undefined;
+  const fakeDir = slash(path.resolve('/faketmpdir'));
+  const hashRegexp = /^[0-9a-f]{8}$/;
+
+  /** Wrapper that calls `prepareChangelogPaths` and converts the result to forward slashes */
+  function prepareChangelogPathsWrapper(options: Parameters<typeof prepareChangelogPaths>[0]) {
+    const paths = prepareChangelogPaths(options);
+    if (paths.md) paths.md = slash(paths.md);
+    if (paths.json) paths.json = slash(paths.json);
+    return paths;
+  }
+
+  function slash(str: string) {
+    return str.replace(/\\/g, '/');
+  }
+
+  beforeAll(() => {
+    consoleLogMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnMock.mockClear();
+    tempDir && removeTempDir(tempDir);
+    tempDir = undefined;
+  });
+
+  it('returns empty paths if generateChangelog is false', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: false, changelog: {} },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({});
+  });
+
+  it('returns default paths if generateChangelog is true (hashFilenames unset)', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({ md: `${fakeDir}/CHANGELOG.md`, json: `${fakeDir}/CHANGELOG.json` });
+  });
+
+  it('returns only default md path if generateChangelog is "md" (hashFilenames unset)', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: 'md' },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({ md: `${fakeDir}/CHANGELOG.md` });
+  });
+
+  it('returns only default json path if generateChangelog is "json" (hashFilenames unset)', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: 'json' },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({ json: `${fakeDir}/CHANGELOG.json` });
+  });
+
+  it('returns new hashed paths if hashFilenames is true and no files exist', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({
+      md: `${fakeDir}/CHANGELOG-${paths.hash}.md`,
+      json: `${fakeDir}/CHANGELOG-${paths.hash}.json`,
+      hash: expect.stringMatching(hashRegexp),
+    });
+  });
+
+  it('returns new hashed md path if hashFilenames is true and generateChangelog is "md"', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: 'md', changelog: { hashFilenames: true } },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({
+      md: `${fakeDir}/CHANGELOG-${paths.hash}.md`,
+      hash: expect.stringMatching(hashRegexp),
+    });
+  });
+
+  it('returns new hashed json path if hashFilenames is true and generateChangelog is "json"', () => {
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: 'json', changelog: { hashFilenames: true } },
+      changelogAbsDir: fakeDir,
+    });
+
+    expect(paths).toEqual({
+      json: `${fakeDir}/CHANGELOG-${paths.hash}.json`,
+      hash: expect.stringMatching(hashRegexp),
+    });
+  });
+
+  it('detects existing hashed files if hashFilenames is true', () => {
+    const hash = 'abcdef12';
+    tempDir = createTestFileStructure({
+      [`CHANGELOG-${hash}.md`]: 'existing md',
+      [`CHANGELOG-${hash}.json`]: {},
+    });
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG-${hash}.md`,
+      json: `${tempDir}/CHANGELOG-${hash}.json`,
+      hash,
+    });
+  });
+
+  it('detects hash from existing md file if hashFilenames is true', () => {
+    // only the md file is present, but its hash will be used for both files
+    const hash = 'abcdef12';
+    tempDir = createTestFileStructure({
+      [`CHANGELOG-${hash}.md`]: 'existing md',
+    });
+
+    const pathsWithBoth = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+    expect(pathsWithBoth).toEqual({
+      md: `${tempDir}/CHANGELOG-${hash}.md`,
+      json: `${tempDir}/CHANGELOG-${hash}.json`,
+      hash,
+    });
+  });
+
+  it('detects hash from existing json file if hashFilenames is true', () => {
+    // only the json file is present, but its hash will be used for both files
+    const hash = 'abcdef12';
+    tempDir = createTestFileStructure({
+      [`CHANGELOG-${hash}.json`]: {},
+    });
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG-${hash}.md`,
+      json: `${tempDir}/CHANGELOG-${hash}.json`,
+      hash,
+    });
+  });
+
+  it('uses newer hash if hashFilenames is true and md/json files have different hashes', async () => {
+    const hashJson = 'abcdef34';
+    const hashMd = 'abcdef12';
+    tempDir = createTestFileStructure({
+      [`CHANGELOG-${hashJson}.json`]: {},
+    });
+    // ensure different timestamps by waiting 1ms
+    await new Promise(resolve => setTimeout(resolve, 1));
+    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${hashMd}.md`), 'existing md');
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+    // md hash is preferred for both files because the file is newer
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG-${hashMd}.md`,
+      json: `${tempDir}/CHANGELOG-${hashMd}.json`,
+      hash: hashMd,
+    });
+    expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('Found changelog files with multiple hashes'));
+  });
+
+  it('uses newest hash if hashFilenames is true and there are multiple hashed files', async () => {
+    const lastHash = 'abcdef12';
+    tempDir = createTestFileStructure({
+      'CHANGELOG-12345678.md': 'existing md',
+      'CHANGELOG-abcd40ef.md': 'existing md',
+    });
+    // ensure different timestamps by waiting 1ms
+    await new Promise(resolve => setTimeout(resolve, 1));
+    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${lastHash}.md`), 'existing md');
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG-${lastHash}.md`,
+      json: `${tempDir}/CHANGELOG-${lastHash}.json`,
+      hash: lastHash,
+    });
+    expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('Found changelog files with multiple hashes'));
+  });
+
+  it('migrates existing non-hashed file to hashed path', () => {
+    tempDir = createTestFileStructure({
+      'CHANGELOG.md': 'existing md',
+    });
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      changelogAbsDir: tempDir,
+    });
+
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG-${paths.hash}.md`,
+      json: `${tempDir}/CHANGELOG-${paths.hash}.json`,
+      hash: expect.stringMatching(hashRegexp),
+    });
+    expect(fs.existsSync(`${tempDir}/CHANGELOG.md`)).toBe(false);
+    expect(fs.readFileSync(paths.md!, 'utf8')).toBe('existing md');
+
+    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing non-hashed changelog file'));
+  });
+
+  it('migrates existing hashed file to non-hashed path', () => {
+    const hashedName = 'CHANGELOG-abcdef08.md';
+    tempDir = createTestFileStructure({
+      [hashedName]: 'existing md',
+    });
+
+    const paths = prepareChangelogPathsWrapper({
+      options: { generateChangelog: true },
+      changelogAbsDir: tempDir,
+    });
+
+    expect(paths).toEqual({
+      md: `${tempDir}/CHANGELOG.md`,
+      json: `${tempDir}/CHANGELOG.json`,
+    });
+
+    expect(fs.existsSync(`${tempDir}/${hashedName}`)).toBe(false);
+    expect(fs.readFileSync(paths.md!, 'utf8')).toBe('existing md');
+
+    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing hashed changelog file'));
+  });
+});

--- a/src/__functional__/changelog/prepareChangelogPaths.test.ts
+++ b/src/__functional__/changelog/prepareChangelogPaths.test.ts
@@ -10,7 +10,7 @@ describe('prepareChangelogPaths', () => {
   let consoleWarnMock: jest.SpiedFunction<typeof console.warn>;
   let tempDir: string | undefined;
   const fakeDir = slash(path.resolve('/faketmpdir'));
-  const hashRegexp = /^[0-9a-f]{8}$/;
+  const suffixRegexp = /^[0-9a-f]{8}$/;
 
   /** Wrapper that calls `prepareChangelogPaths` and converts the result to forward slashes */
   function prepareChangelogPathsWrapper(options: Parameters<typeof prepareChangelogPaths>[0]) {
@@ -44,7 +44,7 @@ describe('prepareChangelogPaths', () => {
     expect(paths).toEqual({});
   });
 
-  it('returns default paths if generateChangelog is true (hashFilenames unset)', () => {
+  it('returns default paths if generateChangelog is true (uniqueFilenames unset)', () => {
     const paths = prepareChangelogPathsWrapper({
       options: { generateChangelog: true },
       changelogAbsDir: fakeDir,
@@ -53,7 +53,7 @@ describe('prepareChangelogPaths', () => {
     expect(paths).toEqual({ md: `${fakeDir}/CHANGELOG.md`, json: `${fakeDir}/CHANGELOG.json` });
   });
 
-  it('returns only default md path if generateChangelog is "md" (hashFilenames unset)', () => {
+  it('returns only default md path if generateChangelog is "md" (uniqueFilenames unset)', () => {
     const paths = prepareChangelogPathsWrapper({
       options: { generateChangelog: 'md' },
       changelogAbsDir: fakeDir,
@@ -62,7 +62,7 @@ describe('prepareChangelogPaths', () => {
     expect(paths).toEqual({ md: `${fakeDir}/CHANGELOG.md` });
   });
 
-  it('returns only default json path if generateChangelog is "json" (hashFilenames unset)', () => {
+  it('returns only default json path if generateChangelog is "json" (uniqueFilenames unset)', () => {
     const paths = prepareChangelogPathsWrapper({
       options: { generateChangelog: 'json' },
       changelogAbsDir: fakeDir,
@@ -71,167 +71,173 @@ describe('prepareChangelogPaths', () => {
     expect(paths).toEqual({ json: `${fakeDir}/CHANGELOG.json` });
   });
 
-  it('returns new hashed paths if hashFilenames is true and no files exist', () => {
+  it('returns new suffixed paths if uniqueFilenames is true and no files exist', () => {
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: fakeDir,
     });
 
     expect(paths).toEqual({
-      md: `${fakeDir}/CHANGELOG-${paths.hash}.md`,
-      json: `${fakeDir}/CHANGELOG-${paths.hash}.json`,
-      hash: expect.stringMatching(hashRegexp),
+      md: `${fakeDir}/CHANGELOG-${paths.suffix}.md`,
+      json: `${fakeDir}/CHANGELOG-${paths.suffix}.json`,
+      suffix: expect.stringMatching(suffixRegexp),
     });
   });
 
-  it('returns new hashed md path if hashFilenames is true and generateChangelog is "md"', () => {
+  it('returns new suffixed md path if uniqueFilenames is true and generateChangelog is "md"', () => {
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: 'md', changelog: { hashFilenames: true } },
+      options: { generateChangelog: 'md', changelog: { uniqueFilenames: true } },
       changelogAbsDir: fakeDir,
     });
 
     expect(paths).toEqual({
-      md: `${fakeDir}/CHANGELOG-${paths.hash}.md`,
-      hash: expect.stringMatching(hashRegexp),
+      md: `${fakeDir}/CHANGELOG-${paths.suffix}.md`,
+      suffix: expect.stringMatching(suffixRegexp),
     });
   });
 
-  it('returns new hashed json path if hashFilenames is true and generateChangelog is "json"', () => {
+  it('returns new suffixed json path if uniqueFilenames is true and generateChangelog is "json"', () => {
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: 'json', changelog: { hashFilenames: true } },
+      options: { generateChangelog: 'json', changelog: { uniqueFilenames: true } },
       changelogAbsDir: fakeDir,
     });
 
     expect(paths).toEqual({
-      json: `${fakeDir}/CHANGELOG-${paths.hash}.json`,
-      hash: expect.stringMatching(hashRegexp),
+      json: `${fakeDir}/CHANGELOG-${paths.suffix}.json`,
+      suffix: expect.stringMatching(suffixRegexp),
     });
   });
 
-  it('detects existing hashed files if hashFilenames is true', () => {
-    const hash = 'abcdef12';
+  it('detects existing suffixed files if uniqueFilenames is true', () => {
+    const suffix = 'abcdef12';
     tempDir = createTestFileStructure({
-      [`CHANGELOG-${hash}.md`]: 'existing md',
-      [`CHANGELOG-${hash}.json`]: {},
+      [`CHANGELOG-${suffix}.md`]: 'existing md',
+      [`CHANGELOG-${suffix}.json`]: {},
     });
 
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
     expect(paths).toEqual({
-      md: `${tempDir}/CHANGELOG-${hash}.md`,
-      json: `${tempDir}/CHANGELOG-${hash}.json`,
-      hash,
+      md: `${tempDir}/CHANGELOG-${suffix}.md`,
+      json: `${tempDir}/CHANGELOG-${suffix}.json`,
+      suffix,
     });
   });
 
-  it('detects hash from existing md file if hashFilenames is true', () => {
-    // only the md file is present, but its hash will be used for both files
-    const hash = 'abcdef12';
+  it('detects suffix from existing md file if uniqueFilenames is true', () => {
+    // only the md file is present, but its suffix will be used for both files
+    const suffix = 'abcdef12';
     tempDir = createTestFileStructure({
-      [`CHANGELOG-${hash}.md`]: 'existing md',
+      [`CHANGELOG-${suffix}.md`]: 'existing md',
     });
 
     const pathsWithBoth = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
     expect(pathsWithBoth).toEqual({
-      md: `${tempDir}/CHANGELOG-${hash}.md`,
-      json: `${tempDir}/CHANGELOG-${hash}.json`,
-      hash,
+      md: `${tempDir}/CHANGELOG-${suffix}.md`,
+      json: `${tempDir}/CHANGELOG-${suffix}.json`,
+      suffix,
     });
   });
 
-  it('detects hash from existing json file if hashFilenames is true', () => {
-    // only the json file is present, but its hash will be used for both files
-    const hash = 'abcdef12';
+  it('detects suffix from existing json file if uniqueFilenames is true', () => {
+    // only the json file is present, but its suffix will be used for both files
+    const suffix = 'abcdef12';
     tempDir = createTestFileStructure({
-      [`CHANGELOG-${hash}.json`]: {},
+      [`CHANGELOG-${suffix}.json`]: {},
     });
 
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
     expect(paths).toEqual({
-      md: `${tempDir}/CHANGELOG-${hash}.md`,
-      json: `${tempDir}/CHANGELOG-${hash}.json`,
-      hash,
+      md: `${tempDir}/CHANGELOG-${suffix}.md`,
+      json: `${tempDir}/CHANGELOG-${suffix}.json`,
+      suffix,
     });
   });
 
-  it('uses newer hash if hashFilenames is true and md/json files have different hashes', async () => {
-    const hashJson = 'abcdef34';
-    const hashMd = 'abcdef12';
+  it('uses newer suffix if uniqueFilenames is true and md/json files have different suffixes', async () => {
+    const suffixJson = 'abcdef34';
+    const suffixMd = 'abcdef12';
     tempDir = createTestFileStructure({
-      [`CHANGELOG-${hashJson}.json`]: {},
+      [`CHANGELOG-${suffixJson}.json`]: {},
     });
     // ensure different timestamps by waiting 1ms
     await new Promise(resolve => setTimeout(resolve, 1));
-    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${hashMd}.md`), 'existing md');
+    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${suffixMd}.md`), 'existing md');
 
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
-    // md hash is preferred for both files because the file is newer
+    // md suffix is preferred for both files because the file is newer
     expect(paths).toEqual({
-      md: `${tempDir}/CHANGELOG-${hashMd}.md`,
-      json: `${tempDir}/CHANGELOG-${hashMd}.json`,
-      hash: hashMd,
+      md: `${tempDir}/CHANGELOG-${suffixMd}.md`,
+      json: `${tempDir}/CHANGELOG-${suffixMd}.json`,
+      suffix: suffixMd,
     });
-    expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('Found changelog files with multiple hashes'));
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('Found changelog files with multiple suffixes')
+    );
   });
 
-  it('uses newest hash if hashFilenames is true and there are multiple hashed files', async () => {
-    const lastHash = 'abcdef12';
+  it('uses newest suffix if uniqueFilenames is true and there are multiple suffixed files', async () => {
+    const lastSuffix = 'abcdef12';
     tempDir = createTestFileStructure({
       'CHANGELOG-12345678.md': 'existing md',
       'CHANGELOG-abcd40ef.md': 'existing md',
     });
     // ensure different timestamps by waiting 1ms
     await new Promise(resolve => setTimeout(resolve, 1));
-    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${lastHash}.md`), 'existing md');
+    fs.writeFileSync(path.join(tempDir, `CHANGELOG-${lastSuffix}.md`), 'existing md');
 
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
     expect(paths).toEqual({
-      md: `${tempDir}/CHANGELOG-${lastHash}.md`,
-      json: `${tempDir}/CHANGELOG-${lastHash}.json`,
-      hash: lastHash,
+      md: `${tempDir}/CHANGELOG-${lastSuffix}.md`,
+      json: `${tempDir}/CHANGELOG-${lastSuffix}.json`,
+      suffix: lastSuffix,
     });
-    expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('Found changelog files with multiple hashes'));
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('Found changelog files with multiple suffixes')
+    );
   });
 
-  it('migrates existing non-hashed file to hashed path', () => {
+  it('migrates existing non-suffixed file to suffixed path', () => {
     tempDir = createTestFileStructure({
       'CHANGELOG.md': 'existing md',
     });
 
     const paths = prepareChangelogPathsWrapper({
-      options: { generateChangelog: true, changelog: { hashFilenames: true } },
+      options: { generateChangelog: true, changelog: { uniqueFilenames: true } },
       changelogAbsDir: tempDir,
     });
 
     expect(paths).toEqual({
-      md: `${tempDir}/CHANGELOG-${paths.hash}.md`,
-      json: `${tempDir}/CHANGELOG-${paths.hash}.json`,
-      hash: expect.stringMatching(hashRegexp),
+      md: `${tempDir}/CHANGELOG-${paths.suffix}.md`,
+      json: `${tempDir}/CHANGELOG-${paths.suffix}.json`,
+      suffix: expect.stringMatching(suffixRegexp),
     });
     expect(fs.existsSync(`${tempDir}/CHANGELOG.md`)).toBe(false);
     expect(fs.readFileSync(paths.md!, 'utf8')).toBe('existing md');
 
-    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing non-hashed changelog file'));
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringContaining('Renamed existing non-suffixed changelog file')
+    );
   });
 
-  it('migrates existing hashed file to non-hashed path', () => {
-    const hashedName = 'CHANGELOG-abcdef08.md';
+  it('migrates existing suffixed file to non-suffixed path', () => {
+    const suffixedName = 'CHANGELOG-abcdef08.md';
     tempDir = createTestFileStructure({
-      [hashedName]: 'existing md',
+      [suffixedName]: 'existing md',
     });
 
     const paths = prepareChangelogPathsWrapper({
@@ -244,9 +250,9 @@ describe('prepareChangelogPaths', () => {
       json: `${tempDir}/CHANGELOG.json`,
     });
 
-    expect(fs.existsSync(`${tempDir}/${hashedName}`)).toBe(false);
+    expect(fs.existsSync(`${tempDir}/${suffixedName}`)).toBe(false);
     expect(fs.readFileSync(paths.md!, 'utf8')).toBe('existing md');
 
-    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing hashed changelog file'));
+    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing suffixed changelog file'));
   });
 });

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -11,7 +11,7 @@ import {
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { writeChangelog } from '../../changelog/writeChangelog';
-import { _getExistingHashedChangelogs } from '../../changelog/prepareChangelogPaths';
+import { _getExistingSuffixedChangelogs } from '../../changelog/prepareChangelogPaths';
 import { getPackageInfos } from '../../monorepo/getPackageInfos';
 import { readChangeFiles } from '../../changefile/readChangeFiles';
 import type { BeachballOptions } from '../../types/BeachballOptions';
@@ -513,7 +513,7 @@ describe('writeChangelog', () => {
     });
   });
 
-  it('appends to existing changelog when migrating from non-hashed to hashed changelog filenames', async () => {
+  it('appends to existing changelog when migrating from non-suffixed to suffixed changelog filenames', async () => {
     repo = sharedSingleRepo;
     const options = getOptions();
 
@@ -530,15 +530,15 @@ describe('writeChangelog', () => {
     // Delete the initial change files
     fs.emptyDirSync(getChangePath(options));
 
-    // Change the options to used hashed filenames, generate new change files, and re-generate changelogs
-    options.changelog = { hashFilenames: true };
+    // Change the options to used suffixed filenames, generate new change files, and re-generate changelogs
+    options.changelog = { uniqueFilenames: true };
     generateChangeFiles([getChange('foo', 'extra change')], options);
     await writeChangelogWrapper({ options });
 
     // Verify the old changelog is moved
     expect(readChangelogMd(repo.rootPath)).toBeNull();
-    // Get hashed changelog paths
-    const paths = _getExistingHashedChangelogs(repo.rootPath);
+    // Get suffixed changelog paths
+    const paths = _getExistingSuffixedChangelogs(repo.rootPath);
     expect(paths).toMatchObject({ md: expect.any(String), json: expect.any(String) });
 
     // Read the changelogs again and verify that the previous content is still there

--- a/src/changefile/writeChangeFiles.ts
+++ b/src/changefile/writeChangeFiles.ts
@@ -1,9 +1,9 @@
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
 import { getBranchName, stage, commit } from 'workspace-tools';
+import crypto from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 import type { BeachballOptions } from '../types/BeachballOptions';
 
 /**
@@ -26,7 +26,7 @@ export function writeChangeFiles(
     fs.mkdirpSync(changePath);
   }
 
-  const getChangeFile = (prefix: string) => path.join(changePath, `${prefix}-${uuidv4()}.json`);
+  const getChangeFile = (prefix: string) => path.join(changePath, `${prefix}-${crypto.randomUUID()}.json`);
   let changeFiles: string[];
 
   if (groupChanges) {

--- a/src/changelog/prepareChangelogPaths.ts
+++ b/src/changelog/prepareChangelogPaths.ts
@@ -1,15 +1,13 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { v4 as uuid } from 'uuid';
 import type { BeachballOptions } from '../types/BeachballOptions';
 
 interface ChangelogPaths {
-  /** Absolute path to changelog md file (new or existing) */
+  /** Absolute path to changelog md file (new or existing), if it should be generated. */
   md?: string;
-  /** Absolute path to changelog json file (new or existing) */
+  /** Absolute path to changelog json file (new or existing), if it should be generated. */
   json?: string;
-  /** Suffix being used in files, if any */
-  suffix?: string;
 }
 
 /**
@@ -20,15 +18,15 @@ interface ChangelogPaths {
  */
 export function prepareChangelogPaths(params: {
   options: Pick<BeachballOptions, 'changelog' | 'generateChangelog'>;
+  packageName: string;
   /** cwd where changelogs are located */
   changelogAbsDir: string;
 }): ChangelogPaths {
-  const { options, changelogAbsDir: cwd } = params;
+  const { options, changelogAbsDir: cwd, packageName } = params;
   const { changelog, generateChangelog } = options;
   const { uniqueFilenames } = changelog || {};
 
   const paths: ChangelogPaths = {};
-  let existingSuffixedPaths: ChangelogPaths | undefined;
 
   if (!generateChangelog) {
     return paths;
@@ -41,30 +39,26 @@ export function prepareChangelogPaths(params: {
 
     const defaultPath = path.join(cwd, `CHANGELOG.${ext}`);
 
-    if (uniqueFilenames) {
-      // Filenames should use a suffix. Start by getting any existing suffixed changelogs...
-      existingSuffixedPaths ??= _getExistingSuffixedChangelogs(cwd);
-      // Use the existing suffix or generate a new one
-      paths.suffix ??= existingSuffixedPaths.suffix ?? uuid().slice(0, 8);
+    // Generate a unique filename based on the package name hash.
+    const hash = crypto.createHash('md5').update(packageName).digest('hex').slice(0, 8);
+    const pathWithHash = path.join(cwd, `CHANGELOG-${hash}.${ext}`);
 
-      if (existingSuffixedPaths[ext]) {
-        // Suffixed file already exists, so use it
-        paths[ext] = existingSuffixedPaths[ext];
-      } else {
-        // New suffixed file
-        paths[ext] = path.join(cwd, `CHANGELOG-${paths.suffix}.${ext}`);
-        // Move any existing non-suffixed file to the new suffixed path
-        moveIfNeeded({ oldPath: defaultPath, newPath: paths[ext]!, hadSuffix: false });
-      }
-    } else {
-      // Filenames should not use a suffix
-      paths[ext] = defaultPath;
+    // Choose the changelog file path based on whether unique filenames are enabled.
+    const filePath = (paths[ext] = uniqueFilenames ? pathWithHash : defaultPath);
 
-      if (!fs.existsSync(defaultPath)) {
-        // If the default file doesn't exist, check for a suffixed file to move back
-        existingSuffixedPaths ??= _getExistingSuffixedChangelogs(cwd);
-        if (existingSuffixedPaths[ext]) {
-          moveIfNeeded({ oldPath: existingSuffixedPaths[ext]!, newPath: defaultPath, hadSuffix: true });
+    if (!fs.existsSync(filePath)) {
+      // The path to use doesn't exist--check if the other path does, and if so, rename it.
+      const renamed = renameIfPresent({
+        oldPath: uniqueFilenames ? defaultPath : pathWithHash,
+        newPath: filePath,
+      });
+
+      if (!renamed) {
+        // Neither path exists. Check for other hashed changelog files in case the package was renamed.
+        // (If there's no other hashed file, it's the first changelog entry for this package.)
+        const existingHashedPath = getExistingHashedPath({ cwd, ext });
+        if (existingHashedPath) {
+          renameIfPresent({ oldPath: existingHashedPath, newPath: filePath });
         }
       }
     }
@@ -74,69 +68,42 @@ export function prepareChangelogPaths(params: {
 }
 
 /**
- * Get paths to existing `CHANGELOG-{suffix}.md` and `CHANGELOG-{suffix}.json` files.
- * Exported for testing only.
+ * Get the path to the newest `CHANGELOG-{hash}.{ext}` file in the given directory.
  */
-export function _getExistingSuffixedChangelogs(cwd: string): ChangelogPaths {
-  let suffixedFiles: { file: string; suffix: string; date?: number }[];
+function getExistingHashedPath(params: { cwd: string; ext: 'md' | 'json' }): string | undefined {
+  const { cwd, ext } = params;
+  const fileRegexp = new RegExp(`^CHANGELOG-[a-f\\d]{8}\\.${ext}$`);
   try {
-    suffixedFiles = fs
-      .readdirSync(cwd)
-      .filter(file => /^CHANGELOG-[a-f\d]{8,}\.(json|md)$/.test(file))
-      .map(file => ({ file, suffix: file.match(/[a-f\d]{8,}/)![0] }));
-  } catch (e) {
-    console.warn(`Error listing files in ${cwd}: ${e}`);
-    return {};
-  }
+    let newestDate = 0;
+    let newestFile: string | undefined;
 
-  if (!suffixedFiles.length) {
-    return {};
-  }
-
-  const paths: ChangelogPaths = {};
-
-  if (suffixedFiles.every(({ suffix }) => suffix === suffixedFiles[0].suffix)) {
-    // All the files have the same suffix, so use that.
-    paths.suffix = suffixedFiles[0].suffix;
-  } else {
-    // Not likely, but just in case there are mismatched suffixes, pick the newest one.
-    try {
-      for (const fileInfo of suffixedFiles) {
-        fileInfo.date = fs.statSync(path.join(cwd, fileInfo.file)).mtimeMs;
+    for (const file of fs.readdirSync(cwd)) {
+      if (!fileRegexp.test(file)) {
+        continue;
       }
-      // sort by date descending
-      suffixedFiles.sort((a, b) => b.date! - a.date!);
-      paths.suffix = suffixedFiles[0].suffix;
-      console.warn(
-        `Found changelog files with multiple suffixes in ${cwd} (using the newest one ${paths.suffix}):\n` +
-          suffixedFiles.map(({ file }) => file).join('\n')
-      );
-    } catch (e) {
-      console.warn(`Error getting changelog file dates in ${cwd}:`, e);
-    }
-  }
 
-  if (paths.suffix) {
-    for (const ext of ['md', 'json'] as const) {
-      // Only return suffixed files that actually exist and match the chosen suffix
-      const extPath = suffixedFiles.find(({ file }) => file.endsWith(`${paths.suffix}.${ext}`))?.file;
-      paths[ext] = extPath && path.join(cwd, extPath);
+      const date = fs.statSync(path.join(cwd, file)).mtimeMs;
+      if (date > newestDate) {
+        newestDate = date;
+        newestFile = file;
+      }
     }
+    return newestFile ? path.join(cwd, newestFile) : undefined;
+  } catch (e) {
+    console.warn(`Error getting changelog file info in ${cwd}: ${e}`);
   }
-
-  return paths;
 }
 
-function moveIfNeeded(params: { oldPath: string; newPath: string; hadSuffix: boolean }) {
-  const { oldPath, newPath, hadSuffix } = params;
+function renameIfPresent(params: { oldPath: string; newPath: string }): boolean {
+  const { oldPath, newPath } = params;
   try {
     if (fs.existsSync(oldPath)) {
       fs.renameSync(oldPath, newPath);
-      console.log(
-        `Renamed existing ${hadSuffix ? 'suffixed' : 'non-suffixed'} changelog file ${oldPath} to ${newPath}`
-      );
+      console.log(`Renamed existing changelog file ${oldPath} to ${path.basename(newPath)}`);
+      return true;
     }
   } catch (e) {
-    console.warn(`Error renaming changelog file ${oldPath} to ${newPath}: ${e}`);
+    console.warn(`Error renaming changelog file ${oldPath} to ${path.basename(newPath)}: ${e}`);
   }
+  return false;
 }

--- a/src/changelog/prepareChangelogPaths.ts
+++ b/src/changelog/prepareChangelogPaths.ts
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuid } from 'uuid';
+import type { BeachballOptions } from '../types/BeachballOptions';
+
+interface ChangelogPaths {
+  /** Absolute path to changelog md file (new or existing) */
+  md?: string;
+  /** Absolute path to changelog json file (new or existing) */
+  json?: string;
+  /** Hash being used in files, if any */
+  hash?: string;
+}
+
+/**
+ * Get the paths to the changelog files. Also handles conversion between `changelog.hashFilenames`
+ * being true and false/unset (moving the files if needed).
+ *
+ * @returns object with each changelog path, or undefined if that changelog shouldn't be written.
+ */
+export function prepareChangelogPaths(params: {
+  options: Pick<BeachballOptions, 'changelog' | 'generateChangelog'>;
+  /** cwd where changelogs are located */
+  changelogAbsDir: string;
+}): ChangelogPaths {
+  const { options, changelogAbsDir: cwd } = params;
+  const { changelog, generateChangelog } = options;
+  const { hashFilenames } = changelog || {};
+
+  const paths: ChangelogPaths = {};
+  let existingHashedPaths: ChangelogPaths | undefined;
+
+  if (!generateChangelog) {
+    return paths;
+  }
+
+  for (const ext of ['md', 'json'] as const) {
+    if (generateChangelog !== true && generateChangelog !== ext) {
+      continue; // not generating this file type
+    }
+
+    const defaultPath = path.join(cwd, `CHANGELOG.${ext}`);
+
+    if (hashFilenames) {
+      // Filenames should be hashed. Start by getting any existing hashed changelogs...
+      existingHashedPaths ??= _getExistingHashedChangelogs(cwd);
+      // Use the existing hash or generate a new one
+      paths.hash ??= existingHashedPaths.hash ?? uuid().slice(0, 8);
+
+      if (existingHashedPaths[ext]) {
+        // Hashed file already exists, so use it
+        paths[ext] = existingHashedPaths[ext];
+      } else {
+        // New hashed file
+        paths[ext] = path.join(cwd, `CHANGELOG-${paths.hash}.${ext}`);
+        // Move any existing non-hashed file to the new hashed path
+        moveIfNeeded({ oldPath: defaultPath, newPath: paths[ext]!, wasHashed: false });
+      }
+    } else {
+      // Filenames should not be hashed
+      paths[ext] = defaultPath;
+
+      if (!fs.existsSync(defaultPath)) {
+        // If the default file doesn't exist, check for a hashed file to move back
+        existingHashedPaths ??= _getExistingHashedChangelogs(cwd);
+        if (existingHashedPaths[ext]) {
+          moveIfNeeded({ oldPath: existingHashedPaths[ext]!, newPath: defaultPath, wasHashed: true });
+        }
+      }
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Get paths to existing `CHANGELOG-{hash}.md` and `CHANGELOG-{hash}.json` files.
+ * Exported for testing only.
+ */
+export function _getExistingHashedChangelogs(cwd: string): ChangelogPaths {
+  let hashedFiles: { file: string; hash: string; date?: number }[];
+  try {
+    hashedFiles = fs
+      .readdirSync(cwd)
+      .filter(file => /^CHANGELOG-[a-f\d]{8,}\.(json|md)$/.test(file))
+      .map(file => ({ file, hash: file.match(/[a-f\d]{8,}/)![0] }));
+  } catch (e) {
+    console.warn(`Error listing files in ${cwd}: ${e}`);
+    return {};
+  }
+
+  if (!hashedFiles.length) {
+    return {};
+  }
+
+  const paths: ChangelogPaths = {};
+
+  if (hashedFiles.every(({ hash }) => hash === hashedFiles[0].hash)) {
+    // All the files have the same hash, so use that.
+    paths.hash = hashedFiles[0].hash;
+  } else {
+    // Not likely, but just in case there are mismatched hashes, pick the newest one.
+    try {
+      for (const fileInfo of hashedFiles) {
+        fileInfo.date = fs.statSync(path.join(cwd, fileInfo.file)).mtimeMs;
+      }
+      // sort by date descending
+      hashedFiles.sort((a, b) => b.date! - a.date!);
+      paths.hash = hashedFiles[0].hash;
+      console.warn(
+        `Found changelog files with multiple hashes in ${cwd} (using the newest one ${paths.hash}):\n` +
+          hashedFiles.map(({ file }) => file).join('\n')
+      );
+    } catch (e) {
+      console.warn(`Error getting changelog file dates in ${cwd}:`, e);
+    }
+  }
+
+  if (paths.hash) {
+    for (const ext of ['md', 'json'] as const) {
+      // Only return hashed files that actually exist and match the chosen hash
+      const extPath = hashedFiles.find(({ file }) => file.endsWith(`${paths.hash}.${ext}`))?.file;
+      paths[ext] = extPath && path.join(cwd, extPath);
+    }
+  }
+
+  return paths;
+}
+
+function moveIfNeeded(params: { oldPath: string; newPath: string; wasHashed: boolean }) {
+  const { oldPath, newPath, wasHashed } = params;
+  try {
+    if (fs.existsSync(oldPath)) {
+      fs.renameSync(oldPath, newPath);
+      console.log(`Renamed existing ${wasHashed ? 'hashed' : 'non-hashed'} changelog file ${oldPath} to ${newPath}`);
+    }
+  } catch (e) {
+    console.warn(`Error renaming changelog file ${oldPath} to ${newPath}: ${e}`);
+  }
+}

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -122,7 +122,7 @@ async function writeChangelogFiles(params: {
 }): Promise<void> {
   const { options, newVersionChangelog, changelogAbsDir, isGrouped } = params;
 
-  const changelogPaths = prepareChangelogPaths({ options, changelogAbsDir });
+  const changelogPaths = prepareChangelogPaths({ options, changelogAbsDir, packageName: newVersionChangelog.name });
 
   let previousJson: ChangelogJson | undefined;
 

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -10,6 +10,7 @@ import { BumpInfo } from '../types/BumpInfo';
 import { isPathIncluded } from '../monorepo/isPathIncluded';
 import { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
+import { prepareChangelogPaths } from './prepareChangelogPaths';
 
 export async function writeChangelog(
   bumpInfo: Pick<BumpInfo, 'changeFileChangeInfos' | 'calculatedChangeTypes' | 'dependentChangedBy' | 'packageInfos'>,
@@ -31,7 +32,7 @@ export async function writeChangelog(
       await writeChangelogFiles({
         options,
         newVersionChangelog: changelogs[pkg],
-        changelogPath: packagePath,
+        changelogAbsDir: packagePath,
         isGrouped: false,
       });
     }
@@ -99,7 +100,7 @@ async function writeGroupedChangelog(
       await writeChangelogFiles({
         options,
         newVersionChangelog: groupedChangelog,
-        changelogPath: changelogAbsDir,
+        changelogAbsDir,
         isGrouped: true,
       });
     }
@@ -114,37 +115,39 @@ async function writeGroupedChangelog(
 }
 
 async function writeChangelogFiles(params: {
-  options: Pick<BeachballOptions, 'generateChangelog' | 'changelog'>;
+  options: Pick<BeachballOptions, 'generateChangelog' | 'changelog' | 'path'>;
   newVersionChangelog: PackageChangelog;
-  changelogPath: string;
+  changelogAbsDir: string;
   isGrouped: boolean;
 }): Promise<void> {
-  const { options, newVersionChangelog, changelogPath, isGrouped } = params;
+  const { options, newVersionChangelog, changelogAbsDir, isGrouped } = params;
+
+  const changelogPaths = prepareChangelogPaths({ options, changelogAbsDir });
+
   let previousJson: ChangelogJson | undefined;
 
-  // Update CHANGELOG.json
-  if (options.generateChangelog === true || options.generateChangelog === 'json') {
-    const changelogJsonFile = path.join(changelogPath, 'CHANGELOG.json');
+  // Update CHANGELOG.json if appropriate
+  // (changelogPaths.json will only be set if generateChangelog is true or 'json')
+  if (changelogPaths.json) {
     try {
-      previousJson = fs.existsSync(changelogJsonFile) ? fs.readJSONSync(changelogJsonFile) : undefined;
+      previousJson = fs.existsSync(changelogPaths.json) ? fs.readJSONSync(changelogPaths.json) : undefined;
     } catch (e) {
-      console.warn(`${changelogJsonFile} is invalid: ${e}`);
+      console.warn(`${changelogPaths.json} is invalid: ${e}`);
     }
     try {
       const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
-      fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
+      fs.writeJSONSync(changelogPaths.json, nextJson, { spaces: 2 });
     } catch (e) {
-      console.warn(`Problem writing to ${changelogJsonFile}: ${e}`);
+      console.warn(`Problem writing to ${changelogPaths.json}: ${e}`);
     }
   }
 
   // Update CHANGELOG.md if there are changes of types besides "none"
   if (
-    (options.generateChangelog === true || options.generateChangelog === 'md') &&
+    changelogPaths.md &&
     Object.entries(newVersionChangelog.comments).some(([type, comments]) => type !== 'none' && comments?.length)
   ) {
-    const changelogFile = path.join(changelogPath, 'CHANGELOG.md');
-    const previousContent = fs.existsSync(changelogFile) ? fs.readFileSync(changelogFile).toString() : '';
+    const previousContent = fs.existsSync(changelogPaths.md) ? fs.readFileSync(changelogPaths.md).toString() : '';
 
     const newChangelog = await renderChangelog({
       previousJson,
@@ -154,6 +157,6 @@ async function writeChangelogFiles(params: {
       changelogOptions: options.changelog || {},
     });
 
-    fs.writeFileSync(changelogFile, newChangelog);
+    fs.writeFileSync(changelogPaths.md, newChangelog);
   }
 }

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -35,9 +35,11 @@ export interface ChangelogOptions {
   renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
 
   /**
-   * If true, add a unique suffix to changelog filenames: e.g. `CHANGELOG-d7d39c3f.md`
-   * `and CHANGELOG-d7d39c3f.json`. (Once added, this will stay stable between commits.
-   * Any existing changelog files will be renamed.)
+   * If true, add a unique suffix to changelog filenames, based on the hash of the package name:
+   * e.g. `CHANGELOG-d7d39c3f.md`/`.json`.
+   *
+   * When this is initially enabled, any existing changelog files will be renamed. If the package name
+   * (and therefore the hash) changes, renaming the file should also be handled automatically.
    *
    * This is one option for working around an issue with Git: its default hash algorithm only
    * considers the last 16 characters of filenames, which can lead to collisions and inefficient

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -35,14 +35,15 @@ export interface ChangelogOptions {
   renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
 
   /**
-   * If true, add a hash suffix to changelog filenames: e.g. CHANGELOG-d7d39c3f.md and CHANGELOG-d7d39c3f.json.
-   * (Once added, this suffix will stay stable between commits.)
+   * If true, add a unique suffix to changelog filenames: e.g. `CHANGELOG-d7d39c3f.md`
+   * `and CHANGELOG-d7d39c3f.json`. (Once added, this will stay stable between commits.
+   * Any existing changelog files will be renamed.)
    *
    * This is one option for working around an issue with Git: its default hash algorithm only
    * considers the last 16 characters of filenames, which can lead to collisions and inefficient
    * packing when many files have similar names.
    */
-  hashFilenames?: boolean;
+  uniqueFilenames?: boolean;
 }
 
 /**

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -33,6 +33,16 @@ export interface ChangelogOptions {
    * ```
    */
   renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
+
+  /**
+   * If true, add a hash suffix to changelog filenames: e.g. CHANGELOG-d7d39c3f.md and CHANGELOG-d7d39c3f.json.
+   * (Once added, this suffix will stay stable between commits.)
+   *
+   * This is one option for working around an issue with Git: its default hash algorithm only
+   * considers the last 16 characters of filenames, which can lead to collisions and inefficient
+   * packing when many files have similar names.
+   */
+  hashFilenames?: boolean;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,11 +1570,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^9.0.0":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
-
 "@types/webpack-dev-server@^3":
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz#d8888cfd2f0630203e13d3ed7833a4d11b8a34dc"
@@ -11384,11 +11379,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Add an option `changelog.uniqueFilenames` which adds an 8-character ~~random~~ suffix to the end of the changelog filename (before the extension): e.g. `CHANGELOG-abcd1234.md`.

EDIT: After discussion, the suffix is now the first 8 characters of the MD5 hash digest of the package name.

This will stay stable between commits, and any existing changelog files will be renamed when modified. Existing suffixed files should also be renamed if the package is renamed. (I'm guessing 8 characters is good enough, but we could also use 12 or more.)

This is one option for working around an issue with Git: its default hash algorithm only considers the last 16 characters of filenames, which can lead to collisions and inefficient packing when many files have similar names, which then leads to extreme growth in size for larger repos with many colliding changelog files.

Bonus: while adding the hash, I learned we can use `crypto.randomUUID()` for change file IDs and remove the `uuid` dependency.

(I also updated a couple things with test configuration: disable type checking in ts-jest since it's redundant and slow, and set launch.json to use Node 14 like the rest of the repo.)

Related to #978