### PR TITLE
Remove unnecessary findProjectRoot calls

### DIFF
--- a/change/beachball-f068bff3-5309-4ed8-993b-0dbd66d98601.json
+++ b/change/beachball-f068bff3-5309-4ed8-993b-0dbd66d98601.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Remove unnecessary findProjectRoot calls",
+  "type": "patch",
+  "packageName": "beachball",
+  "email": "ecraig12345@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -16,17 +16,15 @@ export async function performBump(bumpInfo: BumpInfo, options: BeachballOptions)
   await callHook(options.hooks?.prebump, modifiedPackages, packageInfos, options.concurrency);
 
   updatePackageJsons(modifiedPackages, packageInfos);
-  await updateLockFile(options.path);
+  await updateLockFile(options);
 
   if (options.generateChangelog) {
     // Generate changelog
     await writeChangelog(bumpInfo, options);
   }
 
-  if (!options.keepChangeFiles) {
-    // Unlink changelogs
-    unlinkChangeFiles(changeFileChangeInfos, packageInfos, options);
-  }
+  // Unlink changelogs
+  unlinkChangeFiles(changeFileChangeInfos, options);
 
   await callHook(options.hooks?.postbump, modifiedPackages, packageInfos, options.concurrency);
 

--- a/src/bump/updateLockFile.ts
+++ b/src/bump/updateLockFile.ts
@@ -1,24 +1,20 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { findProjectRoot } from 'workspace-tools';
 import { packageManager } from '../packageManager/packageManager';
 import { env } from '../env';
+import type { BeachballOptions } from '../types/BeachballOptions';
 
 /**
  * Detects lockfile for npm, pnpm, or yarn and runs the appropriate command to update it
  */
-export async function updateLockFile(cwd: string): Promise<void> {
+export async function updateLockFile(options: Pick<BeachballOptions, 'path'>): Promise<void> {
   // Never update the lock file while running in tests (if tests are added to cover this step,
   // a method can be added to override this condition with a local variable)
   if (env.isJest) {
     return;
   }
 
-  const root = findProjectRoot(cwd);
-  if (!root) {
-    return;
-  }
-
+  const root = options.path;
   let updateFile: string | undefined;
   let updateCommand: ['npm' | 'pnpm' | 'yarn', ...string[]] | undefined;
 

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -2,33 +2,33 @@ import type { ChangeSet } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
 import fs from 'fs-extra';
 import path from 'path';
-import type { PackageInfos } from '../types/PackageInfo';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { DeepReadonly } from '../types/DeepReadonly';
 
 /**
- * Unlink only change files that are specified in the changes param
+ * Unlink only change files that are specified in the `changeSet` param.
+ * Does nothing if `options.keepChangeFiles` is true.
  *
- * @param changes existing change files to be removed
+ * @param changeSet existing change files to be removed
  */
 export function unlinkChangeFiles(
   changeSet: DeepReadonly<ChangeSet>,
-  packageInfos: PackageInfos,
-  options: Pick<BeachballOptions, 'path' | 'changeDir'>
+  options: Pick<BeachballOptions, 'path' | 'changeDir' | 'keepChangeFiles'>
 ): void {
-  const changePath = getChangePath(options);
-  if (!changeSet?.length) {
+  if (!changeSet.length || options.keepChangeFiles) {
     return;
   }
+
   console.log('Removing change files:');
-  for (const { changeFile, change } of changeSet) {
-    if (changeFile && packageInfos[change.packageName] && !packageInfos[change.packageName].private) {
+  const changePath = getChangePath(options);
+  for (const { changeFile } of changeSet) {
+    if (changeFile) {
       console.log(`- ${changeFile}`);
       fs.removeSync(path.join(changePath, changeFile));
     }
   }
   if (fs.existsSync(changePath) && fs.readdirSync(changePath).length === 0) {
-    console.log('Removing change path');
+    console.log(`Removing empty ${options.changeDir} folder`);
     fs.removeSync(changePath);
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import type { BeachballOptions } from '../types/BeachballOptions';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { findProjectRoot } from 'workspace-tools';
+import { findGitRoot } from 'workspace-tools';
 import { npm } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
 
@@ -14,15 +14,14 @@ function errorExit(message: string): void {
 }
 
 export async function init(options: Pick<BeachballOptions, 'path'>): Promise<void> {
-  let root: string;
   try {
-    root = findProjectRoot(options.path);
+    findGitRoot(options.path);
   } catch {
-    console.log('Please run this command on an existing repository root.');
-    return;
+    console.error('beachball only works in a git repository. Please initialize git and try again.');
+    process.exit(1);
   }
 
-  const packageJsonFilePath = path.join(root, 'package.json');
+  const packageJsonFilePath = path.join(options.path, 'package.json');
 
   if (!fs.existsSync(packageJsonFilePath)) {
     errorExit(`Cannot find package.json at ${packageJsonFilePath}`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -42,5 +42,5 @@ export async function sync(options: BeachballOptions, packageInfos?: PackageInfo
   Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
   updatePackageJsons(modifiedPackages, packageInfos);
-  await updateLockFile(options.path);
+  await updateLockFile(options);
 }

--- a/src/monorepo/getPackageGroups.ts
+++ b/src/monorepo/getPackageGroups.ts
@@ -40,13 +40,12 @@ export function getPackageGroups(
     }
   }
 
-  if (errorPackages.length) {
+  const errorEntries = Object.entries(errorPackages);
+  if (errorEntries.length) {
     console.error(
       `ERROR: Found package(s) belonging to multiple groups:\n` +
         bulletedList(
-          Object.entries(errorPackages)
-            .map(([pkgName, pkgGroups]) => `${pkgName}: [${pkgGroups.map(g => g.name).join(', ')}]`)
-            .sort()
+          errorEntries.map(([pkgName, pkgGroups]) => `${pkgName}: ${pkgGroups.map(g => g.name).join(', ')}`).sort()
         )
     );
     // TODO: probably more appropriate to throw here and let the caller handle it?

--- a/src/options/getCliOptions.ts
+++ b/src/options/getCliOptions.ts
@@ -8,7 +8,9 @@ export interface ProcessInfo {
   argv: string[];
   /**
    * Current directory (search for the project root from here). Usually this should be `process.cwd()`.
-   * It can be empty in tests that don't use the filesystem.
+   *
+   * In tests, this is assumed to be the project root (searching up is skipped).
+   * This can also be an empty string in tests that don't use the filesystem.
    */
   cwd: string;
 }
@@ -136,7 +138,7 @@ export function getCliOptions(processOrArgv: ProcessInfo | string[]): ParsedOpti
   try {
     // If a non-empty cwd is provided, find the project root from there.
     // Empty means this is a test without a filesystem.
-    if (cwd) {
+    if (cwd && !env.isJest) {
       cwd = findProjectRoot(processInfo.cwd);
     }
   } catch {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,11 +1,9 @@
 import path from 'path';
-import { findProjectRoot } from 'workspace-tools';
 import type { BeachballOptions } from './types/BeachballOptions';
 
 /**
  * Get the absolute path to the folder containing beachball change files.
  */
 export function getChangePath(options: Pick<BeachballOptions, 'path' | 'changeDir'>): string {
-  const root = findProjectRoot(options.path);
-  return path.join(root, options.changeDir);
+  return path.join(options.path, options.changeDir);
 }

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -182,9 +182,10 @@ export interface RepoOptions {
   message: string;
   /**
    * The directory to run beachball in.
+   * This is assumed to be the project root (monorepo manager root or git root).
    *
-   * Except in tests, this will be the project root (monorepo manager root or package root),
-   * determined relative to `process.cwd()`.
+   * In real usage, this will be an absolute path determined relative to `process.cwd()`.
+   * In tests which don't use the filesystem, this may be an empty string or fake path.
    */
   path: string;
   /** Prerelease prefix for packages that are specified to receive a prerelease bump */

--- a/src/validation/areChangeFilesDeleted.ts
+++ b/src/validation/areChangeFilesDeleted.ts
@@ -1,12 +1,11 @@
 import { bulletedList } from '../logging/bulletedList';
 import { getChangePath } from '../paths';
 import type { BeachballOptions } from '../types/BeachballOptions';
-import { getChangesBetweenRefs, findProjectRoot } from 'workspace-tools';
+import { getChangesBetweenRefs } from 'workspace-tools';
 
 export function areChangeFilesDeleted(options: Pick<BeachballOptions, 'branch' | 'path' | 'changeDir'>): boolean {
   const { branch, path: cwd } = options;
 
-  const root = findProjectRoot(cwd);
   const changePath = getChangePath(options);
 
   console.log(`Checking for deleted change files against "${branch}"`);
@@ -17,7 +16,7 @@ export function areChangeFilesDeleted(options: Pick<BeachballOptions, 'branch' |
       '--diff-filter=D', // showing only deleted files from the diff.
     ],
     `${changePath}/*.json`,
-    root
+    cwd
   );
 
   if (changeFilesDeletedSinceRef.length) {


### PR DESCRIPTION
`BeachballOptions.path` is already the project root if it's available (or the original `cwd` if not, and in either case we don't need to search again). So remove redundant calls elsewhere in the code.