### PR TITLE
updaterelatedChangeType: move quadratic behavior to linear with topo sort

### DIFF
--- a/change/beachball-14ca2e5d-2f33-4476-8fd4-45b14069cc5a.json
+++ b/change/beachball-14ca2e5d-2f33-4476-8fd4-45b14069cc5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "updateRelatedChangeType: move quadratic performance to linear",
+  "packageName": "beachball",
+  "email": "dstolee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -56,7 +56,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('patch');
@@ -76,7 +76,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
@@ -108,8 +108,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
-    updateRelatedChangeType({ changeFile: 'bar.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json', 'bar.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('major');
@@ -149,14 +148,14 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['baz']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['app']).toBe('patch');
 
-    updateRelatedChangeType({ changeFile: 'baz.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['baz.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
   });
@@ -182,8 +181,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
-    updateRelatedChangeType({ changeFile: 'baz.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['baz.json', 'foo.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['baz']).toBe('patch');
@@ -205,7 +203,7 @@ describe('updateRelatedChangeType', () => {
       ],
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents: {}, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents: {}, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['unrelated']).toBeUndefined();
@@ -225,7 +223,7 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents: {}, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents: {}, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('patch');
     expect(bumpInfo.calculatedChangeTypes['unrelated']).toBeUndefined();
@@ -245,7 +243,7 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents: {}, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents: {}, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('none');
     expect(bumpInfo.calculatedChangeTypes['unrelated']).toBeUndefined();
@@ -265,7 +263,7 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('none');
     expect(bumpInfo.calculatedChangeTypes['unrelated']).toBeUndefined();
@@ -291,7 +289,7 @@ describe('updateRelatedChangeType', () => {
       packageGroups: { grp: { packageNames: ['foo', 'bar'] } },
     });
 
-    updateRelatedChangeType({ changeFile: 'dep.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['dep.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
@@ -322,7 +320,7 @@ describe('updateRelatedChangeType', () => {
       ],
     });
 
-    updateRelatedChangeType({ changeFile: 'dep.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['dep.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
@@ -360,8 +358,7 @@ describe('updateRelatedChangeType', () => {
       ],
     });
 
-    updateRelatedChangeType({ changeFile: 'mergeStyles.json', bumpInfo, dependents, bumpDeps: true });
-    updateRelatedChangeType({ changeFile: 'datetimeUtils.json', bumpInfo, dependents, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['mergeStyles.json', 'datetimeUtils.json'], bumpInfo, dependents, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBe('minor');
     expect(bumpInfo.calculatedChangeTypes['bar']).toBe('minor');
@@ -381,7 +378,7 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    updateRelatedChangeType({ changeFile: 'foo.json', bumpInfo, dependents: {}, bumpDeps: true });
+    updateRelatedChangeType({ changeFiles: ['foo.json'], bumpInfo, dependents: {}, bumpDeps: true });
 
     expect(bumpInfo.calculatedChangeTypes['foo']).toBeUndefined();
   });

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -33,9 +33,12 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions): void
   }
 
   // Calculate change types for packages and dependencies
-  for (const { changeFile } of changeFileChangeInfos) {
-    updateRelatedChangeType({ changeFile, bumpInfo, dependents, bumpDeps });
-  }
+  updateRelatedChangeType({
+    changeFiles: changeFileChangeInfos.map((info: { changeFile: string }) => info.changeFile),
+    bumpInfo,
+    dependents,
+    bumpDeps,
+  });
 
   // pass 3: actually bump the packages in the bumpInfo in memory (no disk writes at this point)
   Object.keys(calculatedChangeTypes).forEach(pkgName => {


### PR DESCRIPTION
When bumping versions for all the dependent packages in a batched beachball run, the `bumpInPlace()` method can call `updateRelatedChangeType()` many times, and each of those runs a graph traversal to determine if some package versions need to be updated. This can be slow as it repeatedly iterates over the list of packages. In fact, it can have `O(N * M)` behavior, where `N` is the number of initial change files and `M` is the number of total packages.

This was hitting an internal monorepo with 3,000+ packages that were all updated via a Typescript upgrade.

Another change is proposed in #1042, but that conflicts with this change. The reason both are proposed is that the other one has less risk but also less benefit. This change is the deeper change, but is more complicated and thus could be causing some unintentional behavior changes.

The tests for this method were adapted to use the multiple starting points when they appeared to be possible, but there could still be some unforeseen behavior changes. For instance, the input set of package names indicate that we shouldn't update the type of update, but the packages _could_ depend on each other. Thus, we should consider whether or not the current filter to avoid that overwriting of an update type is the right behavior and be sure to add a test.

I have also not done the proper performance analysis that I'd like to do. I don't have a local repro of the problematic state myself, but will use this PR as a potential way to collaborate with those who do.