### PR TITLE
updateRelatedChangeType perf improvements

### DIFF
--- a/change/beachball-f68d7ef6-b961-4120-a82e-68dc570bd35f.json
+++ b/change/beachball-f68d7ef6-b961-4120-a82e-68dc570bd35f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove redundant processing in updateRelatedChangeType, and other minor optimizations",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/packageInfos.ts
+++ b/src/__fixtures__/packageInfos.ts
@@ -5,6 +5,10 @@ import { getDefaultOptions } from '../options/getDefaultOptions';
 
 const defaultOptions = getDefaultOptions();
 
+export type PartialPackageInfos = {
+  [name: string]: Partial<Omit<PackageInfo, 'combinedOptions'>> & { combinedOptions?: Partial<BeachballOptions> };
+};
+
 /**
  * Makes a properly typed PackageInfos object from a partial object, filling in defaults:
  * ```
@@ -18,9 +22,7 @@ const defaultOptions = getDefaultOptions();
  * }
  * ```
  */
-export function makePackageInfos(packageInfos: {
-  [name: string]: Partial<Omit<PackageInfo, 'combinedOptions'>> & { combinedOptions?: Partial<BeachballOptions> };
-}): PackageInfos {
+export function makePackageInfos(packageInfos: PartialPackageInfos): PackageInfos {
   return _.mapValues(packageInfos, (info, name): PackageInfo => {
     const { combinedOptions, ...rest } = info;
     return {

--- a/src/__tests__/bump/getDependentsForPackages.test.ts
+++ b/src/__tests__/bump/getDependentsForPackages.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from '@jest/globals';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { consideredDependencies } from '../../types/PackageInfo';
+import { getDependentsForPackages } from '../../bump/getDependentsForPackages';
+
+describe('getDependentsForPackages', () => {
+  it.each(consideredDependencies)('includes %s', depType => {
+    const packages = makePackageInfos({
+      foo: { [depType]: { baz: '1.0.0' } },
+      bar: { [depType]: { baz: '1.0.0' } },
+      baz: {},
+    });
+    const dependents = getDependentsForPackages({
+      packageInfos: packages,
+      scopedPackages: new Set(Object.keys(packages)),
+    });
+    expect(dependents).toEqual({
+      baz: ['foo', 'bar'],
+    });
+  });
+
+  it('does not include transitive dependencies', () => {
+    const packages = makePackageInfos({
+      foo: { dependencies: { bar: '1.0.0' } },
+      bar: { dependencies: { baz: '1.0.0' } },
+      baz: {},
+    });
+    const dependents = getDependentsForPackages({
+      packageInfos: packages,
+      scopedPackages: new Set(Object.keys(packages)),
+    });
+    expect(dependents).toEqual({
+      bar: ['foo'],
+      baz: ['bar'],
+    });
+  });
+
+  it('only includes dependencies of in-scope packages', () => {
+    const packages = makePackageInfos({
+      foo: { dependencies: { bar: '1.0.0' } },
+      bar: { dependencies: { baz: '1.0.0' } },
+      baz: {},
+    });
+    const dependents = getDependentsForPackages({
+      packageInfos: packages,
+      // means only look at dependencies of foo
+      scopedPackages: new Set(['foo']),
+    });
+    expect(dependents).toEqual({
+      bar: ['foo'],
+    });
+  });
+});

--- a/src/__tests__/changefile/changeTypes.test.ts
+++ b/src/__tests__/changefile/changeTypes.test.ts
@@ -60,12 +60,20 @@ describe('initializePackageChangeTypes', () => {
       { change: { packageName: 'bar', type: 'none' } },
       { change: { packageName: 'bar', type: 'minor' } },
       { change: { packageName: 'foo', type: 'patch' } },
-      { change: { packageName: 'baz', type: 'none' } },
     ] as ChangeSet;
+
     expect(initializePackageChangeTypes(changeSet)).toEqual({
       foo: 'minor',
       bar: 'minor',
-      baz: 'none',
     });
+  });
+
+  it('omits "none" change types', () => {
+    const changeSet = [
+      { change: { packageName: 'foo', type: 'none' } },
+      { change: { packageName: 'bar', type: 'patch' } },
+    ] as ChangeSet;
+
+    expect(initializePackageChangeTypes(changeSet)).toEqual({ bar: 'patch' });
   });
 });

--- a/src/bump/bumpInPlace.ts
+++ b/src/bump/bumpInPlace.ts
@@ -33,8 +33,8 @@ export function bumpInPlace(bumpInfo: BumpInfo, options: BeachballOptions): void
   }
 
   // Calculate change types for packages and dependencies
-  for (const { changeFile } of changeFileChangeInfos) {
-    updateRelatedChangeType({ changeFile, bumpInfo, dependents, bumpDeps });
+  for (const { change } of changeFileChangeInfos) {
+    updateRelatedChangeType({ change, bumpInfo, dependents, bumpDeps });
   }
 
   // pass 3: actually bump the packages in the bumpInfo in memory (no disk writes at this point)

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -11,16 +11,10 @@ import { getPackageGroups } from '../monorepo/getPackageGroups';
  * Gather bump info and bump versions in memory.
  */
 export function gatherBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
-  // Collate the changes per package
   const changes = readChangeFiles(options, packageInfos);
 
-  // Clear non-existent packages from changefiles infos
+  // Determine base change types for each package (not considering disallowedChangeTypes or groups)
   const calculatedChangeTypes = initializePackageChangeTypes(changes);
-  Object.keys(calculatedChangeTypes).forEach(packageName => {
-    if (!packageInfos[packageName]) {
-      delete calculatedChangeTypes[packageName];
-    }
-  });
 
   const bumpInfo: BumpInfo = {
     calculatedChangeTypes,

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -1,110 +1,101 @@
-import { getMaxChangeType, MinChangeType } from '../changefile/changeTypes';
+import { MinChangeType, getMaxChangeType } from '../changefile/changeTypes';
 import type { BumpInfo, PackageDependents } from '../types/BumpInfo';
+import { ChangeFileInfo } from '../types/ChangeInfo';
 
 /**
- * This is the core of the bumpInfo dependency bumping logic - done once per change file
+ * This is the core of the `bumpInfo` dependency bumping logic - done once per change info.
  *
- * The algorithm is an iterative graph traversal algorithm (breadth first)
- * - it searches up the parent `dependents` and modifies the "calculatedChangeTypes" entries inside `BumpInfo`
- * - one single root entry from `pkgName` as given by a change file
- * - for all dependents
- *   - apply the `dependentChangeType` as change type
- * - this function is the primary way for package groups to get the same dependent change type by queueing up
- *   all packages within a group to be visited by the loop
+ * The algorithm is an iterative graph traversal algorithm (breadth first):
+ * - One root entry: `change.packageName`
+ * - For each parent in `dependents`:
+ *   - Update its `calculatedChangeTypes` entry to `max(current value, change.dependentChangeType)`
+ *   - Enqueue all of its dependents to be seen
+ * - If the package is part of a group, enqueue all packages in the group
+ *
+ * Preconditions:
+ * - `bumpInfo.calculatedChangeTypes` includes:
+ *   - For non-grouped packages that have changed, the highest change type from any change file
+ *   - For each grouped package where anything in the group has changed, the highest change type
+ *     from any change file in the group
  *
  * What it mutates:
- * - bumpInfo.calculatedChangeTypes: updates packages change type modifed by this function
- * - all dependents change types as part of a group update
+ * - `bumpInfo.calculatedChangeTypes`: updates dependents' change types
+ * - all dependents' change types as part of a group update
  *
  * What it does not do:
- * - bumpInfo.calculatedChangeTypes: will not mutate the entryPoint `pkgName` change type
+ * - `bumpInfo.calculatedChangeTypes`: will not mutate the `change.packageName` change type
  */
 export function updateRelatedChangeType(params: {
-  changeFile: string;
-  bumpInfo: Pick<BumpInfo, 'calculatedChangeTypes' | 'changeFileChangeInfos' | 'packageGroups' | 'packageInfos'>;
+  change: ChangeFileInfo;
+  bumpInfo: Pick<BumpInfo, 'calculatedChangeTypes' | 'packageGroups' | 'packageInfos'>;
   dependents: PackageDependents;
   bumpDeps: boolean;
 }): void {
-  const { changeFile, bumpInfo, dependents, bumpDeps } = params;
-  const { calculatedChangeTypes, changeFileChangeInfos, packageGroups, packageInfos } = bumpInfo;
+  const { change, bumpInfo, dependents, bumpDeps } = params;
+  const { calculatedChangeTypes, packageGroups, packageInfos } = bumpInfo;
 
-  for (const info of changeFileChangeInfos) {
-    if (info.changeFile !== changeFile) {
-      continue;
-    }
+  // If dependentChangeType is none (or somehow unset), there's nothing to do.
+  const updatedChangeType = getMaxChangeType(change.dependentChangeType);
+  if (updatedChangeType === 'none') {
+    return;
+  }
 
-    const {
-      change: { packageName: entryPointPackageName, dependentChangeType },
-    } = info;
+  const entryPointPackageName = change.packageName;
 
-    // Do not do anything if packageInfo is not present: it means this was an invalid changefile that
-    // somehow got checked in. (This should have already been caught by readChangeFiles, but just in case.)
-    if (!packageInfos[entryPointPackageName]) {
-      continue;
-    }
+  // Enqueue the first package.
+  // This part of the bump algorithm is a performance bottleneck, so it's important to bail early
+  // whenever possible, and to use `seen` to reduce queue insertion.
+  // https://github.com/microsoft/beachball/pull/1042
+  const queue = [{ subjectPackage: entryPointPackageName, changeType: MinChangeType }];
+  const seen = new Set<string>();
 
-    const updatedChangeType = getMaxChangeType(dependentChangeType, MinChangeType);
+  while (queue.length > 0) {
+    const { subjectPackage, changeType } = queue.shift()!;
 
-    const queue = [{ subjectPackage: entryPointPackageName, changeType: MinChangeType }];
+    // Step 1. Update change type of the subjectPackage according to dependentChangeType if needed.
+    if (subjectPackage !== entryPointPackageName) {
+      const oldType = calculatedChangeTypes[subjectPackage];
+      calculatedChangeTypes[subjectPackage] = getMaxChangeType(
+        oldType,
+        changeType,
+        packageInfos[subjectPackage]?.combinedOptions?.disallowedChangeTypes
+      );
 
-    // visited is a set of package names that already has been seen by this algorithm - this allows the algo to scale
-    const visited = new Set<string>();
-
-    while (queue.length > 0) {
-      const { subjectPackage, changeType } = queue.shift()!;
-
-      // Step 1. Update change type of the subjectPackage according to the dependent change type propagation
-      const packageInfo = packageInfos[subjectPackage];
-      if (!packageInfo) {
+      if (calculatedChangeTypes[subjectPackage] === oldType) {
+        // We didn't change this type, so keep going.
         continue;
       }
+    }
 
-      const disallowedChangeTypes = packageInfo.combinedOptions?.disallowedChangeTypes ?? [];
+    // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"
+    const dependentPackages = dependents[subjectPackage];
 
-      if (subjectPackage !== entryPointPackageName) {
-        const oldType = calculatedChangeTypes[subjectPackage];
-        calculatedChangeTypes[subjectPackage] = getMaxChangeType(
-          oldType,
-          changeType,
-          disallowedChangeTypes
-        );
-
-        // We didn't change this type, so keep going.
-        if (calculatedChangeTypes[subjectPackage] === oldType) {
+    if (bumpDeps && dependentPackages?.length) {
+      for (const dependentPackage of dependentPackages) {
+        if (seen.has(dependentPackage)) {
           continue;
         }
+
+        seen.add(dependentPackage);
+        queue.push({ subjectPackage: dependentPackage, changeType: updatedChangeType });
       }
+    }
 
-      // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"
-      const dependentPackages = dependents[subjectPackage];
+    // TODO: when we do "locked", or "lock step" versioning, we could simply skip this grouped traversal,
+    //       - set the version for all packages in the group in bumpPackageInfoVersion()
+    //       - the main concern is how to capture the bump reason in grouped changelog
 
-      if (bumpDeps && dependentPackages?.length) {
-        for (const dependentPackage of dependentPackages) {
-          if (visited.has(dependentPackage)) {
-            continue;
-          }
+    // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
+    const group = Object.values(packageGroups).find(g => g.packageNames.includes(subjectPackage));
 
-          visited.add(dependentPackage);
-          queue.push(({ subjectPackage: dependentPackage, changeType: updatedChangeType }));
-        }
-      }
-
-      // TODO: when we do "locked", or "lock step" versioning, we could simply skip this grouped traversal,
-      //       - set the version for all packages in the group in bumpPackageInfoVersion()
-      //       - the main concern is how to capture the bump reason in grouped changelog
-
-      // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
-      const group = Object.values(packageGroups).find(g => g.packageNames.includes(packageInfo.name));
-
-      if (group) {
-        for (const packageNameInGroup of group.packageNames) {
-          if (!group.disallowedChangeTypes?.includes(updatedChangeType) && !visited.has(packageNameInGroup)) {
-            visited.add(packageNameInGroup);
-            queue.push({
-              subjectPackage: packageNameInGroup,
-              changeType: updatedChangeType,
-            });
-          }
+    if (group && !group.disallowedChangeTypes?.includes(updatedChangeType)) {
+      for (const packageNameInGroup of group.packageNames) {
+        if (!seen.has(packageNameInGroup)) {
+          seen.add(packageNameInGroup);
+          queue.push({
+            subjectPackage: packageNameInGroup,
+            changeType: updatedChangeType,
+          });
         }
       }
     }

--- a/src/changefile/changeTypes.ts
+++ b/src/changefile/changeTypes.ts
@@ -23,7 +23,7 @@ export const MinChangeType = SortedChangeTypes[0];
  * Change type weights.
  * Note: the order in which this is defined is IMPORTANT.
  */
-const ChangeTypeWeights = Object.fromEntries(SortedChangeTypes.map((t, i) => [t, i])) as { [t in ChangeType]: number };
+const ChangeTypeWeights = Object.fromEntries(SortedChangeTypes.map((t, i) => [t, i])) as Record<ChangeType, number>;
 
 /**
  * Get initial package change types based on the greatest change type set for each package in any
@@ -40,7 +40,7 @@ export function initializePackageChangeTypes(changeSet: ChangeSet): { [pkgName: 
   return pkgChangeTypes;
 }
 
-function getAllowedChangeType(changeType: ChangeType, disallowedChangeTypes: ChangeType[]): ChangeType {
+function getAllowedChangeType(changeType: ChangeType, disallowedChangeTypes: ReadonlyArray<ChangeType>): ChangeType {
   if (!changeType) {
     return 'none'; // this would be from invalid user input
   }
@@ -61,15 +61,12 @@ function getAllowedChangeType(changeType: ChangeType, disallowedChangeTypes: Cha
 export function getMaxChangeType(
   a: ChangeType | undefined,
   b: ChangeType | undefined,
-  disallowedChangeTypes?: ChangeType[] | null
+  disallowedChangeTypes?: ReadonlyArray<ChangeType> | null
 ): ChangeType {
-  a ??= MinChangeType;
-  b ??= MinChangeType;
-
-  if (disallowedChangeTypes) {
-    a = getAllowedChangeType(a, disallowedChangeTypes);
-    b = getAllowedChangeType(b, disallowedChangeTypes);
+  if (disallowedChangeTypes?.length) {
+    a = a && getAllowedChangeType(a, disallowedChangeTypes);
+    b = b && getAllowedChangeType(b, disallowedChangeTypes);
   }
 
-  return ChangeTypeWeights[a] > ChangeTypeWeights[b] ? a : b;
+  return a && b ? (ChangeTypeWeights[a] > ChangeTypeWeights[b] ? a : b) : a || b || 'none';
 }

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -3,7 +3,10 @@ import type { DeepReadonly } from './DeepReadonly';
 import type { PackageInfos, PackageGroups } from './PackageInfo';
 
 export type BumpInfo = {
-  /** Changes coming from the change files */
+  /**
+   * Changes coming from the change files.
+   * `readChangeFiles` ensures that this will only contain changes for packages that exist.
+   */
   changeFileChangeInfos: DeepReadonly<ChangeSet>;
 
   /**
@@ -12,7 +15,12 @@ export type BumpInfo = {
    */
   packageInfos: PackageInfos;
 
-  /** Change types collated by the package names */
+  /**
+   * Mapping from package name to change type.
+   *
+   * Initially (after `gatherBumpInfo`), this just has change types based on the change files.
+   * It's updated by the early steps of `bumpInPlace` to consider groups and `disallowedChangeTypes`.
+   */
   calculatedChangeTypes: { [pkgName: string]: ChangeType };
 
   /** Package grouping */

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -35,4 +35,11 @@ export interface ChangeInfoMultiple {
 /**
  * List of change file infos (not actually a set).
  */
-export type ChangeSet = { changeFile: string; change: ChangeFileInfo }[];
+export type ChangeSet = Array<{
+  change: ChangeFileInfo;
+  /**
+   * Filename the change came from (under `BeachballOptions.changeDir`).
+   * Multiple entries in the array might have come from the same file.
+   */
+  changeFile: string;
+}>;

--- a/src/validation/isValidDependentChangeType.ts
+++ b/src/validation/isValidDependentChangeType.ts
@@ -1,15 +1,18 @@
+import { SortedChangeTypes } from '../changefile/changeTypes';
 import { ChangeType } from '../types/ChangeInfo';
 
+/**
+ * Returns whether `dependentChangeType` is valid and not disallowed.
+ * Note that `'patch'` is always allowed.
+ */
 export function isValidDependentChangeType(
   dependentChangeType: ChangeType,
   disallowedChangeTypes: ChangeType[] | null
 ): boolean {
-  // patch is always allowed as a dependentChangeType
-  const disallowedDependentChangeTypes = (disallowedChangeTypes || []).filter(t => t !== 'patch');
+  if (dependentChangeType === 'patch') {
+    // patch is always allowed as a dependentChangeType
+    return true;
+  }
 
-  return (
-    ['patch', 'major', 'minor', 'prerelease', 'prepatch', 'praminor', 'premajor', 'none'].includes(
-      dependentChangeType
-    ) && !disallowedDependentChangeTypes.includes(dependentChangeType)
-  );
+  return SortedChangeTypes.includes(dependentChangeType) && !disallowedChangeTypes?.includes(dependentChangeType);
 }


### PR DESCRIPTION
@derrickstolee's PR #1042 got me looking more closely at `updateRelatedChangeType` and its performance, which eventually made me notice that I'd accidentally introduced a (sometimes) *massive* amount of duplicate processing  in that function in #606... 

The problem is [here](https://github.com/microsoft/beachball/pull/606/files#diff-a33757cc26ac8647c5dc7465768d11c4dacdf1b921c1f46e8c75fc29ea952824R34): this function was always meant to process a single change info, but for some reason I updated it to process *all* changes from the same change file, which would then be repeated when the `bumpInPlace` loop runs for every other change from that file. This becomes a problem when a grouped change file has 3000 changes, and of course the graph traversal step is also running on that large graph...

The main change in this PR is removing the outer loop from `updateRelatedChangeType`, and updating it to bail out early if the change type is `'none'`. (I also noticed a lot of other historical weirdness and bugs, but I'm just focusing on lower-risk fixes for now.)

Other smaller (non-test) changes:
- Remove redundant checks for change files referencing packages that don't exist (`readChangeFiles` already does that)
- Update `initializePackageChangeTypes` to ignore `'none'` changes
- In `getMaxChangeType`, reduce the number of cases where `getAllowedChangeType` is called for `disallowedChangeTypes`