### PR TITLE
Rename ChangelogGroupOptions.masterPackageName to mainPackageName

### DIFF
--- a/change/beachball-2e525df7-ec40-40c9-a854-e2692a57feda.json
+++ b/change/beachball-2e525df7-ec40-40c9-a854-e2692a57feda.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add ChangelogGroupOptions.mainPackageName and deprecate ChangelogGroupOptions.masterPackageName",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -156,7 +156,7 @@ describe('readChangeFiles', () => {
       changelog: {
         groups: [
           {
-            masterPackageName: 'foo',
+            mainPackageName: 'foo',
             changelogPath: repo.pathTo('packages/foo'),
             include: ['packages/foo', 'packages/bar'],
           },

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -283,7 +283,7 @@ describe('writeChangelog', () => {
       changelog: {
         groups: [
           {
-            masterPackageName: 'foo',
+            mainPackageName: 'foo',
             changelogPath: '.',
             include: ['packages/*'],
           },
@@ -354,7 +354,7 @@ describe('writeChangelog', () => {
       changelog: {
         groups: [
           {
-            masterPackageName: 'foo',
+            mainPackageName: 'foo',
             changelogPath: 'packages/foo',
             include: ['packages/foo', 'packages/bar'],
           },
@@ -380,7 +380,7 @@ describe('writeChangelog', () => {
     repo = sharedMonoRepo;
     const options = getOptions({
       changelog: {
-        groups: [{ masterPackageName: 'foo', changelogPath: '.', include: ['packages/foo', 'packages/baz'] }],
+        groups: [{ mainPackageName: 'foo', changelogPath: '.', include: ['packages/foo', 'packages/baz'] }],
       },
     });
 
@@ -402,7 +402,7 @@ describe('writeChangelog', () => {
       changelog: {
         groups: [
           // The grouped changelog overlaps with the changelog for packages/foo.
-          { masterPackageName: 'foo', changelogPath: 'packages/foo', include: ['packages/foo', 'packages/baz'] },
+          { mainPackageName: 'foo', changelogPath: 'packages/foo', include: ['packages/foo', 'packages/baz'] },
         ],
       },
     });

--- a/src/__functional__/options/getOptions.test.ts
+++ b/src/__functional__/options/getOptions.test.ts
@@ -68,7 +68,7 @@ describe('getOptions', () => {
       publish: false,
       disallowedChangeTypes: null,
       changelog: {
-        groups: [{ masterPackageName: 'foo', include: ['foo'], changelogPath: '.' }],
+        groups: [{ mainPackageName: 'foo', include: ['foo'], changelogPath: '.' }],
       },
     };
     const config = inDirectory(repo.rootPath, () => {

--- a/src/changelog/mergeChangelogs.ts
+++ b/src/changelog/mergeChangelogs.ts
@@ -5,21 +5,21 @@ import type { ChangeType } from '../types/ChangeInfo';
 
 /**
  * Merge multiple package changelogs into one.
- * `name` and `version` will use the values from `primaryPackage`'s changelog.
+ * `name` and `version` will use the values from `mainPackage`'s changelog.
  * `comments` are merged. `date` will be now.
  */
 export function mergeChangelogs(
   changelogs: PackageChangelog[],
-  primaryPackage: PackageInfo
+  mainPackage: PackageInfo
 ): PackageChangelog | undefined {
-  if (changelogs.length < 1 || !primaryPackage) {
+  if (changelogs.length < 1 || !mainPackage) {
     return undefined;
   }
 
   const result: PackageChangelog = {
-    name: primaryPackage.name,
-    version: primaryPackage.version,
-    tag: generateTag(primaryPackage.name, primaryPackage.version),
+    name: mainPackage.name,
+    version: mainPackage.version,
+    tag: generateTag(mainPackage.name, mainPackage.version),
     date: new Date(),
     comments: {},
   };

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -62,21 +62,23 @@ async function writeGroupedChangelog(
   const changelogs = getPackageChangelogs({ changeFileChangeInfos, calculatedChangeTypes, packageInfos }, options);
 
   const groupedChangelogs: {
-    [changelogAbsDir: string]: { changelogs: PackageChangelog[]; masterPackage: PackageInfo };
+    [changelogAbsDir: string]: { changelogs: PackageChangelog[]; mainPackage: PackageInfo };
   } = {};
 
   // Validate groups and initialize groupedChangelogs
-  for (const { masterPackageName, changelogAbsDir } of changelogGroups) {
-    const masterPackage = packageInfos[masterPackageName];
-    if (!masterPackage) {
-      console.warn(`master package ${masterPackageName} does not exist.`);
+  for (const group of changelogGroups) {
+    const { changelogAbsDir } = group;
+    const mainPackageName = 'mainPackageName' in group ? group.mainPackageName : group.masterPackageName;
+    const mainPackage = packageInfos[mainPackageName];
+    if (!mainPackage) {
+      console.warn(`main package ${mainPackageName} does not exist.`);
       continue;
     }
     if (!fs.existsSync(changelogAbsDir)) {
       console.warn(`changelog path ${changelogAbsDir} does not exist.`);
       continue;
     }
-    groupedChangelogs[changelogAbsDir] = { masterPackage, changelogs: [] };
+    groupedChangelogs[changelogAbsDir] = { mainPackage, changelogs: [] };
   }
 
   // Put changelogs into groups
@@ -94,7 +96,7 @@ async function writeGroupedChangelog(
 
   // Write each grouped changelog if it's not empty
   for (const [groupAbsDir, group] of Object.entries(groupedChangelogs)) {
-    const groupedChangelog = mergeChangelogs(group.changelogs, group.masterPackage);
+    const groupedChangelog = mergeChangelogs(group.changelogs, group.mainPackage);
     if (groupedChangelog) {
       await writeChangelogFiles({
         options,

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -62,16 +62,7 @@ export interface ChangelogOptions {
   includeCommitHashes?: boolean;
 }
 
-/**
- * Options for generating a changelog for a group of packages.
- */
-export interface ChangelogGroupOptions {
-  /**
-   * The main package which a group of changes bubbles up to.
-   * All changes within the group are used to describe changes for the master package.
-   */
-  masterPackageName: string;
-
+interface ChangelogGroupOptionsBase {
   /**
    * minimatch pattern(s) for package paths to include in this group.
    * Patterns are relative to the repo root and must use forward slashes.
@@ -94,6 +85,23 @@ export interface ChangelogGroupOptions {
    */
   changelogPath: string;
 }
+
+/**
+ * Options for generating a changelog for a group of packages.
+ */
+export type ChangelogGroupOptions =
+  | (ChangelogGroupOptionsBase & {
+      /**
+       * The main package which a group of changes bubbles up to.
+       * All changes within the group are used to describe changes for the main package.
+       */
+      mainPackageName: string;
+    })
+  | (ChangelogGroupOptionsBase & {
+      /** @deprecated Use `mainPackageName` */
+      // Change the type back to a single interface once this is removed
+      masterPackageName: string;
+    });
 
 /**
  * Info used for rendering the changelog markdown for a particular package version.

--- a/src/validation/isValidChangelogOptions.ts
+++ b/src/validation/isValidChangelogOptions.ts
@@ -6,11 +6,13 @@ export function isValidChangelogOptions(options: ChangelogOptions): boolean {
     return true;
   }
 
-  const badGroups = options.groups.filter(group => !group.changelogPath || !group.masterPackageName || !group.include);
+  const badGroups = options.groups.filter(
+    group => !group.changelogPath || !('masterPackageName' in group || 'mainPackageName' in group) || !group.include
+  );
 
   if (badGroups.length) {
     console.error(
-      'ERROR: "changelog.groups" entries must define "changelogPath", "masterPackageName", and "include". ' +
+      'ERROR: "changelog.groups" entries must define "changelogPath", "mainPackageName", and "include". ' +
         'Found invalid groups:\n' +
         badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
     );


### PR DESCRIPTION
Deprecate `ChangelogGroupOptions.masterPackageName` and replace it with `ChangelogGroupOptions.mainPackageName`.