### PR TITLE
Remove jest-mock dev dep

### DIFF
--- a/change/beachball-d0b88f44-aa23-4ab8-9baf-35466cb0ac7f.json
+++ b/change/beachball-d0b88f44-aa23-4ab8-9baf-35466cb0ac7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove jest-mock dev dep",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "get-port": "^5.0.0",
     "husky": "^8.0.0",
     "jest": "^29.0.0",
-    "jest-mock": "^29.0.0",
     "lint-staged": "^12.0.0",
     "normalized-tmpdir": "^1.0.1",
     "prettier": "~2.8.4",

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,5 +1,4 @@
 import { jest, afterEach, beforeAll, afterAll } from '@jest/globals';
-import type { SpyInstance } from 'jest-mock';
 
 /** Methods that will be mocked. More could be added later if needed. */
 type MockLogMethod = 'log' | 'warn' | 'error';
@@ -15,7 +14,7 @@ type MockLogsOptions = {
 
 export type MockLogs = {
   /** Mocked methods (to access calls etc) */
-  mocks: { [k in MockLogMethod]: SpyInstance<typeof console.log> };
+  mocks: { [k in MockLogMethod]: jest.SpiedFunction<typeof console.log> };
 
   /** Set override options for one test only */
   setOverrideOptions: (options: MockLogsOptions) => void;

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, jest, beforeEach, afterAll } from '@jest/globals';
-import type { Mock } from 'jest-mock';
 import { gitFailFast } from 'workspace-tools';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { tagPackages } from '../../publish/tagPackages';
@@ -62,7 +61,7 @@ describe('tagPackages', () => {
   initMockLogs();
 
   beforeEach(() => {
-    (gitFailFast as Mock).mockReset();
+    (gitFailFast as jest.Mock).mockReset();
   });
 
   afterAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2509,7 +2509,7 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^29.0.0, jest-mock@^29.7.0:
+jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
   integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==


### PR DESCRIPTION
This dev dep was only being used for types, and those types are now available on the global `jest` object.