### PR TITLE
Never update lock file after publish when running tests

### DIFF
--- a/change/beachball-8be53545-c527-40e6-a9f6-65cdb5dcfd3c.json
+++ b/change/beachball-8be53545-c527-40e6-a9f6-65cdb5dcfd3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Never update lock file after publish when running tests",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/src/bump/updateLockFile.ts
+++ b/src/bump/updateLockFile.ts
@@ -2,11 +2,18 @@ import fs from 'fs-extra';
 import path from 'path';
 import { findProjectRoot } from 'workspace-tools';
 import { packageManager } from '../packageManager/packageManager';
+import { env } from '../env';
 
 /**
  * Detects lockfile for npm, pnpm, or yarn and runs the appropriate command to update it
  */
 export async function updateLockFile(cwd: string): Promise<void> {
+  // Never update the lock file while running in tests (if tests are added to cover this step,
+  // a method can be added to override this condition with a local variable)
+  if (env.isJest) {
+    return;
+  }
+
   const root = findProjectRoot(cwd);
   if (!root) {
     return;


### PR DESCRIPTION
With modern package managers (not yarn v1/old npm) that include local monorepo versions in the lock file, after `npm publish`, it's necessary to run the package manager again to update the lock file. We should entirely skip that check when running tests for now, for efficiency. (This becomes relevant in the beachball next branch that updates to yarn v4.)

Also update the package publish tests to remove concurrent versions from cases where (upon further inspection) they're not adding value and just slowing things down.