### PR TITLE
Add npmReadConcurrency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ beachball publish -r http://localhost:4873 -t beta
 
 ### Overriding concurrency
 
-In large monorepos, the Beachball sync process can be time-consuming due to the high number of packages. To optimize performance, you can override the default concurrency (typically 2 or 5) by setting the `NPM_CONCURRENCY` environment variable to a value that best suits your needs.
+In large monorepos, the process of fetching versions for sync or before publishing can be time-consuming due to the high number of packages. To optimize performance, you can override the concurrency for npm read operations by setting `options.npmReadConcurrency` (default: 5). You can also increase concurrency for hook calls and publish operations via `options.concurrency` (default: 1; respects topological order).
 
 ### API surface
 

--- a/change/beachball-a4ff6165-e9ef-4ae7-9406-a6765d46379c.json
+++ b/change/beachball-a4ff6165-e9ef-4ae7-9406-a6765d46379c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add npmReadConcurrency option",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -22,7 +22,12 @@ describe('sync command (e2e)', () => {
   const mockNpm = initNpmMock();
 
   let repositoryFactory: RepositoryFactory | undefined;
-  const publishOptions: Parameters<typeof packagePublish>[1] = { registry: 'fake', retries: 3, path: undefined };
+  const publishOptions: Parameters<typeof packagePublish>[1] = {
+    registry: 'fake',
+    retries: 3,
+    path: undefined,
+    npmReadConcurrency: 2,
+  };
   const tempDirs: string[] = [];
 
   initMockLogs();

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -41,6 +41,11 @@ describe('packagePublish', () => {
 
   const logs = initMockLogs();
 
+  const defaultOptions: Omit<Parameters<typeof packagePublish>[1], 'path' | 'registry'> = {
+    npmReadConcurrency: 2,
+    retries: 3,
+  };
+
   function getTestPackageInfo(): PackageInfo {
     return {
       ...testPackage,
@@ -85,8 +90,8 @@ describe('packagePublish', () => {
     await registry.reset();
     const testPackageInfo = getTestPackageInfo();
     const publishResult = await packagePublish(testPackageInfo, {
+      ...defaultOptions,
       registry: registry.getUrl(),
-      retries: 2,
       path: tempRoot,
     });
     expect(publishResult).toEqual(successResult);
@@ -109,16 +114,14 @@ describe('packagePublish', () => {
     // Use real npm for this because the republish detection relies on the real error message
     await registry.reset();
     const testPackageInfo = getTestPackageInfo();
-    let publishResult = await packagePublish(testPackageInfo, {
-      registry: registry.getUrl(),
-      retries: 2,
-      path: tempRoot,
-    });
+    const options = { ...defaultOptions, registry: registry.getUrl(), path: tempRoot };
+
+    let publishResult = await packagePublish(testPackageInfo, options);
     expect(publishResult).toEqual(successResult);
     expect(npmSpy).toHaveBeenCalledTimes(1);
     logs.clear();
 
-    publishResult = await packagePublish(testPackageInfo, { registry: registry.getUrl(), retries: 2, path: tempRoot });
+    publishResult = await packagePublish(testPackageInfo, options);
     expect(publishResult).toEqual(failedResult);
     // `retries` should be ignored if the version already exists
     expect(npmSpy).toHaveBeenCalledTimes(2);
@@ -140,7 +143,11 @@ describe('packagePublish', () => {
       Promise.resolve({ success: false, all: 'sloooow', timedOut: true } as NpmResult)
     );
 
-    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3, path: tempRoot });
+    const publishResult = await packagePublish(testPackageInfo, {
+      ...defaultOptions,
+      registry: 'fake',
+      path: tempRoot,
+    });
     expect(publishResult).toEqual(successResult);
     expect(npmSpy).toHaveBeenCalledTimes(3);
 
@@ -156,7 +163,11 @@ describe('packagePublish', () => {
     // Again, mock all npm calls for this test instead of simulating an actual error condition.
     npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'some errors' } as NpmResult));
 
-    const publishResult = await packagePublish(getTestPackageInfo(), { registry: 'fake', retries: 3, path: tempRoot });
+    const publishResult = await packagePublish(getTestPackageInfo(), {
+      ...defaultOptions,
+      registry: 'fake',
+      path: tempRoot,
+    });
     expect(publishResult).toEqual(failedResult);
     expect(npmSpy).toHaveBeenCalledTimes(4);
 
@@ -172,7 +183,11 @@ describe('packagePublish', () => {
     const testPackageInfo = getTestPackageInfo();
     npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code ENEEDAUTH' } as NpmResult));
 
-    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3, path: tempRoot });
+    const publishResult = await packagePublish(testPackageInfo, {
+      ...defaultOptions,
+      registry: 'fake',
+      path: tempRoot,
+    });
     expect(publishResult).toEqual(failedResult);
     expect(npmSpy).toHaveBeenCalledTimes(1);
 
@@ -187,7 +202,11 @@ describe('packagePublish', () => {
     const testPackageInfo = getTestPackageInfo();
     npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code E404' } as NpmResult));
 
-    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3, path: tempRoot });
+    const publishResult = await packagePublish(testPackageInfo, {
+      ...defaultOptions,
+      registry: 'fake',
+      path: tempRoot,
+    });
     expect(publishResult).toEqual(failedResult);
     expect(npmSpy).toHaveBeenCalledTimes(1);
 
@@ -198,7 +217,11 @@ describe('packagePublish', () => {
     const testPackageInfo = getTestPackageInfo();
     npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code E403' } as NpmResult));
 
-    const publishResult = await packagePublish(testPackageInfo, { registry: 'fake', retries: 3, path: tempRoot });
+    const publishResult = await packagePublish(testPackageInfo, {
+      ...defaultOptions,
+      registry: 'fake',
+      path: tempRoot,
+    });
     expect(publishResult).toEqual(failedResult);
     expect(npmSpy).toHaveBeenCalledTimes(1);
 

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../packageManager/npm');
 describe('list npm versions', () => {
   /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
   const npmMock = initNpmMock();
-  const npmOptions: NpmOptions = { registry: 'https://fake', path: undefined };
+  const npmOptions: NpmOptions = { registry: 'https://fake', path: undefined, npmReadConcurrency: 2 };
   const commonArgs = ['show', '--registry', 'https://fake', '--json'];
 
   afterEach(() => {

--- a/src/__tests__/packageManager/npmArgs.test.ts
+++ b/src/__tests__/packageManager/npmArgs.test.ts
@@ -25,7 +25,7 @@ describe('getNpmAuthArgs', () => {
 });
 
 describe('getNpmPublishArgs', () => {
-  const options: Omit<NpmOptions, 'path'> = { registry: 'https://testRegistry' };
+  const options: Omit<NpmOptions, 'path'> = { registry: 'https://testRegistry', npmReadConcurrency: 2 };
 
   const packageInfos = makePackageInfos({
     basic: {},

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -12,7 +12,7 @@ describe('getNewPackages', () => {
   const logs = initMockLogs();
   /** Mock the `npm show` command for `npmAsync` calls. This also handles cleanup after each test. */
   const npmMock = initNpmMock();
-  const npmOptions = {} as NpmOptions;
+  const npmOptions: NpmOptions = { npmReadConcurrency: 2, path: undefined, registry: 'https://fake' };
 
   afterEach(() => {
     _clearPackageVersionsCache();

--- a/src/__tests__/publish/validatePackageVersions.test.ts
+++ b/src/__tests__/publish/validatePackageVersions.test.ts
@@ -12,7 +12,7 @@ describe('validatePackageVersions', () => {
   const logs = initMockLogs();
   /** Mock the `npm show` command. This also handles cleanup after each test. */
   const npmMock = initNpmMock();
-  const npmOptions = {} as NpmOptions;
+  const npmOptions: NpmOptions = { npmReadConcurrency: 2, path: undefined, registry: 'https://fake' };
 
   afterEach(() => {
     _clearPackageVersionsCache();

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,10 +1,11 @@
 const isAzurePipelines = !!process.env.TF_BUILD;
+const isJest = !!process.env.JEST_WORKER_ID;
 
 export const env = Object.freeze({
   // most everything but ADO sets process.env.CI by default
   isCI: !!process.env.CI || isAzurePipelines,
 
-  isJest: !!process.env.JEST_WORKER_ID,
+  isJest,
 
   /**
    * @deprecated This should likely be replaced with a different strategy (it's never set)
@@ -17,6 +18,7 @@ export const env = Object.freeze({
   // These are borrowed from workspace-tools
   workspaceToolsGitDebug: !!process.env.GIT_DEBUG,
   workspaceToolsGitMaxBuffer: (process.env.GIT_MAX_BUFFER && parseInt(process.env.GIT_MAX_BUFFER, 10)) || undefined,
-  // Override default NPM_CONCURRENCY
-  npmConcurrency: (process.env.NPM_CONCURRENCY && parseInt(process.env.NPM_CONCURRENCY)) || undefined,
+  /** @deprecated Use `options.npmReadConcurrency` */
+  // if this is removed, default logic should go to getDefaultOptions
+  npmConcurrency: (process.env.NPM_CONCURRENCY && parseInt(process.env.NPM_CONCURRENCY)) || (isJest ? 2 : 5),
 });

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -23,7 +23,7 @@ const booleanOptions = [
   'version',
   'yes',
 ] as const;
-const numberOptions = ['concurrency', 'depth', 'gitTimeout', 'retries', 'timeout'] as const;
+const numberOptions = ['concurrency', 'depth', 'npmReadConcurrency', 'gitTimeout', 'retries', 'timeout'] as const;
 const stringOptions = [
   'access',
   'authType',

--- a/src/options/getDefaultOptions.ts
+++ b/src/options/getDefaultOptions.ts
@@ -27,6 +27,7 @@ export function getDefaultOptions(): BeachballOptions {
     gitTimeout: undefined,
     message: '',
     new: false,
+    npmReadConcurrency: env.npmConcurrency,
     path: '',
     publish: true,
     push: true,

--- a/src/packageManager/listPackageVersions.ts
+++ b/src/packageManager/listPackageVersions.ts
@@ -18,8 +18,6 @@ export type NpmShowResult = PackageJson & {
 
 let packageVersionsCache: { [pkgName: string]: NpmShowResult | false } = {};
 
-const NPM_CONCURRENCY = env.npmConcurrency ?? (env.isJest ? 2 : 5);
-
 /** Specific `npm show` properties requested by `listPackageVersions` */
 export const npmShowProperties = ['versions', 'dist-tags'];
 
@@ -61,7 +59,7 @@ export async function listPackageVersionsByTag(
   tag: string | undefined,
   options: NpmOptions
 ): Promise<{ [pkg: string]: string }> {
-  const limit = pLimit(NPM_CONCURRENCY);
+  const limit = pLimit(options.npmReadConcurrency);
   const versions: { [pkg: string]: string } = {};
 
   await Promise.all(
@@ -86,7 +84,7 @@ export async function listPackageVersions(
   packageList: string[],
   options: NpmOptions
 ): Promise<{ [pkg: string]: string[] }> {
-  const limit = pLimit(NPM_CONCURRENCY);
+  const limit = pLimit(options.npmReadConcurrency);
   const versions: { [pkg: string]: string[] } = {};
 
   await Promise.all(

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -28,6 +28,7 @@ export interface CliOptions
     | 'keepChangeFiles'
     | 'message'
     | 'new'
+    | 'npmReadConcurrency'
     | 'path'
     | 'prereleasePrefix'
     | 'publish'
@@ -111,11 +112,18 @@ export interface RepoOptions {
    */
   commit?: boolean;
   /**
-   * Maximum concurrency.
-   * As of writing, concurrency only applies for calling hooks and publishing to npm.
+   * Maximum concurrency for write operations.
+   * As of writing, this only applies for calling `hooks` and publishing to npm.
+   * (See also `npmReadConcurrency`.)
    * @default 1
    */
   concurrency: number;
+  /**
+   * Maximum concurrency for read-only `npm` operations (listing package versions/tags).
+   * (See also `concurrency`.)
+   * @default 5
+   */
+  npmReadConcurrency: number;
   /**
    * The default dist-tag used for npm publish
    * @default 'latest'

--- a/src/types/NpmOptions.ts
+++ b/src/types/NpmOptions.ts
@@ -1,5 +1,5 @@
 import type { BeachballOptions } from './BeachballOptions';
 
-export type NpmOptions = Required<Pick<BeachballOptions, 'registry'>> & { path: string | undefined } & Partial<
-    Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout' | 'verbose'>
-  >;
+export type NpmOptions = Required<Pick<BeachballOptions, 'registry' | 'npmReadConcurrency'>> & {
+  path: string | undefined;
+} & Partial<Pick<BeachballOptions, 'token' | 'authType' | 'access' | 'timeout' | 'verbose'>>;


### PR DESCRIPTION
Add an option `npmReadConcurrency` which controls the number of simultaneous `npm show` requests when getting current package versions from the registry. This replaces the `NPM_CONCURRENCY` env.