### PR TITLE
Dependency validation and formatting improvements

### DIFF
--- a/change/beachball-0ae4a3b0-1089-4a2a-a577-c0f9b4c550b2.json
+++ b/change/beachball-0ae4a3b0-1089-4a2a-a577-c0f9b4c550b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Validate that there are no private packages among `peerDependencies` or `optionalDependencies` of published packages (not just `dependencies`). There's a slight chance this could be a breaking change.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/beachball-59922bcc-56c0-47ba-af4f-fdefad037e8c.json
+++ b/change/beachball-59922bcc-56c0-47ba-af4f-fdefad037e8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Improve formatting of lists in CLI output. If you're parsing `beachball check` or `beachball publish` output for some reason, this could be a breaking change.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__functional__/git/ensureSharedHistory.test.ts
+++ b/src/__functional__/git/ensureSharedHistory.test.ts
@@ -5,7 +5,7 @@ import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { ensureSharedHistory } from '../../git/ensureSharedHistory';
 import { defaultBranchName, defaultRemoteBranchName, optsWithLang } from '../../__fixtures__/gitDefaults';
 
-// required for `jest.spyOn('workspace-tools', git)` to work
+// required for `jest.spyOn(workspaceTools, git)` to work
 jest.mock('workspace-tools', () => {
   const original = jest.requireActual<typeof workspaceTools>('workspace-tools');
   return {
@@ -133,12 +133,12 @@ describe('ensureSharedHistory', () => {
       "Target branch "origin/master" does not exist locally, and fetching is disabled.
 
       Some possible fixes:
-      - Fetch the branch manually:
-         git remote set-branches --add origin master && git fetch origin
-      - Omit the "--no-fetch" / "--fetch=false" option from the command line
-      - Remove "fetch: false" from the beachball config
-      - If this is a CI build, ensure that adequate history is being fetched
-        - For GitHub Actions (actions/checkout), add the option "fetch-depth: 0" in the checkout step"
+        • Fetch the branch manually:
+            git remote set-branches --add origin master && git fetch origin
+        • Omit the "--no-fetch" / "--fetch=false" option from the command line
+        • Remove "fetch: false" from the beachball config
+        • If this is a CI build, ensure that adequate history is being fetched
+          ▪ For GitHub Actions (actions/checkout), add the option "fetch-depth: 0" in the checkout step."
     `);
   });
 
@@ -219,12 +219,12 @@ describe('ensureSharedHistory', () => {
       "This repo is a shallow clone, fetching is disabled, and not enough history is available to connect HEAD to "origin/master".
 
       Some possible fixes:
-      - Verify that you're using the correct target branch
-      - Unshallow or deepen the clone manually
-      - Omit the "--no-fetch" / "--fetch=false" option from the command line
-      - Remove "fetch: false" from the beachball config
-      - If this is a CI build, ensure that adequate history is being fetched
-        - For GitHub Actions (actions/checkout), add the option "fetch-depth: 0" in the checkout step"
+        • Verify that you're using the correct target branch
+        • Unshallow or deepen the clone manually
+        • Omit the "--no-fetch" / "--fetch=false" option from the command line
+        • Remove "fetch: false" from the beachball config
+        • If this is a CI build, ensure that adequate history is being fetched
+          ▪ For GitHub Actions (actions/checkout), add the option "fetch-depth: 0" in the checkout step."
     `);
   });
 

--- a/src/__tests__/logging/bulletedList.test.ts
+++ b/src/__tests__/logging/bulletedList.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from '@jest/globals';
+import { bulletedList } from '../../logging/bulletedList';
+
+describe('bulletedList', () => {
+  it('bullets a flat array', () => {
+    expect(bulletedList(['Item 1', 'Item 2', 'Item 3'])).toMatchInlineSnapshot(`
+      "  • Item 1
+        • Item 2
+        • Item 3"
+    `);
+  });
+
+  it('indents multi-line bullet points', () => {
+    expect(bulletedList(['Item 1', 'Item 2\nStack:\n  something', 'Item 3'])).toMatchInlineSnapshot(`
+      "  • Item 1
+        • Item 2
+          Stack:
+            something
+        • Item 3"
+    `);
+  });
+
+  it('indents as requested', () => {
+    expect(bulletedList(['Item 1', 'Item 2', 'Item 3'], 2)).toMatchInlineSnapshot(`
+      "    ▪ Item 1
+          ▪ Item 2
+          ▪ Item 3"
+    `);
+  });
+
+  it('handles one level of nesting', () => {
+    expect(bulletedList(['Item 1', 'Item 2', ['Nested 1']])).toMatchInlineSnapshot(`
+      "  • Item 1
+        • Item 2
+          ▪ Nested 1"
+    `);
+  });
+
+  it('handles nested arrays', () => {
+    expect(
+      bulletedList([
+        'Item 1',
+        'Item 2',
+        [
+          'Nested Item 1',
+          ['Extra nested 1\nanother line', 'Extra nested 2', ['More nesting', ['Even more', ['Ran out of bullets']]]],
+          'Nested Item 2',
+        ],
+
+        'Item 3',
+      ])
+    ).toMatchInlineSnapshot(`
+      "  • Item 1
+        • Item 2
+          ▪ Nested Item 1
+            ◦ Extra nested 1
+              another line
+            ◦ Extra nested 2
+              ▫ More nesting
+                - Even more
+                  • Ran out of bullets
+          ▪ Nested Item 2
+        • Item 3"
+    `);
+  });
+
+  it('throws if level is less than 1', () => {
+    expect(() => bulletedList(['hello'], 0)).toThrow('Level must be 1 or greater');
+    expect(() => bulletedList(['hello'], -1)).toThrow('Level must be 1 or greater');
+  });
+});

--- a/src/__tests__/logging/indent.test.ts
+++ b/src/__tests__/logging/indent.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from '@jest/globals';
+import { indent } from '../../logging/indent';
+
+describe('indent', () => {
+  it('indents by specified level', () => {
+    expect(indent('hello', 0)).toBe('hello');
+    expect(indent('hello', 1)).toBe('  hello');
+    expect(indent('hello', 2)).toBe('    hello');
+  });
+
+  it('indents multi-line text', () => {
+    expect(indent('hello\nworld', 1)).toBe('  hello\n  world');
+    // preserves existing indentation
+    expect(indent('hello\n  world', 1)).toBe('  hello\n    world');
+  });
+
+  it('indents multi-line text with first-line offset', () => {
+    expect(indent('hello\nworld', 1, -1)).toBe('hello\n  world');
+    expect(indent('hello\nworld', 2, -1)).toBe('  hello\n    world');
+    expect(indent('hello\nworld', 1, 1)).toBe('    hello\n  world');
+    expect(indent('hello\nworld', 2, -2)).toBe('hello\n    world');
+    expect(indent('hello\n  world', 1, -1)).toBe('hello\n    world');
+  });
+
+  it('throws if level is less than 0', () => {
+    expect(() => indent('hello', -1)).toThrow('Level must be 0 or greater');
+  });
+
+  it('throws if firstLineOffset would result in negative indent', () => {
+    expect(() => indent('hello', 1, -2)).toThrow('First line cannot have negative indent');
+  });
+});

--- a/src/__tests__/publish/validatePackageVersions.test.ts
+++ b/src/__tests__/publish/validatePackageVersions.test.ts
@@ -33,7 +33,7 @@ describe('validatePackageVersions', () => {
       Validating new package versions...
       [log]
       Package versions are OK to publish:
-      - foo@1.0.1"
+        • foo@1.0.1"
     `);
   });
 
@@ -48,7 +48,7 @@ describe('validatePackageVersions', () => {
       Validating new package versions...
       [log]
       Package versions are OK to publish:
-      - foo@1.0.0"
+        • foo@1.0.0"
     `);
   });
 
@@ -60,7 +60,7 @@ describe('validatePackageVersions', () => {
     expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "ERROR: Attempting to publish package versions that already exist in the registry:
-      - foo@1.0.0"
+        • foo@1.0.0"
     `);
   });
 
@@ -75,10 +75,10 @@ describe('validatePackageVersions', () => {
       Validating new package versions...
       [log]
       Package versions are OK to publish:
-      - bar@1.0.1
+        • bar@1.0.1
       [error]
       ERROR: Attempting to publish package versions that already exist in the registry:
-      - foo@1.0.0"
+        • foo@1.0.0"
     `);
   });
 });

--- a/src/logging/bulletedList.ts
+++ b/src/logging/bulletedList.ts
@@ -1,0 +1,33 @@
+import { indent } from './indent';
+
+const bulletCharacters = ['•', '▪', '◦', '▫', '-'];
+
+export type BulletList = (string | undefined | BulletList)[];
+
+/**
+ * Writes a bulleted list of lines.
+ * Newlines within items will be indented to a matching level.
+ */
+export function bulletedList(lines: BulletList, level = 1, bulletChar?: string): string {
+  if (level < 1) {
+    throw new RangeError('Level must be 1 or greater');
+  }
+
+  // The bullet used is relative to the indent level. Indent level 1 should use the first
+  // bullet character, indent level 2 should use the second, etc.
+  const bullet = bulletChar || bulletCharacters[(level - 1) % bulletCharacters.length];
+
+  return lines
+    .reduce((prev: string[], next: BulletList[number]): string[] => {
+      if (next) {
+        if (Array.isArray(next)) {
+          prev.push(bulletedList(next, level + 1));
+        } else {
+          prev.push(indent(`${bullet} ${next}`, level + 1, -1));
+        }
+      }
+
+      return prev;
+    }, [] as string[])
+    .join('\n');
+}

--- a/src/logging/indent.ts
+++ b/src/logging/indent.ts
@@ -1,0 +1,23 @@
+/**
+ * Indent a string by `level * 2` spaces.
+ * Newlines within items will be indented to the same level.
+ * @param text Text to indent
+ * @param level Indent level. The number of spaces will be `level * 2`.
+ * @param firstLineOffset Relative indent level for the first line (can be negative,
+ * as long as `level + firstLineOffset` is 0 or greater)
+ */
+export function indent(text: string, level: number, firstLineOffset: number = 0): string {
+  if (level < 0) {
+    throw new RangeError('Level must be 0 or greater');
+  }
+  if (level + firstLineOffset < 0) {
+    throw new RangeError('First line cannot have negative indent');
+  }
+
+  const indentString = '  '.repeat(level);
+  const firstLineIndent = '  '.repeat(level + firstLineOffset);
+  return text
+    .split('\n')
+    .map((line, i) => `${i === 0 ? firstLineIndent : indentString}${line}`)
+    .join('\n');
+}

--- a/src/logging/singleLineStringify.ts
+++ b/src/logging/singleLineStringify.ts
@@ -1,8 +1,3 @@
-/** Format strings as a bulleted list with line breaks */
-export function formatList(items: string[]): string {
-  return items.map(item => `- ${item}`).join('\n');
-}
-
 /**
  * Format an object on a single line with spaces between the properties and brackets
  * (similar to `JSON.stringify(obj, null, 2)` but without the line breaks).

--- a/src/monorepo/getPackageGroups.ts
+++ b/src/monorepo/getPackageGroups.ts
@@ -2,6 +2,7 @@ import type { VersionGroupOptions } from '../types/BeachballOptions';
 import path from 'path';
 import type { PackageInfos, PackageGroups } from '../types/PackageInfo';
 import { isPathIncluded } from './isPathIncluded';
+import { bulletedList } from '../logging/bulletedList';
 
 export function getPackageGroups(
   packageInfos: PackageInfos,
@@ -42,10 +43,11 @@ export function getPackageGroups(
   if (errorPackages.length) {
     console.error(
       `ERROR: Found package(s) belonging to multiple groups:\n` +
-        Object.entries(errorPackages)
-          .map(([pkgName, pkgGroups]) => `- ${pkgName}: [${pkgGroups.map(g => g.name).join(', ')}]`)
-          .sort()
-          .join('\n')
+        bulletedList(
+          Object.entries(errorPackages)
+            .map(([pkgName, pkgGroups]) => `${pkgName}: [${pkgGroups.map(g => g.name).join(', ')}]`)
+            .sort()
+        )
     );
     // TODO: probably more appropriate to throw here and let the caller handle it?
     process.exit(1);

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -1,3 +1,4 @@
+import { bulletedList } from '../logging/bulletedList';
 import type { BumpInfo } from '../types/BumpInfo';
 
 export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set<string> = new Set<string>()): void {
@@ -6,7 +7,7 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
 
   bumpInfo.modifiedPackages.forEach(pkg => {
     const packageInfo = bumpInfo.packageInfos[pkg];
-    const entry = `- ${packageInfo.name}@${packageInfo.version}`;
+    const entry = `${packageInfo.name}@${packageInfo.version}`;
     if (succeededPackages.has(packageInfo.name)) {
       succeededLines.push(entry);
     } else {
@@ -15,14 +16,15 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
   });
 
   console.error(
-    'Something went wrong with publishing! Manually update these package and versions:\n' + errorLines.sort().join('\n')
+    'Something went wrong with publishing! Manually update these package and versions:\n' +
+      bulletedList(errorLines.sort())
   );
 
   if (succeededLines.length) {
     console.warn(
       'These packages and versions were successfully published, but may be invalid if they depend on ' +
         'package versions for which publishing failed:\n' +
-        succeededLines.sort().join('\n') +
+        bulletedList(succeededLines.sort()) +
         '\n\nTo recover from this, run "beachball sync" to synchronize local package.json files with the registry. ' +
         'If necessary, unpublish or deprecate any invalid packages from the above list after "beachball sync".'
     );

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -1,4 +1,4 @@
-import { formatList } from '../logging/format';
+import { bulletedList } from '../logging/bulletedList';
 import type { PublishBumpInfo } from '../types/BumpInfo';
 import { toposortPackages } from './toposortPackages';
 
@@ -43,7 +43,7 @@ export function getPackagesToPublish(bumpInfo: PublishBumpInfo, validationMode?:
 
   // this log is not helpful when called from `validate`
   if (skippedPackageReasons.length && !validationMode) {
-    console.log(`\nSkipping publishing the following packages:\n${formatList(skippedPackageReasons.sort())}`);
+    console.log(`\nSkipping publishing the following packages:\n${bulletedList(skippedPackageReasons.sort())}`);
   }
 
   return packagesToPublish;

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -95,7 +95,7 @@ export async function publishToRegistry(originalBumpInfo: PublishBumpInfo, optio
     let err = error;
     if (Array.isArray(error)) {
       const errorSet = new Set(error);
-      err = new Error(Array.from(errorSet).join('\n'));
+      err = new Error(Array.from(errorSet).join('\n\n'));
     }
     displayManualRecovery(bumpInfo, succeededPackages);
     throw err;

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -1,31 +1,39 @@
-import type { PackageInfos } from '../types/PackageInfo';
+import { consideredDependencies, type PackageInfos } from '../types/PackageInfo';
+import { bulletedList } from '../logging/bulletedList';
+
+const prodDepTypes = consideredDependencies.filter(t => t !== 'devDependencies');
 
 /**
  * Validate no private package is listed as package dependency for packages which will be published.
  */
 export function validatePackageDependencies(packagesToValidate: string[], packageInfos: PackageInfos): boolean {
-  /** Mapping from dep to all validated packages that depend on it */
-  const allDeps: { [dep: string]: string[] } = {};
+  /** Mapping from in-repo dep to all validated packages that depend on it */
+  const prodDeps: { [dep: string]: string[] } = {};
+
   for (const pkg of packagesToValidate) {
-    for (const dep of Object.keys(packageInfos[pkg].dependencies || {})) {
-      allDeps[dep] ??= [];
-      allDeps[dep].push(pkg);
+    for (const depType of prodDepTypes) {
+      for (const dep of Object.keys(packageInfos[pkg][depType] || {})) {
+        if (packageInfos[dep]) {
+          (prodDeps[dep] ??= []).push(pkg);
+        }
+      }
     }
   }
 
   console.log(`Validating no private package among package dependencies`);
-  const errorDeps = Object.keys(allDeps).filter(dep => packageInfos[dep]?.private);
+
+  // This makes the assumption that any dep matching a monorepo package name refers to the
+  // in-repo version. If there's an issue because that's not the case, extra logic could be added
+  // to verify that the versions are `workspace:` or semver-satisfied (which would also require
+  // logic for catalog versions).
+  const errorDeps = Object.keys(prodDeps).filter(dep => packageInfos[dep]?.private);
   if (errorDeps.length) {
     console.error(
       `ERROR: Found private packages among published package dependencies:\n` +
-        errorDeps
-          .map(dep => `- ${dep}: used by ${allDeps[dep].join(', ')}`)
-          .sort()
-          .join('\n')
+        bulletedList(errorDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort())
     );
     return false;
   }
-
   console.log('  OK!\n');
   return true;
 }

--- a/src/publish/validatePackageVersions.ts
+++ b/src/publish/validatePackageVersions.ts
@@ -1,6 +1,6 @@
 import { listPackageVersions } from '../packageManager/listPackageVersions';
 import type { NpmOptions } from '../types/NpmOptions';
-import { formatList } from '../logging/format';
+import { bulletedList } from '../logging/bulletedList';
 import type { PackageInfos } from '../types/PackageInfo';
 
 /**
@@ -30,12 +30,12 @@ export async function validatePackageVersions(
 
   if (okVersions.length) {
     // keep the original order here to show what order they'll be published in
-    console.log(`\nPackage versions are OK to publish:\n${formatList(okVersions)}`);
+    console.log(`\nPackage versions are OK to publish:\n${bulletedList(okVersions)}`);
   }
   if (errorVersions.length) {
     console.error(
       `\nERROR: Attempting to publish package versions that already exist in the registry:\n` +
-        formatList(errorVersions.sort())
+        bulletedList(errorVersions.sort())
     );
     return false;
   }

--- a/src/validation/areChangeFilesDeleted.ts
+++ b/src/validation/areChangeFilesDeleted.ts
@@ -1,3 +1,4 @@
+import { bulletedList } from '../logging/bulletedList';
 import { getChangePath } from '../paths';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { getChangesBetweenRefs, findProjectRoot } from 'workspace-tools';
@@ -21,7 +22,7 @@ export function areChangeFilesDeleted(options: Pick<BeachballOptions, 'branch' |
 
   if (changeFilesDeletedSinceRef.length) {
     const changeFiles = changeFilesDeletedSinceRef.map(file => `- ${file}`);
-    console.error(`ERROR: The following change files were deleted:\n${changeFiles.join('\n')}\n`);
+    console.error(`ERROR: The following change files were deleted:\n${bulletedList(changeFiles)}\n`);
     return true;
   }
 

--- a/src/validation/isValidChangelogOptions.ts
+++ b/src/validation/isValidChangelogOptions.ts
@@ -1,4 +1,5 @@
-import { singleLineStringify } from '../logging/format';
+import { bulletedList } from '../logging/bulletedList';
+import { singleLineStringify } from '../logging/singleLineStringify';
 import type { ChangelogOptions } from '../types/ChangelogOptions';
 
 export function isValidChangelogOptions(options: ChangelogOptions): boolean {
@@ -14,7 +15,7 @@ export function isValidChangelogOptions(options: ChangelogOptions): boolean {
     console.error(
       'ERROR: "changelog.groups" entries must define "changelogPath", "mainPackageName", and "include". ' +
         'Found invalid groups:\n' +
-        badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
+        bulletedList(badGroups.map(group => singleLineStringify(group)))
     );
     return false;
   }

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -1,4 +1,5 @@
-import { formatList, singleLineStringify } from '../logging/format';
+import { bulletedList } from '../logging/bulletedList';
+import { singleLineStringify } from '../logging/singleLineStringify';
 import type { VersionGroupOptions } from '../types/BeachballOptions';
 import type { PackageGroups, PackageInfos } from '../types/PackageInfo';
 
@@ -15,7 +16,7 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]): boolean {
   if (badGroups.length) {
     console.error(
       'ERROR: "groups" configuration entries must define "include" and "name". Found invalid groups:\n' +
-        badGroups.map(group => '  ' + singleLineStringify(group)).join('\n')
+        bulletedList(badGroups.map(group => singleLineStringify(group)))
     );
     return false;
   }
@@ -40,7 +41,7 @@ export function isValidGroupedPackageOptions(packageInfos: PackageInfos, package
     console.error(
       'ERROR: Found package configs that define disallowedChangeTypes and are also part of a group. ' +
         'Define disallowedChangeTypes in the group instead.\n' +
-        formatList(errorPackages.sort())
+        bulletedList(errorPackages.sort())
     );
     return false;
   }

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -17,6 +17,7 @@ import { isValidDependentChangeType } from './isValidDependentChangeType';
 import { getPackagesToPublish } from '../publish/getPackagesToPublish';
 import { env } from '../env';
 import type { PackageInfos } from '../types/PackageInfo';
+import { bulletedList } from '../logging/bulletedList';
 
 type ValidationOptions = {
   /**
@@ -76,7 +77,7 @@ export function validate(
   const untracked = getUntrackedChanges(options.path);
 
   if (untracked.length) {
-    console.warn('WARN: There are untracked changes in your repository:\n' + untracked.join('\n- '));
+    console.warn('WARN: There are untracked changes in your repository:\n' + bulletedList(untracked));
     !env.isCI && console.warn('Changes in these files will not trigger a prompt for change descriptions');
   }
 


### PR DESCRIPTION
Validate that there are no private packages among `peerDependencies` or `optionalDependencies` of published packages (not just `dependencies`). There's a slight chance this could be a breaking change.

Copy the `bulletedList` helper from Cloudpack and update list formatting in CLI output. If someone is parsing `beachball check` or `beachball publish` output for some reason, this could be a breaking change.