### PR TITLE
Move internal cloneObject helper

### DIFF
--- a/change/beachball-89e24360-0190-49b7-aa7f-0557b2828c19.json
+++ b/change/beachball-89e24360-0190-49b7-aa7f-0557b2828c19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move internal cloneObject helper",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -7,7 +7,7 @@ import { tmpdir } from './tmpdir';
 import { gitFailFast } from 'workspace-tools';
 import { setDefaultBranchName } from './gitDefaults';
 import { env } from '../env';
-import { _cloneObject } from '../publish/cloneBumpInfo';
+import { cloneObject } from '../object/cloneObject';
 
 /**
  * Standard fixture options. See {@link getSinglePackageFixture}, {@link getMonorepoFixture} and
@@ -177,7 +177,7 @@ export class RepositoryFactory {
             : fixtureParam === 'monorepo'
             ? getMonorepoFixture()
             : // Clone the user-provided fixture so it's safe to modify
-              _cloneObject(fixtureParam),
+              cloneObject(fixtureParam),
       };
     }
 

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -8,7 +8,7 @@ import type { PackageInfos, PackageInfo } from '../../types/PackageInfo';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import type { PackageOptions } from '../../types/BeachballOptions';
-import { _cloneObject } from '../../publish/cloneBumpInfo';
+import { cloneObject } from '../../object/cloneObject';
 import { getParsedOptions } from '../../options/getOptions';
 import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
 
@@ -24,7 +24,7 @@ function cleanPath(root: string, filePath: string) {
 function cleanPackageInfos(root: string, packageInfos: PackageInfos) {
   const cleanedInfos: PackageInfos = {};
   for (const [pkgName, originalInfo] of Object.entries(packageInfos)) {
-    const pkgInfo = (cleanedInfos[pkgName] = _cloneObject(originalInfo));
+    const pkgInfo = (cleanedInfos[pkgName] = cloneObject(originalInfo));
 
     // Remove absolute paths
     pkgInfo.packageJsonPath = cleanPath(root, pkgInfo.packageJsonPath);

--- a/src/__tests__/object/cloneObject.test.ts
+++ b/src/__tests__/object/cloneObject.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { _cloneObject, cloneBumpInfo } from '../../publish/cloneBumpInfo';
 import type { BumpInfo } from '../../types/BumpInfo';
+import { cloneObject } from '../../object/cloneObject';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import { getChange } from '../../__fixtures__/changeFiles';
 
-describe('_cloneObject', () => {
+describe('cloneObject', () => {
   it.each<[string, object | unknown[]]>([
     ['empty object', {}],
     ['empty object with null prototype', Object.create(null)],
@@ -15,14 +15,14 @@ describe('_cloneObject', () => {
     ['set', new Set([1, 2, 3])],
     ['object of sets', { a: new Set([1, 2, 3]), b: new Set(['a', 'b', 'c']) }],
   ])('clones %s', (desc, val) => {
-    const cloned = _cloneObject(val);
+    const cloned = cloneObject(val);
     expect(cloned).toEqual(val);
     expect(cloned).not.toBe(val);
   });
 
   it('deeply clones nested object', () => {
     const orig = { a: { b: { c: 1 } } };
-    const cloned = _cloneObject(orig);
+    const cloned = cloneObject(orig);
     expect(cloned).toEqual(orig);
     expect(cloned).not.toBe(orig);
     expect(cloned.a).not.toBe(orig.a);
@@ -31,7 +31,7 @@ describe('_cloneObject', () => {
 
   it('deep clones array of objects and arrays', () => {
     const orig = [{ a: 1 }, [2, 3, 4]];
-    const cloned = _cloneObject(orig);
+    const cloned = cloneObject(orig);
     expect(cloned).toEqual(orig);
     expect(cloned).not.toBe(orig);
     expect(cloned[0]).not.toBe(orig[0]);
@@ -39,15 +39,13 @@ describe('_cloneObject', () => {
   });
 
   it('throws on other object types', () => {
-    expect(() => _cloneObject(new Date())).toThrow('Unsupported object type found while cloning bump info: Date');
-    expect(() => _cloneObject(/abc/)).toThrow('Unsupported object type found while cloning bump info: RegExp');
-    expect(() => _cloneObject(new Map())).toThrow('Unsupported object type found while cloning bump info: Map');
+    expect(() => cloneObject(new Date())).toThrow('Unsupported object type found while cloning bump info: Date');
+    expect(() => cloneObject(/abc/)).toThrow('Unsupported object type found while cloning bump info: RegExp');
+    expect(() => cloneObject(new Map())).toThrow('Unsupported object type found while cloning bump info: Map');
     class Foo {}
-    expect(() => _cloneObject(new Foo())).toThrow('Unsupported object type found while cloning bump info: Foo');
+    expect(() => cloneObject(new Foo())).toThrow('Unsupported object type found while cloning bump info: Foo');
   });
-});
 
-describe('cloneBumpInfo', () => {
   it('clones bump info structure', () => {
     const original: BumpInfo = {
       // There's no attempt at consistency because it doesn't matter here
@@ -63,7 +61,7 @@ describe('cloneBumpInfo', () => {
       scopedPackages: new Set(['a', 'b']),
     };
 
-    const cloned = cloneBumpInfo(original);
+    const cloned = cloneObject(original);
     expect(cloned).toEqual(original);
     expect(cloned).not.toBe(original);
     expect(cloned.packageInfos).not.toBe(original.packageInfos);

--- a/src/object/cloneObject.ts
+++ b/src/object/cloneObject.ts
@@ -1,15 +1,3 @@
-import type { BumpInfo } from '../types/BumpInfo';
-
-/**
- * Clone a bump info object. Only handles the data types found in bump info.
- *
- * This is decently faster than `structuredClone` or `JSON.parse(JSON.stringify())` on a
- * very large object. https://jsperf.app/rugosa/5
- */
-export function cloneBumpInfo(oldInfo: BumpInfo): BumpInfo {
-  return _cloneObject(oldInfo);
-}
-
 /**
  * Clone an object, fast.
  * Currently only handles data types expected in `BumpInfo` but could be expanded if needed.
@@ -19,9 +7,9 @@ export function cloneBumpInfo(oldInfo: BumpInfo): BumpInfo {
  *
  * @internal Exported for testing (and usage in tests)
  */
-export function _cloneObject<T extends unknown[]>(obj: T): T;
-export function _cloneObject<T extends object>(obj: T): T;
-export function _cloneObject<T extends object>(obj: T): T {
+export function cloneObject<T extends unknown[]>(obj: T): T;
+export function cloneObject<T extends object>(obj: T): T;
+export function cloneObject<T extends object>(obj: T): T {
   if (!obj || typeof obj !== 'object') {
     return obj;
   }
@@ -32,13 +20,13 @@ export function _cloneObject<T extends object>(obj: T): T {
       const val = obj[i];
       // Skip the recursive call if not an object.
       // This check is repeatedly done inline on sub-properties for performance.
-      clone[i] = val && typeof val === 'object' ? _cloneObject(val) : val;
+      clone[i] = val && typeof val === 'object' ? cloneObject(val) : val;
     }
     return clone;
   }
 
   if (obj instanceof Set) {
-    return new Set(Array.from(obj).map(item => (item && typeof item === 'object' ? _cloneObject(item) : item))) as T;
+    return new Set(Array.from(obj).map(item => (item && typeof item === 'object' ? cloneObject(item) : item))) as T;
   }
 
   if (obj.constructor?.name && obj.constructor.name !== 'Object') {
@@ -47,7 +35,7 @@ export function _cloneObject<T extends object>(obj: T): T {
 
   const clone = {} as typeof obj;
   for (const [key, val] of Object.entries(obj)) {
-    (clone as any)[key] = val && typeof val === 'object' ? _cloneObject(val) : val;
+    (clone as any)[key] = val && typeof val === 'object' ? cloneObject(val) : val;
   }
   return clone;
 }

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -11,7 +11,7 @@ import { callHook } from '../bump/callHook';
 import { getPackageGraph } from '../monorepo/getPackageGraph';
 import type { PackageInfo } from '../types/PackageInfo';
 import { packPackage } from '../packageManager/packPackage';
-import { cloneBumpInfo } from './cloneBumpInfo';
+import { cloneObject } from '../object/cloneObject';
 
 /**
  * Publish all the bumped packages to the registry, OR if `packToPath` is specified,
@@ -22,7 +22,7 @@ import { cloneBumpInfo } from './cloneBumpInfo';
 export async function publishToRegistry(originalBumpInfo: PublishBumpInfo, options: BeachballOptions): Promise<void> {
   const verb = options.packToPath ? 'pack' : 'publish';
 
-  const bumpInfo = cloneBumpInfo(originalBumpInfo);
+  const bumpInfo = cloneObject(originalBumpInfo);
 
   if (options.bump) {
     await performBump(bumpInfo, options);


### PR DESCRIPTION
Rename `_cloneObject` to `cloneObject` and move it to a new `objects` folder. Remove `cloneBumpInfo` wrapper.