### PR TITLE
Clarify internal validation logic + don't check for change needed in bump command

### DIFF
--- a/change/beachball-c96251d0-33c6-465e-b32e-d7f0e1b1aecd.json
+++ b/change/beachball-c96251d0-33c6-465e-b32e-d7f0e1b1aecd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "bump command shouldn't check if change files are needed (+ clarify internal validation options)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/validate.test.ts
+++ b/src/__e2e__/validate.test.ts
@@ -41,7 +41,7 @@ describe('validate', () => {
     repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
 
-    const result = validate(getOptions());
+    const result = validate(getOptions(), { checkChangeNeeded: true });
 
     expect(result.isChangeNeeded).toBe(false);
     expect(logs.mocks.error).not.toHaveBeenCalled();
@@ -53,17 +53,17 @@ describe('validate', () => {
     repo.checkout('-b', 'test');
     repo.stageChange('packages/foo/test.js');
 
-    expect(() => validate(getOptions())).toThrowError(/process\.exit/);
+    expect(() => validate(getOptions(), { checkChangeNeeded: true })).toThrowError(/process\.exit/);
     expect(processExit).toHaveBeenCalledWith(1);
     expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files are needed!');
   });
 
-  it('returns an error if change files are needed and allowMissingChangeFiles is true', () => {
+  it('returns and does not log an error if change files are needed and allowMissingChangeFiles is true', () => {
     repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
     repo.stageChange('packages/foo/test.js');
 
-    const result = validate(getOptions(), { allowMissingChangeFiles: true });
+    const result = validate(getOptions(), { checkChangeNeeded: true, allowMissingChangeFiles: true });
     expect(result.isChangeNeeded).toBe(true);
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,12 +25,12 @@ import { validate } from './validation/validate';
   // Run the commands
   switch (options.command) {
     case 'check':
-      validate(options);
+      validate(options, { checkChangeNeeded: true, checkDependencies: true });
       console.log('No change files are needed');
       break;
 
     case 'publish':
-      validate(options, { allowFetching: false });
+      validate(options, { checkDependencies: true });
 
       // set a default publish message
       options.message = options.message || 'applying package updates';
@@ -38,12 +38,12 @@ import { validate } from './validation/validate';
       break;
 
     case 'bump':
-      validate(options);
+      validate(options, { checkDependencies: true });
       await bump(options);
       break;
 
     case 'canary':
-      validate(options, { allowFetching: false });
+      validate(options, { checkDependencies: true });
       await canary(options);
       break;
 
@@ -56,7 +56,7 @@ import { validate } from './validation/validate';
       break;
 
     case 'change': {
-      const { isChangeNeeded } = validate(options, { allowMissingChangeFiles: true });
+      const { isChangeNeeded } = validate(options, { checkChangeNeeded: true, allowMissingChangeFiles: true });
 
       if (!isChangeNeeded && !options.package) {
         console.log('No change files are needed');

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -14,6 +14,7 @@ export interface CliOptions
     | 'bumpDeps'
     | 'changehint'
     | 'changeDir'
+    | 'concurrency'
     | 'depth'
     | 'disallowedChangeTypes'
     | 'fetch'
@@ -34,7 +35,6 @@ export interface CliOptions
   canaryName?: string | undefined;
   command: string;
   commit?: boolean;
-  concurrency: number;
   configPath?: string;
   dependentChangeType?: ChangeType;
   disallowDeletedChangeFiles?: boolean;
@@ -104,6 +104,12 @@ export interface RepoOptions {
   changeDir: string;
   /** Options for customizing changelog rendering */
   changelog?: ChangelogOptions;
+  /**
+   * Maximum concurrency.
+   * As of writing, concurrency only applies for calling hooks and publishing to npm.
+   * @default 1
+   */
+  concurrency: number;
   /**
    * The default dist-tag used for npm publish
    * @default 'latest'


### PR DESCRIPTION
Previously `validate()` had an option `allowFetching` (default true) which was hiding the actual behavior. It was also not precise about which commands needed to validate dependencies or not. Update the options as follows:
- `checkChangeNeeded`: check whether change files are needed (`change`, `check`)
- `allowMissingChangeFiles`: used with above, but don't error on missing change files (`change`)
- `checkDependencies`: perform an in-memory bump and validate that no package to be bumped (including dependents) have private dependencies (most commands but `change`). Previously in some cases, `change` would include this check, which just slows it down and isn't needed.

As a side effect of the confusing options, previously the `bump` command was checking for whether change files are needed, which was odd and probably an artifact of `allowFetching` defaulting to true, not intentional.