### PR TITLE
Add option packToPath to pack packages instead of publishing

### DIFF
--- a/change/beachball-55d9e364-8092-44cb-b48b-1c8adf681703.json
+++ b/change/beachball-55d9e364-8092-44cb-b48b-1c8adf681703.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option packToPath to pack packages instead of publishing",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
@@ -37,10 +37,6 @@ describe('publish command (git)', () => {
       ...overrides,
     };
   }
-
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
 
   beforeEach(() => {
     repositoryFactory = new RepositoryFactory('single');

--- a/src/__functional__/packageManager/packPackage.test.ts
+++ b/src/__functional__/packageManager/packPackage.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, beforeEach, jest, afterEach } from '@jest/globals';
+import fs from 'fs-extra';
+import path from 'path';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
+import type * as npmModuleType from '../../packageManager/npm';
+import type { NpmResult } from '../../packageManager/npm';
+import { packPackage } from '../../packageManager/packPackage';
+import { PackageInfo } from '../../types/PackageInfo';
+import { getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
+
+// Spawning actual npm is slow, so mock it for most of these tests.
+// A couple tests also use the real npm command.
+jest.mock('../../packageManager/npm');
+
+const { npm: actualNpm } = jest.requireActual('../../packageManager/npm') as typeof npmModuleType;
+
+describe('packPackage', () => {
+  const npmMock = initNpmMock();
+  let tempRoot: string;
+  let tempPackageJsonPath = '';
+  let tempPackPath: string;
+
+  const logs = initMockLogs();
+
+  function getTestPackage(name: string) {
+    const version = '0.6.0';
+    const json = { name, version };
+    const info: PackageInfo = {
+      ...json,
+      packageJsonPath: tempPackageJsonPath,
+      private: false,
+      combinedOptions: {} as any,
+      packageOptions: {} as any,
+    };
+    return {
+      name,
+      version,
+      json,
+      info,
+      spec: `${name}@${version}`,
+      packName: getMockNpmPackName({ name, version }),
+    };
+  }
+
+  beforeEach(() => {
+    tempRoot = tmpdir();
+    tempPackageJsonPath = path.join(tempRoot, 'package.json');
+    tempPackPath = tmpdir();
+  });
+
+  afterEach(() => {
+    removeTempDir(tempRoot);
+    removeTempDir(tempPackPath);
+  });
+
+  it('packs package', async () => {
+    const testPkg = getTestPackage('testpkg');
+    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(true);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledWith(
+      ['pack', '--loglevel', 'warn'],
+      expect.objectContaining({ cwd: tempRoot })
+    );
+    // file is moved to correct location (not the package folder)
+    expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+  });
+
+  it('packs scoped package', async () => {
+    const testPkg = getTestPackage('@foo/bar');
+    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(true);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledWith(
+      ['pack', '--loglevel', 'warn'],
+      expect.objectContaining({ cwd: tempRoot })
+    );
+    // file is moved to correct location (not the package folder)
+    expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+  });
+
+  it('packs package with correct longer prefix', async () => {
+    const testPkg = getTestPackage('testpkg');
+    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+
+    // There are 100 packages to pack, so index 1 should be prefixed with "002-"
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 1, total: 100 });
+    expect(packResult).toEqual(true);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(npmMock.mock).toHaveBeenCalledWith(
+      ['pack', '--loglevel', 'warn'],
+      expect.objectContaining({ cwd: tempRoot })
+    );
+    expect(fs.existsSync(path.join(tempPackPath, '002-' + testPkg.packName))).toBe(true);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '002-' + testPkg.packName)}`);
+  });
+
+  it('handles failure packing', async () => {
+    const testPkg = getTestPackage('testpkg');
+    // It's difficult to simulate actual error conditions, so mock an npm call failure.
+    npmMock.setCommandOverride('pack', () =>
+      Promise.resolve({ success: false, stdout: 'oh no', all: 'oh no' } as NpmResult)
+    );
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(false);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`Packing ${testPkg.spec} failed (see above for details)`);
+  });
+
+  it('handles if filename is missing from output', async () => {
+    const testPkg = getTestPackage('testpkg');
+    npmMock.setCommandOverride('pack', () =>
+      Promise.resolve({ success: true, stdout: 'not a file', all: 'not a file' } as NpmResult)
+    );
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(false);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`npm pack output for ${testPkg.spec} (above) did not end with a filename that exists`);
+  });
+
+  it('handles if filename in output does not exist', async () => {
+    const testPkg = getTestPackage('testpkg');
+    npmMock.setCommandOverride('pack', () =>
+      Promise.resolve({ success: true, stdout: 'nope.tgz', all: 'nope.tgz' } as NpmResult)
+    );
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(false);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(`npm pack output for ${testPkg.spec} (above) did not end with a filename that exists`);
+  });
+
+  it('handles failure moving file', async () => {
+    const testPkg = getTestPackage('testpkg');
+    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+
+    // create a file with the same name to simulate a move failure
+    fs.writeFileSync(path.join(tempPackPath, '1-' + testPkg.packName), 'other content');
+
+    const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+    expect(packResult).toEqual(false);
+    expect(npmMock.mock).toHaveBeenCalledTimes(1);
+
+    const allLogs = logs.getMockLines('all');
+    expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+    expect(allLogs).toMatch(
+      `Failed to move ${path.join(tempRoot, testPkg.packName)} to ${path.join(
+        tempPackPath,
+        '1-' + testPkg.packName
+      )}: Error:`
+    );
+
+    // tgz file is cleaned up
+    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+  });
+
+  // These tests are slow, so only cover minimal cases
+  describe('real npm', () => {
+    beforeEach(() => {
+      npmMock.setCommandOverride('pack', (_, args, opts) => {
+        return actualNpm(['pack', ...args], opts);
+      });
+    });
+
+    it('packs scoped package', async () => {
+      const testPkg = getTestPackage('@foo/bar');
+      fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+
+      const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
+      expect(packResult).toEqual(true);
+      expect(npmMock.mock).toHaveBeenCalledTimes(1);
+      expect(npmMock.mock).toHaveBeenCalledWith(
+        ['pack', '--loglevel', 'warn'],
+        expect.objectContaining({ cwd: tempRoot })
+      );
+      // file is moved to correct location (not the package folder)
+      expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+      expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+
+      const allLogs = logs.getMockLines('all');
+      expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
+      expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+    });
+  });
+});

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -63,7 +63,6 @@ describe('packagePublish', () => {
 
   beforeAll(() => {
     registry = new Registry(__filename);
-    jest.setTimeout(30000);
 
     // Create a test package.json in a temporary location for use in tests.
     tempRoot = tmpdir();

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -37,7 +37,7 @@ export async function canary(options: BeachballOptions): Promise<void> {
 
   await performBump(bumpInfo, options);
 
-  if (options.publish) {
+  if (options.publish || options.packToPath) {
     await publishToRegistry(bumpInfo, options);
   } else {
     console.log('Skipping publish');

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -74,8 +74,10 @@ export async function publish(options: BeachballOptions): Promise<void> {
 
   // Step 1. Bump on disk + npm publish
   // npm / yarn publish
-  if (options.publish) {
-    console.log('\nBumping versions and publishing to npm');
+  if (options.publish || options.packToPath) {
+    console.log(
+      `\nBumping versions and ${options.packToPath ? `packing packages to ${options.packToPath}` : 'publishing to npm'}`
+    );
     await publishToRegistry(bumpInfo, options);
     console.log();
   } else {

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -35,6 +35,7 @@ const stringOptions = [
   'dependentChangeType',
   'fromRef',
   'message',
+  'packToPath',
   'prereleasePrefix',
   'registry',
   'tag',

--- a/src/packageManager/npmArgs.ts
+++ b/src/packageManager/npmArgs.ts
@@ -2,6 +2,10 @@ import type { AuthType } from '../types/Auth';
 import type { NpmOptions } from '../types/NpmOptions';
 import type { PackageInfo } from '../types/PackageInfo';
 
+export function getNpmLogLevelArgs(verbose: boolean | undefined): string[] {
+  return ['--loglevel', verbose ? 'notice' : 'warn'];
+}
+
 export function getNpmPublishArgs(packageInfo: PackageInfo, options: Omit<NpmOptions, 'path'>): string[] {
   const { registry, token, authType, access } = options;
   const pkgCombinedOptions = packageInfo.combinedOptions;
@@ -11,8 +15,7 @@ export function getNpmPublishArgs(packageInfo: PackageInfo, options: Omit<NpmOpt
     registry,
     '--tag',
     pkgCombinedOptions.tag || pkgCombinedOptions.defaultNpmTag || 'latest',
-    '--loglevel',
-    options.verbose ? 'notice' : 'warn',
+    ...getNpmLogLevelArgs(options.verbose),
     ...getNpmAuthArgs(registry, token, authType),
   ];
 

--- a/src/packageManager/packPackage.ts
+++ b/src/packageManager/packPackage.ts
@@ -1,0 +1,68 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { PackageInfo } from '../types/PackageInfo';
+import { BeachballOptions } from '../types/BeachballOptions';
+import { npm } from './npm';
+import { getNpmLogLevelArgs } from './npmArgs';
+
+/**
+ * Attempts to pack the package and move the tgz to `options.packPath`.
+ * The packed filename will be prefixed with a number.
+ * @returns true if successful, false if not.
+ */
+export async function packPackage(
+  packageInfo: PackageInfo,
+  options: Required<Pick<BeachballOptions, 'packToPath'>> &
+    Pick<BeachballOptions, 'verbose'> & {
+      /** Index of this package in the topologically-sorted list to publish */
+      index: number;
+      /** Total number of packages to publish */
+      total: number;
+    }
+): Promise<boolean> {
+  const { packToPath, verbose, index, total } = options;
+
+  const packArgs = ['pack', ...getNpmLogLevelArgs(verbose)];
+
+  const packageRoot = path.dirname(packageInfo.packageJsonPath);
+  const packageSpec = `${packageInfo.name}@${packageInfo.version}`;
+  console.log(`\nPacking - ${packageSpec}`);
+  console.log(`  (cwd: ${packageRoot})`);
+
+  // Run npm pack in the package directory
+  const result = await npm(packArgs, { cwd: packageRoot, all: true });
+  // log afterwards instead of piping because we need to access the output to get the filename
+  console.log(result.all);
+
+  if (!result.success) {
+    console.error(`\nPacking ${packageSpec} failed (see above for details)`);
+    return false;
+  }
+
+  const packFile = result.stdout.trim().split('\n').pop()!;
+  const packFilePath = path.join(packageRoot, packFile);
+  if (!packFile.endsWith('.tgz') || !fs.existsSync(packFilePath)) {
+    console.error(`\nnpm pack output for ${packageSpec} (above) did not end with a filename that exists`);
+    return false;
+  }
+
+  // Prepend a numeric prefix to the pack file (0-padded so basic sorting works).
+  // The prefix isn't strictly needed for single packages, but use it for consistency in case of a
+  // monorepo which usually publishes multiple packages but sometimes only one has changed.
+  const packPrefix = String(index + 1).padStart(String(total).length, '0') + '-';
+  const finalPackFilePath = path.join(packToPath, packPrefix + packFile);
+  try {
+    fs.ensureDirSync(packToPath);
+    fs.moveSync(packFilePath, finalPackFilePath);
+  } catch (err) {
+    console.error(`\nFailed to move ${packFilePath} to ${finalPackFilePath}: ${err}`);
+    try {
+      // attempt to clean up the pack file (ignore any failures)
+      fs.removeSync(packFilePath);
+    } catch {}
+    return false;
+  }
+
+  console.log(`\nPacked ${packageSpec} to ${finalPackFilePath}`);
+  return true;
+}

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -29,6 +29,7 @@ export interface CliOptions
     | 'message'
     | 'new'
     | 'npmReadConcurrency'
+    | 'packToPath'
     | 'path'
     | 'prereleasePrefix'
     | 'publish'
@@ -183,6 +184,11 @@ export interface RepoOptions {
    * @default true
    */
   publish: boolean;
+  /**
+   * If provided, pack packages to the specified path instead of publishing.
+   * Implies `publish: false`.
+   */
+  packToPath?: string;
   /**
    * Whether to push to the remote git branch when publishing
    * @default true


### PR DESCRIPTION
New version of #935: Add an option `packToPath` to support the new workflow of using an ADO task to publish to npm. If this option is provided, the actual publish step will be skipped, and instead `npm pack` will be called on each package (with the resulting files moved to the specified directory).

Usage from command line (could also be in a config file):
`beachball publish --packToPath /somewhere/my-pack-dir`

The files in the pack directory will look like this, supposing `foo` depends on `bar` depends on `baz`:
```
/somewhere/my-pack-dir
  1-baz-1.0.0.tgz
  2-bar-1.0.0.tgz
  3-foo-1.0.0.tgz
```
The numeric prefixes reflect the proper topological ordering, to prevent dependency references to new package versions that don't exist yet if there's a failure or slowdown midway through the publishing job in a monorepo. (For > 9 files, the prefixes would be 0-padded for proper sorting, e.g. `01-bar-...` or `001-bar-...`.)