### PR TITLE
Add option to disable commit hashes in changelogs

### DIFF
--- a/change/beachball-ec0a58b8-699d-4d02-832d-e3ae639b0f70.json
+++ b/change/beachball-ec0a58b8-699d-4d02-832d-e3ae639b0f70.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option to disable commit hashes in changelogs (`options.changelog.includeCommitHashes`, default true)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/types/ChangeInfo.ts
+++ b/src/types/ChangeInfo.ts
@@ -22,7 +22,11 @@ export interface ChangeFileInfo {
  * Info saved in each change file, plus the commit hash.
  */
 export interface ChangeInfo extends ChangeFileInfo {
-  commit: string;
+  /**
+   * Commit hash where the change was made, if available.
+   * Will be undefined if `options.change.includeCommitHashes` is false.
+   */
+  commit?: string;
 }
 
 /**

--- a/src/types/ChangeLog.ts
+++ b/src/types/ChangeLog.ts
@@ -25,8 +25,10 @@ export interface ChangelogEntry {
    *
    * Could also be `"not available"` for other commits if there was an issue determing the hash
    * at changelog generation time.
+   *
+   * Will be undefined if `options.change.includeCommitHashes` is false.
    */
-  commit: string;
+  commit?: string;
   /** Package name the change was in */
   package: string;
   /** Extra info added to the change file via custom prompts */

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -53,6 +53,13 @@ export interface ChangelogOptions {
    * (If the md file is truncated, it will include a comment about referring to git for older entries.)
    */
   maxVersions?: number;
+
+  /**
+   * If true (the default), each `CHANGELOG.json` entry and `ChangeInfo` object will include the
+   * commit hash where the change was made. This can be disabled for performance reasons.
+   * @default true
+   */
+  includeCommitHashes?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add an option `options.changelog.includeCommitHashes` which defaults to true but can be used to disable fetching and writing commit hashes to the changelog.

Fixes #1048