### PR TITLE
For version groups, use the max change type from the group, not the first encountered

### DIFF
--- a/change/beachball-1a687403-625b-49a9-b681-841901a12186.json
+++ b/change/beachball-1a687403-625b-49a9-b681-841901a12186.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "For version groups, use the max change type from the group, not the first one encountered",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/changelog/writeChangelog.test.ts
+++ b/src/__functional__/changelog/writeChangelog.test.ts
@@ -54,10 +54,10 @@ describe('writeChangelog', () => {
     const calculatedChangeTypes: BumpInfo['calculatedChangeTypes'] = {};
     for (const { change } of changeFileChangeInfos) {
       const { packageName, type } = change;
-      calculatedChangeTypes[packageName] = getMaxChangeType(type, calculatedChangeTypes[packageName]);
+      calculatedChangeTypes[packageName] = getMaxChangeType([type, calculatedChangeTypes[packageName]]);
     }
     for (const pkgName of Object.keys(dependentChangedBy)) {
-      calculatedChangeTypes[pkgName] = getMaxChangeType('patch', calculatedChangeTypes[pkgName]);
+      calculatedChangeTypes[pkgName] = getMaxChangeType(['patch', calculatedChangeTypes[pkgName]]);
     }
 
     // Bump versions in package info and package.json for more realistic changelogs.

--- a/src/__tests__/changefile/changeTypes.test.ts
+++ b/src/__tests__/changefile/changeTypes.test.ts
@@ -3,48 +3,52 @@ import { getMaxChangeType, initializePackageChangeTypes } from '../../changefile
 import type { ChangeSet } from '../../types/ChangeInfo';
 
 describe('getMaxChangeType', () => {
+  it('handles empty change type array', () => {
+    expect(getMaxChangeType([], null)).toBe('none');
+  });
+
+  it('handles single change type', () => {
+    expect(getMaxChangeType(['patch'], null)).toBe('patch');
+  });
+
   it('handles equal change types', () => {
-    const changeType = getMaxChangeType('patch', 'patch', null);
+    const changeType = getMaxChangeType(['patch', 'patch'], null);
     expect(changeType).toBe('patch');
   });
 
   it('returns greater change type without disallowedChangeTypes', () => {
-    expect(getMaxChangeType('patch', 'minor', null)).toBe('minor');
-    expect(getMaxChangeType('minor', 'patch', null)).toBe('minor');
-    expect(getMaxChangeType('minor', 'major', null)).toBe('major');
-    expect(getMaxChangeType('patch', 'major', null)).toBe('major');
-    expect(getMaxChangeType('patch', 'prerelease', null)).toBe('patch');
-    expect(getMaxChangeType('patch', 'none', null)).toBe('patch');
-    expect(getMaxChangeType('prerelease', 'none', null)).toBe('prerelease');
+    expect(getMaxChangeType(['patch', 'minor'], null)).toBe('minor');
+    expect(getMaxChangeType(['minor', 'patch'], null)).toBe('minor');
+    expect(getMaxChangeType(['minor', 'major'], null)).toBe('major');
+    expect(getMaxChangeType(['patch', 'major'], null)).toBe('major');
+    expect(getMaxChangeType(['patch', 'prerelease'], null)).toBe('patch');
+    expect(getMaxChangeType(['patch', 'none'], null)).toBe('patch');
+    expect(getMaxChangeType(['prerelease', 'none'], null)).toBe('prerelease');
+  });
+
+  it('handles longer array of changeTypes with max in middle', () => {
+    const changeType = getMaxChangeType(['patch', 'minor', 'major', 'patch'], null);
+    expect(changeType).toBe('major');
   });
 
   it('returns none if all given change types are disallowed', () => {
-    const changeType = getMaxChangeType('patch', 'major', [
-      'major',
-      'minor',
-      'patch',
-      'prerelease',
-      'premajor',
-      'preminor',
-      'prepatch',
-    ]);
+    const changeType = getMaxChangeType(
+      ['patch', 'major'],
+      ['major', 'minor', 'patch', 'prerelease', 'premajor', 'preminor', 'prepatch']
+    );
     expect(changeType).toBe('none');
   });
 
   it('returns next greatest change type if max is disallowed', () => {
-    const changeType = getMaxChangeType('patch', 'major', ['major', 'premajor', 'preminor', 'prepatch']);
+    const changeType = getMaxChangeType(['patch', 'major'], ['major', 'premajor', 'preminor', 'prepatch']);
     expect(changeType).toBe('minor');
   });
 
   it('handles prerelease only case', () => {
-    const changeType = getMaxChangeType('patch', 'major', [
-      'major',
-      'minor',
-      'patch',
-      'premajor',
-      'preminor',
-      'prepatch',
-    ]);
+    const changeType = getMaxChangeType(
+      ['patch', 'major'],
+      ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch']
+    );
     expect(changeType).toBe('prerelease');
   });
 });

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -35,7 +35,7 @@ export function updateRelatedChangeType(params: {
   const { calculatedChangeTypes, packageGroups, packageInfos } = bumpInfo;
 
   // If dependentChangeType is none (or somehow unset), there's nothing to do.
-  const updatedChangeType = getMaxChangeType(change.dependentChangeType);
+  const updatedChangeType = getMaxChangeType([change.dependentChangeType]);
   if (updatedChangeType === 'none') {
     return;
   }
@@ -56,8 +56,7 @@ export function updateRelatedChangeType(params: {
     if (subjectPackage !== entryPointPackageName) {
       const oldType = calculatedChangeTypes[subjectPackage];
       calculatedChangeTypes[subjectPackage] = getMaxChangeType(
-        oldType,
-        changeType,
+        [oldType, changeType],
         packageInfos[subjectPackage]?.combinedOptions?.disallowedChangeTypes
       );
 

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -68,7 +68,7 @@ async function writeGroupedChangelog(
   // Validate groups and initialize groupedChangelogs
   for (const group of changelogGroups) {
     const { changelogAbsDir } = group;
-    const mainPackageName = 'mainPackageName' in group ? group.mainPackageName : group.masterPackageName;
+    const mainPackageName = group.mainPackageName ?? group.masterPackageName!;
     const mainPackage = packageInfos[mainPackageName];
     if (!mainPackage) {
       console.warn(`main package ${mainPackageName} does not exist.`);

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -150,7 +150,10 @@ export interface RepoOptions {
    * - `'json'` to generate only CHANGELOG.json
    */
   generateChangelog: boolean | 'md' | 'json';
-  /** Options for bumping package versions together */
+  /**
+   * Options for bumping package versions together.
+   * (For changelog groups, use `BeachballOptions.changelog.groups`.)
+   */
   groups?: VersionGroupOptions[];
   /**
    * Whether to create git tags for published packages
@@ -255,6 +258,8 @@ export interface PackageOptions {
 
 /**
  * Options for bumping package versions together.
+ *
+ * For changelog groups, use `BeachballOptions.changelog.groups` (`ChangelogGroupOptions`).
  */
 export interface VersionGroupOptions {
   /** name of the version group */

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -23,7 +23,9 @@ export type BumpInfo = {
    */
   calculatedChangeTypes: { [pkgName: string]: ChangeType };
 
-  /** Package grouping */
+  /**
+   * Package version groups (not changelog groups) derived from `BeachballOptions.groups` (`VersionGroupOptions`).
+   */
   packageGroups: DeepReadonly<PackageGroups>;
 
   /** Set of packages that had been modified */

--- a/src/types/ChangelogOptions.ts
+++ b/src/types/ChangelogOptions.ts
@@ -9,7 +9,12 @@ import type { ChangeType } from './ChangeInfo';
  * to achieve the desired level of customization.
  */
 export interface ChangelogOptions {
-  /** Options for grouping packages together in a single changelog. */
+  /**
+   * Options for grouping packages together in a single changelog.
+   *
+   * Note that this only impacts changelogs, not version bumping.
+   * For version bumping, use `BeachballOptions.groups` (`VersionGroupOptions`).
+   */
   groups?: ChangelogGroupOptions[];
 
   /**
@@ -62,7 +67,13 @@ export interface ChangelogOptions {
   includeCommitHashes?: boolean;
 }
 
-interface ChangelogGroupOptionsBase {
+/**
+ * Options for generating a changelog for a group of packages.
+ *
+ * Note that this only impacts changelogs, not version bumping.
+ * For version bumping, use `BeachballOptions.groups` (`VersionGroupOptions`).
+ */
+export interface ChangelogGroupOptions {
   /**
    * minimatch pattern(s) for package paths to include in this group.
    * Patterns are relative to the repo root and must use forward slashes.
@@ -84,24 +95,16 @@ interface ChangelogGroupOptionsBase {
    * Can be relative to the root, or absolute.
    */
   changelogPath: string;
-}
 
-/**
- * Options for generating a changelog for a group of packages.
- */
-export type ChangelogGroupOptions =
-  | (ChangelogGroupOptionsBase & {
-      /**
-       * The main package which a group of changes bubbles up to.
-       * All changes within the group are used to describe changes for the main package.
-       */
-      mainPackageName: string;
-    })
-  | (ChangelogGroupOptionsBase & {
-      /** @deprecated Use `mainPackageName` */
-      // Change the type back to a single interface once this is removed
-      masterPackageName: string;
-    });
+  /**
+   * The main package which a group of changes bubbles up to.
+   * All changes within the group are used to describe changes for the main package.
+   */
+  mainPackageName: string;
+
+  /** @deprecated Use `mainPackageName` */
+  masterPackageName?: string;
+}
 
 /**
  * Info used for rendering the changelog markdown for a particular package version.

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -63,6 +63,9 @@ export interface PackageGroupsInfo {
   disallowedChangeTypes: ChangeType[] | null;
 }
 
+/**
+ * Package version groups (not changelog groups) derived from `BeachballOptions.groups` (`VersionGroupOptions`).
+ */
 export type PackageGroups = { [groupName: string]: PackageGroupsInfo };
 
 /** Types of dependencies to consider when bumping. */


### PR DESCRIPTION
New version of #691 (thanks @tannerlyons!)

For packages in a version group, find the max change type from all changed packages in the group, rather than using the first change type encountered on the filesystem.

The main change is in `bumpInPlace.ts`. The rest is mostly comments and changing `getMaxChangeType` to take an array.