### PR TITLE
Remove lodash usage

### DIFF
--- a/change/beachball-bb24d305-4fab-40c2-943b-1e3d21fb8fe5.json
+++ b/change/beachball-bb24d305-4fab-40c2-943b-1e3d21fb8fe5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove lodash usage for minor perf improvement",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "cosmiconfig": "^9.0.0",
     "execa": "^5.0.0",
     "fs-extra": "^11.1.1",
-    "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
     "p-graph": "^1.1.2",
     "p-limit": "^3.0.2",
@@ -63,7 +62,6 @@
   "devDependencies": {
     "@jest/globals": "^29.0.0",
     "@types/fs-extra": "^11.0.0",
-    "@types/lodash": "^4.14.191",
     "@types/minimatch": "^5.0.0",
     "@types/node": "^14.0.0",
     "@types/prompts": "^2.4.2",

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -1,6 +1,5 @@
 import { afterAll, afterEach, beforeAll, type jest } from '@jest/globals';
 import fs from 'fs-extra';
-import _ from 'lodash';
 import path from 'path';
 import semver from 'semver';
 import { npmShowProperties, type NpmShowResult } from '../packageManager/listPackageVersions';
@@ -122,7 +121,9 @@ export function initNpmMock(): NpmMock {
 
 /** (exported for testing) Make full registry data from partial data */
 export function _makeRegistryData(data: PartialRegistryData): MockNpmRegistry {
-  return _.mapValues(data, (pkg, name): MockNpmRegistryPackage => {
+  const registry: MockNpmRegistry = {};
+
+  for (const [name, pkg] of Object.entries(data)) {
     let versions = pkg.versions;
     let distTags = pkg['dist-tags'];
     if (!versions && !distTags) {
@@ -136,13 +137,15 @@ export function _makeRegistryData(data: PartialRegistryData): MockNpmRegistry {
     // Ensure "latest" is set
     distTags.latest ??= versions.slice(-1)[0];
 
-    return {
+    registry[name] = {
       versions,
       'dist-tags': distTags,
       // Fill in basic package.json data for each version
       versionData: Object.fromEntries(versions.map(version => [version, { name, version }])),
     };
-  });
+  }
+
+  return registry;
 }
 
 /** (exported for testing) Mock npm show based on the registry data */

--- a/src/__fixtures__/packageInfos.ts
+++ b/src/__fixtures__/packageInfos.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { PackageInfo, PackageInfos } from '../types/PackageInfo';
 import { getDefaultOptions } from '../options/getDefaultOptions';
@@ -23,9 +22,10 @@ export type PartialPackageInfos = {
  * ```
  */
 export function makePackageInfos(packageInfos: PartialPackageInfos): PackageInfos {
-  return _.mapValues(packageInfos, (info, name): PackageInfo => {
+  const acc: PackageInfos = {};
+  for (const [name, info] of Object.entries(packageInfos)) {
     const { combinedOptions, ...rest } = info;
-    return {
+    acc[name] = {
       name,
       version: '1.0.0',
       private: false,
@@ -34,5 +34,6 @@ export function makePackageInfos(packageInfos: PartialPackageInfos): PackageInfo
       packageJsonPath: '',
       ...rest,
     };
-  });
+  }
+  return acc;
 }

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -7,7 +7,7 @@ import { tmpdir } from './tmpdir';
 import { gitFailFast } from 'workspace-tools';
 import { setDefaultBranchName } from './gitDefaults';
 import { env } from '../env';
-import _ from 'lodash';
+import { _cloneObject } from '../publish/cloneBumpInfo';
 
 /**
  * Standard fixture options. See {@link getSinglePackageFixture}, {@link getMonorepoFixture} and
@@ -177,7 +177,7 @@ export class RepositoryFactory {
             : fixtureParam === 'monorepo'
             ? getMonorepoFixture()
             : // Clone the user-provided fixture so it's safe to modify
-              _.cloneDeep(fixtureParam),
+              _cloneObject(fixtureParam),
       };
     }
 

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import _ from 'lodash';
 import {
   listPackageVersions,
   listPackageVersionsByTag,
@@ -51,7 +50,8 @@ describe('list npm versions', () => {
       npmMock.setRegistryData(showData);
 
       const versions = await listPackageVersions(packages, npmOptions);
-      expect(versions).toEqual(_.mapValues(showData, x => x.versions));
+      const expectedVerions = Object.fromEntries(Object.entries(showData).map(([k, v]) => [k, v.versions]));
+      expect(versions).toEqual(expectedVerions);
       expect(npmMock.mock).toHaveBeenCalledTimes(packages.length);
     });
 
@@ -123,10 +123,10 @@ describe('list npm versions', () => {
       const packages = 'abcdefghij'.split('');
       const showData = Object.fromEntries(packages.map((x, i) => [x, { 'dist-tags': { latest: `${i}.0.0` } }]));
       npmMock.setRegistryData(showData);
-      const packageInfos = Object.values(makePackageInfos(_.mapValues(showData, () => ({}))));
+      const packageInfos = Object.values(makePackageInfos(Object.fromEntries(packages.map(x => [x, {}]))));
 
       expect(await listPackageVersionsByTag(packageInfos, 'latest', npmOptions)).toEqual(
-        _.mapValues(showData, x => x['dist-tags']?.latest)
+        Object.fromEntries(Object.entries(showData).map(([k, v]) => [k, v['dist-tags'].latest]))
       );
       expect(npmMock.mock).toHaveBeenCalledTimes(packages.length);
     });

--- a/src/__tests__/publish/cloneBumpInfo.test.ts
+++ b/src/__tests__/publish/cloneBumpInfo.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from '@jest/globals';
+import { _cloneObject, cloneBumpInfo } from '../../publish/cloneBumpInfo';
+import type { BumpInfo } from '../../types/BumpInfo';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { getChange } from '../../__fixtures__/changeFiles';
+
+describe('_cloneObject', () => {
+  it.each<[string, object | unknown[]]>([
+    ['empty object', {}],
+    ['empty object with null prototype', Object.create(null)],
+    ['object', { a: 1, b: '2', c: true }],
+    ['object with null prototype', Object.assign(Object.create(null), { a: 1, b: '2', c: true })],
+    ['empty array', []],
+    ['array', [1, '2', true]],
+    ['set', new Set([1, 2, 3])],
+    ['object of sets', { a: new Set([1, 2, 3]), b: new Set(['a', 'b', 'c']) }],
+  ])('clones %s', (desc, val) => {
+    const cloned = _cloneObject(val);
+    expect(cloned).toEqual(val);
+    expect(cloned).not.toBe(val);
+  });
+
+  it('deeply clones nested object', () => {
+    const orig = { a: { b: { c: 1 } } };
+    const cloned = _cloneObject(orig);
+    expect(cloned).toEqual(orig);
+    expect(cloned).not.toBe(orig);
+    expect(cloned.a).not.toBe(orig.a);
+    expect(cloned.a.b).not.toBe(orig.a.b);
+  });
+
+  it('deep clones array of objects and arrays', () => {
+    const orig = [{ a: 1 }, [2, 3, 4]];
+    const cloned = _cloneObject(orig);
+    expect(cloned).toEqual(orig);
+    expect(cloned).not.toBe(orig);
+    expect(cloned[0]).not.toBe(orig[0]);
+    expect(cloned[1]).not.toBe(orig[1]);
+  });
+
+  it('throws on other object types', () => {
+    expect(() => _cloneObject(new Date())).toThrow('Unsupported object type found while cloning bump info: Date');
+    expect(() => _cloneObject(/abc/)).toThrow('Unsupported object type found while cloning bump info: RegExp');
+    expect(() => _cloneObject(new Map())).toThrow('Unsupported object type found while cloning bump info: Map');
+    class Foo {}
+    expect(() => _cloneObject(new Foo())).toThrow('Unsupported object type found while cloning bump info: Foo');
+  });
+});
+
+describe('cloneBumpInfo', () => {
+  it('clones bump info structure', () => {
+    const original: BumpInfo = {
+      // There's no attempt at consistency because it doesn't matter here
+      calculatedChangeTypes: { pkgA: 'minor', pkgB: 'patch' },
+      packageInfos: makePackageInfos({ a: { dependencies: { b: '^1.0.0' } }, b: {} }),
+      changeFileChangeInfos: [
+        { change: getChange('a'), changeFile: '' },
+        { change: getChange('b'), changeFile: '' },
+      ],
+      packageGroups: { group1: { packageNames: ['a', 'b'], disallowedChangeTypes: null } },
+      dependentChangedBy: { a: new Set(['b']) },
+      modifiedPackages: new Set(['a']),
+      scopedPackages: new Set(['a', 'b']),
+    };
+
+    const cloned = cloneBumpInfo(original);
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+    expect(cloned.packageInfos).not.toBe(original.packageInfos);
+    expect(cloned.packageInfos.a).not.toBe(original.packageInfos.a);
+    expect(cloned.changeFileChangeInfos).not.toBe(original.changeFileChangeInfos);
+    expect(cloned.changeFileChangeInfos[0]).not.toBe(original.changeFileChangeInfos[0]);
+    expect(cloned.changeFileChangeInfos[0].change).not.toBe(original.changeFileChangeInfos[0].change);
+    expect(cloned.packageGroups).not.toBe(original.packageGroups);
+    expect(cloned.dependentChangedBy).not.toBe(original.dependentChangedBy);
+    expect(cloned.dependentChangedBy.a).not.toBe(original.dependentChangedBy.a);
+    expect(cloned.modifiedPackages).not.toBe(original.modifiedPackages);
+    expect(cloned.scopedPackages).not.toBe(original.scopedPackages);
+  });
+});

--- a/src/changelog/renderPackageChangelog.ts
+++ b/src/changelog/renderPackageChangelog.ts
@@ -1,5 +1,4 @@
 import type { ChangelogEntry } from '../types/ChangeLog';
-import _ from 'lodash';
 import type { PackageChangelogRenderInfo, ChangelogRenderers } from '../types/ChangelogOptions';
 import type { ChangeType } from '../types/ChangeInfo';
 import { SortedChangeTypes } from '../changefile/changeTypes';
@@ -67,11 +66,14 @@ async function _renderEntries(changeType: ChangeType, renderInfo: PackageChangel
   }
 
   if (renderInfo.isGrouped) {
-    const entriesByPackage = _.entries(_.groupBy(entries, entry => entry.package));
+    const entriesByPackage: Record<string, ChangelogEntry[]> = {};
+    for (const entry of entries) {
+      (entriesByPackage[entry.package] ??= []).push(entry);
+    }
 
     // Use a for loop here (not map) so that if renderEntry does network requests, we don't fire them all at once
     const packagesText: string[] = [];
-    for (const [pkgName, pkgEntries] of entriesByPackage) {
+    for (const [pkgName, pkgEntries] of Object.entries(entriesByPackage)) {
       const entriesText = (await _renderEntriesBasic(pkgEntries, renderInfo)).map(entry => `  ${entry}`).join('\n');
 
       packagesText.push(`- \`${pkgName}\`\n${entriesText}`);

--- a/src/publish/cloneBumpInfo.ts
+++ b/src/publish/cloneBumpInfo.ts
@@ -1,0 +1,53 @@
+import type { BumpInfo } from '../types/BumpInfo';
+
+/**
+ * Clone a bump info object. Only handles the data types found in bump info.
+ *
+ * This is decently faster than `structuredClone` or `JSON.parse(JSON.stringify())` on a
+ * very large object. https://jsperf.app/rugosa/5
+ */
+export function cloneBumpInfo(oldInfo: BumpInfo): BumpInfo {
+  return _cloneObject(oldInfo);
+}
+
+/**
+ * Clone an object, fast.
+ * Currently only handles data types expected in `BumpInfo` but could be expanded if needed.
+ *
+ * This is decently faster than `structuredClone` or `JSON.parse(JSON.stringify())` on a
+ * very large object (bump info can be huge in certain repos). https://jsperf.app/rugosa/5
+ *
+ * @internal Exported for testing (and usage in tests)
+ */
+export function _cloneObject<T extends unknown[]>(obj: T): T;
+export function _cloneObject<T extends object>(obj: T): T;
+export function _cloneObject<T extends object>(obj: T): T {
+  if (!obj || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    const clone = [] as typeof obj;
+    for (let i = 0; i < obj.length; i++) {
+      const val = obj[i];
+      // Skip the recursive call if not an object.
+      // This check is repeatedly done inline on sub-properties for performance.
+      clone[i] = val && typeof val === 'object' ? _cloneObject(val) : val;
+    }
+    return clone;
+  }
+
+  if (obj instanceof Set) {
+    return new Set(Array.from(obj).map(item => (item && typeof item === 'object' ? _cloneObject(item) : item))) as T;
+  }
+
+  if (obj.constructor?.name && obj.constructor.name !== 'Object') {
+    throw new Error(`Unsupported object type found while cloning bump info: ${obj.constructor.name}`);
+  }
+
+  const clone = {} as typeof obj;
+  for (const [key, val] of Object.entries(obj)) {
+    (clone as any)[key] = val && typeof val === 'object' ? _cloneObject(val) : val;
+  }
+  return clone;
+}

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { performBump } from '../bump/performBump';
 import type { PublishBumpInfo } from '../types/BumpInfo';
 import type { BeachballOptions } from '../types/BeachballOptions';
@@ -12,6 +11,7 @@ import { callHook } from '../bump/callHook';
 import { getPackageGraph } from '../monorepo/getPackageGraph';
 import type { PackageInfo } from '../types/PackageInfo';
 import { packPackage } from '../packageManager/packPackage';
+import { cloneBumpInfo } from './cloneBumpInfo';
 
 /**
  * Publish all the bumped packages to the registry, OR if `packToPath` is specified,
@@ -22,7 +22,7 @@ import { packPackage } from '../packageManager/packPackage';
 export async function publishToRegistry(originalBumpInfo: PublishBumpInfo, options: BeachballOptions): Promise<void> {
   const verb = options.packToPath ? 'pack' : 'publish';
 
-  const bumpInfo = _.cloneDeep(originalBumpInfo);
+  const bumpInfo = cloneBumpInfo(originalBumpInfo);
 
   if (options.bump) {
     await performBump(bumpInfo, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,7 +655,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.175", "@types/lodash@^4.14.191":
+"@types/lodash@^4.14.175":
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.20.tgz#1ca77361d7363432d29f5e55950d9ec1e1c6ea93"
   integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
@@ -2933,7 +2933,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@4, lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.21:
+lodash@4, lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Replace lodash usage with native functions and other helpers. The new object cloning helper is derived from one in Cloudpack which was verified to be significantly faster than `structuredClone` or `JSON.parse(JSON.stringify(obj))` for large objects (good because bump info can be huge). There should also be a very minor parse/startup time improvement.