### PR TITLE
Fix issues flagged by lint rules

### DIFF
--- a/change/beachball-e300f8e4-e881-44c4-b266-4150412232fe.json
+++ b/change/beachball-e300f8e4-e881-44c4-b266-4150412232fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix issues found by lint rules",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -10,6 +10,7 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
 import type { Repository } from '../__fixtures__/repository';
 import { getDefaultOptions } from '../options/getDefaultOptions';
+import type { PackageJson } from '../types/PackageInfo';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -277,7 +278,7 @@ describe('version bumping', () => {
 
   it('should not bump out-of-scope package even if package has change', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
-    const monorepo = repositoryFactory.fixture.folders!;
+    const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
     const options = getOptions({
@@ -299,7 +300,7 @@ describe('version bumping', () => {
 
   it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
-    const monorepo = repositoryFactory.fixture.folders!;
+    const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
     const options = getOptions({
@@ -622,7 +623,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect(fs.readJSONSync(jsonPath).version).toBe('1.0.0');
+          expect((fs.readJSONSync(jsonPath) as PackageJson).version).toBe('1.0.0');
         }),
       },
     });
@@ -652,7 +653,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect((await fs.readJSON(jsonPath)).version).toBe('1.0.0');
+          expect(((await fs.readJSON(jsonPath)) as PackageJson).version).toBe('1.0.0');
         }),
       },
     });
@@ -677,7 +678,7 @@ describe('version bumping', () => {
       path: repo.rootPath,
       bumpDeps: false,
       hooks: {
-        prebump: async (_packagePath, _name, _version): Promise<void> => {
+        prebump: (): Promise<void> => {
           throw new Error('Foo');
         },
       },
@@ -708,7 +709,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect(fs.readJSONSync(jsonPath).version).toBe('1.1.0');
+          expect((fs.readJSONSync(jsonPath) as PackageJson).version).toBe('1.1.0');
         }),
       },
     });
@@ -738,7 +739,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect((await fs.readJSON(jsonPath)).version).toBe('1.1.0');
+          expect(((await fs.readJSON(jsonPath)) as PackageJson).version).toBe('1.1.0');
         }),
       },
     });
@@ -762,7 +763,7 @@ describe('version bumping', () => {
     const options = getOptions({
       bumpDeps: false,
       hooks: {
-        postbump: async (_packagePath, _name, _version): Promise<void> => {
+        postbump: (): Promise<void> => {
           throw new Error('Foo');
         },
       },

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -12,6 +12,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { ChangeFileInfo } from '../types/ChangeInfo';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { getDefaultOptions } from '../options/getDefaultOptions';
+import type { PackageJson } from '../types/PackageInfo';
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory;
@@ -61,7 +62,7 @@ describe('publish command (git)', () => {
 
     const newRepo = repositoryFactory.cloneRepository();
 
-    const packageJson = fs.readJSONSync(newRepo.pathTo('package.json'));
+    const packageJson = fs.readJSONSync(newRepo.pathTo('package.json')) as PackageJson;
 
     expect(packageJson.version).toBe('1.1.0');
   });
@@ -91,7 +92,7 @@ describe('publish command (git)', () => {
     const newRepo = repositoryFactory.cloneRepository();
     const changeFiles = getChangeFiles({ ...options1, path: newRepo.rootPath });
     expect(changeFiles).toHaveLength(1);
-    const changeFileContent: ChangeFileInfo = fs.readJSONSync(changeFiles[0]);
+    const changeFileContent = fs.readJSONSync(changeFiles[0]) as ChangeFileInfo;
     expect(changeFileContent.packageName).toBe('foo2');
   });
 });

--- a/src/__fixtures__/changelog.ts
+++ b/src/__fixtures__/changelog.ts
@@ -38,7 +38,7 @@ export function readChangelogJson(packagePath: string, filename?: string, noClea
     return null;
   }
 
-  const changelog: ChangelogJson = fs.readJSONSync(changelogJsonFile, { encoding: 'utf-8' });
+  const changelog = fs.readJSONSync(changelogJsonFile, { encoding: 'utf-8' }) as ChangelogJson;
   if (noClean) {
     return changelog;
   }
@@ -50,7 +50,7 @@ export function readChangelogJson(packagePath: string, filename?: string, noClea
     }
 
     for (const comments of Object.values(entry.comments)) {
-      for (const comment of comments!) {
+      for (const comment of comments) {
         if (comment.commit) {
           comment.commit = fakeCommit;
         }

--- a/src/__fixtures__/gitDefaults.ts
+++ b/src/__fixtures__/gitDefaults.ts
@@ -9,7 +9,7 @@ export const defaultRemoteBranchName = 'origin/master';
  * users have configured a different default branch name.
  * @param isRemoteRepo Whether this is the bare repo used as the remote
  */
-export function setDefaultBranchName(cwd: string, isRemoteRepo?: boolean) {
+export function setDefaultBranchName(cwd: string, isRemoteRepo?: boolean): void {
   if (isRemoteRepo) {
     // Change the name of the default branch on the repo used for the remote
     // (for clones, this is unnecessary and can cause problems)
@@ -26,6 +26,6 @@ export function setDefaultBranchName(cwd: string, isRemoteRepo?: boolean) {
  * (This should NOT be used to make full snapshots of git logs, or as the primary means of testing.
  * But it can be useful for allowing backup checks for absence of strings like "warning" or "fatal".)
  */
-export function optsWithLang(opts?: Parameters<typeof git>[1]) {
+export function optsWithLang(opts?: Parameters<typeof git>[1]): Parameters<typeof git>[1] {
   return { ...opts, env: { ...opts?.env, LANG: 'en_US.UTF-8' } };
 }

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -38,8 +38,8 @@ export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
 
   const logs: MockLogs = {
     mocks: {} as MockLogs['mocks'],
-    setOverrideOptions: options => {
-      overrideOptions = options;
+    setOverrideOptions: opt => {
+      overrideOptions = opt;
     },
     clear: () => {
       allLines = [];

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jes
 import fs from 'fs-extra';
 import { NpmResult, npm } from '../packageManager/npm';
 import { PackageJson } from '../types/PackageInfo';
-import { initNpmMock, _makeRegistryData, _mockNpmPublish, _mockNpmShow } from './mockNpm';
+import { initNpmMock, _makeRegistryData, _mockNpmPublish, _mockNpmShow, type MockNpmResult } from './mockNpm';
 
 jest.mock('fs-extra');
 jest.mock('../packageManager/npm');
@@ -338,16 +338,16 @@ describe('mockNpm', () => {
   });
 
   it('respects mocked command', async () => {
-    const mockShow = jest.fn(() => 'hi');
-    npmMock.setCommandOverride('show', mockShow as any);
+    const mockShow = jest.fn(() => Promise.resolve('hi' as unknown as MockNpmResult));
+    npmMock.setCommandOverride('show', mockShow);
     const result = await npm(['show', 'foo'], { cwd: undefined });
     expect(result).toEqual('hi');
     expect(mockShow).toHaveBeenCalledWith(expect.any(Object), ['foo'], { cwd: undefined });
   });
 
   it("respects extra mocked command that's not normally supported", async () => {
-    const mockPack = jest.fn(() => 'hi');
-    npmMock.setCommandOverride('pack', mockPack as any);
+    const mockPack = jest.fn(() => Promise.resolve('hi' as unknown as MockNpmResult));
+    npmMock.setCommandOverride('pack', mockPack);
     const result = await npm(['pack'], { cwd: undefined });
     expect(result).toEqual('hi');
     expect(mockPack).toHaveBeenCalledWith(expect.any(Object), [], { cwd: undefined });

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -6,6 +6,7 @@ import semver from 'semver';
 import { NpmShowResult } from '../packageManager/listPackageVersions';
 import { npm, NpmResult } from '../packageManager/npm';
 import { PackageJson } from '../types/PackageInfo';
+import type { PackageManagerOptions } from '../packageManager/packageManager';
 
 /** Published versions and dist-tags for a package */
 type NpmPackageVersionsData = Pick<NpmShowResult, 'versions' | 'dist-tags'>;
@@ -21,17 +22,19 @@ type MockNpmRegistry = Record<string, MockNpmRegistryPackage>;
 /** Mapping from package name to partial registry data (easier to specify in tests) */
 type PartialRegistryData = Record<string, Partial<NpmPackageVersionsData>>;
 
+export type MockNpmResult = Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'success' | 'failed'>;
+
 /**
  * Mock implementation of an npm command.
  * @param registryData Fake registry data to operate on
  * @param args Command line args, *excluding* the command name
  * @param opts Command line options, notably `cwd` for publish
  */
-type MockNpmCommand = (
+export type MockNpmCommand = (
   registryData: MockNpmRegistry,
   args: string[],
-  opts: Parameters<typeof npm>[1]
-) => Promise<Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'success' | 'failed'>>;
+  opts: PackageManagerOptions
+) => Promise<MockNpmResult>;
 
 export type NpmMock = {
   /**
@@ -187,11 +190,7 @@ export const _mockNpmShow: MockNpmCommand = async (registryData, args) => {
 };
 
 /** (exported for testing) Mock npm publish to the registry data */
-export const _mockNpmPublish: MockNpmCommand = async (
-  registryData,
-  args: string[],
-  opts: Parameters<typeof npm>[1]
-) => {
+export const _mockNpmPublish: MockNpmCommand = async (registryData, args, opts) => {
   if (!opts?.cwd) {
     throw new Error('cwd is required for mock npm publish');
   }

--- a/src/__fixtures__/mockStdin.ts
+++ b/src/__fixtures__/mockStdin.ts
@@ -1,5 +1,5 @@
 import stream from 'stream';
-import readline from 'readline';
+import type readline from 'readline';
 
 /**
  * Mock stdin stream. This is a modernized version of https://www.npmjs.com/package/mock-stdin
@@ -15,14 +15,21 @@ export class MockStdin extends stream.Readable {
     emittedData: false,
     lastOutput: null,
   };
-  // @ts-expect-error private property of parent class
-  private _readableState: { length: number; ended: boolean; endEmitted: boolean; buffer: any[] };
+  // This is a private property of the parent class. As of TS ES2022 output, it's necessary to use
+  // `declare` to prevent TS from emitting an unset property which overwrites the one from the parent.
+  protected declare _readableState?: {
+    length: number;
+    ended: boolean;
+    endEmitted: boolean;
+    // this is some object with a length (probably string or buffer)
+    buffer: Array<{ length: number }>;
+  };
 
   constructor(private restoreTarget?: stream.Stream) {
     super({ highWaterMark: 0 });
   }
 
-  emit(event: string, ...args: any[]): boolean {
+  emit(event: string, ...args: unknown[]): boolean {
     if (event === 'data') {
       this._flags.emittedData = true;
       this._flags.lastOutput = null;
@@ -34,7 +41,7 @@ export class MockStdin extends stream.Readable {
    * Emit a keypress event as defined by `readline`
    * https://nodejs.org/api/readline.html#rlwritedata-key
    */
-  emitKey(key: readline.Key) {
+  emitKey(key: readline.Key): boolean {
     return this.emit('keypress', null, key);
   }
 
@@ -42,7 +49,7 @@ export class MockStdin extends stream.Readable {
    * Send text in a way that's presumably intended to simulate real `process.stdin` input
    * (this approach is copied from `mock-stdin`).
    */
-  send(text: string[] | Buffer | string | null, encoding?: BufferEncoding) {
+  send(text: string[] | Buffer | string | null, encoding?: BufferEncoding): MockStdin {
     if (Array.isArray(text)) {
       if (encoding) {
         throw new TypeError('Cannot invoke MockStdin#send(): `encoding` specified while text specified as an array.');
@@ -52,7 +59,7 @@ export class MockStdin extends stream.Readable {
     if (Buffer.isBuffer(text) || typeof text === 'string' || text === null) {
       this._mockData.push(new MockData(text, encoding));
       this._read();
-      if (!this._flags.emittedData && this._readableState.length) {
+      if (!this._flags.emittedData && this._readableState?.length) {
         this.drainData();
       }
       if (text === null) {
@@ -66,7 +73,7 @@ export class MockStdin extends stream.Readable {
   /**
    * Send `text` character by character (with `process.nextTick` in between) to simulate typing.
    */
-  async sendByChar(text: string) {
+  async sendByChar(text: string): Promise<MockStdin> {
     await new Promise(resolve => process.nextTick(resolve));
     for (const char of text) {
       this.send(char);
@@ -75,12 +82,12 @@ export class MockStdin extends stream.Readable {
     return this;
   }
 
-  end() {
+  end(): MockStdin {
     this.send(null);
     return this;
   }
 
-  restore() {
+  restore(): MockStdin {
     if (this.restoreTarget) {
       Object.defineProperty(process, 'stdin', {
         value: this.restoreTarget,
@@ -91,16 +98,18 @@ export class MockStdin extends stream.Readable {
     return this;
   }
 
-  reset(removeListeners: boolean) {
-    this._readableState.ended = false;
-    this._readableState.endEmitted = false;
+  reset(removeListeners: boolean): MockStdin {
+    if (this._readableState) {
+      this._readableState.ended = false;
+      this._readableState.endEmitted = false;
+    }
     if (removeListeners) {
       this.removeAllListeners();
     }
     return this;
   }
 
-  _read(size: number = Infinity) {
+  _read(size: number = Infinity): void {
     let count = 0;
     let read = true;
     while (read && this._mockData.length && count < size) {
@@ -122,13 +131,13 @@ export class MockStdin extends stream.Readable {
     }
   }
 
-  setRawMode() {
+  setRawMode(): MockStdin {
     return this;
   }
 
   private endReadable() {
     // Synchronously emit an end event, if possible.
-    if (!this._readableState.length) {
+    if (this._readableState && !this._readableState.length) {
       this._readableState.ended = true;
       this._readableState.endEmitted = true;
       this.readable = false;
@@ -138,7 +147,7 @@ export class MockStdin extends stream.Readable {
 
   private drainData() {
     const state = this._readableState;
-    while (state.buffer.length) {
+    while (state?.buffer.length) {
       const chunk = state.buffer.shift();
       if (chunk !== null && chunk !== undefined) {
         state.length -= chunk.length;
@@ -181,7 +190,7 @@ class MockData {
   }
 }
 
-export function mockProcessStdin() {
+export function mockProcessStdin(): MockStdin {
   const mock = new MockStdin(process.stdin);
   Object.defineProperty(process, 'stdin', {
     value: mock,

--- a/src/__fixtures__/mockStdout.ts
+++ b/src/__fixtures__/mockStdout.ts
@@ -34,23 +34,23 @@ export class MockStdout extends stream.Writable {
   }
 
   /** Gets non-empty output chunks that have been written to the stream, joined with newlines */
-  getOutput() {
+  getOutput(): string {
     return this.chunks.join('\n');
   }
 
   /** Gets the last non-empty output chunk written to the stream */
-  lastOutput() {
+  lastOutput(): string {
     return this.chunks.slice(-1)[0];
   }
 
   /** Clears the record of output to the stream */
-  clearOutput() {
+  clearOutput(): void {
     this.chunks = [];
   }
 
-  _write(chunk: any, encoding: string, callback: (error?: Error | null) => void) {
+  _write(chunk: unknown, encoding: string, callback: (error?: Error | null) => void): void {
     // Trim each line so that if it's used in a snapshot, there won't be trailing whitespace issues
-    let text = stripAnsi(chunk.toString())
+    let text = stripAnsi(String(chunk))
       .split('\n')
       .map(line => line.trimEnd())
       .join('\n')

--- a/src/__fixtures__/npmShow.ts
+++ b/src/__fixtures__/npmShow.ts
@@ -24,5 +24,5 @@ export async function npmShow(
   expect(!!showResult.timedOut).toBe(false);
   expect(showResult.failed).toBe(!!shouldFail);
 
-  return shouldFail ? undefined : JSON.parse(showResult.stdout);
+  return shouldFail ? undefined : (JSON.parse(showResult.stdout) as NpmShowResult);
 }

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -24,7 +24,7 @@ export type PackageJsonFixture = Omit<PackageJson, 'name'> & {
   /** Name is inferred from the package folder name by default */
   name?: string;
   /** Allow arbitrary keys */
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type RepoFixture = {
@@ -199,7 +199,7 @@ export class RepositoryFactory {
     // Create the fixture files and save the full fixture objects.
     // The files are committed all together at the end to speed things up.
     this.fixtures = {};
-    for (let [parentFolder, fixture] of Object.entries(initialFixtures)) {
+    for (const [parentFolder, fixture] of Object.entries(initialFixtures)) {
       if (!fixture.folders && !fixture.rootPackage) {
         throw new Error('`fixtures` must define `rootPackage` and/or `folders`');
       }
@@ -259,7 +259,7 @@ export class RepositoryFactory {
    * Doing this in CI is unnecessary because all the fixtures use unique temp directories (no collisions)
    * and the agents are wiped after each job, so manually deleting the files just slows things down.
    */
-  cleanUp() {
+  cleanUp(): void {
     if (!this.root) return;
 
     try {
@@ -269,7 +269,7 @@ export class RepositoryFactory {
       }
     } catch (err) {
       // This is non-fatal since the temp dir will eventually be cleaned up automatically
-      console.warn('Could not clean up factory: ' + err);
+      console.warn(`Could not clean up factory: ${err}`);
     }
     this.root = undefined;
     for (const repo of this.childRepos) {

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -28,7 +28,7 @@ export function tmpdir(options?: tmp.DirOptions): string {
 }
 
 /** Remove the temp directory, ignoring errors */
-export function removeTempDir(dir: string) {
+export function removeTempDir(dir: string): void {
   try {
     fs.rmSync(dir, { force: true });
   } catch {

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -137,7 +137,7 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('runs transform.changeFiles functions if provided', async () => {
+  it('runs transform.changeFiles functions if provided', () => {
     const editedComment: string = 'Edited comment for testing';
     repo = sharedMonoRepo;
 

--- a/src/__functional__/changefile/writeChangeFiles.test.ts
+++ b/src/__functional__/changefile/writeChangeFiles.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 
-import { ChangeFileInfo } from '../../types/ChangeInfo';
+import type { ChangeFileInfo, ChangeInfoMultiple } from '../../types/ChangeInfo';
 import { writeChangeFiles } from '../../changefile/writeChangeFiles';
 import { getChangeFiles } from '../../__fixtures__/changeFiles';
 import { listAllTrackedFiles } from 'workspace-tools';
@@ -71,7 +71,7 @@ describe('writeChangeFiles', () => {
     expect(repo.getCurrentHash()).not.toEqual(previousHead);
 
     // also verify contents of one file
-    const changeFileContents = fs.readJSONSync(changeFiles[0]);
+    const changeFileContents = fs.readJSONSync(changeFiles[0]) as ChangeFileInfo;
     expect(changeFileContents).toEqual({ packageName: 'bar' });
   });
 
@@ -128,7 +128,7 @@ describe('writeChangeFiles', () => {
     const trackedFiles = listAllTrackedFiles(['change/*'], repo.rootPath);
     expect(cleanChangeFilePaths(repo.rootPath, trackedFiles)).toEqual(expectedFile);
 
-    const changeFileContents = fs.readJSONSync(changeFiles[0]);
+    const changeFileContents = fs.readJSONSync(changeFiles[0]) as ChangeInfoMultiple;
     expect(changeFileContents).toEqual({
       changes: [{ packageName: 'foo' }, { packageName: 'bar' }],
     });

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -153,7 +153,7 @@ describe('writeChangelog', () => {
     expect(new Set(commits).size).toEqual(minorComments.length);
 
     // The first entry should be the newest
-    expect(minorComments[0].commit).toBe(repo!.getCurrentHash());
+    expect(minorComments[0].commit).toBe(repo.getCurrentHash());
   });
 
   it('generates changelog with custom changeDir', async () => {

--- a/src/__functional__/git/ensureSharedHistory.test.ts
+++ b/src/__functional__/git/ensureSharedHistory.test.ts
@@ -7,7 +7,7 @@ import { defaultBranchName, defaultRemoteBranchName, optsWithLang } from '../../
 
 // required for `jest.spyOn('workspace-tools', git)` to work
 jest.mock('workspace-tools', () => {
-  const original = jest.requireActual('workspace-tools') as typeof workspaceTools;
+  const original = jest.requireActual<typeof workspaceTools>('workspace-tools');
   return {
     ...original,
     git: jest.fn(original.git),
@@ -19,13 +19,13 @@ describe('ensureSharedHistory', () => {
   const logs = initMockLogs();
   const testBranch = 'test';
 
-  const realGit = (jest.requireActual('workspace-tools') as typeof workspaceTools).git;
+  const realGit = jest.requireActual<typeof workspaceTools>('workspace-tools').git;
   /**
    * Set this to override the git implementation for one test.
    * (Use this instead of `.mockImplementation()` to avoid interference with other mocks.)
    */
   let gitOverride: typeof workspaceTools.git | undefined;
-  let gitSpy = jest
+  const gitSpy = jest
     .spyOn(workspaceTools, 'git')
     // Attempt to force git to use English in logs, so we can check for absence of "warning" strings
     .mockImplementation((args, opts) => (gitOverride || realGit)(args, optsWithLang(opts)));
@@ -162,7 +162,8 @@ describe('ensureSharedHistory', () => {
     gitSpy.mockClear();
 
     // this simulates a network error or something
-    gitOverride = (...args) => (args[0][0] === 'fetch' ? ({ success: false } as any) : realGit(...args));
+    gitOverride = (...args) =>
+      args[0][0] === 'fetch' ? ({ success: false } as workspaceTools.GitProcessOutput) : realGit(...args);
 
     expect(() =>
       ensureSharedHistory({ path: repo.rootPath, verbose: true, branch: defaultRemoteBranchName, fetch: true })

--- a/src/__functional__/git/fetch.test.ts
+++ b/src/__functional__/git/fetch.test.ts
@@ -9,7 +9,7 @@ import { GitProcessOutput } from 'workspace-tools';
 
 // required for `jest.spyOn('workspace-tools', git)` to work
 jest.mock('workspace-tools', () => {
-  const original = jest.requireActual('workspace-tools') as typeof workspaceTools;
+  const original = jest.requireActual<typeof workspaceTools>('workspace-tools');
   return {
     ...original,
     git: jest.fn(original.git),
@@ -27,13 +27,13 @@ describe('gitFetch', () => {
   /** To speed things up, some tests only check the arguments and skip the git operation */
   const noOpSuccess = () => ({ success: true, stdout: '', stderr: '', status: 0 } as GitProcessOutput);
 
-  const realGit = (jest.requireActual('workspace-tools') as typeof workspaceTools).git;
+  const realGit = jest.requireActual<typeof workspaceTools>('workspace-tools').git;
   /**
    * Set this to override the git implementation for one test.
    * (Use this instead of `.mockImplementation()` to avoid interference with other mocks.)
    */
   let gitOverride: typeof realGit | undefined;
-  let gitSpy = jest.spyOn(workspaceTools, 'git').mockImplementation((...args) => (gitOverride || realGit)(...args));
+  const gitSpy = jest.spyOn(workspaceTools, 'git').mockImplementation((...args) => (gitOverride || realGit)(...args));
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory('single');

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -4,9 +4,10 @@ import { gitFailFast } from 'workspace-tools';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { tmpdir } from '../../__fixtures__/tmpdir';
 import { getPackageInfos } from '../../monorepo/getPackageInfos';
-import { PackageInfos } from '../../types/PackageInfo';
+import type { PackageInfos, PackageInfo } from '../../types/PackageInfo';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
+import type { PackageOptions } from '../../types/BeachballOptions';
 
 const defaultOptions = getDefaultOptions();
 
@@ -28,15 +29,15 @@ function cleanPackageInfos(root: string, packageInfos: PackageInfos) {
 
     // Remove beachball options which are defaulted
     for (const [key, value] of Object.entries(pkgInfo.combinedOptions)) {
-      if (value === (defaultOptions as any)[key]) {
-        delete (pkgInfo.combinedOptions as any)[key];
+      if (value === defaultOptions[key as keyof PackageOptions]) {
+        delete pkgInfo.combinedOptions[key as keyof PackageOptions];
       }
     }
 
     // Remove options set to undefined or empty object (keep null because it may be meaningful/interesting)
     for (const [key, value] of Object.entries(pkgInfo)) {
       if (value === undefined || (value && typeof value === 'object' && !Object.keys(value).length)) {
-        delete (pkgInfo as any)[key];
+        delete pkgInfo[key as keyof PackageInfo];
       }
     }
   }

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -9,6 +9,7 @@ import * as npmModule from '../../packageManager/npm';
 import { packagePublish } from '../../packageManager/packagePublish';
 import { PackageInfo } from '../../types/PackageInfo';
 import { npm, NpmResult } from '../../packageManager/npm';
+import type { PackageOptions } from '../../types/BeachballOptions';
 
 const testTag = 'testbeachballtag';
 const testName = 'testbeachballpackage';
@@ -51,7 +52,7 @@ describe('packagePublish', () => {
         defaultNpmTag: 'latest',
         disallowedChangeTypes: [],
       },
-      packageOptions: {} as any,
+      packageOptions: {} as PackageOptions,
     };
   }
 

--- a/src/__tests__/changefile/getQuestionsForPackage.test.ts
+++ b/src/__tests__/changefile/getQuestionsForPackage.test.ts
@@ -4,6 +4,7 @@ import { getQuestionsForPackage } from '../../changefile/getQuestionsForPackage'
 import { ChangeFilePromptOptions } from '../../types/ChangeFilePrompt';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import type { ChangeType } from '../../types/ChangeInfo';
 
 /**
  * This covers the first part of `promptForChange`: determining what questions to ask for each package.
@@ -75,7 +76,7 @@ describe('getQuestionsForPackage', () => {
       ...defaultQuestionsParams,
       packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
     });
-    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['patch', 'minor', 'none']);
   });
 
@@ -84,7 +85,7 @@ describe('getQuestionsForPackage', () => {
       ...defaultQuestionsParams,
       packageInfos: makePackageInfos({ [pkg]: { version: '1.0.0-beta.1' } }),
     });
-    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['prerelease', 'patch', 'minor', 'none', 'major']);
   });
 
@@ -96,7 +97,7 @@ describe('getQuestionsForPackage', () => {
         [pkg]: { version: '1.0.0-beta.1', combinedOptions: { disallowedChangeTypes: ['prerelease'] } },
       }),
     });
-    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value);
+    const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['patch', 'minor', 'none', 'major']);
   });
 

--- a/src/__tests__/changefile/promptForChange.test.ts
+++ b/src/__tests__/changefile/promptForChange.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import prompts from 'prompts';
-import {
-  promptForChange,
-  _getChangeFileInfoFromResponse,
-  _promptForPackageChange,
-} from '../../changefile/promptForChange';
+import { promptForChange } from '../../changefile/promptForChange';
 import { ChangeFilePromptOptions } from '../../types/ChangeFilePrompt';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { MockStdin } from '../../__fixtures__/mockStdin';
@@ -16,7 +12,7 @@ import { makePackageInfos } from '../../__fixtures__/packageInfos';
 let stdin: MockStdin;
 let stdout: MockStdout;
 jest.mock('prompts', () => {
-  const realPrompts = jest.requireActual('prompts') as typeof prompts;
+  const realPrompts = jest.requireActual<typeof prompts>('prompts');
 
   return ((questions, options) => {
     const questionsArr = Array.isArray(questions) ? questions : [questions];

--- a/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
+++ b/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
-import { _getChangeFileInfoFromResponse } from '../../changefile/promptForChange';
+import { _getChangeFileInfoFromResponse, type ChangePromptResponse } from '../../changefile/promptForChange';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
+import type { ChangeType } from '../../types/ChangeInfo';
 
 /**
  * This covers the last part of `promptForChange`: translating the user's responses into a `ChangeFileInfo`.
@@ -95,7 +96,10 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
   });
 
   it('returns error if response.type is invalid', () => {
-    const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { type: 'invalid' as any } });
+    const change = _getChangeFileInfoFromResponse({
+      ...defaultParams,
+      response: { type: 'invalid' as unknown as ChangeType },
+    });
     expect(change).toBeUndefined();
     expect(logs.mocks.error).toHaveBeenCalledTimes(1);
     expect(logs.mocks.error).toHaveBeenCalledWith('Prompt response contains invalid change type "invalid"');
@@ -105,7 +109,7 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
   it('preserves extra properties on the returned object', () => {
     const change = _getChangeFileInfoFromResponse({
       ...defaultParams,
-      response: { comment, type: 'patch', extra: 'extra' } as any,
+      response: { comment, type: 'patch', extra: 'extra' } as unknown as ChangePromptResponse,
     });
     expect(change).toMatchObject({ extra: 'extra' });
   });

--- a/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
+++ b/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
@@ -12,7 +12,7 @@ import { getQuestionsForPackage } from '../../changefile/getQuestionsForPackage'
 let stdin: MockStdin;
 let stdout: MockStdout;
 jest.mock('prompts', () => {
-  const realPrompts = jest.requireActual('prompts') as typeof prompts;
+  const realPrompts = jest.requireActual<typeof prompts>('prompts');
 
   return ((questions, options) => {
     const questionsArr = Array.isArray(questions) ? questions : [questions];

--- a/src/__tests__/changelog/renderChangelog.test.ts
+++ b/src/__tests__/changelog/renderChangelog.test.ts
@@ -7,7 +7,7 @@ import {
   _trimPreviousLog,
   trimmedVersionsNote,
 } from '../../changelog/renderChangelog';
-import { ChangelogEntry, PackageChangelog } from '../../types/ChangeLog';
+import type { ChangelogEntry, PackageChangelog, ChangelogJson } from '../../types/ChangeLog';
 
 /** Make a changelog string with a header and basic content for each version */
 function changelogFromVersions(versions: string[]): string {
@@ -45,7 +45,7 @@ describe('renderChangelog', () => {
         },
       },
       previousContent: [previousHeader, markerComment, previousVersion].join('\n\n'),
-      previousJson: {} as any,
+      previousJson: {} as ChangelogJson,
       changelogOptions: {},
     };
   }

--- a/src/__tests__/changelog/renderPackageChangelog.test.ts
+++ b/src/__tests__/changelog/renderPackageChangelog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { PackageChangelogRenderInfo } from '../../types/ChangelogOptions';
 import { defaultRenderers, renderPackageChangelog } from '../../changelog/renderPackageChangelog';
-import { ChangelogEntry } from '../../types/ChangeLog';
+import type { ChangelogEntry, ChangelogJson } from '../../types/ChangeLog';
 import { SortedChangeTypes } from '../../changefile/changeTypes';
 
 const { renderEntry, renderEntries, renderChangeTypeHeader, renderChangeTypeSection, renderHeader } = defaultRenderers;
@@ -30,7 +30,7 @@ describe('changelog renderers -', () => {
           ],
         },
       },
-      previousJson: {} as any,
+      previousJson: {} as ChangelogJson,
       renderers: { ...defaultRenderers }, // copy in case of modification
     };
   }

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -151,7 +151,7 @@ describe('getPackageGraph', () => {
   });
 
   it('throws if package info is missing', async () => {
-    const packageInfos = {} as any as PackageInfos;
+    const packageInfos = {} as PackageInfos;
 
     await expect(async () => {
       await getPackageGraphPackageNames(['foo', 'bar'], packageInfos);

--- a/src/__tests__/packageManager/npmArgs.test.ts
+++ b/src/__tests__/packageManager/npmArgs.test.ts
@@ -19,8 +19,8 @@ describe('getNpmAuthArgs', () => {
     { token, authType: 'authtoken', expected: '--//testRegistry:_authToken=someToken' },
     { token, authType: 'password', expected: '--//testRegistry:_password=someToken' },
     { token, authType: 'invalidvalue' as AuthType, expected: '--//testRegistry:_authToken=someToken' },
-  ])('token = $token, authType = $authType', ({ token, authType, expected }) => {
-    expect(getNpmAuthArgs(registry, token, authType).join(' ')).toStrictEqual(expected);
+  ])('token = $token, authType = $authType', ({ token: tkn, authType, expected }) => {
+    expect(getNpmAuthArgs(registry, tkn, authType).join(' ')).toStrictEqual(expected);
   });
 });
 

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import _ from 'lodash';
 import { _clearPackageVersionsCache } from '../../packageManager/listPackageVersions';
 import { getNewPackages } from '../../publish/getNewPackages';
 import { NpmOptions } from '../../types/NpmOptions';

--- a/src/__tests__/publish/performPublishOverrides.test.ts
+++ b/src/__tests__/publish/performPublishOverrides.test.ts
@@ -48,7 +48,7 @@ describe('performPublishOverrides', () => {
           return _.cloneDeep(packageJsons[pkg.name]);
         }
       }
-      throw new Error('not found: ' + path);
+      throw new Error(`not found: ${path as string}`);
     });
 
     return { packageInfos, packageJsons };

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -79,7 +79,7 @@ describe('tagPackages', () => {
     expect(gitFailFast).toHaveBeenCalledTimes(1);
 
     // verify git is being called to create new auto tag for foo and bar
-    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos!['foo'].version);
+    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos['foo'].version);
     expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters(newFooTag, ''));
   });
 
@@ -91,7 +91,7 @@ describe('tagPackages', () => {
     expect(gitFailFast).toHaveBeenCalledTimes(1);
 
     // verify git is being called to create new auto tag for foo
-    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos!['foo'].version);
+    const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos['foo'].version);
     expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters(newFooTag, ''));
   });
 

--- a/src/__tests__/publish/toposortPackages.test.ts
+++ b/src/__tests__/publish/toposortPackages.test.ts
@@ -55,7 +55,7 @@ describe('toposortPackages', () => {
   });
 
   it('throws if package info is missing', () => {
-    const packageInfos = {} as any as PackageInfos;
+    const packageInfos = {} as PackageInfos;
 
     expect(() => {
       toposortPackages(['foo'], packageInfos);

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -23,9 +23,7 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions): void
 
   // pass 2: initialize grouped calculatedChangeTypes together
   for (const { change: changeInfo } of changeFileChangeInfos) {
-    const group = Object.values(bumpInfo.packageGroups).find(group =>
-      group.packageNames.includes(changeInfo.packageName)
-    );
+    const group = Object.values(bumpInfo.packageGroups).find(g => g.packageNames.includes(changeInfo.packageName));
 
     if (group) {
       for (const packageNameInGroup of group.packageNames) {

--- a/src/bump/updatePackageJsons.ts
+++ b/src/bump/updatePackageJsons.ts
@@ -12,7 +12,7 @@ export function updatePackageJsons(modifiedPackages: Set<string>, packageInfos: 
       console.warn(`Skipping ${pkgName} since package.json does not exist`);
       continue;
     }
-    const packageJson: PackageJson = fs.readJSONSync(info.packageJsonPath);
+    const packageJson = fs.readJSONSync(info.packageJsonPath) as PackageJson;
 
     if (!info.private) {
       packageJson.version = info.version;

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -87,7 +87,7 @@ export function updateRelatedChangeType(params: {
       //       - the main concern is how to capture the bump reason in grouped changelog
 
       // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
-      const group = Object.values(packageGroups).find(group => group.packageNames.includes(packageInfo.name));
+      const group = Object.values(packageGroups).find(g => g.packageNames.includes(packageInfo.name));
 
       if (group) {
         for (const packageNameInGroup of group.packageNames) {

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -9,7 +9,7 @@ import { BeachballOptions } from '../types/BeachballOptions';
 import { PackageInfos, PackageInfo } from '../types/PackageInfo';
 import { ensureSharedHistory } from '../git/ensureSharedHistory';
 
-const count = (count: number, str: string) => `${count} ${str}${count === 1 ? '' : 's'}`;
+const count = (n: number, str: string) => `${n} ${str}${n === 1 ? '' : 's'}`;
 
 function getMatchingPackageInfo(
   file: string,
@@ -108,13 +108,14 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
   }
   for (const moddedFile of nonIgnoredChanges) {
     const packageInfo = getMatchingPackageInfo(moddedFile, cwd, packageInfosByPath);
+    if (!packageInfo) continue;
 
     const { isIncluded, reason } = isPackageIncluded(packageInfo, scopedPackages);
 
     if (!isIncluded) {
       logIgnored(moddedFile, reason);
     } else {
-      includedPackages.add(packageInfo!.name);
+      includedPackages.add(packageInfo.name);
       fileCount++;
       logIncluded(moddedFile);
     }
@@ -130,7 +131,7 @@ function getAllChangedPackages(options: BeachballOptions, packageInfos: PackageI
 /**
  * Gets all the changed packages which do not already have a change file
  */
-export function getChangedPackages(options: BeachballOptions, packageInfos: PackageInfos) {
+export function getChangedPackages(options: BeachballOptions, packageInfos: PackageInfos): string[] {
   const { path: cwd, branch, changeDir } = options;
 
   const changePath = getChangePath(options);
@@ -154,7 +155,7 @@ export function getChangedPackages(options: BeachballOptions, packageInfos: Pack
   // Loop through the change files, building up a set of packages that we can skip
   for (const file of changeFiles) {
     try {
-      const changeInfo: ChangeFileInfo | ChangeInfoMultiple = fs.readJSONSync(path.join(cwd, file));
+      const changeInfo = fs.readJSONSync(path.join(cwd, file)) as ChangeFileInfo | ChangeInfoMultiple;
       const changes = (changeInfo as ChangeInfoMultiple).changes || [changeInfo];
 
       for (const change of changes) {

--- a/src/changefile/getQuestionsForPackage.ts
+++ b/src/changefile/getQuestionsForPackage.ts
@@ -26,7 +26,7 @@ export function getQuestionsForPackage(params: {
   }
 
   const defaultPrompt: DefaultPrompt = {
-    changeType: !options.type && changeTypePrompt.choices!.length > 1 ? changeTypePrompt : undefined,
+    changeType: !options.type && changeTypePrompt.choices.length > 1 ? changeTypePrompt : undefined,
     description: !options.message ? getDescriptionPrompt(recentMessages) : undefined,
   };
 
@@ -41,13 +41,13 @@ function getChangeTypePrompt(params: {
   packageInfos: PackageInfos;
   packageGroups: PackageGroups;
   options: Pick<BeachballOptions, 'type'>;
-}): prompts.PromptObject<string> | undefined {
+}): (prompts.PromptObject & Required<Pick<prompts.PromptObject, 'choices'>>) | undefined {
   const { pkg, packageInfos, packageGroups, options } = params;
   const packageInfo = packageInfos[pkg];
 
   const disallowedChangeTypes = getDisallowedChangeTypes(pkg, packageInfos, packageGroups) || [];
 
-  if (options.type && disallowedChangeTypes.includes(options.type as ChangeType)) {
+  if (options.type && disallowedChangeTypes.includes(options.type)) {
     console.error(`Change type "${options.type}" is not allowed for package "${pkg}"`);
     return;
   }
@@ -77,7 +77,7 @@ function getChangeTypePrompt(params: {
   };
 }
 
-function getDescriptionPrompt(recentMessages: string[]): prompts.PromptObject<string> {
+function getDescriptionPrompt(recentMessages: string[]): prompts.PromptObject {
   // Do case-insensitive filtering of recent commit messages
   const recentMessageChoices: prompts.Choice[] = recentMessages.map(msg => ({ title: msg }));
   const getSuggestions = (input: string) =>
@@ -95,7 +95,7 @@ function getDescriptionPrompt(recentMessages: string[]): prompts.PromptObject<st
     // previously implemented hack of adding the input to the returned list from `suggest`
     // no longer works. So this new hack adds the current input as the fallback.
     // https://github.com/terkelg/prompts/issues/131
-    onState: function (this: any, state: any) {
+    onState: function (this: { input: string; value: string; fallback: string }) {
       // If there are no suggestions, update the value to match the input, and unset the fallback
       // (this.suggestions may be out of date if the user pasted text ending with a newline, so re-calculate)
       if (!getSuggestions(this.input).length) {

--- a/src/changefile/promptForChange.ts
+++ b/src/changefile/promptForChange.ts
@@ -5,7 +5,7 @@ import { isValidChangeType } from '../validation/isValidChangeType';
 import { PackageGroups, PackageInfos } from '../types/PackageInfo';
 import { getQuestionsForPackage } from './getQuestionsForPackage';
 
-type ChangePromptResponse = { type?: ChangeType; comment?: string };
+export type ChangePromptResponse = { type?: ChangeType; comment?: string };
 
 /**
  * Uses `prompts` package to prompt for change type and description.
@@ -36,7 +36,7 @@ export async function promptForChange(params: {
 
   // Now prompt for each package
   const packageChangeInfo: ChangeFileInfo[] = [];
-  for (let pkg of changedPackages) {
+  for (const pkg of changedPackages) {
     const response = await _promptForPackageChange(packageQuestions[pkg], pkg);
     if (!response) {
       return; // user cancelled
@@ -73,8 +73,7 @@ export async function _promptForPackageChange(
   const onCancel = () => {
     isCancelled = true;
   };
-  // onCancel is missing from the typings
-  const response: ChangePromptResponse = await prompts(questions, { onCancel } as any);
+  const response: ChangePromptResponse = await prompts(questions, { onCancel });
 
   if (isCancelled) {
     console.log('Cancelled, no change files are written');
@@ -117,7 +116,7 @@ export function _getChangeFileInfoFromResponse(params: {
   }
 
   // prevent invalid change types from being entered via custom prompts
-  if (!isValidChangeType(response.type!)) {
+  if (!response.type || !isValidChangeType(response.type)) {
     console.error(`Prompt response contains invalid change type "${response.type}"`);
     return;
   }

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -63,7 +63,7 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
 
     let changeInfo: ChangeInfo | ChangeInfoMultiple;
     try {
-      changeInfo = fs.readJSONSync(changeFilePath);
+      changeInfo = fs.readJSONSync(changeFilePath) as ChangeInfo | ChangeInfoMultiple;
     } catch (e) {
       console.warn(`Error reading or parsing change file ${changeFilePath}: ${e}`);
       continue;
@@ -81,7 +81,7 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
       }
     }
 
-    const changes: ChangeInfo[] = changeInfo.changes || [changeInfo as ChangeInfo];
+    const changes = (changeInfo as ChangeInfoMultiple).changes || [changeInfo as ChangeInfo];
 
     // Filter the changes from this file
     for (const change of changes) {
@@ -96,7 +96,7 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
         const resolution = options.groupChanges ? 'remove the entry from this file' : 'delete this file';
         console.warn(
           `Change detected for ${warningType} package ${change.packageName}; ${resolution}: "${path.resolve(
-            changePath!,
+            changePath,
             changeFile
           )}"`
         );

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -21,7 +21,7 @@ export function unlinkChangeFiles(
     return;
   }
   console.log('Removing change files:');
-  for (let { changeFile, change } of changeSet) {
+  for (const { changeFile, change } of changeSet) {
     if (changeFile && packageInfos[change.packageName] && !packageInfos[change.packageName].private) {
       console.log(`- ${changeFile}`);
       fs.removeSync(path.join(changePath, changeFile));

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -37,7 +37,7 @@ export function getPackageChangelogs(
 
     changelogs[packageName].comments ??= {};
     changelogs[packageName].comments[changeType] ??= [];
-    changelogs[packageName].comments[changeType]!.push({
+    changelogs[packageName].comments[changeType]?.push({
       author: change.email,
       package: packageName,
       commit: changeFileCommits[changeFile],
@@ -63,7 +63,7 @@ export function getPackageChangelogs(
 
     for (const dep of changedBy) {
       if (dep !== dependent) {
-        changelogs[dependent].comments[changeType]!.push({
+        changelogs[dependent].comments[changeType]?.push({
           author: 'beachball',
           package: dependent,
           comment: `Bump ${dep} to v${packageInfos[dep].version}`,

--- a/src/changelog/mergeChangelogs.ts
+++ b/src/changelog/mergeChangelogs.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { PackageChangelog } from '../types/ChangeLog';
 import { PackageInfo } from '../types/PackageInfo';
 import { generateTag } from '../git/generateTag';

--- a/src/changelog/renderChangelog.ts
+++ b/src/changelog/renderChangelog.ts
@@ -39,7 +39,7 @@ export async function renderChangelog(renderOptions: MarkdownChangelogRenderOpti
     // Otherwise look for an h2 (used as version header with default renderer).
     // If that's not present, preserve the previous content as-is.
     const h2Match = previousContent.match(/^## /m);
-    previousLogEntries = h2Match ? previousContent.substring(h2Match.index!) : previousContent;
+    previousLogEntries = h2Match ? previousContent.substring(h2Match.index || 0) : previousContent;
   }
 
   try {
@@ -107,7 +107,7 @@ export function _trimPreviousLog(params: {
   let count = 0;
   // We need to use a regexp anchored to the line start to avoid matching lower level headers
   // (e.g. if the header prefix is '## ', we don't want to match a substring of '### ').
-  let headerRegexp = new RegExp(`^${headerPrefix}`, 'gm');
+  const headerRegexp = new RegExp(`^${headerPrefix}`, 'gm');
   let lastMatch: RegExpExecArray | null = null;
   while (count < maxVersions && (lastMatch = headerRegexp.exec(previousLogEntries))) {
     count++;

--- a/src/changelog/renderPackageChangelog.ts
+++ b/src/changelog/renderPackageChangelog.ts
@@ -70,7 +70,7 @@ async function _renderEntries(changeType: ChangeType, renderInfo: PackageChangel
     const entriesByPackage = _.entries(_.groupBy(entries, entry => entry.package));
 
     // Use a for loop here (not map) so that if renderEntry does network requests, we don't fire them all at once
-    let packagesText: string[] = [];
+    const packagesText: string[] = [];
     for (const [pkgName, pkgEntries] of entriesByPackage) {
       const entriesText = (await _renderEntriesBasic(pkgEntries, renderInfo)).map(entry => `  ${entry}`).join('\n');
 
@@ -87,7 +87,7 @@ async function _renderEntriesBasic(
   renderInfo: PackageChangelogRenderInfo
 ): Promise<string[]> {
   // Use a for loop here (not map) so that if renderEntry does network requests, we don't fire them all at once
-  let results: string[] = [];
+  const results: string[] = [];
   for (const entry of entries) {
     results.push(await renderInfo.renderers.renderEntry(entry, renderInfo));
   }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs-extra';
-import _ from 'lodash';
 import { PackageInfo } from '../types/PackageInfo';
 import { getPackageChangelogs } from './getPackageChangelogs';
 import { renderChangelog } from './renderChangelog';
@@ -94,13 +93,13 @@ async function writeGroupedChangelog(
   }
 
   // Write each grouped changelog if it's not empty
-  for (const [changelogAbsDir, { masterPackage, changelogs }] of Object.entries(groupedChangelogs)) {
-    const groupedChangelog = mergeChangelogs(changelogs, masterPackage);
+  for (const [groupAbsDir, group] of Object.entries(groupedChangelogs)) {
+    const groupedChangelog = mergeChangelogs(group.changelogs, group.masterPackage);
     if (groupedChangelog) {
       await writeChangelogFiles({
         options,
         newVersionChangelog: groupedChangelog,
-        changelogAbsDir,
+        changelogAbsDir: groupAbsDir,
         isGrouped: true,
       });
     }
@@ -130,7 +129,9 @@ async function writeChangelogFiles(params: {
   // (changelogPaths.json will only be set if generateChangelog is true or 'json')
   if (changelogPaths.json) {
     try {
-      previousJson = fs.existsSync(changelogPaths.json) ? fs.readJSONSync(changelogPaths.json) : undefined;
+      previousJson = fs.existsSync(changelogPaths.json)
+        ? (fs.readJSONSync(changelogPaths.json) as ChangelogJson)
+        : undefined;
     } catch (e) {
       console.warn(`${changelogPaths.json} is invalid: ${e}`);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ import { validate } from './validation/validate';
       await sync(options);
       break;
 
-    case 'change':
+    case 'change': {
       const { isChangeNeeded } = validate(options, { allowMissingChangeFiles: true });
 
       if (!isChangeNeeded && !options.package) {
@@ -66,6 +66,7 @@ import { validate } from './validation/validate';
       await change(options);
 
       break;
+    }
 
     default:
       throw new Error('Invalid command: ' + options.command);
@@ -73,7 +74,7 @@ import { validate } from './validation/validate';
 })().catch(e => {
   showVersion();
   console.error('An error has been detected while running beachball!');
-  console.error(e?.stack || e);
+  console.error((e as Error)?.stack || e);
 
   process.exit(1);
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,7 +17,7 @@ export async function init(options: Pick<BeachballOptions, 'path'>): Promise<voi
   let root: string;
   try {
     root = findProjectRoot(options.path);
-  } catch (err) {
+  } catch {
     console.log('Please run this command on an existing repository root.');
     return;
   }
@@ -35,16 +35,16 @@ export async function init(options: Pick<BeachballOptions, 'path'>): Promise<voi
 
   let beachballVersion = '';
   try {
-    const beachballInfo = JSON.parse(npmResult.stdout.toString());
+    const beachballInfo = JSON.parse(npmResult.stdout.toString()) as { 'dist-tags': { latest: string } };
     beachballVersion = beachballInfo['dist-tags'].latest;
-  } catch (err) {
+  } catch {
     errorExit("Couldn't parse beachball version from npm");
   }
 
   let packageJson = {} as PackageJson;
   try {
-    packageJson = fs.readJSONSync(packageJsonFilePath, 'utf-8');
-  } catch (err) {
+    packageJson = fs.readJSONSync(packageJsonFilePath, 'utf-8') as PackageJson;
+  } catch {
     errorExit(`Failed to read package.json at ${packageJsonFilePath}`);
   }
 

--- a/src/git/gitAsync.ts
+++ b/src/git/gitAsync.ts
@@ -42,8 +42,8 @@ export async function gitAsync(args: string[], options: GitAsyncOptions): Promis
   });
 
   if (shouldLog === 'live') {
-    child.stdout!.pipe(process.stdout);
-    child.stderr!.pipe(process.stderr);
+    child.stdout?.pipe(process.stdout);
+    child.stderr?.pipe(process.stderr);
   }
 
   const execaResult = await child;

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,5 +1,7 @@
+import type { PackageJson } from './types/PackageInfo';
+
 export function showVersion(): void {
-  const packageJson = require('../package.json');
+  const packageJson = require('../package.json') as PackageJson;
   console.log(`beachball v${packageJson.version} - the sunniest version bumping tool`);
 }
 

--- a/src/logging/format.ts
+++ b/src/logging/format.ts
@@ -7,6 +7,6 @@ export function formatList(items: string[]): string {
  * Format an object on a single line with spaces between the properties and brackets
  * (similar to `JSON.stringify(obj, null, 2)` but without the line breaks).
  */
-export function singleLineStringify(obj: any): string {
+export function singleLineStringify(obj: unknown): string {
   return JSON.stringify(obj, null, 2).replace(/\n\s*/g, ' ');
 }

--- a/src/monorepo/getPackageGraph.ts
+++ b/src/monorepo/getPackageGraph.ts
@@ -2,11 +2,14 @@ import { PackageInfo, PackageInfos } from '../types/PackageInfo';
 import pGraph, { PGraphNodeMap } from 'p-graph';
 import { getPackageDependencyGraph } from './getPackageDependencyGraph';
 
+// this export is missing from the top level of the package
+type PGraph = ReturnType<typeof pGraph>;
+
 export function getPackageGraph(
   affectedPackages: Iterable<string>,
   packageInfos: PackageInfos,
   runHook: (packageInfo: PackageInfo) => Promise<void>
-) {
+): PGraph {
   const nodeMap: PGraphNodeMap = new Map();
   for (const packageToBump of affectedPackages) {
     nodeMap.set(packageToBump, {
@@ -23,5 +26,5 @@ export function getPackageGraph(
 }
 
 function filterDependencyGraph(dependencyGraph: [string | undefined, string][]): [string, string][] {
-  return dependencyGraph.filter(([dep, _]) => dep !== undefined) as [string, string][];
+  return dependencyGraph.filter(([dep]) => dep !== undefined) as [string, string][];
 }

--- a/src/monorepo/getPackageGroups.ts
+++ b/src/monorepo/getPackageGroups.ts
@@ -43,7 +43,7 @@ export function getPackageGroups(
     console.error(
       `ERROR: Found package(s) belonging to multiple groups:\n` +
         Object.entries(errorPackages)
-          .map(([pkgName, groups]) => `- ${pkgName}: [${groups.map(g => g.name).join(', ')}]`)
+          .map(([pkgName, pkgGroups]) => `- ${pkgName}: [${pkgGroups.map(g => g.name).join(', ')}]`)
           .sort()
           .join('\n')
     );

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -7,7 +7,7 @@ import {
   findProjectRoot,
   WorkspaceInfo,
 } from 'workspace-tools';
-import { PackageInfos } from '../types/PackageInfo';
+import type { PackageInfos, PackageJson } from '../types/PackageInfo';
 import { infoFromPackageJson } from './infoFromPackageJson';
 
 /**
@@ -31,7 +31,7 @@ function getPackageInfosFromWorkspace(projectRoot: string): PackageInfos | undef
   try {
     // first try using the workspace provided packages (if available)
     workspacePackages = getWorkspacePackages(projectRoot);
-  } catch (e) {
+  } catch {
     // not a recognized workspace from workspace-tools
   }
 
@@ -68,7 +68,7 @@ function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string): PackageIn
   for (const packageJsonPath of packageJsonFiles) {
     try {
       const packageJsonFullPath = path.join(projectRoot, packageJsonPath);
-      const packageJson = fs.readJSONSync(packageJsonFullPath);
+      const packageJson = fs.readJSONSync(packageJsonFullPath) as PackageJson;
       if (!packageInfos[packageJson.name]) {
         packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
       } else {
@@ -96,7 +96,7 @@ function getPackageInfosFromNonWorkspaceMonorepo(projectRoot: string): PackageIn
 function getPackageInfosFromSingleRepo(packageRoot: string): PackageInfos {
   const packageInfos: PackageInfos = {};
   const packageJsonFullPath = path.resolve(packageRoot, 'package.json');
-  const packageJson = fs.readJSONSync(packageJsonFullPath);
+  const packageJson = fs.readJSONSync(packageJsonFullPath) as PackageJson;
   packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonFullPath);
   return packageInfos;
 }

--- a/src/monorepo/infoFromPackageJson.ts
+++ b/src/monorepo/infoFromPackageJson.ts
@@ -5,7 +5,7 @@ import { getPackageOptions, getCombinedPackageOptions } from '../options/getPack
 export function infoFromPackageJson(packageJson: PackageJson, packageJsonPath: string): PackageInfo {
   const packageOptions = getPackageOptions(path.dirname(packageJsonPath));
   return {
-    name: packageJson.name!,
+    name: packageJson.name,
     version: packageJson.version,
     packageJsonPath,
     dependencies: packageJson.dependencies,

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -128,7 +128,7 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
   let cwd: string;
   try {
     cwd = findProjectRoot(process.cwd());
-  } catch (err) {
+  } catch {
     cwd = process.cwd();
   }
 
@@ -142,14 +142,15 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
     path: cwd,
   };
 
-  if (args.branch) {
+  const branchArg = args.branch as string | undefined;
+  if (branchArg) {
     // TODO: This logic assumes the first segment of any branch name with a slash must be the remote,
     // which is not necessarily accurate. Ideally we should check if a remote with that name exists,
     // and if not, perform the default remote lookup.
     cliOptions.branch =
-      args.branch.indexOf('/') > -1
-        ? args.branch
-        : getDefaultRemoteBranch({ branch: args.branch, verbose: args.verbose, cwd });
+      branchArg.indexOf('/') > -1
+        ? branchArg
+        : getDefaultRemoteBranch({ branch: branchArg, verbose: args.verbose as boolean | undefined, cwd });
   }
 
   if (cliOptions.command === 'canary') {
@@ -163,7 +164,7 @@ function getCliOptionsUncached(argv: string[]): CliOptions {
     } else if (typeof value === 'number' && isNaN(value)) {
       throw new Error(`Non-numeric value passed for numeric option "${key}"`);
     } else if (knownOptions.includes(key)) {
-      if (Array.isArray(value) && !arrayOptions.includes(key as any)) {
+      if (Array.isArray(value) && !arrayOptions.includes(key as (typeof arrayOptions)[number])) {
         throw new Error(`Option "${key}" only accepts a single value. Received: ${value.join(' ')}`);
       }
     } else if (value === 'true') {

--- a/src/options/getPackageOptions.ts
+++ b/src/options/getPackageOptions.ts
@@ -30,8 +30,8 @@ export function getPackageOptions(packagePath: string): Partial<PackageOptions> 
   const configExplorer = cosmiconfigSync('beachball', { cache: false });
   try {
     const results = configExplorer.load(path.join(packagePath, 'package.json'));
-    return (results && results.config) || {};
-  } catch (e) {
+    return (results?.config as PackageOptions) || {};
+  } catch {
     // File does not exist, returns the default packageOptions
     return {};
   }

--- a/src/options/getRepoOptions.ts
+++ b/src/options/getRepoOptions.ts
@@ -3,7 +3,7 @@ import { getDefaultRemoteBranch } from 'workspace-tools';
 import { env } from '../env';
 import { RepoOptions, CliOptions, BeachballOptions } from '../types/BeachballOptions';
 
-let cachedRepoOptions = new Map<CliOptions, RepoOptions>();
+const cachedRepoOptions = new Map<CliOptions, RepoOptions>();
 
 export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
   const { configPath, path: cwd, branch } = cliOptions;
@@ -45,11 +45,11 @@ export function getRepoOptions(cliOptions: CliOptions): RepoOptions {
 function tryLoadConfig(configPath: string): RepoOptions | null {
   const configExplorer = cosmiconfigSync('beachball');
   const loadResults = configExplorer.load(configPath);
-  return (loadResults && loadResults.config) || null;
+  return (loadResults?.config as RepoOptions) || null;
 }
 
 function trySearchConfig(): RepoOptions | null {
   const configExplorer = cosmiconfigSync('beachball');
   const searchResults = configExplorer.search();
-  return (searchResults && searchResults.config) || null;
+  return (searchResults?.config as RepoOptions) || null;
 }

--- a/src/packageManager/packageManager.ts
+++ b/src/packageManager/packageManager.ts
@@ -1,6 +1,7 @@
 import execa from 'execa';
 
 export type PackageManagerResult = execa.ExecaReturnValue & { success: boolean };
+export type PackageManagerOptions = execa.Options & { cwd: string | undefined };
 
 /**
  * Run a package manager command. Returns the error result instead of throwing on failure.
@@ -12,8 +13,8 @@ export type PackageManagerResult = execa.ExecaReturnValue & { success: boolean }
 export async function packageManager(
   manager: 'npm' | 'yarn' | 'pnpm',
   args: string[],
-  options: execa.Options & { cwd: string | undefined }
-): Promise<execa.ExecaReturnValue & { success: boolean }> {
+  options: PackageManagerOptions
+): Promise<PackageManagerResult> {
   try {
     const result = await execa(manager, args, {
       ...options,

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -53,7 +53,7 @@ export async function packagePublish(
       console.error(`${packageSpec} already exists in the registry. ${output}`);
       break;
     }
-    if (result.all!.includes('code E403')) {
+    if (result.all?.includes('code E403')) {
       // This is apparently a less common variant of trying to publish over an existing version
       // (not sure when this error is used vs. EPUBLISHCONFLICT). Keep the message generic since
       // there may be other possible causes for 403 errors.
@@ -65,12 +65,12 @@ export async function packagePublish(
       console.error(`Publishing ${packageSpec} failed due to a 403 error. ${output}`);
       break;
     }
-    if (result.all!.includes('ENEEDAUTH')) {
+    if (result.all?.includes('ENEEDAUTH')) {
       // ENEEDAUTH only happens if no auth was attempted (no token/password provided).
       console.error(`Publishing ${packageSpec} failed due to an auth error. ${output}`);
       break;
     }
-    if (result.all!.includes('code E404')) {
+    if (result.all?.includes('code E404')) {
       // All types of invalid credentials appear to cause E404.
       // validate() already checks for the most common ways invalid variable names might show up,
       // so log a slightly more generic message instead of details about the token.

--- a/src/publish/performPublishOverrides.ts
+++ b/src/publish/performPublishOverrides.ts
@@ -17,7 +17,7 @@ const acceptedKeys: (keyof PublishConfig)[] = [
 export function performPublishOverrides(packagesToPublish: string[], packageInfos: PackageInfos): void {
   for (const pkgName of packagesToPublish) {
     const info = packageInfos[pkgName];
-    const packageJson = fs.readJSONSync(info.packageJsonPath);
+    const packageJson = fs.readJSONSync(info.packageJsonPath) as PackageJson;
 
     performWorkspaceVersionOverrides(packageJson, packageInfos);
     performPublishConfigOverrides(packageJson);
@@ -32,7 +32,7 @@ function performPublishConfigOverrides(packageJson: PackageJson): void {
     for (const [k, value] of Object.entries(packageJson.publishConfig)) {
       const key = k as keyof Required<PackageJson>['publishConfig'];
       if (acceptedKeys.includes(key)) {
-        packageJson[key] = value;
+        packageJson[key] = value as any;
         delete packageJson.publishConfig[key];
       }
     }

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -74,12 +74,13 @@ export async function publishToRegistry(originalBumpInfo: PublishBumpInfo, optio
     }
   } catch (error) {
     // p-graph will throw an array of errors if it fails to run all tasks
+    let err = error;
     if (Array.isArray(error)) {
       const errorSet = new Set(error);
-      error = new Error(Array.from(errorSet).join('\n'));
+      err = new Error(Array.from(errorSet).join('\n'));
     }
     displayManualRecovery(bumpInfo, succeededPackages);
-    throw error;
+    throw err;
   }
 
   // if there is a postpublish hook perform a postpublish pass, calling the routine on each package

--- a/src/types/DeepReadonly.ts
+++ b/src/types/DeepReadonly.ts
@@ -10,7 +10,7 @@ export type DeepReadonly<T> = T extends (infer R)[]
   ? DeepReadonlyObject<T>
   : T;
 
-interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+type DeepReadonlyArray<T> = ReadonlyArray<DeepReadonly<T>>;
 
 type DeepReadonlyObject<T> = {
   readonly [P in keyof T]: DeepReadonly<T[P]>;

--- a/src/validation/isGitAvailable.ts
+++ b/src/validation/isGitAvailable.ts
@@ -4,7 +4,7 @@ export function isGitAvailable(cwd: string): boolean {
   const result = git(['--version']);
   try {
     return result.success && !!findGitRoot(cwd);
-  } catch (err) {
+  } catch {
     return false;
   }
 }

--- a/src/validation/isValidChangeType.ts
+++ b/src/validation/isValidChangeType.ts
@@ -1,5 +1,6 @@
 import { SortedChangeTypes } from '../changefile/changeTypes';
+import type { ChangeType } from '../types/ChangeInfo';
 
 export function isValidChangeType(changeType: string): boolean {
-  return SortedChangeTypes.includes(changeType as any);
+  return SortedChangeTypes.includes(changeType as ChangeType);
 }


### PR DESCRIPTION
In the [beachball next (v3) branch](https://github.com/microsoft/beachball/tree/next), I enabled eslint. This PR brings back some of the fixes made in response to lint rules:
- use optional catch bindings (remove `(err)` from `catch (err)` if not used)
- replace non-null assertions with optional chaining or other checks
- fix shadowed names
- prefer const
- ensure the correct types are used instead of implicit or explicit any
- remove unused imports and parameters
- use explicit module boundary types

(I didn't enable eslint in master/v2 because in next I'm using eslint v9 flat config, which is probably not compatible with Node 14, and I'm not sure it's worthwhile to back-port the config.)