### PR TITLE
Allow changelog render functions to be synchronous

### DIFF
--- a/change/beachball-05fd5096-f4e9-4726-9ce4-1a19e197f1bb.json
+++ b/change/beachball-05fd5096-f4e9-4726-9ce4-1a19e197f1bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow changelog render functions to be synchronous",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/changelog/renderChangelog.test.ts
+++ b/src/__tests__/changelog/renderChangelog.test.ts
@@ -104,14 +104,14 @@ describe('renderChangelog', () => {
   it('merges default and custom renderers', async () => {
     const options = getOptions();
     options.changelogOptions.customRenderers = {
-      renderHeader: async renderInfo => {
+      renderHeader: renderInfo => {
         return [
           `## ${renderInfo.newVersionChangelog.version}`,
           renderInfo.newVersionChangelog.date.toUTCString(),
           `[Compare changes](http://real-github-compare-link)`,
         ].join('\n');
       },
-      renderEntry: async (entry, renderInfo) => `- ${entry.comment} (${entry.author}, PR #123)`,
+      renderEntry: entry => `- ${entry.comment} (${entry.author}, PR #123)`,
     };
 
     const result = await renderChangelog(options);
@@ -122,7 +122,7 @@ describe('renderChangelog', () => {
 
   it('uses full custom renderer', async () => {
     const options = getOptions();
-    options.changelogOptions.renderPackageChangelog = async renderInfo =>
+    options.changelogOptions.renderPackageChangelog = renderInfo =>
       `## ${renderInfo.newVersionChangelog.version}\n\nno notes for you`;
 
     const result = await renderChangelog(options);
@@ -147,10 +147,10 @@ describe('renderChangelog', () => {
       ],
     };
     options.changelogOptions.customRenderers = {
-      renderEntry: jest.fn(async (entry: ChangelogEntry) => `- ${entry.comment} ${entry.extra})`),
+      renderEntry: jest.fn((entry: ChangelogEntry) => `- ${entry.comment} ${entry.extra})`),
     };
     options.changelogOptions.renderMainHeader = jest.fn(
-      async (packageChangelog: PackageChangelog) => `Custom main header ${packageChangelog.name}`
+      (packageChangelog: PackageChangelog) => `Custom main header ${packageChangelog.name}`
     );
 
     const result = await renderChangelog(options);

--- a/src/__tests__/changelog/renderPackageChangelog.test.ts
+++ b/src/__tests__/changelog/renderPackageChangelog.test.ts
@@ -160,7 +160,7 @@ describe('changelog renderers -', () => {
 
     it('uses custom renderEntry', async () => {
       const renderInfo = getGroupedRenderInfo();
-      renderInfo.renderers.renderEntry = async (entry, renderInfo) => `- ${entry.comment} (#123)`;
+      renderInfo.renderers.renderEntry = entry => `- ${entry.comment} (#123)`;
 
       const result = await renderPackageChangelog(renderInfo);
       expect(result).toContain('#123');
@@ -169,8 +169,8 @@ describe('changelog renderers -', () => {
 
     it('uses custom renderEntries', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderEntries = async (changeType, renderInfo) => {
-        const entries = renderInfo.newVersionChangelog.comments[changeType];
+      renderInfo.renderers.renderEntries = (changeType, info) => {
+        const entries = info.newVersionChangelog.comments[changeType];
         return entries ? entries.map(entry => `${entry.comment}!!!`).join('\n\n') : '';
       };
 
@@ -181,7 +181,7 @@ describe('changelog renderers -', () => {
 
     it('uses custom renderChangeTypeHeader', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderChangeTypeHeader = async (changeType, renderInfo) =>
+      renderInfo.renderers.renderChangeTypeHeader = changeType =>
         changeType === 'minor' || changeType === 'major' ? '### Important stuff' : '### Boring stuff';
 
       const result = await renderPackageChangelog(renderInfo);
@@ -191,8 +191,8 @@ describe('changelog renderers -', () => {
 
     it('uses custom renderChangeTypeSection', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderChangeTypeSection = async (changeType, renderInfo) =>
-        changeType === 'minor' || changeType === 'major' ? renderChangeTypeSection(changeType, renderInfo) : '';
+      renderInfo.renderers.renderChangeTypeSection = async (changeType, info) =>
+        changeType === 'minor' || changeType === 'major' ? renderChangeTypeSection(changeType, info) : '';
 
       const result = await renderPackageChangelog(renderInfo);
       expect(result).not.toContain('Patches');
@@ -201,9 +201,9 @@ describe('changelog renderers -', () => {
 
     it('uses custom renderHeader', async () => {
       const renderInfo = getRenderInfo();
-      renderInfo.renderers.renderHeader = async renderInfo =>
+      renderInfo.renderers.renderHeader = info =>
         [
-          `## ${renderInfo.newVersionChangelog.version}`,
+          `## ${info.newVersionChangelog.version}`,
           renderInfo.newVersionChangelog.date.toUTCString(),
           `[Compare changes](http://real-github-compare-link)`,
         ].join('\n');

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -1,6 +1,6 @@
 import { renderPackageChangelog, defaultRenderers } from './renderPackageChangelog';
-import { renderMainHeader } from './renderMainHeader';
 import { ChangelogOptions, PackageChangelogRenderInfo } from '../types/ChangelogOptions';
+import type { PackageChangelog } from '../types/ChangeLog';
 
 export interface MarkdownChangelogRenderOptions extends Omit<PackageChangelogRenderInfo, 'renderers'> {
   previousContent: string;
@@ -66,7 +66,7 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
 
     return (
       [
-        await (customRenderMainHeader || renderMainHeader)(newVersionChangelog),
+        await (customRenderMainHeader || _renderMainHeader)(newVersionChangelog),
         `<!-- This log was last generated on ${newVersionChangelog.date.toUTCString()} and should not be manually modified. -->`,
         markerComment,
         packageChangelog,
@@ -119,4 +119,8 @@ export function _trimPreviousLog(params: {
   }
 
   return previousLogEntries;
+}
+
+function _renderMainHeader(newVersionChangelog: PackageChangelog): string {
+  return `# Change Log - ${newVersionChangelog.name}`;
 }

--- a/src/changelog/renderMainHeader.ts
+++ b/src/changelog/renderMainHeader.ts
@@ -1,5 +1,0 @@
-import { PackageChangelog } from '../types/ChangeLog';
-
-export async function renderMainHeader(newVersionChangelog: PackageChangelog) {
-  return `# Change Log - ${newVersionChangelog.name}`;
-}

--- a/src/changelog/renderPackageChangelog.ts
+++ b/src/changelog/renderPackageChangelog.ts
@@ -41,7 +41,7 @@ export async function renderPackageChangelog(renderInfo: PackageChangelogRenderI
   return sections.join('\n\n');
 }
 
-async function _renderHeader(renderInfo: PackageChangelogRenderInfo): Promise<string> {
+function _renderHeader(renderInfo: PackageChangelogRenderInfo): string {
   return `## ${renderInfo.newVersionChangelog.version}\n\n${renderInfo.newVersionChangelog.date.toUTCString()}`;
 }
 
@@ -56,7 +56,7 @@ async function _renderChangeTypeSection(
     : '';
 }
 
-async function _renderChangeTypeHeader(changeType: ChangeType): Promise<string> {
+function _renderChangeTypeHeader(changeType: ChangeType): string {
   return `### ${groupNames[changeType]}`;
 }
 
@@ -94,7 +94,7 @@ async function _renderEntriesBasic(
   return results;
 }
 
-async function _renderEntry(entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo): Promise<string> {
+function _renderEntry(entry: ChangelogEntry): string {
   if (entry.author === 'beachball') {
     return `- ${entry.comment}`;
   }

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -17,7 +17,7 @@ export interface ChangelogOptions {
    * Default renderers (and `customRenderers` if provided) will be available in `renderInfo.renderers`
    * but will not be called automatically.
    */
-  renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderPackageChangelog?: (renderInfo: PackageChangelogRenderInfo) => string | Promise<string>;
 
   /**
    * Fine-grained custom renderers for individual parts of the changelog.
@@ -33,7 +33,7 @@ export interface ChangelogOptions {
    * # Change Log - @scope/package-name
    * ```
    */
-  renderMainHeader?: (packageChangelog: PackageChangelog) => Promise<string>;
+  renderMainHeader?: (packageChangelog: PackageChangelog) => string | Promise<string>;
 
   /**
    * If true, add a unique suffix to changelog filenames, based on the hash of the package name:
@@ -117,7 +117,7 @@ export interface ChangelogRenderers {
    * Wed, 25 Mar 2020 20:20:02 GMT
    * ```
    */
-  renderHeader?: (renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderHeader?: (renderInfo: PackageChangelogRenderInfo) => string | Promise<string>;
 
   /**
    * Custom renderer for the section about `changeType` changes for a particular package version.
@@ -129,7 +129,10 @@ export interface ChangelogRenderers {
    * - Really interesting change (user1@microsoft.com)
    * ```
    */
-  renderChangeTypeSection?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderChangeTypeSection?: (
+    changeType: ChangeType,
+    renderInfo: PackageChangelogRenderInfo
+  ) => string | Promise<string>;
 
   /**
    * Custom renderer for the section header about `changeType` changes for a particular package version.
@@ -139,7 +142,7 @@ export interface ChangelogRenderers {
    * ### Minor changes
    * ```
    */
-  renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderChangeTypeHeader?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string | Promise<string>;
 
   /**
    * Custom renderer for the list of `changeType` changes (not including the change type header)
@@ -159,7 +162,7 @@ export interface ChangelogRenderers {
    *   - Boring change (user2@microsoft.com)
    * ```
    */
-  renderEntries?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderEntries?: (changeType: ChangeType, renderInfo: PackageChangelogRenderInfo) => string | Promise<string>;
 
   /**
    * Custom renderer for an individual change entry.
@@ -169,5 +172,5 @@ export interface ChangelogRenderers {
    * - Really interesting change (user1@microsoft.com)
    * ```
    */
-  renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => Promise<string>;
+  renderEntry?: (entry: ChangelogEntry, renderInfo: PackageChangelogRenderInfo) => string | Promise<string>;
 }


### PR DESCRIPTION
Previously the render functions in `ChangelogOptions` could only return a promise. There's no reason they can't be synchronous, so update the types to allow either one.