### PR TITLE
updateRelatedChangeTypes: fix cubic behavior

### DIFF
--- a/change/beachball-828497fb-eabf-414f-921a-503cd3c291f5.json
+++ b/change/beachball-828497fb-eabf-414f-921a-503cd3c291f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix cubic graph walk performance to quadratic",
+  "packageName": "beachball",
+  "email": "dstolee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -98,11 +98,7 @@ export function updateRelatedChangeType(params: {
 
       if (group) {
         for (const packageNameInGroup of group.packageNames) {
-          if (!group.disallowedChangeTypes?.includes(updatedChangeType)) {
-            if (visited.has(packageNameInGroup)) {
-              continue;
-            }
-
+          if (!group.disallowedChangeTypes?.includes(updatedChangeType) && !visited.has(packageNameInGroup)) {
             visited.add(packageNameInGroup);
             queue.push({
               subjectPackage: packageNameInGroup,

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -62,11 +62,17 @@ export function updateRelatedChangeType(params: {
       const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
 
       if (subjectPackage !== entryPointPackageName) {
+        const oldType = calculatedChangeTypes[subjectPackage];
         calculatedChangeTypes[subjectPackage] = getMaxChangeType(
-          calculatedChangeTypes[subjectPackage],
+          oldType,
           changeType,
           disallowedChangeTypes
         );
+
+        // We didn't change this type, so keep going.
+        if (calculatedChangeTypes[subjectPackage] === oldType) {
+          continue;
+        }
       }
 
       // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"


### PR DESCRIPTION
The `updateRelatedChangeType()` method can be called with individual packages or a list of packages. In either case, this presents a _minimum_ of quadratic performance as it does a breadth-first-search of the dependency graph starting at each input package, one a at a time. For example, in an internal monorepo that recently had a Typescript upgrade initiate 3000+ package updates at once, `bumpInPlace()` calls this method 3000+ times and each does a bunch of repeated work.

To resolve this issue, we will need to combine things into a single DAG walk. That is a more involved change that will take more time and testing. I will report back later. We need something to resolve the pain sooner.

The current implementation has a more immediate issue: the quadratic behavior is actually sometimes _cubic_. The point here is that there are two data structures handling the BFS walk:

1. `queue` is a list that handles the boundary of the walk. These are the nodes we want to explore next.
2. `visited` is a set that prevents exploring a node multiple times.

The issue here is that the `visited` set needs to protect insertion into `queue`, not just prevent repeat visiting a node as we pop off of the queue. As it stands, we will insert a dependent package into the queue for each package that depends on it. This adds space and time concerns that contribute to the slowness of this method.

This PR moves the use of the `visited` set interactions into the locations that care about pushing into `queue`, lowering the space and time constraints around the queue.