### PR TITLE
Only calculate options and package info once

### DIFF
--- a/change/beachball-eae7cb7f-6b39-44eb-bae7-d0d1d9e84205.json
+++ b/change/beachball-eae7cb7f-6b39-44eb-bae7-d0d1d9e84205.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Calculate options and PackageInfos once, and pass around between functions. This should significantly improve perf in large repos.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -7,10 +7,11 @@ import { initMockLogs } from '../__fixtures__/mockLogs';
 import { type RepoFixture, RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-import type { BeachballOptions, HooksOptions } from '../types/BeachballOptions';
+import type { HooksOptions, RepoOptions } from '../types/BeachballOptions';
 import type { Repository } from '../__fixtures__/repository';
-import { getDefaultOptions } from '../options/getDefaultOptions';
 import type { PackageJson } from '../types/PackageInfo';
+import { getParsedOptions } from '../options/getOptions';
+import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -18,12 +19,14 @@ describe('version bumping', () => {
 
   initMockLogs();
 
-  function getOptions(options?: Partial<BeachballOptions>): BeachballOptions {
-    return {
-      ...getDefaultOptions(),
-      path: repo?.rootPath || '',
-      ...options,
-    };
+  function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>, cwd?: string) {
+    const parsedOptions = getParsedOptions({
+      cwd: cwd || repo?.rootPath || '',
+      argv: [],
+      testRepoOptions: { branch: defaultRemoteBranchName, ...repoOptions },
+    });
+    const originalPackageInfos = getPackageInfos(parsedOptions);
+    return { originalPackageInfos, options: parsedOptions.options, parsedOptions };
   }
 
   afterEach(() => {
@@ -47,15 +50,15 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: false,
     });
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
@@ -84,16 +87,16 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: false,
       changeDir: testChangedir,
     });
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
@@ -104,24 +107,26 @@ describe('version bumping', () => {
     expect(changeFiles).toHaveLength(0);
   });
 
-  it('for multi-workspace (multi-monorepo), only bumps packages in the current workspace', async () => {
+  it('for multi-root monorepo, only bumps packages in the current root', async () => {
     repositoryFactory = new RepositoryFactory('multi-workspace');
     expect(Object.keys(repositoryFactory.fixtures)).toEqual(['workspace-a', 'workspace-b']);
     repo = repositoryFactory.cloneRepository();
 
     const workspaceARoot = repo.pathTo('workspace-a');
     const workspaceBRoot = repo.pathTo('workspace-b');
-    const optionsA = getOptions({ path: workspaceARoot, bumpDeps: true });
-    const optionsB = getOptions({ path: workspaceBRoot, bumpDeps: true });
+    const infoA = getOptionsAndPackages({ bumpDeps: true }, workspaceARoot);
+    const optionsA = infoA.options;
+    const infoB = getOptionsAndPackages({ bumpDeps: true }, workspaceBRoot);
+    const optionsB = infoB.options;
 
     generateChangeFiles([{ packageName: '@workspace-a/foo' }], optionsA);
     generateChangeFiles([{ packageName: '@workspace-a/foo', type: 'major' }], optionsB);
     repo.push();
 
-    await bump(optionsA);
+    await bump(optionsA, infoA.originalPackageInfos);
 
-    const packageInfosA = getPackageInfos(workspaceARoot);
-    const packageInfosB = getPackageInfos(workspaceBRoot);
+    const packageInfosA = getPackageInfos(infoA.parsedOptions);
+    const packageInfosB = getPackageInfos(infoB.parsedOptions);
     expect(packageInfosA['@workspace-a/foo'].version).toBe('1.1.0');
     expect(packageInfosB['@workspace-b/foo'].version).toBe('1.0.0');
 
@@ -143,7 +148,9 @@ describe('version bumping', () => {
     repo = repositoryFactory.cloneRepository();
 
     // generate an initial set of change files
-    const options = getOptions({ bumpDeps: false });
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
+      bumpDeps: false,
+    });
     generateChangeFiles(['pkg-1'], options);
     // set the initial change files commit as fromRef
     options.fromRef = repo.getCurrentHash();
@@ -152,9 +159,9 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-3'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     expect(packageInfos['pkg-1'].version).toBe(monorepo['packages']['pkg-1'].version);
     expect(packageInfos['pkg-2'].version).toBe(monorepo['packages']['pkg-2'].version);
@@ -178,13 +185,15 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({ bumpDeps: true });
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
+      bumpDeps: true,
+    });
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.1.0';
     const dependentNewVersion = '1.0.1';
@@ -215,16 +224,16 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       groups: [{ include: 'packages/*', name: 'testgroup', disallowedChangeTypes: [] }],
     });
     generateChangeFiles(['pkg-1'], options);
 
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const newVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -255,7 +264,7 @@ describe('version bumping', () => {
       },
     });
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       groups: [{ include: 'packages/*', disallowedChangeTypes: null, name: 'grp' }],
       bumpDeps: true,
       commit: true,
@@ -269,9 +278,9 @@ describe('version bumping', () => {
     );
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     expect(packageInfos['pkg-1'].version).toBe('1.1.0');
     expect(packageInfos['z-commonlib'].version).toBe('1.1.0');
@@ -297,16 +306,16 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       groups: [{ include: 'packages/grp/*', name: 'grp', disallowedChangeTypes: [] }],
       bumpDeps: true,
     });
     generateChangeFiles([{ packageName: 'commonlib', dependentChangeType: 'minor' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const groupNewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(groupNewVersion);
@@ -325,16 +334,16 @@ describe('version bumping', () => {
     const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       scope: ['!packages/foo'],
     });
     generateChangeFiles(['foo'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
     expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
     expect(packageInfos['bar'].version).toBe(monorepo['packages']['bar'].version);
 
@@ -347,16 +356,16 @@ describe('version bumping', () => {
     const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       scope: ['!packages/foo'],
     });
     generateChangeFiles([{ packageName: 'bar', type: 'patch' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
     expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
     expect(packageInfos['bar'].version).toBe('1.3.5');
     expect(packageInfos['foo'].dependencies!['bar']).toBe(monorepo['packages']['foo'].dependencies!['bar']);
@@ -378,7 +387,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: false,
       keepChangeFiles: true,
     });
@@ -386,9 +395,9 @@ describe('version bumping', () => {
 
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
@@ -419,7 +428,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       prereleasePrefix: 'beta',
@@ -427,9 +436,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const newVersion = '1.0.1-beta.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -460,7 +469,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       prereleasePrefix: 'beta',
@@ -469,9 +478,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const newVersion = '1.0.1-beta.1';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -502,7 +511,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       prereleasePrefix: 'beta',
@@ -511,9 +520,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const newVersion = '1.0.1-beta';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -544,7 +553,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       prereleasePrefix: 'beta',
@@ -552,9 +561,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease', dependentChangeType: 'prerelease' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const newVersion = '1.0.1-beta.0';
     expect(packageInfos['pkg-1'].version).toBe(newVersion);
@@ -584,7 +593,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options, parsedOptions } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       prereleasePrefix: 'beta',
@@ -592,9 +601,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease', dependentChangeType: 'prerelease' }], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
-    const packageInfos = getPackageInfos(repo.rootPath);
+    const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.0.1-beta.1';
     const othersNewVersion = '1.0.1-beta.0';
@@ -622,7 +631,7 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: true,
       keepChangeFiles: false,
       generateChangelog: true,
@@ -640,7 +649,7 @@ describe('version bumping', () => {
 
     repo.push();
 
-    const bumpInfo = await bump(options);
+    const bumpInfo = await bump(options, originalPackageInfos);
 
     const modified = [...bumpInfo.modifiedPackages];
     expect(modified).toContain('package1');
@@ -658,7 +667,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: false,
       hooks: {
         prebump: jest.fn<Required<HooksOptions>['prebump']>((packagePath, name, version) => {
@@ -675,7 +684,7 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
     expect(options.hooks?.prebump).toHaveBeenCalled();
   });
@@ -688,7 +697,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: false,
       hooks: {
         prebump: jest.fn<Required<HooksOptions>['prebump']>(async (packagePath, name, version) => {
@@ -705,7 +714,7 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
     expect(options.hooks?.prebump).toHaveBeenCalled();
   });
@@ -718,7 +727,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       path: repo.rootPath,
       bumpDeps: false,
       hooks: {
@@ -731,9 +740,7 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    const bumpResult = bump(options);
-
-    await expect(bumpResult).rejects.toThrow('Foo');
+    await expect(() => bump(options, originalPackageInfos)).rejects.toThrow('Foo');
   });
 
   it('calls sync postbump hook before packages are bumped', async () => {
@@ -744,7 +751,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: false,
       hooks: {
         postbump: jest.fn<Required<HooksOptions>['postbump']>((packagePath, name, version) => {
@@ -761,7 +768,7 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
     expect(options.hooks?.postbump).toHaveBeenCalled();
   });
@@ -774,7 +781,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: false,
       hooks: {
         postbump: jest.fn<Required<HooksOptions>['postbump']>(async (packagePath, name, version) => {
@@ -791,7 +798,7 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options);
+    await bump(options, originalPackageInfos);
 
     expect(options.hooks?.postbump).toHaveBeenCalled();
   });
@@ -804,7 +811,7 @@ describe('version bumping', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const options = getOptions({
+    const { originalPackageInfos, options } = getOptionsAndPackages({
       bumpDeps: false,
       hooks: {
         postbump: (): Promise<void> => {
@@ -816,8 +823,6 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    const bumpResult = bump(options);
-
-    await expect(bumpResult).rejects.toThrow('Foo');
+    await expect(() => bump(options, originalPackageInfos)).rejects.toThrow('Foo');
   });
 });

--- a/src/__fixtures__/packageInfos.ts
+++ b/src/__fixtures__/packageInfos.ts
@@ -1,39 +1,42 @@
-import type { BeachballOptions } from '../types/BeachballOptions';
 import type { PackageInfo, PackageInfos } from '../types/PackageInfo';
-import { getDefaultOptions } from '../options/getDefaultOptions';
-
-const defaultOptions = getDefaultOptions();
+import { getPackageInfosWithOptions } from '../options/getPackageInfosWithOptions';
+import type { RepoOptions } from '../types/BeachballOptions';
+import { defaultRemoteBranchName } from './gitDefaults';
 
 export type PartialPackageInfos = {
-  [name: string]: Partial<Omit<PackageInfo, 'combinedOptions'>> & { combinedOptions?: Partial<BeachballOptions> };
+  [name: string]: Omit<Partial<PackageInfo>, 'combinedOptions' | 'packageOptions'> & {
+    beachball?: PackageInfo['packageOptions'];
+  };
 };
 
 /**
  * Makes a properly typed PackageInfos object from a partial object, filling in defaults:
- * ```
+ * ```js
  * {
  *   name: '<key>',
  *   version: '1.0.0',
  *   private: false,
- *   combinedOptions: {},
- *   packageOptions: {},
  *   packageJsonPath: ''
  * }
  * ```
+ * Other defaults and values are filled by the actual logic in `getPackageInfosWithOptions`,
+ * including the overrides in `repoOptions` merged in realistic order.
  */
-export function makePackageInfos(packageInfos: PartialPackageInfos): PackageInfos {
-  const acc: PackageInfos = {};
-  for (const [name, info] of Object.entries(packageInfos)) {
-    const { combinedOptions, ...rest } = info;
-    acc[name] = {
-      name,
-      version: '1.0.0',
-      private: false,
-      combinedOptions: { ...defaultOptions, ...combinedOptions },
-      packageOptions: {},
-      packageJsonPath: '',
-      ...rest,
-    };
-  }
-  return acc;
+export function makePackageInfos(packageInfos: PartialPackageInfos, repoOptions?: Partial<RepoOptions>): PackageInfos {
+  return getPackageInfosWithOptions(
+    Object.entries(packageInfos).map(([name, info]) => {
+      return {
+        name,
+        version: '1.0.0',
+        private: false,
+        packageOptions: {},
+        packageJsonPath: '',
+        ...info,
+      };
+    }),
+    {
+      repoOptions: { branch: defaultRemoteBranchName, ...repoOptions },
+      cliOptions: { path: '', command: '' },
+    }
+  );
 }

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -8,6 +8,9 @@ import type { PackageInfos, PackageInfo } from '../../types/PackageInfo';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import type { PackageOptions } from '../../types/BeachballOptions';
+import { _cloneObject } from '../../publish/cloneBumpInfo';
+import { getParsedOptions } from '../../options/getOptions';
+import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
 
 const defaultOptions = getDefaultOptions();
 
@@ -21,8 +24,7 @@ function cleanPath(root: string, filePath: string) {
 function cleanPackageInfos(root: string, packageInfos: PackageInfos) {
   const cleanedInfos: PackageInfos = {};
   for (const [pkgName, originalInfo] of Object.entries(packageInfos)) {
-    // Make a copy deep enough to cover anything that will be modified
-    const pkgInfo = (cleanedInfos[pkgName] = { ...originalInfo, combinedOptions: { ...originalInfo.combinedOptions } });
+    const pkgInfo = (cleanedInfos[pkgName] = _cloneObject(originalInfo));
 
     // Remove absolute paths
     pkgInfo.packageJsonPath = cleanPath(root, pkgInfo.packageJsonPath);
@@ -56,14 +58,22 @@ describe('getPackageInfos', () => {
   // factories can be reused between these tests because none of them push changes
   let singleFactory: RepositoryFactory;
   let monorepoFactory: RepositoryFactory;
-  let multiWorkspaceFactory: RepositoryFactory;
+  let multiMonorepoFactory: RepositoryFactory;
   let tempDir: string | undefined;
   const logs = initMockLogs();
+
+  function getOptions(cwd: string) {
+    return getParsedOptions({
+      cwd,
+      argv: [],
+      testRepoOptions: { branch: defaultRemoteBranchName }, // skip trying to read this from git
+    });
+  }
 
   beforeAll(() => {
     singleFactory = new RepositoryFactory('single');
     monorepoFactory = new RepositoryFactory('monorepo');
-    multiWorkspaceFactory = new RepositoryFactory('multi-workspace');
+    multiMonorepoFactory = new RepositoryFactory('multi-workspace');
   });
 
   afterEach(() => {
@@ -74,10 +84,12 @@ describe('getPackageInfos', () => {
   afterAll(() => {
     singleFactory.cleanUp();
     monorepoFactory.cleanUp();
-    multiWorkspaceFactory.cleanUp();
+    multiMonorepoFactory.cleanUp();
   });
 
-  it('throws if run outside a git repo', () => {
+  // This is irrelevant with the new signature because the exception would have been thrown when
+  // the options were being parsed.
+  it('throws if run outside a git repo (old signature)', () => {
     tempDir = tmpdir();
     expect(() => getPackageInfos(tempDir!)).toThrow(/not in a git repository/);
   });
@@ -86,9 +98,10 @@ describe('getPackageInfos', () => {
     tempDir = tmpdir();
     gitFailFast(['init'], { cwd: tempDir });
     expect(getPackageInfos(tempDir)).toEqual({});
+    expect(getPackageInfos({ cliOptions: { path: tempDir!, command: '' }, repoOptions: {} })).toEqual({});
   });
 
-  it('works in single-package repo', () => {
+  it('works in single-package repo (old signature)', () => {
     const repo = singleFactory.cloneRepository();
     let packageInfos = getPackageInfos(repo.rootPath);
     packageInfos = cleanPackageInfos(repo.rootPath, packageInfos);
@@ -106,49 +119,78 @@ describe('getPackageInfos', () => {
     });
   });
 
-  // both yarn and npm define "workspaces" in package.json
-  it('works in yarn/npm monorepo', () => {
-    const repo = monorepoFactory.cloneRepository();
-    let packageInfos = getPackageInfos(repo.rootPath);
+  it('works in single-package repo', () => {
+    const repo = singleFactory.cloneRepository();
+    const parsedOptions = getOptions(repo.rootPath);
+    let packageInfos = getPackageInfos(parsedOptions);
     packageInfos = cleanPackageInfos(repo.rootPath, packageInfos);
     expect(packageInfos).toEqual({
-      a: {
-        name: 'a',
-        packageJsonPath: 'packages/grouped/a/package.json',
-        private: false,
-        version: '3.1.2',
-      },
-      b: {
-        name: 'b',
-        packageJsonPath: 'packages/grouped/b/package.json',
-        private: false,
-        version: '3.1.2',
-      },
-      bar: {
-        dependencies: {
-          baz: '^1.3.4',
-        },
-        name: 'bar',
-        packageJsonPath: 'packages/bar/package.json',
-        private: false,
-        version: '1.3.4',
-      },
-      baz: {
-        name: 'baz',
-        packageJsonPath: 'packages/baz/package.json',
-        private: false,
-        version: '1.3.4',
-      },
       foo: {
         dependencies: {
-          bar: '^1.3.4',
+          bar: '1.0.0',
+          baz: '1.0.0',
         },
         name: 'foo',
-        packageJsonPath: 'packages/foo/package.json',
+        packageJsonPath: 'package.json',
         private: false,
         version: '1.0.0',
       },
     });
+  });
+
+  const expectedYarnPackages: Record<string, Partial<PackageInfo>> = {
+    a: {
+      name: 'a',
+      packageJsonPath: 'packages/grouped/a/package.json',
+      private: false,
+      version: '3.1.2',
+    },
+    b: {
+      name: 'b',
+      packageJsonPath: 'packages/grouped/b/package.json',
+      private: false,
+      version: '3.1.2',
+    },
+    bar: {
+      dependencies: {
+        baz: '^1.3.4',
+      },
+      name: 'bar',
+      packageJsonPath: 'packages/bar/package.json',
+      private: false,
+      version: '1.3.4',
+    },
+    baz: {
+      name: 'baz',
+      packageJsonPath: 'packages/baz/package.json',
+      private: false,
+      version: '1.3.4',
+    },
+    foo: {
+      dependencies: {
+        bar: '^1.3.4',
+      },
+      name: 'foo',
+      packageJsonPath: 'packages/foo/package.json',
+      private: false,
+      version: '1.0.0',
+    },
+  };
+
+  // both yarn and npm define "workspaces" in package.json
+  it('works in yarn/npm monorepo (old signature)', () => {
+    const repo = monorepoFactory.cloneRepository();
+    let packageInfos = getPackageInfos(repo.rootPath);
+    packageInfos = cleanPackageInfos(repo.rootPath, packageInfos);
+    expect(packageInfos).toEqual(expectedYarnPackages);
+  });
+
+  it('works in yarn/npm monorepo', () => {
+    const repo = monorepoFactory.cloneRepository();
+    const parsedOptions = getOptions(repo.rootPath);
+    let packageInfos = getPackageInfos(parsedOptions);
+    packageInfos = cleanPackageInfos(repo.rootPath, packageInfos);
+    expect(packageInfos).toEqual(expectedYarnPackages);
   });
 
   it('works in pnpm monorepo', () => {
@@ -156,8 +198,9 @@ describe('getPackageInfos', () => {
     fs.writeJSONSync(repo.pathTo('package.json'), { name: 'pnpm-monorepo', version: '1.0.0', private: true });
     fs.writeFileSync(repo.pathTo('pnpm-lock.yaml'), '');
     fs.writeFileSync(repo.pathTo('pnpm-workspace.yaml'), 'packages: ["packages/*", "packages/grouped/*"]');
+    const parsedOptions = getOptions(repo.rootPath);
 
-    const rootPackageInfos = getPackageInfos(repo.rootPath);
+    const rootPackageInfos = getPackageInfos(parsedOptions);
     expect(getPackageNamesAndPaths(repo.rootPath, rootPackageInfos)).toEqual({
       a: 'packages/grouped/a/package.json',
       b: 'packages/grouped/b/package.json',
@@ -174,8 +217,9 @@ describe('getPackageInfos', () => {
     fs.writeJSONSync(repo.pathTo('rush.json'), {
       projects: [{ projectFolder: 'packages' }, { projectFolder: 'packages/grouped' }],
     });
+    const parsedOptions = getOptions(repo.rootPath);
 
-    const rootPackageInfos = getPackageInfos(repo.rootPath);
+    const rootPackageInfos = getPackageInfos(parsedOptions);
     expect(getPackageNamesAndPaths(repo.rootPath, rootPackageInfos)).toEqual({
       a: 'packages/grouped/a/package.json',
       b: 'packages/grouped/b/package.json',
@@ -190,8 +234,9 @@ describe('getPackageInfos', () => {
     const repo = monorepoFactory.cloneRepository();
     fs.writeJSONSync(repo.pathTo('package.json'), { name: 'lerna-monorepo', version: '1.0.0', private: true });
     fs.writeJSONSync(repo.pathTo('lerna.json'), { packages: ['packages/*', 'packages/grouped/*'] });
+    const parsedOptions = getOptions(repo.rootPath);
 
-    const rootPackageInfos = getPackageInfos(repo.rootPath);
+    const rootPackageInfos = getPackageInfos(parsedOptions);
     expect(getPackageNamesAndPaths(repo.rootPath, rootPackageInfos)).toEqual({
       a: 'packages/grouped/a/package.json',
       b: 'packages/grouped/b/package.json',
@@ -201,11 +246,12 @@ describe('getPackageInfos', () => {
     });
   });
 
-  it('works multi-workspace monorepo', () => {
-    const repo = multiWorkspaceFactory.cloneRepository();
+  it('works in multi-root monorepo', () => {
+    const repo = multiMonorepoFactory.cloneRepository();
 
     // For this test, only snapshot the package names and paths
-    const rootPackageInfos = getPackageInfos(repo.rootPath);
+    const rootOptions = getOptions(repo.rootPath);
+    const rootPackageInfos = getPackageInfos(rootOptions);
     expect(getPackageNamesAndPaths(repo.rootPath, rootPackageInfos)).toEqual({
       '@workspace-a/a': 'workspace-a/packages/grouped/a/package.json',
       '@workspace-a/b': 'workspace-a/packages/grouped/b/package.json',
@@ -222,7 +268,8 @@ describe('getPackageInfos', () => {
     });
 
     const workspaceARoot = repo.pathTo('workspace-a');
-    const packageInfosA = getPackageInfos(workspaceARoot);
+    const workspaceAOptions = getOptions(workspaceARoot);
+    const packageInfosA = getPackageInfos(workspaceAOptions);
     expect(getPackageNamesAndPaths(workspaceARoot, packageInfosA)).toEqual({
       '@workspace-a/a': 'packages/grouped/a/package.json',
       '@workspace-a/b': 'packages/grouped/b/package.json',
@@ -232,7 +279,8 @@ describe('getPackageInfos', () => {
     });
 
     const workspaceBRoot = repo.pathTo('workspace-b');
-    const packageInfosB = getPackageInfos(workspaceBRoot);
+    const workspaceBOptions = getOptions(workspaceBRoot);
+    const packageInfosB = getPackageInfos(workspaceBOptions);
     expect(getPackageNamesAndPaths(workspaceBRoot, packageInfosB)).toEqual({
       '@workspace-b/a': 'packages/grouped/a/package.json',
       '@workspace-b/b': 'packages/grouped/b/package.json',
@@ -242,15 +290,15 @@ describe('getPackageInfos', () => {
     });
   });
 
-  it('throws if multiple packages have the same name in multi-workspace monorepo', () => {
+  it('throws if multiple packages have the same name in multi-root monorepo', () => {
     // If there are multiple workspaces in a monorepo, it's possible that two packages in different
     // workspaces could share the same name, which causes problems for beachball.
     // (This is only known to have been an issue with the test fixture, but is worth testing.)
-    const repo = multiWorkspaceFactory.cloneRepository();
+    const repo = multiMonorepoFactory.cloneRepository();
     repo.updateJsonFile('workspace-a/packages/foo/package.json', { name: 'foo' });
     repo.updateJsonFile('workspace-b/packages/foo/package.json', { name: 'foo' });
-
-    expect(() => getPackageInfos(repo.rootPath)).toThrow('Duplicate package names found (see above for details)');
+    const parsedOptions = getOptions(repo.rootPath);
+    expect(() => getPackageInfos(parsedOptions)).toThrow('Duplicate package names found (see above for details)');
 
     const allLogs = logs.getMockLines('all').replace(/\\/g, '/');
     expect(allLogs).toMatchInlineSnapshot(`

--- a/src/__functional__/monorepo/getScopedPackages.test.ts
+++ b/src/__functional__/monorepo/getScopedPackages.test.ts
@@ -13,8 +13,12 @@ describe('getScopedPackages', () => {
   beforeAll(() => {
     repoFactory = new RepositoryFactory('monorepo');
     repo = repoFactory.cloneRepository();
-    packageInfos = getPackageInfos(repo.rootPath);
+    packageInfos = getPackageInfos({
+      cliOptions: { path: repo.rootPath, command: '' },
+      repoOptions: {},
+    });
   });
+
   afterAll(() => {
     repoFactory.cleanUp();
   });

--- a/src/__functional__/options/getCliOptions.test.ts
+++ b/src/__functional__/options/getCliOptions.test.ts
@@ -9,11 +9,6 @@ jest.mock('workspace-tools', () => {
   };
 });
 
-/** test wrapper for `getCliOptions` which adds common args */
-function getCliOptionsTest(args: string[]) {
-  return getCliOptions(['node', 'beachball', ...args], true /*disableCache*/);
-}
-
 //
 // These tests cover a mix of built-in parser behavior, provided options, and custom overrides.
 // It's worth having tests for relevant built-in behaviors in case we change parsers in the future
@@ -26,6 +21,14 @@ describe('getCliOptions', () => {
   const projectRoot = 'fake-root';
   const mockFindProjectRoot = findProjectRoot as jest.MockedFunction<typeof findProjectRoot>;
   const defaults = { command: 'change', path: projectRoot };
+
+  /** test wrapper for `getCliOptions` which adds common args */
+  function getCliOptionsTest(args: string[], cwd?: string) {
+    return getCliOptions({
+      argv: ['node', 'beachball', ...args],
+      cwd: cwd || projectRoot,
+    });
+  }
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -153,12 +156,12 @@ describe('getCliOptions', () => {
     expect(options).toEqual({ ...defaults, command: 'publish', canaryName: 'foo', tag: 'bar' });
   });
 
-  it('falls back to process.cwd as path if findProjectRoot fails', () => {
+  it('falls back to given cwd as path if findProjectRoot fails', () => {
     mockFindProjectRoot.mockImplementationOnce(() => {
       throw new Error('nope');
     });
-    const options = getCliOptionsTest([]);
-    expect(options).toEqual({ ...defaults, path: process.cwd() });
+    const options = getCliOptionsTest([], 'somewhere');
+    expect(options).toEqual({ ...defaults, path: 'somewhere' });
   });
 
   it('uses provided branch if it contains a slash', () => {

--- a/src/__functional__/options/getOptions.test.ts
+++ b/src/__functional__/options/getOptions.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it, beforeAll, afterAll, jest } from '@jest/globals';
 import fs from 'fs-extra';
+import path from 'path';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
-import { getOptions } from '../../options/getOptions';
+import { getOptions, getParsedOptions } from '../../options/getOptions';
 import type { RepoOptions } from '../../types/BeachballOptions';
-
-// Return a new object each time since getRepoOptions caches the result based on object identity.
-const baseArgv = () => ['node.exe', 'bin.js'];
 
 describe('getOptions', () => {
   let repositoryFactory: RepositoryFactory;
   // Don't reuse a repo in these tests! If multiple tests load beachball.config.js from the same path,
   // it will use the version from the require cache, which will have outdated contents.
+
+  const baseArgv = () => ['node.exe', 'bin.js'];
+
+  const inDirectory = <T>(directory: string, cb: () => T): T => {
+    const originalDirectory = process.cwd();
+    process.chdir(directory);
+    try {
+      return cb();
+    } finally {
+      process.chdir(originalDirectory);
+    }
+  };
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory('single');
@@ -84,12 +94,117 @@ describe('getOptions', () => {
   });
 });
 
-const inDirectory = <T>(directory: string, cb: () => T): T => {
-  const originalDirectory = process.cwd();
-  process.chdir(directory);
-  try {
-    return cb();
-  } finally {
-    process.chdir(originalDirectory);
-  }
-};
+describe('getParsedOptions', () => {
+  let repositoryFactory: RepositoryFactory;
+  // Don't reuse a repo in these tests! If multiple tests load beachball.config.js from the same path,
+  // it will use the version from the require cache, which will have outdated contents.
+
+  // Return a new object each time since getRepoOptions caches the result based on object identity.
+  const baseArgv = () => ['node', 'beachball', 'stuff'];
+
+  beforeAll(() => {
+    repositoryFactory = new RepositoryFactory('single');
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    repositoryFactory.cleanUp();
+    jest.restoreAllMocks();
+  });
+
+  it('uses the branch name defined in beachball.config.js', () => {
+    const repo = repositoryFactory.cloneRepository();
+    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo' };
+    fs.writeFileSync(
+      path.join(repo.rootPath, 'beachball.config.js'),
+      `module.exports = ${JSON.stringify(repoOptions)};`
+    );
+
+    const parsedOptions = getParsedOptions({ argv: baseArgv(), cwd: repo.rootPath });
+    expect(parsedOptions).toEqual({
+      options: expect.objectContaining({ branch: 'origin/foo' }),
+      repoOptions: { branch: 'origin/foo' },
+      cliOptions: { path: repo.rootPath, command: 'stuff' },
+    });
+  });
+
+  it('reads config from package.json', () => {
+    const repo = repositoryFactory.cloneRepository();
+    fs.writeJsonSync(path.join(repo.rootPath, 'package.json'), { beachball: { branch: 'origin/foo' } });
+
+    const parsedOptions = getParsedOptions({ argv: baseArgv(), cwd: repo.rootPath });
+    expect(parsedOptions).toEqual({
+      options: expect.objectContaining({ branch: 'origin/foo' }),
+      repoOptions: { branch: 'origin/foo' },
+      cliOptions: { path: repo.rootPath, command: 'stuff' },
+    });
+  });
+
+  it('finds a .beachballrc.json file', () => {
+    const repo = repositoryFactory.cloneRepository();
+    fs.writeJsonSync(path.join(repo.rootPath, '.beachballrc.json'), { branch: 'origin/foo' });
+
+    const parsedOptions = getParsedOptions({ argv: baseArgv(), cwd: repo.rootPath });
+    expect(parsedOptions.options.branch).toEqual('origin/foo');
+  });
+
+  it('--config overrides configuration path', () => {
+    const repo = repositoryFactory.cloneRepository();
+    fs.writeFileSync(path.join(repo.rootPath, 'beachball.config.js'), 'module.exports = { branch: "origin/main" };');
+    fs.writeFileSync(path.join(repo.rootPath, 'alternate.config.js'), 'module.exports = { branch: "origin/foo" };');
+
+    const parsedOptions = getParsedOptions({
+      argv: [...baseArgv(), '--config', 'alternate.config.js'],
+      cwd: repo.rootPath,
+    });
+    expect(parsedOptions.options.branch).toEqual('origin/foo');
+  });
+
+  it('overrides repo options with CLI options', () => {
+    const repo = repositoryFactory.cloneRepository();
+    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo' };
+    fs.writeFileSync(
+      path.join(repo.rootPath, 'beachball.config.js'),
+      `module.exports = ${JSON.stringify(repoOptions)};`
+    );
+
+    const parsedOptions = getParsedOptions({
+      argv: [...baseArgv(), '--branch', 'origin/bar'],
+      cwd: repo.rootPath,
+    });
+    expect(parsedOptions).toEqual({
+      options: expect.objectContaining({ branch: 'origin/bar' }),
+      repoOptions: { branch: 'origin/foo' },
+      cliOptions: { path: repo.rootPath, command: 'stuff', branch: 'origin/bar' },
+    });
+  });
+
+  it('merges options including objects', () => {
+    const repo = repositoryFactory.cloneRepository();
+    // Ideally this test should include nested objects from multiple sources, but as of writing,
+    // the only place that can have nested objects is the repo options.
+    const repoOptions: Partial<RepoOptions> = {
+      access: 'public',
+      publish: false,
+      disallowedChangeTypes: null,
+      changelog: {
+        groups: [{ mainPackageName: 'foo', include: ['foo'], changelogPath: '.' }],
+      },
+    };
+    fs.writeFileSync(
+      path.join(repo.rootPath, 'beachball.config.js'),
+      `module.exports = ${JSON.stringify(repoOptions)};`
+    );
+
+    const parsedOptions = getParsedOptions({
+      argv: [...baseArgv(), '--disallowed-change-types', 'patch'],
+      cwd: repo.rootPath,
+    });
+    expect(parsedOptions.options).toMatchObject({
+      access: 'public',
+      publish: false,
+      disallowedChangeTypes: ['patch'],
+    });
+    expect(parsedOptions.options.changelog).toEqual(repoOptions.changelog);
+  });
+});

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -227,7 +227,7 @@ describe('updateRelatedChangeType', () => {
         bar: {},
         foo: {
           dependencies: { bar: '1.0.0' },
-          combinedOptions: { disallowedChangeTypes: ['minor', 'major'] },
+          beachball: { disallowedChangeTypes: ['minor', 'major'] },
         },
       },
     });

--- a/src/__tests__/changefile/getDisallowedChangeTypes.test.ts
+++ b/src/__tests__/changefile/getDisallowedChangeTypes.test.ts
@@ -14,7 +14,7 @@ describe('getDisallowedChangeTypes', () => {
 
   it('returns disallowedChangeTypes for package', () => {
     const packageInfos = makePackageInfos({
-      foo: { combinedOptions: { disallowedChangeTypes: ['major', 'minor'] } },
+      foo: { beachball: { disallowedChangeTypes: ['major', 'minor'] } },
     });
     expect(getDisallowedChangeTypes('foo', packageInfos, {})).toEqual(['major', 'minor']);
   });
@@ -29,7 +29,7 @@ describe('getDisallowedChangeTypes', () => {
 
   it('returns disallowedChangeTypes for package if not in a group', () => {
     const packageInfos = makePackageInfos({
-      foo: { combinedOptions: { disallowedChangeTypes: ['patch'] } },
+      foo: { beachball: { disallowedChangeTypes: ['patch'] } },
     });
     const packageGroups: PackageGroups = {
       group: { packageNames: ['bar'], disallowedChangeTypes: ['major', 'minor'] },
@@ -39,7 +39,7 @@ describe('getDisallowedChangeTypes', () => {
 
   it('prefers disallowedChangeTypes for group over package', () => {
     const packageInfos = makePackageInfos({
-      foo: { combinedOptions: { disallowedChangeTypes: ['patch'] } },
+      foo: { beachball: { disallowedChangeTypes: ['patch'] } },
     });
     const packageGroups: PackageGroups = {
       group: { packageNames: ['foo'], disallowedChangeTypes: ['major', 'minor'] },

--- a/src/__tests__/changefile/getQuestionsForPackage.test.ts
+++ b/src/__tests__/changefile/getQuestionsForPackage.test.ts
@@ -53,7 +53,7 @@ describe('getQuestionsForPackage', () => {
   it('errors if options.type is disallowed', () => {
     const questions = getQuestionsForPackage({
       ...defaultQuestionsParams,
-      packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+      packageInfos: makePackageInfos({ [pkg]: { beachball: { disallowedChangeTypes: ['major'] } } }),
       options: { type: 'major', message: '' },
     });
     expect(questions).toBeUndefined();
@@ -64,7 +64,7 @@ describe('getQuestionsForPackage', () => {
     const questions = getQuestionsForPackage({
       ...defaultQuestionsParams,
       packageInfos: makePackageInfos({
-        [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+        [pkg]: { beachball: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
       }),
     });
     expect(questions).toBeUndefined();
@@ -74,7 +74,7 @@ describe('getQuestionsForPackage', () => {
   it('respects disallowedChangeTypes', () => {
     const questions = getQuestionsForPackage({
       ...defaultQuestionsParams,
-      packageInfos: makePackageInfos({ [pkg]: { combinedOptions: { disallowedChangeTypes: ['major'] } } }),
+      packageInfos: makePackageInfos({ [pkg]: { beachball: { disallowedChangeTypes: ['major'] } } }),
     });
     const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['patch', 'minor', 'none']);
@@ -94,7 +94,7 @@ describe('getQuestionsForPackage', () => {
     const questions = getQuestionsForPackage({
       ...defaultQuestionsParams,
       packageInfos: makePackageInfos({
-        [pkg]: { version: '1.0.0-beta.1', combinedOptions: { disallowedChangeTypes: ['prerelease'] } },
+        [pkg]: { version: '1.0.0-beta.1', beachball: { disallowedChangeTypes: ['prerelease'] } },
       }),
     });
     const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
@@ -114,7 +114,7 @@ describe('getQuestionsForPackage', () => {
     const questions = getQuestionsForPackage({
       ...defaultQuestionsParams,
       packageInfos: makePackageInfos({
-        [pkg]: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
+        [pkg]: { beachball: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
       }),
     });
     expect(questions).toHaveLength(1);
@@ -127,7 +127,7 @@ describe('getQuestionsForPackage', () => {
       packageInfos: makePackageInfos({
         [pkg]: {
           version: '1.0.0-beta.1',
-          combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
+          beachball: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
         },
       }),
     });

--- a/src/__tests__/changefile/promptForChange.test.ts
+++ b/src/__tests__/changefile/promptForChange.test.ts
@@ -102,7 +102,7 @@ describe('promptForChange', () => {
       ...defaultParams(),
       packageInfos: makePackageInfos({
         foo: {},
-        bar: { combinedOptions: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
+        bar: { beachball: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
       }),
     });
 

--- a/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -93,7 +93,7 @@ describe('list npm versions', () => {
     it('returns requested tag for one package', async () => {
       npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(
-        makePackageInfos({ foo: { combinedOptions: { tag: 'latest', defaultNpmTag: 'latest' } } })
+        makePackageInfos({ foo: { beachball: { tag: 'latest', defaultNpmTag: 'latest' } } })
       );
 
       const versions = await listPackageVersionsByTag(packageInfos, 'beta', npmOptions);
@@ -109,8 +109,8 @@ describe('list npm versions', () => {
       });
       const packageInfos = Object.values(
         makePackageInfos({
-          foo: { combinedOptions: { tag: 'latest' } },
-          bar: { combinedOptions: { tag: 'latest' } },
+          foo: { beachball: { tag: 'latest' } },
+          bar: { beachball: { tag: 'latest' } },
         })
       );
 
@@ -131,10 +131,10 @@ describe('list npm versions', () => {
       expect(npmMock.mock).toHaveBeenCalledTimes(packages.length);
     });
 
-    it('falls back to combinedOptions.tag', async () => {
+    it('falls back to beachball.tag', async () => {
       npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
       const packageInfos = Object.values(
-        makePackageInfos({ foo: { combinedOptions: { tag: 'beta', defaultNpmTag: 'latest' } } })
+        makePackageInfos({ foo: { beachball: { tag: 'beta', defaultNpmTag: 'latest' } } })
       );
 
       const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
@@ -142,9 +142,9 @@ describe('list npm versions', () => {
       expect(npmMock.mock).toHaveBeenCalledTimes(1);
     });
 
-    it('falls back to combinedOptions.defaultNpmTag if combinedOptions.tag is unset', async () => {
+    it('falls back to beachball.defaultNpmTag if beachball.tag is unset', async () => {
       npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
-      const packageInfos = Object.values(makePackageInfos({ foo: { combinedOptions: { defaultNpmTag: 'beta' } } }));
+      const packageInfos = Object.values(makePackageInfos({ foo: { beachball: { defaultNpmTag: 'beta' } } }));
 
       const versions = await listPackageVersionsByTag(packageInfos, undefined, npmOptions);
       expect(versions).toEqual({ foo: '2.0.0-beta' });
@@ -176,8 +176,8 @@ describe('list npm versions', () => {
       });
       const packageInfos = Object.values(
         makePackageInfos({
-          foo: { combinedOptions: { defaultNpmTag: 'latest' } },
-          bar: { combinedOptions: { tag: 'beta', defaultNpmTag: 'latest' } },
+          foo: { beachball: { defaultNpmTag: 'latest' } },
+          bar: { beachball: { tag: 'beta', defaultNpmTag: 'latest' } },
         })
       );
 

--- a/src/__tests__/packageManager/npmArgs.test.ts
+++ b/src/__tests__/packageManager/npmArgs.test.ts
@@ -29,8 +29,8 @@ describe('getNpmPublishArgs', () => {
 
   const packageInfos = makePackageInfos({
     basic: {},
-    tag: { combinedOptions: { tag: 'testTag', defaultNpmTag: 'testDefaultTag' } },
-    defaultTag: { combinedOptions: { defaultNpmTag: 'testDefaultTag' } },
+    tag: { beachball: { tag: 'testTag', defaultNpmTag: 'testDefaultTag' } },
+    defaultTag: { beachball: { defaultNpmTag: 'testDefaultTag' } },
     '@scoped/foo': {},
   });
 

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -15,22 +15,19 @@ const createTagParameters = (tag: string, cwd: string) => {
 
 type TagBumpInfo = Parameters<typeof tagPackages>[0];
 
-/** foo and bar disable gitTags */
+/** repo options disable gitTags */
 const noTagBumpInfo: TagBumpInfo = {
   calculatedChangeTypes: {
     foo: 'minor',
     bar: 'major',
   },
-  packageInfos: makePackageInfos({
-    foo: {
-      version: '1.0.0',
-      combinedOptions: { gitTags: false },
+  packageInfos: makePackageInfos(
+    {
+      foo: { version: '1.0.0' },
+      bar: { version: '1.0.1' },
     },
-    bar: {
-      version: '1.0.1',
-      combinedOptions: { gitTags: false },
-    },
-  }),
+    { gitTags: false }
+  ),
   modifiedPackages: new Set(['foo', 'bar']),
   newPackages: [],
 };
@@ -41,11 +38,11 @@ const oneTagBumpInfo: TagBumpInfo = {
   packageInfos: makePackageInfos({
     foo: {
       version: '1.0.0',
-      combinedOptions: { gitTags: true },
+      beachball: { gitTags: true },
     },
     bar: {
       version: '1.0.1',
-      combinedOptions: { gitTags: false },
+      beachball: { gitTags: false },
     },
   }),
 };

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -3,9 +3,16 @@ import { performBump } from '../bump/performBump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { BumpInfo } from '../types/BumpInfo';
+import type { PackageInfos } from '../types/PackageInfo';
 
-export async function bump(options: BeachballOptions): Promise<BumpInfo> {
-  const bumpInfo = gatherBumpInfo(options, getPackageInfos(options.path));
+/**
+ * Bump versions and update changelogs, but don't commit, push, or publish.
+ */
+export async function bump(options: BeachballOptions, packageInfos: PackageInfos): Promise<BumpInfo>;
+/** @deprecated Must provide the package infos */
+export async function bump(options: BeachballOptions): Promise<BumpInfo>;
+export async function bump(options: BeachballOptions, packageInfos?: PackageInfos): Promise<BumpInfo> {
+  const bumpInfo = gatherBumpInfo(options, packageInfos || getPackageInfos(options.path));
   // The bumpInfo is returned for testing
   return performBump(bumpInfo, options);
 }

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -6,9 +6,13 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
 import { publishToRegistry } from '../publish/publishToRegistry';
 import type { BeachballOptions } from '../types/BeachballOptions';
+import type { PackageInfos } from '../types/PackageInfo';
 
-export async function canary(options: BeachballOptions): Promise<void> {
-  const oldPackageInfo = getPackageInfos(options.path);
+export async function canary(options: BeachballOptions, oldPackageInfo: PackageInfos): Promise<void>;
+/** @deprecated Must provide the package infos */
+export async function canary(options: BeachballOptions): Promise<void>;
+export async function canary(options: BeachballOptions, oldPackageInfo?: PackageInfos): Promise<void> {
+  oldPackageInfo = oldPackageInfo || getPackageInfos(options.path);
 
   const bumpInfo = gatherBumpInfo(options, oldPackageInfo);
 

--- a/src/commands/change.ts
+++ b/src/commands/change.ts
@@ -5,11 +5,18 @@ import { getPackageInfos } from '../monorepo/getPackageInfos';
 import { getRecentCommitMessages, getUserEmail } from 'workspace-tools';
 import { getChangedPackages } from '../changefile/getChangedPackages';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
+import type { PackageInfos } from '../types/PackageInfo';
 
-export async function change(options: BeachballOptions): Promise<void> {
+/**
+ * Generate change files.
+ */
+export async function change(options: BeachballOptions, packageInfos: PackageInfos): Promise<void>;
+/** @deprecated Must provide the package infos */
+export async function change(options: BeachballOptions): Promise<void>;
+export async function change(options: BeachballOptions, packageInfos?: PackageInfos): Promise<void> {
   const { branch, path: cwd, package: specificPackage } = options;
 
-  const packageInfos = getPackageInfos(cwd);
+  packageInfos ||= getPackageInfos(cwd);
   const packageGroups = getPackageGroups(packageInfos, cwd, options.groups);
 
   const changedPackages =

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -8,13 +8,20 @@ import { publishToRegistry } from '../publish/publishToRegistry';
 import { getNewPackages } from '../publish/getNewPackages';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import type { PublishBumpInfo } from '../types/BumpInfo';
+import type { PackageInfos } from '../types/PackageInfo';
 
-export async function publish(options: BeachballOptions): Promise<void> {
+/**
+ * Potentially bump, publish, and push package changes depending on options.
+ */
+export async function publish(options: BeachballOptions, oldPackageInfos: PackageInfos): Promise<void>;
+/** @deprecated Must provide the package infos */
+export async function publish(options: BeachballOptions): Promise<void>;
+export async function publish(options: BeachballOptions, oldPackageInfos?: PackageInfos): Promise<void> {
   console.log('\nPreparing to publish');
 
   const { path: cwd, branch, registry, tag } = options;
   // First, validate that we have changes to publish
-  const oldPackageInfos = getPackageInfos(cwd);
+  oldPackageInfos ||= getPackageInfos(cwd);
   const changes = readChangeFiles(options, oldPackageInfos);
 
   if (!changes.length) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,9 +6,16 @@ import semver from 'semver';
 import { setDependentVersions } from '../bump/setDependentVersions';
 import { updateLockFile } from '../bump/updateLockFile';
 import { updatePackageJsons } from '../bump/updatePackageJsons';
+import type { PackageInfos } from '../types/PackageInfo';
 
-export async function sync(options: BeachballOptions): Promise<void> {
-  const packageInfos = getPackageInfos(options.path);
+/**
+ * Sync with the latest versions on the registry.
+ */
+export async function sync(options: BeachballOptions, packageInfos: PackageInfos): Promise<void>;
+/** @deprecated Must provide the package infos */
+export async function sync(options: BeachballOptions): Promise<void>;
+export async function sync(options: BeachballOptions, packageInfos?: PackageInfos): Promise<void> {
+  packageInfos ||= getPackageInfos(options.path);
   const scopedPackages = new Set(getScopedPackages(options, packageInfos));
 
   const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));

--- a/src/options/getPackageInfosWithOptions.ts
+++ b/src/options/getPackageInfosWithOptions.ts
@@ -1,5 +1,11 @@
 import type { PackageInfo as WSPackageInfo } from 'workspace-tools';
-import type { PackageOptions } from '../types/BeachballOptions';
+import type {
+  ParsedOptions,
+  PackageOptions,
+  BeachballOptions,
+  CliOptions,
+  RepoOptions,
+} from '../types/BeachballOptions';
 import { getCliOptions } from './getCliOptions';
 import { getRepoOptions } from './getRepoOptions';
 import { getDefaultOptions } from './getDefaultOptions';
@@ -10,20 +16,40 @@ import type { PackageInfos } from '../types/PackageInfo';
  * Fill in options to convert `workspace-tools` `PackageInfos` to the format used in this repo,
  * which includes merged beachball options.
  */
-export function getPackageInfosWithOptions(wsPackageInfos: WSPackageInfo[]): PackageInfos {
-  const packageInfos: PackageInfos = {};
-
-  // Get the CLI and repo options once instead of re-calculating for every package.
-  // TODO: pass the unmerged options in instead of re-calculating...
+export function getPackageInfosWithOptions(
+  wsPackageInfos: WSPackageInfo[],
+  parsedOptions: Pick<ParsedOptions, 'repoOptions' | 'cliOptions'>
+): PackageInfos;
+/** @deprecated Provide the pre-parsed options */
+export function getPackageInfosWithOptions(wsPackageInfos: WSPackageInfo[]): PackageInfos;
+export function getPackageInfosWithOptions(
+  wsPackageInfos: WSPackageInfo[],
+  parsedOptions?: Pick<ParsedOptions, 'repoOptions' | 'cliOptions'>
+): PackageInfos {
+  let { repoOptions, cliOptions } = parsedOptions || {};
+  if (!repoOptions || !cliOptions) {
+    // Don't use options from process.argv or the beachball repo in tests
+    cliOptions = !env.isJest ? getCliOptions(process.argv) : { path: '', command: 'change' };
+    repoOptions = cliOptions?.path ? getRepoOptions(cliOptions) : {};
+  }
   const defaultOptions = getDefaultOptions();
-  // Don't use options from process.argv or the beachball repo in tests
-  const cliOptions = !env.isJest ? getCliOptions(process.argv) : undefined;
-  const repoOptions = cliOptions?.path ? getRepoOptions(cliOptions) : undefined;
+  const preMergedOptions = _mergePackageOptions({
+    defaultOptions,
+    repoOptions,
+    cliOptions,
+    packageOptions: {},
+  });
+
+  const packageInfos: PackageInfos = {};
 
   for (const packageJson of wsPackageInfos) {
     // Package-level JS config files aren't currently supported - https://github.com/microsoft/beachball/issues/1021
-    // (just the "beachball" key in package.json)
-    const packageOptions = (packageJson.beachball || {}) as Partial<PackageOptions>;
+    // (just the "beachball" key in package.json).
+    // If the package has no specific options (most common), reuse the pre-merged object for performance.
+    const packageOptions = packageJson.beachball as Partial<PackageOptions> | undefined;
+    const combinedOptions = packageOptions
+      ? _mergePackageOptions({ defaultOptions, repoOptions, cliOptions, packageOptions })
+      : { ...preMergedOptions };
 
     packageInfos[packageJson.name] = {
       name: packageJson.name,
@@ -33,17 +59,44 @@ export function getPackageInfosWithOptions(wsPackageInfos: WSPackageInfo[]): Pac
       devDependencies: packageJson.devDependencies,
       peerDependencies: packageJson.peerDependencies,
       optionalDependencies: packageJson.optionalDependencies,
-      private: packageJson.private !== undefined ? packageJson.private : false,
-      // TODO: proper recursive merging
-      combinedOptions: {
-        ...defaultOptions,
-        ...repoOptions,
-        ...packageOptions,
-        ...cliOptions,
-      },
-      packageOptions,
+      private: packageJson.private ?? false,
+      combinedOptions,
+      packageOptions: packageOptions || {},
     };
   }
 
   return packageInfos;
+}
+
+const packageKeys = Object.keys({
+  tag: true,
+  defaultNpmTag: true,
+  disallowedChangeTypes: true,
+  gitTags: true,
+  shouldPublish: true,
+} satisfies Record<keyof PackageOptions, true>) as (keyof PackageOptions)[];
+
+/**
+ * Merge ONLY the relevant package-level options into `combinedOptions`.
+ * In giant repos, this should improve performance.
+ */
+export function _mergePackageOptions(
+  params: Pick<ParsedOptions, 'repoOptions' | 'cliOptions'> & {
+    packageOptions: Partial<PackageOptions>;
+    defaultOptions: BeachballOptions;
+  }
+): PackageOptions {
+  const { defaultOptions, repoOptions, cliOptions, packageOptions } = params;
+  const mergedOptions = {} as PackageOptions;
+  for (const key of packageKeys) {
+    (mergedOptions as any)[key] =
+      key in cliOptions
+        ? cliOptions[key as keyof CliOptions]
+        : key in packageOptions
+        ? packageOptions[key]
+        : key in repoOptions
+        ? repoOptions[key as keyof RepoOptions]
+        : defaultOptions[key];
+  }
+  return mergedOptions;
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -6,6 +6,16 @@ import type { PackageInfos } from './PackageInfo';
 
 export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 
+/** Separate options objects, returned for reuse in `getPackageInfos`. */
+export interface ParsedOptions {
+  /** Only the specified repo options */
+  repoOptions: Partial<RepoOptions>;
+  /** Only the specified CLI options, plus the path and command */
+  cliOptions: Partial<CliOptions> & Pick<CliOptions, 'path' | 'command'>;
+  /** Merged repo-level options (includes repo, CLI, and defaults) */
+  options: BeachballOptions;
+}
+
 export interface CliOptions
   extends Pick<
     RepoOptions,
@@ -171,8 +181,10 @@ export interface RepoOptions {
   /** For the `change` command, change message. For the `publish` command, commit message. */
   message: string;
   /**
-   * The directory to run beachball in
-   * @default process.cwd()
+   * The directory to run beachball in.
+   *
+   * Except in tests, this will be the project root (monorepo manager root or package root),
+   * determined relative to `process.cwd()`.
    */
   path: string;
   /** Prerelease prefix for packages that are specified to receive a prerelease bump */

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -1,4 +1,4 @@
-import type { PackageOptions, BeachballOptions } from './BeachballOptions';
+import type { PackageOptions, RepoOptions } from './BeachballOptions';
 import type { ChangeType } from './ChangeInfo';
 
 export interface PackageDeps {
@@ -32,7 +32,11 @@ export interface PackageJson {
   optionalDependencies?: PackageDeps;
   private?: boolean;
   scripts?: Record<string, string>;
-  beachball?: BeachballOptions;
+  /**
+   * At a monorepo repo root, this may contain any beachball config.
+   * For a single package, only package config is respected.
+   */
+  beachball?: Partial<PackageOptions> | Partial<RepoOptions>;
   /** Overrides applied during publishing */
   publishConfig?: PublishConfig;
 }


### PR DESCRIPTION
Previously, each primary internal subroutine (`validate`, `publish`, `change`, etc) was redundantly calling `getPackageInfos` rather than accepting it as a parameter, which is probably a significant slowdown for the `change` command in a large repo (since it calls `validate` first). This PR adds the package info as a parameter instead.

I also made some improvements to options reading/merging and `getPackageInfos` (specifically `getPackageInfosWithOptions`).
- Rather than calling `getRepoOptions` and `getCliOptions` to get the info needed for `combinedOptions`, require that the caller pass them through. The old way generally worked fine in the actual CLI but caused some inconsistency in tests (and was inefficient).
- In `getCliOptions`, explicitly take the initial `cwd` and `argv` as params rather than falling back to `process`. If `cwd` is `''`, assume it's a test and don't try to find the project root.
  - I also removed the caching code because now that `get*Options` should only be called once, it's not necessary.
- In `getRepoOptions`, explicitly pass an absolute path to `cosmiconfig` instead of implicitly using `process.cwd`
- When merging `PackageInfo.combinedOptions`, only include the specific keys needed rather than spreading everything. This will probably also be a small performance boost in large repos.

(The main changes have been implemented in a way that's somewhat backwards-compatible for repos using beachball's internal APIs, though that was never intended and will break in v3.)