### PR TITLE
Add concurrency flag

### DIFF
--- a/change/beachball-8dc8dc7e-34ec-4fe1-be0b-8a2af1f96f16.json
+++ b/change/beachball-8dc8dc7e-34ec-4fe1-be0b-8a2af1f96f16.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add concurrency flag",
+  "packageName": "beachball",
+  "email": "nemanjatesic@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prompts": "^2.4.2",
     "semver": "^7.0.0",
     "toposort": "^2.0.2",
+    "p-graph": "^1.1.2",
     "uuid": "^9.0.0",
     "workspace-tools": "^0.36.3",
     "yargs-parser": "^21.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "toposort": "^2.0.2",
     "p-graph": "^1.1.2",
     "uuid": "^9.0.0",
-    "workspace-tools": "^0.36.3",
+    "workspace-tools": "^0.38.0",
     "yargs-parser": "^21.0.0"
   },
   "devDependencies": {

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -7,11 +7,11 @@ import { defaultBranchName, defaultRemoteBranchName } from '../__fixtures__/gitD
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { npmShow } from '../__fixtures__/npmShow';
 import { Repository } from '../__fixtures__/repository';
-import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
+import { PackageJsonFixture, RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { publish } from '../commands/publish';
 import { getDefaultOptions } from '../options/getDefaultOptions';
 import { BeachballOptions } from '../types/BeachballOptions';
-import { initNpmMock } from '../__fixtures__/mockNpm';
+import { _mockNpmPublish, initNpmMock } from '../__fixtures__/mockNpm';
 import os from 'os';
 
 // Spawning actual npm to run commands against a fake registry is extremely slow, so mock it for
@@ -23,7 +23,7 @@ jest.mock('../packageManager/npm');
 
 describe('publish command (e2e)', () => {
   const concurrencyValues = [[1],[os.cpus().length]];
-  initNpmMock();
+  const npmMock = initNpmMock();
 
   let repositoryFactory: RepositoryFactory | undefined;
   let repo: Repository | undefined;
@@ -79,13 +79,12 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual(['foo_v1.1.0']);
   });
 
-  it.each(concurrencyValues)('can perform a successful npm publish in detached HEAD, concurrency: %s', async (concurrency: number) => {
+  it('can perform a successful npm publish in detached HEAD', async () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
     const options = getOptions({
       push: false,
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -191,7 +190,7 @@ describe('publish command (e2e)', () => {
     expect(contents.dependencies.baz).toBeUndefined();
   });
 
-  it.each(concurrencyValues)('can perform a successful npm publish without bump, concurrency: %s', async (concurrency: number) => {
+  it('can perform a successful npm publish without bump', async () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
@@ -214,11 +213,11 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual([]);
   });
 
-  it.each(concurrencyValues)('publishes only changed packages in a monorepo, concurrency: %s', async (concurrency: number) => {
+  it('publishes only changed packages in a monorepo', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({ concurrency: concurrency });
+    const options = getOptions();
 
     generateChangeFiles(['foo'], options);
     repo.push();
@@ -238,11 +237,11 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual(['foo_v1.1.0']);
   });
 
-  it.each(concurrencyValues)('publishes dependent packages in a monorepo, concurrency: %s', async (concurrency: number) => {
+  it('publishes dependent packages in a monorepo', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({ concurrency: concurrency });
+    const options = getOptions();
 
     // bump baz => dependent bump bar => dependent bump foo
     generateChangeFiles(['baz'], options);
@@ -277,7 +276,7 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual(['bar_v1.3.5', 'baz_v1.4.0', 'foo_v1.0.1']);
   });
 
-  it.each(concurrencyValues)('publishes new monorepo packages if requested, concurrency: %s', async (concurrency: number) => {
+  it('publishes new monorepo packages if requested', async () => {
     // use a slightly smaller fixture to only publish one extra package
     repositoryFactory = new RepositoryFactory({
       folders: {
@@ -288,7 +287,6 @@ describe('publish command (e2e)', () => {
 
     const options = getOptions({
       new: true,
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -334,7 +332,7 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual(['bar_v1.4.0']);
   });
 
-  it.each(concurrencyValues)('should respect prepublish hooks, concurrency: %s', async (concurrency: number) => {
+  it('should respect prepublish hooks', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
@@ -350,7 +348,6 @@ describe('publish command (e2e)', () => {
           }
         },
       },
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -374,7 +371,7 @@ describe('publish command (e2e)', () => {
     expect(fooPackageJson.onPublish.main).toBe('lib/index.js');
   });
 
-  it.each(concurrencyValues)('should respect postpublish hooks, concurrency: %s', async (concurrency: number) => {
+  it('should respect postpublish hooks', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
     let notified;
@@ -389,7 +386,6 @@ describe('publish command (e2e)', () => {
           }
         },
       },
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -402,13 +398,12 @@ describe('publish command (e2e)', () => {
     expect(notified).toBe(fooPackageJson.afterPublish.notify);
   });
 
-  it.each(concurrencyValues)('can perform a successful npm publish without fetch, concurrency: %s', async (concurrency: number) => {
+  it('can perform a successful npm publish without fetch', async () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
     const options = getOptions({
       fetch: false,
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -434,13 +429,12 @@ describe('publish command (e2e)', () => {
     expect(fetchCount).toBe(0);
   });
 
-  it.each(concurrencyValues)('should specify fetch depth when depth param is defined, concurrency: %s', async (concurrency: number) => {
+  it('should specify fetch depth when depth param is defined', async () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
     const options = getOptions({
       depth: 10,
-      concurrency: concurrency,
      });
 
     generateChangeFiles(['foo'], options);
@@ -466,7 +460,7 @@ describe('publish command (e2e)', () => {
     expect(fetchCommand).toMatch('--depth=10');
   });
 
-  it.each(concurrencyValues)('calls precommit hook before committing changes, concurrency: %s', async (concurrency: number) => {
+  it('calls precommit hook before committing changes', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
@@ -478,7 +472,6 @@ describe('publish command (e2e)', () => {
           });
         },
       },
-      concurrency: concurrency,
     });
 
     generateChangeFiles(['foo'], options);
@@ -493,5 +486,176 @@ describe('publish command (e2e)', () => {
     expect(repo.getCurrentTags()).toEqual(['foo_v1.1.0']);
     const manifestJson = fs.readFileSync(repo.pathTo('foo.txt'));
     expect(manifestJson.toString()).toMatchInlineSnapshot(`"foo"`);
+  });
+
+  it('publishes multiple packages concurrently respecting the concurrency limit', async () => {
+    const packagesToPublish = ['pkg1', 'pkg2', 'pkg3', 'pkg4', 'pkg5', 'pkg6', 'pkg7', 'pkg8', 'pkg9'];
+    const packages: { [packageName: string]: PackageJsonFixture } = {};
+    for (const name of packagesToPublish) {
+      packages[name] = { version: '1.0.0' };
+    }
+
+    repositoryFactory = new RepositoryFactory({
+      folders: {
+        packages: packages,
+      },
+    });
+    repo = repositoryFactory.cloneRepository();
+
+    const concurrency = 2;
+    const options = getOptions({ concurrency: concurrency });
+
+    generateChangeFiles(packagesToPublish, options);
+    repo.push();
+
+    const simulateWait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    let currentConcurrency = 0;
+    let maxConcurrency = 0;
+    npmMock.setCommandOverride('publish', async (registryData, args, opts) => {
+      currentConcurrency++;
+      await simulateWait(100);
+      const result = await _mockNpmPublish(registryData, args, opts);
+      maxConcurrency = Math.max(maxConcurrency, currentConcurrency);
+      currentConcurrency--;
+      return result;
+    });
+
+    await publish(options);
+    // Verify that at most `concurrency` number of packages were published concurrently
+    expect(maxConcurrency).toBe(concurrency);
+
+    // Verify all packages were published
+    for (const pkg of packagesToPublish) {
+      expect(await npmShow(pkg)).toMatchObject({
+        name: pkg,
+        versions: ['1.1.0'],
+        'dist-tags': { latest: '1.1.0' },
+      });
+    }
+
+    repo.checkout(defaultBranchName);
+    repo.pull();
+    const expectedTags = packagesToPublish.map(pkg => `${pkg}_v1.1.0`);
+    // Verify all tags were updated
+    expect(repo.getCurrentTags().sort()).toEqual(expectedTags.sort());
+  });
+
+  it('handles errors correctly when one of the packages fails during concurrent publishing', async () => {
+    const packageNames = ['pkg1', 'pkg2', 'pkg3', 'pkg4', 'pkg5', 'pkg6', 'pkg7', 'pkg8'];
+    const packages: { [packageName: string]: PackageJsonFixture } = {};
+    const packageToFail = 'pkg4';
+    for (const name of packageNames) {
+      packages[name] = { version: '1.0.0' };
+    }
+    packages['pkg8'].dependencies = { [packageToFail]: '1.0.0' };
+    packages['pkg7'].dependencies = { [packageToFail]: '1.0.0' };
+
+    repositoryFactory = new RepositoryFactory({
+      folders: {
+        packages: packages,
+      },
+    });
+    repo = repositoryFactory.cloneRepository();
+
+    const options = getOptions({ concurrency: 3 });
+
+    generateChangeFiles(packageNames, options);
+    repo.push();
+
+    npmMock.setCommandOverride('publish', async (registryData, args, opts) => {
+      if (opts.cwd?.endsWith(packageToFail)) {
+        return {
+          failed: true,
+          stderr: 'Failed to publish package',
+          stdout: '',
+          success: false,
+          all: 'Failed to publish package',
+        }
+      }
+      return _mockNpmPublish(registryData, args, opts);
+    });
+
+    await expect(publish(options)).rejects.toThrow('Error publishing! Refer to the previous logs for recovery instructions.');
+
+    for (const name of packageNames) {
+      if (['pkg7', 'pkg8', packageToFail].includes(name)) {
+        // Verify that the packages that failed to publish are not published
+        // pkg7 and pkg8 are not published because they depend on pkg4 and pkg4 failed to publish
+        await npmShow(name, { shouldFail: true });
+      } else {
+        // Verify that the packages that did not fail to publish are published
+        expect(await npmShow(name)).toMatchObject({
+          name: name,
+          versions: ['1.1.0'],
+          'dist-tags': { latest: '1.1.0' },
+        });
+      }
+    }
+  });
+
+  it('should respect postpublish hook respecting the concurrency limit when publishing multiple packages concurrently', async () => {
+    const packagesToPublish = ['pkg1', 'pkg2', 'pkg3', 'pkg4', 'pkg5', 'pkg6', 'pkg7', 'pkg8', 'pkg9'];
+    const packages: { [packageName: string]: PackageJsonFixture } = {};
+    for (const name of packagesToPublish) {
+      packages[name] = {
+        version: '1.0.0',
+        afterPublish: {
+          notify: `message-${name}`,
+        },
+      };
+    }
+
+    repositoryFactory = new RepositoryFactory({
+      folders: {
+        packages: packages,
+      },
+    });
+    repo = repositoryFactory.cloneRepository();
+
+    const simulateWait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const afterPublishStrings: { packageName: string; notify: string }[] = [];
+    const concurrency = 2;
+    let currentConcurrency = 0;
+    let maxConcurrency = 0;
+    const options = getOptions({
+      hooks: {
+        postpublish: async (packagePath) => {
+          currentConcurrency++;
+          await simulateWait(100);
+          const packageName = path.basename(packagePath);
+          const packageJsonPath = path.join(packagePath, 'package.json');
+          const packageJson = fs.readJSONSync(packageJsonPath);
+          if (packageJson.afterPublish) {
+            afterPublishStrings.push({
+              packageName,
+              notify: packageJson.afterPublish.notify,
+            });
+          }
+          maxConcurrency = Math.max(maxConcurrency, currentConcurrency);
+          currentConcurrency--;
+        },
+      },
+      concurrency: concurrency,
+    });
+
+    generateChangeFiles(packagesToPublish, options);
+    repo.push();
+
+    await publish(options);
+    // Verify that at most `concurrency` number of postpublish hooks were running concurrently
+    expect(maxConcurrency).toBe(concurrency);
+
+    for (const pkg of packagesToPublish) {
+      const packageJson = fs.readJSONSync(repo.pathTo(`packages/${pkg}/package.json`));
+      if (packageJson.afterPublish) {
+        // Verify that all postpublish hooks were called
+        expect(afterPublishStrings).toContainEqual({
+          packageName: pkg,
+          notify: packageJson.afterPublish.notify,
+        });
+      }
+    }
   });
 });

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -120,50 +120,50 @@ describe('_mockNpmShow', () => {
     },
   });
 
-  it("errors if package doesn't exist", () => {
+  it("errors if package doesn't exist", async () => {
     const emptyData = _makeRegistryData({});
-    const result = _mockNpmShow(emptyData, ['foo'], { cwd: undefined });
+    const result = await _mockNpmShow(emptyData, ['foo'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ error: '[fake] code E404 - foo - not found' }));
   });
 
-  it('returns requested version plus dist-tags and version list', () => {
-    const result = _mockNpmShow(data, ['foo@1.0.0'], { cwd: undefined });
+  it('returns requested version plus dist-tags and version list', async () => {
+    const result = await _mockNpmShow(data, ['foo@1.0.0'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data: data, name: 'foo', version: '1.0.0' }));
   });
 
-  it('returns requested version of scoped package', () => {
-    const result = _mockNpmShow(data, ['@foo/bar@2.0.0'], { cwd: undefined });
+  it('returns requested version of scoped package', async () => {
+    const result = await _mockNpmShow(data, ['@foo/bar@2.0.0'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.0' }));
   });
 
-  it('returns requested tag', () => {
-    const result = _mockNpmShow(data, ['foo@beta'], { cwd: undefined });
+  it('returns requested tag', async () => {
+    const result = await _mockNpmShow(data, ['foo@beta'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data, name: 'foo', version: '1.0.0-beta' }));
   });
 
-  it('returns requested tag of scoped package', () => {
-    const result = _mockNpmShow(data, ['@foo/bar@beta'], { cwd: undefined });
+  it('returns requested tag of scoped package', async () => {
+    const result = await _mockNpmShow(data, ['@foo/bar@beta'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.0-beta' }));
   });
 
-  it('returns latest version if no version requested', () => {
-    const result = _mockNpmShow(data, ['foo'], { cwd: undefined });
+  it('returns latest version if no version requested', async () => {
+    const result = await _mockNpmShow(data, ['foo'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data, name: 'foo', version: '1.0.1' }));
   });
 
-  it('returns latest version of scoped package if no version requested', () => {
-    const result = _mockNpmShow(data, ['@foo/bar'], { cwd: undefined });
+  it('returns latest version of scoped package if no version requested', async () => {
+    const result = await _mockNpmShow(data, ['@foo/bar'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ data, name: '@foo/bar', version: '2.0.1' }));
   });
 
-  it("errors if requested version doesn't exist", () => {
-    const result = _mockNpmShow(data, ['foo@2.0.0'], { cwd: undefined });
+  it("errors if requested version doesn't exist", async () => {
+    const result = await _mockNpmShow(data, ['foo@2.0.0'], { cwd: undefined });
     expect(result).toEqual(getShowResult({ error: '[fake] code E404 - foo@2.0.0 - not found' }));
   });
 
   // support for this could be added later
-  it('currently throws if requested version is a range', () => {
-    expect(() => _mockNpmShow(data, ['foo@^1.0.0'], { cwd: undefined })).toThrow(/not currently supported/);
+  it('currently throws if requested version is a range', async () => {
+    await expect(() => _mockNpmShow(data, ['foo@^1.0.0'], { cwd: undefined })).rejects.toThrow(/not currently supported/);
   });
 });
 
@@ -198,19 +198,19 @@ describe('_mockNpmPublish', () => {
     jest.restoreAllMocks();
   });
 
-  it('throws if cwd is not specified', () => {
-    expect(() => _mockNpmPublish({}, [], { cwd: undefined })).toThrow('cwd is required for mock npm publish');
+  it('throws if cwd is not specified', async () => {
+    await expect(() => _mockNpmPublish({}, [], { cwd: undefined })).rejects.toThrow('cwd is required for mock npm publish');
   });
 
-  it('errors if reading package.json fails', () => {
+  it('errors if reading package.json fails', async () => {
     // this error is from the fs.readJsonSync mock, but it's the same code path as if reading the file fails
-    expect(() => _mockNpmPublish({}, [], { cwd: 'fake' })).toThrow('packageJson not set');
+    await expect(() => _mockNpmPublish({}, [], { cwd: 'fake' })).rejects.toThrow('packageJson not set');
   });
 
-  it('errors on re-publish', () => {
+  it('errors on re-publish', async () => {
     const data = _makeRegistryData({ foo: { versions: ['1.0.0'] } });
     packageJson = { name: 'foo', version: '1.0.0', main: 'nope.js' };
-    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    const result = await _mockNpmPublish(data, [], { cwd: 'fake' });
     expect(result).toEqual(
       getPublishResult({
         error: '[fake] EPUBLISHCONFLICT foo@1.0.0 already exists in registry',
@@ -221,11 +221,11 @@ describe('_mockNpmPublish', () => {
     expect(data.foo.versionData['1.0.0'].main).toBeUndefined();
   });
 
-  it('publishes to empty registry with default tag latest', () => {
+  it('publishes to empty registry with default tag latest', async () => {
     const data = _makeRegistryData({});
     packageJson = { name: 'foo', version: '1.0.0', main: 'index.js' };
 
-    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    const result = await _mockNpmPublish(data, [], { cwd: 'fake' });
     expect(result).toEqual(getPublishResult({ tag: 'latest' }));
     expect(data.foo).toEqual({
       versions: ['1.0.0'],
@@ -234,13 +234,13 @@ describe('_mockNpmPublish', () => {
     });
   });
 
-  it('publishes package and updates latest tag', () => {
+  it('publishes package and updates latest tag', async () => {
     const data = _makeRegistryData({
       foo: { versions: ['1.0.0'], 'dist-tags': { latest: '1.0.0' } },
     });
     packageJson = { name: 'foo', version: '2.0.0', main: 'index.js' };
 
-    const result = _mockNpmPublish(data, [], { cwd: 'fake' });
+    const result = await _mockNpmPublish(data, [], { cwd: 'fake' });
     expect(result).toEqual(getPublishResult({ tag: 'latest' }));
     expect(data.foo).toEqual({
       versions: ['1.0.0', '2.0.0'],
@@ -253,13 +253,13 @@ describe('_mockNpmPublish', () => {
     });
   });
 
-  it('publishes requested tag and does not update latest', () => {
+  it('publishes requested tag and does not update latest', async () => {
     const data = _makeRegistryData({
       foo: { versions: ['1.0.0'], 'dist-tags': { latest: '1.0.0', beta: '1.0.0' } },
     });
     packageJson = { name: 'foo', version: '2.0.0', main: 'index.js' };
 
-    const result = _mockNpmPublish(data, ['--tag', 'beta'], { cwd: 'fake' });
+    const result = await _mockNpmPublish(data, ['--tag', 'beta'], { cwd: 'fake' });
     expect(result).toEqual(getPublishResult({ tag: 'beta' }));
     expect(data.foo).toEqual({
       versions: ['1.0.0', '2.0.0'],

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -31,7 +31,7 @@ type MockNpmCommand = (
   registryData: MockNpmRegistry,
   args: string[],
   opts: Parameters<typeof npm>[1]
-) => Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'success' | 'failed'>;
+) => Promise<Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'success' | 'failed'>>;
 
 export type NpmMock = {
   /**
@@ -88,7 +88,7 @@ export function initNpmMock(): NpmMock {
       if (!func) {
         throw new Error(`Command not supported by mock npm: ${command}`);
       }
-      return func(registryData, args, opts) as NpmResult;
+      return await func(registryData, args, opts) as NpmResult;
     });
   });
 
@@ -142,7 +142,7 @@ export function _makeRegistryData(data: PartialRegistryData): MockNpmRegistry {
 }
 
 /** (exported for testing) Mock npm show based on the registry data */
-export const _mockNpmShow: MockNpmCommand = (registryData, args) => {
+export const _mockNpmShow: MockNpmCommand = async (registryData, args) => {
   // Assumption: all beachball callers to "npm show" list the package name last
   const packageSpec = args.slice(-1)[0];
 
@@ -187,7 +187,7 @@ export const _mockNpmShow: MockNpmCommand = (registryData, args) => {
 };
 
 /** (exported for testing) Mock npm publish to the registry data */
-export const _mockNpmPublish: MockNpmCommand = (registryData, args: string[], opts: Parameters<typeof npm>[1]) => {
+export const _mockNpmPublish: MockNpmCommand = async (registryData, args: string[], opts: Parameters<typeof npm>[1]) => {
   if (!opts?.cwd) {
     throw new Error('cwd is required for mock npm publish');
   }

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -149,6 +149,6 @@ describe('getPackageGraph', () => {
 
     await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
-    }).rejects.toThrow(`Failed to create the package graph. Affected packages size (2) is different from the created graph size (0). Affected packages: foo, bar, created graph packages:`);
+    }).rejects.toThrow(`Package info is missing for foo.`);
   });
 });

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from '@jest/globals';
+import { toposortPackages } from '../../publish/toposortPackages';
+import { PackageInfo, PackageInfos } from '../../types/PackageInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { getPackageGraph } from '../../monorepo/getPackageGraph';
+
+describe('getPackageGraph', () => {
+  /**
+   * @returns all package names in the package graph
+   */
+  async function getPackageGraphPackageNames(affectedPackages: Iterable<string>, packageInfos: PackageInfos, runHook?: (packageInfo: PackageInfo) => Promise<void>): Promise<string[]> {
+    const visitedPackages: string[] = [];
+    const packageGraph = getPackageGraph(affectedPackages, packageInfos, async (packageInfo: PackageInfo) => {
+      visitedPackages.push(packageInfo.name);
+      if (runHook) {
+        await runHook(packageInfo);
+      }
+    });
+    await packageGraph.run({
+      concurrency: 1,
+      continue: false,
+    });
+
+    return visitedPackages;
+  }
+
+  /**
+   * Ensure that both `toposortPackages` and `getPackageGraph` are running the same logic for sorting packages.
+   */
+  async function validateToposortPackagesAndPackageGraph(inputPackages: string[], packageInfos: PackageInfos, possibleSolutions: string[][]): Promise<void> {
+    const toposortPackagesOutput = (toposortPackages(inputPackages, packageInfos))
+    const getPackageGraphPackageNamesOutput = await getPackageGraphPackageNames(inputPackages, packageInfos);
+
+    expect(possibleSolutions).toContainEqual(toposortPackagesOutput);
+    expect(possibleSolutions).toContainEqual(getPackageGraphPackageNamesOutput);
+  }
+
+  it('sort packages which none of them has dependency', async () => {
+    const packageInfos: PackageInfos = makePackageInfos({ foo: {}, bar: {} });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'bar'], packageInfos, [
+      ['foo', 'bar'],
+      ['bar', 'foo'],
+    ]);
+  });
+
+  it('sort packages with dependencies', async () => {
+    const packageInfos = makePackageInfos({
+      foo: {
+        dependencies: { foo3: '1.0.0', bar2: '1.0.0' },
+      },
+      foo3: { dependencies: { foo2: '1.0.0' } },
+      foo2: {},
+    });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'foo2', 'foo3'], packageInfos, [
+      ['foo2', 'foo3', 'foo']
+    ]);
+  });
+
+  it('sort packages with different kinds of dependencies', async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0' }, peerDependencies: { foo4: '1.0.0', bar: '1.0.0' } },
+      foo2: { dependencies: {} },
+      foo3: { dependencies: { foo2: '1.0.0' } },
+      foo4: { devDependencies: { foo2: '1.0.0' } },
+    });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'foo2', 'foo3', 'foo4'], packageInfos, [
+      ['foo2', 'foo3', 'foo4', 'foo'],
+      ['foo2', 'foo4', 'foo3', 'foo'],
+    ]);
+  });
+
+  it('sort packages with all different kinds of dependencies', async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0' }, peerDependencies: { foo4: '1.0.0', bar: '1.0.0' } },
+      foo2: { dependencies: {} },
+      foo3: { optionalDependencies: { foo2: '1.0.0' } },
+      foo4: { devDependencies: { foo2: '1.0.0' } },
+    });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'foo2', 'foo3', 'foo4'], packageInfos, [
+      ['foo2', 'foo3', 'foo4', 'foo']
+    ]);
+  });
+
+  it('do not sort packages if it is not included', async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0', bar: '1.0.0' } },
+      foo2: {},
+      foo3: { dependencies: { foo2: '1.0.0' } },
+    });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'foo3'], packageInfos, [
+      ['foo3', 'foo']
+    ]);
+  });
+
+  it('do not sort packages if it is not included harder scenario', async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { foo3: '1.0.0', bar: '1.0.0' } },
+      foo2: { dependencies: { foo4: '1.0.0' } },
+      foo3: { dependencies: { foo2: '1.0.0' } },
+      foo4: { dependencies: {}},
+      bar: { dependencies: { foo: '1.0.0' } },
+    });
+
+    await validateToposortPackagesAndPackageGraph(['foo', 'foo3'], packageInfos, [
+      ['foo3', 'foo']
+    ]);
+  });
+
+  it('throws if contains circular dependencies inside affected packages', async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { bar: '1.0.0',  } },
+      bar: { dependencies: { foo: '1.0.0' } },
+    });
+
+    expect(async () => {
+      await getPackageGraphPackageNames(['foo', 'bar'], packageInfos);
+    }).rejects.toThrow(/We could not find a node in the graph with no dependencies, this likely means there is a cycle including all nodes/);
+  });
+
+  it('throws if contains circular dependencies', () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: { bar: '1.0.0', bar2: '1.0.0' } },
+      bar: { dependencies: { foo: '1.0.0' } },
+    });
+
+    expect(async () => {
+      await getPackageGraphPackageNames(['foo', 'bar', 'bar2'], packageInfos);
+    }).rejects.toThrow(/A cycle has been detected including the following nodes:\nfoo\nbar/);
+  });
+
+  it(`doesn't throws if graph contains circular dependencies outside affected packages`, async () => {
+    const packageInfos = makePackageInfos({
+      foo: { dependencies: {  } },
+      bar: { dependencies: {  } },
+      bar2: { dependencies: { bar3: '1.0.0' } },
+      bar3: { dependencies: { bar2: '1.0.0', bar: '1.0.0' } },
+    });
+
+    await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
+  });
+
+  it('throws if package info is missing', () => {
+    const packageInfos = {} as any as PackageInfos;
+
+    expect(async () => {
+      await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
+    }).rejects.toThrow(`Cannot read properties of undefined (reading 'name')`);
+  });
+});

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -129,8 +129,8 @@ describe('getPackageGraph', () => {
     });
 
     await expect(async () => {
-      await getPackageGraphPackageNames(['foo', 'bar', 'bar2'], packageInfos);
-    }).rejects.toThrow(/A cycle has been detected including the following nodes:\nfoo\nbar/);
+      await getPackageGraphPackageNames(['foo', 'bar'], packageInfos);
+    }).rejects.toThrow(/We could not find a node in the graph with no dependencies, this likely means there is a cycle including all nodes/);
   });
 
   it(`doesn't throws if graph contains circular dependencies outside affected packages`, async () => {
@@ -149,6 +149,6 @@ describe('getPackageGraph', () => {
 
     await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
-    }).rejects.toThrow(`Cannot read properties of undefined (reading 'name')`);
+    }).rejects.toThrow(`Failed to create the package graph. Affected packages size (2) is different from the created graph size (0). Affected packages: foo, bar, created graph packages:`);
   });
 });

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -117,18 +117,18 @@ describe('getPackageGraph', () => {
       bar: { dependencies: { foo: '1.0.0' } },
     });
 
-    expect(async () => {
+    await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar'], packageInfos);
     }).rejects.toThrow(/We could not find a node in the graph with no dependencies, this likely means there is a cycle including all nodes/);
   });
 
-  it('throws if contains circular dependencies', () => {
+  it('throws if contains circular dependencies', async () => {
     const packageInfos = makePackageInfos({
       foo: { dependencies: { bar: '1.0.0', bar2: '1.0.0' } },
       bar: { dependencies: { foo: '1.0.0' } },
     });
 
-    expect(async () => {
+    await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar', 'bar2'], packageInfos);
     }).rejects.toThrow(/A cycle has been detected including the following nodes:\nfoo\nbar/);
   });
@@ -144,10 +144,10 @@ describe('getPackageGraph', () => {
     await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
   });
 
-  it('throws if package info is missing', () => {
+  it('throws if package info is missing', async () => {
     const packageInfos = {} as any as PackageInfos;
 
-    expect(async () => {
+    await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar'], packageInfos)
     }).rejects.toThrow(`Cannot read properties of undefined (reading 'name')`);
   });

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -13,7 +13,7 @@ import { updateLockFile } from './updateLockFile';
 export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions): Promise<BumpInfo> {
   const { modifiedPackages, packageInfos, changeFileChangeInfos } = bumpInfo;
 
-  await callHook(options.hooks?.prebump, modifiedPackages, packageInfos);
+  await callHook(options.hooks?.prebump, modifiedPackages, packageInfos, options.concurrency);
 
   updatePackageJsons(modifiedPackages, packageInfos);
   await updateLockFile(options.path);
@@ -28,7 +28,7 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
     unlinkChangeFiles(changeFileChangeInfos, packageInfos, options);
   }
 
-  await callHook(options.hooks?.postbump, modifiedPackages, packageInfos);
+  await callHook(options.hooks?.postbump, modifiedPackages, packageInfos, options.concurrency);
 
   // This is returned from bump() for testing
   return bumpInfo;

--- a/src/monorepo/getPackageDependencyGraph.ts
+++ b/src/monorepo/getPackageDependencyGraph.ts
@@ -1,0 +1,32 @@
+import { PackageInfos } from '../types/PackageInfo';
+
+/**
+ * @returns Each element is a tuple of [dependency, dependent] where `dependent` depends on `dependency`.
+ * These are the edges of the dependency graph.
+ */
+export function getPackageDependencyGraph(packages: string[], packageInfos: PackageInfos): [string | undefined, string][] {
+  const packageSet = new Set(packages);
+  const dependencyGraph: [string | undefined, string][] = [];
+
+  for (const pkgName of packageSet) {
+    const info = packageInfos[pkgName];
+    if (!info) {
+      throw new Error(`Package info is missing for ${pkgName}.`);
+    }
+
+    const allDeps = new Set(
+      [info.dependencies, info.devDependencies, info.peerDependencies, info.optionalDependencies]
+        .flatMap(deps => Object.keys(deps || {}))
+        .filter(pkg => packageSet.has(pkg))
+    );
+    if (allDeps.size) {
+      for (const depPkgName of allDeps) {
+        dependencyGraph.push([depPkgName, pkgName]);
+      }
+    } else {
+      dependencyGraph.push([undefined, pkgName]);
+    }
+  }
+
+  return dependencyGraph;
+}

--- a/src/monorepo/getPackageDependencyGraph.ts
+++ b/src/monorepo/getPackageDependencyGraph.ts
@@ -1,3 +1,4 @@
+import { getPackageDependencies } from 'workspace-tools/lib/graph/getPackageDependencies';
 import { PackageInfos } from '../types/PackageInfo';
 
 /**
@@ -14,12 +15,8 @@ export function getPackageDependencyGraph(packages: string[], packageInfos: Pack
       throw new Error(`Package info is missing for ${pkgName}.`);
     }
 
-    const allDeps = new Set(
-      [info.dependencies, info.devDependencies, info.peerDependencies, info.optionalDependencies]
-        .flatMap(deps => Object.keys(deps || {}))
-        .filter(pkg => packageSet.has(pkg))
-    );
-    if (allDeps.size) {
+    const allDeps = getPackageDependencies(info, packageSet, { withDevDependencies: true, withPeerDependencies: true });
+    if (allDeps.length > 0) {
       for (const depPkgName of allDeps) {
         dependencyGraph.push([depPkgName, pkgName]);
       }

--- a/src/monorepo/getPackageDependencyGraph.ts
+++ b/src/monorepo/getPackageDependencyGraph.ts
@@ -5,7 +5,10 @@ import { PackageInfos } from '../types/PackageInfo';
  * @returns Each element is a tuple of [dependency, dependent] where `dependent` depends on `dependency`.
  * These are the edges of the dependency graph.
  */
-export function getPackageDependencyGraph(packages: string[], packageInfos: PackageInfos): [string | undefined, string][] {
+export function getPackageDependencyGraph(
+  packages: string[],
+  packageInfos: PackageInfos
+): [string | undefined, string][] {
   const packageSet = new Set(packages);
   const dependencyGraph: [string | undefined, string][] = [];
 
@@ -15,7 +18,11 @@ export function getPackageDependencyGraph(packages: string[], packageInfos: Pack
       throw new Error(`Package info is missing for ${pkgName}.`);
     }
 
-    const allDeps = getPackageDependencies(info, packageSet, { withDevDependencies: true, withPeerDependencies: true });
+    const allDeps = getPackageDependencies(info, packageSet, {
+      withDevDependencies: true,
+      withPeerDependencies: true,
+      withOptionalDependencies: true,
+    });
     if (allDeps.length > 0) {
       for (const depPkgName of allDeps) {
         dependencyGraph.push([depPkgName, pkgName]);

--- a/src/monorepo/getPackageGraph.ts
+++ b/src/monorepo/getPackageGraph.ts
@@ -42,5 +42,9 @@ function createPackageGraphInternal(packageInfos: PackageInfos, affectedPackages
     dependencies: packageGraph.dependencies.filter(dep => affectedPackages.includes(dep.name) && affectedPackages.includes(dep.dependency)),
   };
 
+  if (filteredGraph.packages.length !== affectedPackages.length) {
+    throw new Error(`Failed to create the package graph. Affected packages size (${affectedPackages.length}) is different from the created graph size (${filteredGraph.packages.length}). Affected packages: ${affectedPackages.join(', ')}, created graph packages: ${filteredGraph.packages.join(', ')}`);
+  }
+
   return filteredGraph;
 }

--- a/src/monorepo/getPackageGraph.ts
+++ b/src/monorepo/getPackageGraph.ts
@@ -1,14 +1,12 @@
-import { createPackageGraph, PackageDependency, PackageGraph } from 'workspace-tools';
 import { PackageInfo, PackageInfos } from '../types/PackageInfo';
-import pGraph, { DependencyList, PGraphNodeMap } from 'p-graph';
+import pGraph, { PGraphNodeMap } from 'p-graph';
+import { getPackageDependencyGraph } from './getPackageDependencyGraph';
 
 export function getPackageGraph(
   affectedPackages: Iterable<string>,
   packageInfos: PackageInfos,
   runHook: (packageInfo: PackageInfo) => Promise<void>
 ) {
-  const packageGraph: PackageGraph = createPackageGraphInternal(packageInfos, Array.from(affectedPackages));
-
   const nodeMap: PGraphNodeMap = new Map();
   for (const packageToBump of affectedPackages) {
     nodeMap.set(packageToBump, {
@@ -16,35 +14,11 @@ export function getPackageGraph(
     });
   }
 
-  return pGraph(nodeMap, createDependencyList(packageGraph.dependencies));
+  const dependencyGraph: [string | undefined, string][] = getPackageDependencyGraph(Array.from(affectedPackages), packageInfos);
+  const filteredDependencyGraph = filterDependencyGraph(dependencyGraph);
+  return pGraph(nodeMap, filteredDependencyGraph);
 }
 
-function createDependencyList(dependencies: PackageDependency[]): DependencyList {
-  return dependencies.map(dependency => [dependency.dependency, dependency.name]);
-}
-
-/**
- * @returns A package graph that only contains the affected packages and their dependencies. This is done by filtering the
- * original package graph, which could contain more packages than the affected packages. This can happen if some scope is
- * provided to the command which filters some package.
- */
-function createPackageGraphInternal(packageInfos: PackageInfos, affectedPackages: string[]): PackageGraph {
-  const packageGraph: PackageGraph = createPackageGraph(packageInfos, {
-    namePatterns: affectedPackages,
-    includeDependents: true,
-    includeDependencies: true,
-    withDevDependencies: true,
-    withPeerDependencies: true,
-  });
-
-  const filteredGraph: PackageGraph = {
-    packages: packageGraph.packages.filter(pkg => affectedPackages.includes(pkg)),
-    dependencies: packageGraph.dependencies.filter(dep => affectedPackages.includes(dep.name) && affectedPackages.includes(dep.dependency)),
-  };
-
-  if (filteredGraph.packages.length !== affectedPackages.length) {
-    throw new Error(`Failed to create the package graph. Affected packages size (${affectedPackages.length}) is different from the created graph size (${filteredGraph.packages.length}). Affected packages: ${affectedPackages.join(', ')}, created graph packages: ${filteredGraph.packages.join(', ')}`);
-  }
-
-  return filteredGraph;
+function filterDependencyGraph(dependencyGraph: [string | undefined, string][]): [string, string][] {
+  return dependencyGraph.filter(([dep, _]) => dep !== undefined) as [string, string][];
 }

--- a/src/monorepo/getPackageGraph.ts
+++ b/src/monorepo/getPackageGraph.ts
@@ -1,0 +1,29 @@
+import { createPackageGraph, PackageDependency } from 'workspace-tools';
+import { PackageInfo, PackageInfos } from '../types/PackageInfo';
+import pGraph, { DependencyList, PGraphNodeMap } from 'p-graph';
+
+export function getPackageGraph(
+  affectedPackages: Iterable<string>,
+  packageInfos: PackageInfos,
+  runHook: (packageInfo: PackageInfo) => Promise<void>
+) {
+  const packageGraph = createPackageGraph(packageInfos, {
+    namePatterns: Array.from(affectedPackages),
+    includeDependents: true,
+    includeDependencies: false,
+    withDevDependencies: true,
+  });
+
+  const nodeMap: PGraphNodeMap = new Map();
+  for (const packageToBump of affectedPackages) {
+    nodeMap.set(packageToBump, {
+      run: async () => await runHook(packageInfos[packageToBump]),
+    });
+  }
+
+  return pGraph(nodeMap, createDependencyList(packageGraph.dependencies));
+}
+
+function createDependencyList(dependencies: PackageDependency[]): DependencyList {
+  return dependencies.map(dependency => [dependency.dependency, dependency.name]);
+}

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -23,7 +23,7 @@ const booleanOptions = [
   'version',
   'yes',
 ] as const;
-const numberOptions = ['depth', 'gitTimeout', 'retries', 'timeout'] as const;
+const numberOptions = ['concurrency', 'depth', 'gitTimeout', 'retries', 'timeout'] as const;
 const stringOptions = [
   'access',
   'authType',

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -17,6 +17,7 @@ export function getDefaultOptions(): BeachballOptions {
     changeDir: 'change',
     command: 'change',
     commit: true,
+    concurrency: 1,
     defaultNpmTag: 'latest',
     depth: undefined,
     disallowedChangeTypes: null,

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -40,7 +40,7 @@ export async function packagePublish(
     });
 
     if (result.success) {
-      console.log('Published!');
+      console.log(`Published! - ${packageSpec}`);
       return result;
     }
 

--- a/src/publish/toposortPackages.ts
+++ b/src/publish/toposortPackages.ts
@@ -1,5 +1,6 @@
 import toposort from 'toposort';
 import { PackageInfos } from '../types/PackageInfo';
+import { getPackageDependencyGraph } from '../monorepo/getPackageDependencyGraph';
 
 /**
  * Topologically sort the packages based on their dependency graph.
@@ -8,31 +9,8 @@ import { PackageInfos } from '../types/PackageInfo';
  * @param packageInfos PackagesInfos for the sorted packages.
  */
 export function toposortPackages(packages: string[], packageInfos: PackageInfos): string[] {
-  const packageSet = new Set(packages);
-  const dependencyGraph: [string | undefined, string][] = [];
-
-  for (const pkgName of packageSet) {
-    const info = packageInfos[pkgName];
-    if (!info) {
-      throw new Error(`Package info is missing for ${pkgName}.`);
-    }
-
-    const allDeps = new Set(
-      [info.dependencies, info.devDependencies, info.peerDependencies, info.optionalDependencies]
-        .flatMap(deps => Object.keys(deps || {}))
-        .filter(pkg => packageSet.has(pkg))
-    );
-    if (allDeps.size) {
-      for (const depPkgName of allDeps) {
-        dependencyGraph.push([depPkgName, pkgName]);
-      }
-    } else {
-      dependencyGraph.push([undefined, pkgName]);
-    }
-  }
-
   try {
-    return toposort(dependencyGraph).filter((pkg): pkg is string => !!pkg);
+    return toposort(getPackageDependencyGraph(packages, packageInfos)).filter((pkg): pkg is string => !!pkg);
   } catch (err) {
     throw new Error(`Failed to topologically sort packages: ${(err as Error)?.message}`);
   }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -34,6 +34,7 @@ export interface CliOptions
   canaryName?: string | undefined;
   command: string;
   commit?: boolean;
+  concurrency: number;
   configPath?: string;
   dependentChangeType?: ChangeType;
   disallowDeletedChangeFiles?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,6 +8746,11 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
 
+p-graph@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/p-graph/-/p-graph-1.1.2.tgz#594010591e258ebc013f275f414ef6c5bfc25d51"
+  integrity sha512-GnEEHrOMozk0hCjXBm011oYb3zpaOolxHgqL2s7Od2niGAJKyk/4FZ2VRUAgjqqqoQnZQtwkF6fjGDJkIQTjDQ==
+
 p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11899,10 +11899,10 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.36.3:
-  version "0.36.4"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.36.4.tgz#57504c687569785148c5b7ef1470dadc9be970c5"
-  integrity sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==
+workspace-tools@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.38.0.tgz#5d7677f9c9f0a7df592537b17b378d1c33eddb86"
+  integrity sha512-BpvydL36Q+AVBU6Rj/a7nfxfEhxvX4ZkLVCsUx5LJ5UpzIcvLDgxvnolBSY+2MUU8VYhvf+PGtF7eWS8xBC1Iw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     fast-glob "^3.3.1"


### PR DESCRIPTION
This pull request introduces a new concurrency flag to the Beachball package, updates dependencies, and refactors the `publish` command tests to support concurrency. Additionally, it includes new tests for the `getPackageGraph` function.

### New Feature:
* Added concurrency flag to the Beachball package, by default it is set to 1 to keep backwards compatibility with previous behavior while we test new behavior.

### Dependency Updates:
* Added `p-graph` dependency for running publishing command and hooks in parallel but in order of dependency graph.

### New Tests:
* Added comprehensive tests for `getPackageGraph` in `getPackageGraph.test.ts` to validate package sorting and handling of dependencies.
* Added E2E tests for `publish` command to validate all existing scenarios for both concurrency being 1 and greater.

### Refactoring:
* Modified `callHook` function to take in concurrency as a parameter and made it so that if concurrency is 1 we will use the old behavior (doing a for loop for each package) and if concurrency is greater then 1, will be using `getPackageGraph` function to create a p-graph and run the hook in parallel.
* Modified `toposortPackages` function to extract the logic of creating the dependencyGraph so that it can be reused between `toposortPackages` and `getPackageGraph` functions.
* Modified `publishToRegistry` function to use `getPackageGraph` function to create a p-graph and run the publish command in parallel when concurrency is greater than 1 and default to old behavior when concurrency is 1