### PR TITLE
Fix publish failure package exists check to work with npm 10

### DIFF
--- a/change/beachball-053e98de-4e97-4d4e-bc5d-ee4787e38a7f.json
+++ b/change/beachball-053e98de-4e97-4d4e-bc5d-ee4787e38a7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix publish failure package exists check to work with npm 10",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -49,7 +49,7 @@ export async function packagePublish(
 
     // First check the output for specific cases where retries are unlikely to help.
     // NOTE: much of npm's output is localized, so it's best to only check for error codes.
-    if (result.all!.includes('EPUBLISHCONFLICT')) {
+    if (result.all?.includes('EPUBLISHCONFLICT') || result.all?.includes('E409')) {
       console.error(`${packageSpec} already exists in the registry. ${output}`);
       break;
     }


### PR DESCRIPTION
npm 10 uses `E409` in the publish output if the version already exists.