### PR TITLE
Add option changelog.maxVersions

### DIFF
--- a/change/beachball-d06fb0b6-4977-44f2-9e5f-cc4f2ca0b5f5.json
+++ b/change/beachball-d06fb0b6-4977-44f2-9e5f-cc4f2ca0b5f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option changelog.maxVersions",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/changelog/__snapshots__/writeChangelog.test.ts.snap
+++ b/src/__functional__/changelog/__snapshots__/writeChangelog.test.ts.snap
@@ -7,7 +7,7 @@ exports[`writeChangelog generates basic changelog: changelog md 1`] = `
 
 <!-- Start content -->
 
-## 1.0.0
+## 1.1.0
 
 (date)
 
@@ -29,13 +29,13 @@ exports[`writeChangelog generates changelogs with dependent changes in monorepo:
 
 <!-- Start content -->
 
-## 1.3.4
+## 1.3.5
 
 (date)
 
 ### Patches
 
-- Bump baz to v1.3.4
+- Bump baz to v1.4.0
 "
 `;
 
@@ -46,7 +46,7 @@ exports[`writeChangelog generates changelogs with dependent changes in monorepo:
 
 <!-- Start content -->
 
-## 1.3.4
+## 1.4.0
 
 (date)
 
@@ -63,14 +63,14 @@ exports[`writeChangelog generates changelogs with dependent changes in monorepo:
 
 <!-- Start content -->
 
-## 1.0.0
+## 1.1.0
 
 (date)
 
 ### Minor changes
 
 - foo comment (test@test.com)
-- Bump bar to v1.3.4
+- Bump bar to v1.3.5
 "
 `;
 
@@ -81,7 +81,7 @@ exports[`writeChangelog generates grouped changelog in monorepo: grouped CHANGEL
 
 <!-- Start content -->
 
-## 1.0.0
+## 1.1.0
 
 (date)
 
@@ -92,5 +92,32 @@ exports[`writeChangelog generates grouped changelog in monorepo: grouped CHANGEL
   - foo comment (test@test.com)
 - \`baz\`
   - baz comment (test@test.com)
+"
+`;
+
+exports[`writeChangelog trims previous changelog entries over maxVersions: CHANGELOG.md 1`] = `
+"# Change Log - foo
+
+<!-- This log was last generated on (date) and should not be manually modified. -->
+
+<!-- Start content -->
+
+## 1.3.0
+
+(date)
+
+### Minor changes
+
+- foo comment 3 (test@test.com)
+
+## 1.2.0
+
+(date)
+
+### Minor changes
+
+- foo comment 2 (test@test.com)
+
+**Changelog has been truncated. Refer to git history for older versions.**
 "
 `;

--- a/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
+++ b/src/__tests__/changelog/__snapshots__/renderChangelog.test.ts.snap
@@ -46,7 +46,7 @@ Thu, 22 Aug 2019 21:20:40 GMT
 
 # Change Log - foo
 
-This log was last generated on Wed, 21 Aug 2019 21:20:40 GMT and should not be manually modified.
+<!-- This log was last generated on Wed, 21 Aug 2019 21:20:40 GMT and should not be manually modified. -->
 "
 `;
 
@@ -73,7 +73,11 @@ Thu, 22 Aug 2019 21:20:40 GMT
 
 ## 1.2.0
 
-(content here)
+(date)
+
+### Patch changes
+
+- content of 1.2.0
 "
 `;
 
@@ -100,7 +104,11 @@ Thu, 22 Aug 2019 21:20:40 GMT
 
 ## 1.2.0
 
-(content here)
+(date)
+
+### Patch changes
+
+- content of 1.2.0
 "
 `;
 
@@ -127,7 +135,52 @@ Thu, 22 Aug 2019 21:20:40 GMT
 
 ## 1.2.0
 
-(content here)
+(date)
+
+### Patch changes
+
+- content of 1.2.0
+"
+`;
+
+exports[`renderChangelog trims previous versions if over maxVersions 1`] = `
+"# Change Log - foo
+
+<!-- This log was last generated on Thu, 22 Aug 2019 21:20:40 GMT and should not be manually modified. -->
+
+<!-- Start content -->
+
+## 1.2.3
+
+Thu, 22 Aug 2019 21:20:40 GMT
+
+### Minor changes
+
+- Awesome change (user1@example.com)
+- Boring change (user2@example.com)
+
+### Patches
+
+- Fix (user1@example.com)
+- stuff (user2@example.com)
+
+## 1.2.0
+
+(date)
+
+### Patch changes
+
+- content of 1.2.0
+
+## 1.1.9
+
+(date)
+
+### Patch changes
+
+- content of 1.1.9
+
+**Changelog has been truncated. Refer to git history for older versions.**
 "
 `;
 
@@ -144,6 +197,10 @@ no notes for you
 
 ## 1.2.0
 
-(content here)
+(date)
+
+### Patch changes
+
+- content of 1.2.0
 "
 `;

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -7,7 +7,13 @@ export interface MarkdownChangelogRenderOptions extends Omit<PackageChangelogRen
   changelogOptions: ChangelogOptions;
 }
 
+/** Comment dividing the generated header content and the package version changelog entries */
 export const markerComment = '<!-- Start content -->';
+
+/** Note indicating that the changelog has been truncated */
+export const trimmedVersionsNote = '**Changelog has been truncated. Refer to git history for older versions.**';
+
+let loggedCustomRender = false;
 
 export async function renderChangelog(renderOptions: MarkdownChangelogRenderOptions): Promise<string> {
   const {
@@ -19,9 +25,12 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
       renderPackageChangelog: customRenderPackageChangelog,
       customRenderers,
       renderMainHeader: customRenderMainHeader,
+      maxVersions,
     },
   } = renderOptions;
 
+  // Figure out where the previous log entries (not the main header) started based on the marker comment.
+  // (The end of the previous entries might be trimmed later based on the maxVersions option.)
   let previousLogEntries: string;
   if (previousContent.includes(markerComment)) {
     // Preferably determine where the previous entries start based on a special comment
@@ -35,7 +44,8 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
 
   try {
     if (customRenderPackageChangelog || customRenderers) {
-      console.log('Using custom renderer for package version changelog.');
+      !loggedCustomRender && console.log('Using custom renderer for package version changelog.');
+      loggedCustomRender = true;
     }
 
     const renderInfo: PackageChangelogRenderInfo = {
@@ -48,12 +58,18 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
       },
     };
 
+    const packageChangelog = await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo);
+
+    if (maxVersions) {
+      previousLogEntries = _trimPreviousLog({ packageChangelog, previousLogEntries, maxVersions });
+    }
+
     return (
       [
         await (customRenderMainHeader || renderMainHeader)(newVersionChangelog),
         `<!-- This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified. -->`,
         markerComment,
-        await (customRenderPackageChangelog || renderPackageChangelog)(renderInfo),
+        packageChangelog,
         previousLogEntries,
       ]
         .join('\n\n')
@@ -63,4 +79,44 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
     console.log('Error occurred rendering package version changelog:', err);
     return '';
   }
+}
+
+/**
+ * Trim the previous changelog entries if over the threshold.
+ *
+ * (exported for testing only)
+ */
+export function _trimPreviousLog(params: {
+  packageChangelog: string;
+  previousLogEntries: string;
+  maxVersions: number;
+}): string {
+  const { packageChangelog, previousLogEntries, maxVersions } = params;
+
+  // Find a markdown header prefix which will be used to split the entries
+  const headerPrefix = packageChangelog.match(/^#+ /m)?.[0];
+  if (!headerPrefix) {
+    // This could happen if someone has a custom renderer that doesn't start entries with a markdown header
+    console.warn(
+      `Changelog truncation to ${maxVersions} entries was requested, but the header format is not recognized.`
+    );
+    return previousLogEntries;
+  }
+
+  // Iterate through finding the next header and counting the number of versions
+  let count = 0;
+  // We need to use a regexp anchored to the line start to avoid matching lower level headers
+  // (e.g. if the header prefix is '## ', we don't want to match a substring of '### ').
+  let headerRegexp = new RegExp(`^${headerPrefix}`, 'gm');
+  let lastMatch: RegExpExecArray | null = null;
+  while (count < maxVersions && (lastMatch = headerRegexp.exec(previousLogEntries))) {
+    count++;
+  }
+
+  // If there are too many versions (counting the new one), trim the entries and add a note
+  if (count >= maxVersions && lastMatch) {
+    return previousLogEntries.substring(0, lastMatch.index).trim() + '\n\n' + trimmedVersionsNote;
+  }
+
+  return previousLogEntries;
 }

--- a/src/changelog/renderJsonChangelog.ts
+++ b/src/changelog/renderJsonChangelog.ts
@@ -1,10 +1,18 @@
 import { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 
-export function renderJsonChangelog(
-  changelog: PackageChangelog,
-  previousChangelog: ChangelogJson | undefined
-): ChangelogJson {
+export function renderJsonChangelog(params: {
+  changelog: PackageChangelog;
+  previousChangelog: ChangelogJson | undefined;
+  maxVersions: number | undefined;
+}): ChangelogJson {
+  const { changelog, previousChangelog, maxVersions } = params;
   const { name, date, ...rest } = changelog;
+
+  let previousEntries = previousChangelog?.entries || [];
+  if (maxVersions) {
+    previousEntries = previousEntries.slice(0, maxVersions - 1);
+  }
+
   return {
     name,
     entries: [
@@ -12,7 +20,7 @@ export function renderJsonChangelog(
         date: changelog.date.toUTCString(),
         ...rest,
       },
-      ...(previousChangelog?.entries || []),
+      ...previousEntries,
     ],
   };
 }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -131,7 +131,11 @@ async function writeChangelogFiles(params: {
       console.warn(`${changelogJsonFile} is invalid: ${e}`);
     }
     try {
-      const nextJson = renderJsonChangelog(newVersionChangelog, previousJson);
+      const nextJson = renderJsonChangelog({
+        changelog: newVersionChangelog,
+        previousChangelog: previousJson,
+        maxVersions: options.changelog?.maxVersions,
+      });
       fs.writeJSONSync(changelogJsonFile, nextJson, { spaces: 2 });
     } catch (e) {
       console.warn(`Problem writing to ${changelogJsonFile}: ${e}`);

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -24,6 +24,7 @@ export interface ChangelogOptions {
    * If using a custom `renderPackageChangelog`, these will not be called automatically.
    */
   customRenderers?: ChangelogRenderers;
+
   /**
    * Custom renderer for the header for the entire changelog.
    *
@@ -33,6 +34,12 @@ export interface ChangelogOptions {
    * ```
    */
   renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
+
+  /**
+   * Maximum number of versions to keep in the changelog md and json files.
+   * (If the md file is truncated, it will include a comment about referring to git for older entries.)
+   */
+  maxVersions?: number;
 }
 
 /**
@@ -89,6 +96,7 @@ export interface PackageChangelogRenderInfo {
 export interface ChangelogRenderers {
   /**
    * Custom renderer for the header for a particular package version.
+   * The returned string must start with a markdown header, usually h2 (`##`).
    *
    * Default is like this (no leading or trailing newlines):
    * ```txt


### PR DESCRIPTION
Add an option `changelog.maxVersions` which truncates the number of versions stored in `CHANGELOG.md` and `CHANGELOG.json`.

Related to #978