### PR TITLE
docs: fix grammar mistake

### DIFF
--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -28,7 +28,7 @@ The `beachball.config.js` example below uses JSDoc type annotations to enable in
 
 ```js
 // @ts-check
-/** @type {import('beachball').BeachallConfig} */
+/** @type {import('beachball').BeachballConfig} */
 const config = {
   disallowedChangeTypes: ['major'],
   changehint: 'Run "yarn change" to generate a change file',


### PR DESCRIPTION
Documentation on https://microsoft.github.io/beachball/overview/configuration.html page says ```
/** @type {import('beachball').BeachallConfig} */
```
instead of
```/** @type {import('beachball').BeachballConfig} */```