### PR TITLE
Improve perf of readChangeFiles, and improve object stringifying in errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 logs
 *.log
+coverage/
 dist
 node_modules/
 .DS_Store

--- a/change/beachball-508e4cfc-b065-4957-80fe-ab0f71bfa1c8.json
+++ b/change/beachball-508e4cfc-b065-4957-80fe-ab0f71bfa1c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve perf of readChangeFiles, and improve object stringifying in errors",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -71,34 +71,35 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 
 "Applies to" indicates where the settings can be specified: repo-level config or package-level config.
 
-| Option                  | Type                           | Default        | Applies to    | Description                                                                                     |
-| ----------------------- | ------------------------------ | -------------- | ------------- | ----------------------------------------------------------------------------------------------- |
-| `access`                | `'public'` or `'restricted'`   | `'restricted'` | repo          | publish access level for scoped package names (e.g. `@foo/bar`)                                 |
-| `branch`                | `string`                       | [see notes][5] | repo          | target branch; [see notes][5]                                                                   |
-| `bumpDeps`              | `boolean`                      | `true`         | repo          | bump dependent packages during publish (if B is bumped, and A depends on B, also bump A)        |
-| `changeFilePrompt`      | [`ChangeFilePromptOptions`][1] |                | repo          | customize the prompt for change files (can be used to add custom fields)                        |
-| `changehint`            | `string`                       |                | repo          | hint message for when change files are not detected but required                                |
-| `changeDir`             | `string`                       | `change`       | repo          | directory where change files are stored (relative to repo root)                                 |
-| `changelog`             | [`ChangelogOptions`][2]        |                | repo          | changelog rendering and grouping options                                                        |
-| `defaultNpmTag`         | `string`                       | `'latest'`     | repo, package | the default dist-tag used for NPM publish                                                       |
-| `disallowedChangeTypes` | `string[]`                     |                | repo, package | what change types are disallowed                                                                |
-| `fetch`                 | `boolean`                      | `true`         | repo          | fetch from remote before doing diff comparisons                                                 |
-| `generateChangelog`     | `boolean \| 'md' \| 'json'`    | `true`         | repo          | whether to generate `CHANGELOG.md/json` (`'md'` or `'json'` to generate only that type)         |
-| `gitTags`               | `boolean`                      | `true`         | repo, package | whether to create git tags for published packages (eg: foo_v1.0.1)                              |
-| `groups`                | [`VersionGroupOptions[]`][3]   |                | repo          | bump these packages together ([see details][3])                                                 |
-| `groupChanges`          | `boolean`                      | `false`        | repo          | write multiple changes to a single changefile                                                   |
-| `hooks`                 | [`HooksOptions`][4]            |                | repo          | hooks for custom pre/post publish actions                                                       |
-| `ignorePatterns`        | `string[]`                     |                | repo          | ignore changes in files matching these glob patterns ([see notes][6])                           |
-| `package`               | `string`                       |                | repo          | specifies which package the command relates to (overrides change detection based on `git diff`) |
-| `prereleasePrefix`      | `string`                       |                | repo          | prerelease prefix for packages that are specified to receive a prerelease bump                  |
-| `publish`               | `boolean`                      | `true`         | repo          | whether to publish to npm registry                                                              |
-| `push`                  | `boolean`                      | `true`         | repo          | whether to push to the remote git branch                                                        |
-| `registry`              | `string`                       |                | repo          | target NPM registry to publish                                                                  |
-| `retries`               | `number`                       | `3`            | repo          | number of retries for a package publish before failing                                          |
-| `scope`                 | `string[]`                     |                | repo          | only consider package paths matching these patterns ([see details](#scoping))                   |
-| `shouldPublish`         | `false \| undefined`           |                | package       | manually disable publishing of a package by beachball (does not work to force publishing)       |
-| `tag`                   | `string`                       | `'latest'`     | repo, package | dist-tag for npm when published                                                                 |
-| `transform`             | [`TransformOptions`][4]        |                | repo          | transformations for change files                                                                |
+<!-- prettier-ignore -->
+| Option | Type | Default | Applies to | Description |
+| ------ | ---- | ------- | ---------- | ----------- |
+| `access` | `'public'` or `'restricted'` | `'restricted'` | repo | publish access level for scoped package names (e.g. `@foo/bar`) |
+| `branch` | `string` | [see notes][5] | repo | target branch; [see notes][5] |
+| `bumpDeps` | `boolean` | `true` | repo | bump dependent packages during publish (if B is bumped, and A depends on B, also bump A) |
+| `changeFilePrompt` | [`ChangeFilePromptOptions`][1] | | repo | customize the prompt for change files (can be used to add custom fields) |
+| `changehint` | `string` | | repo | hint message for when change files are not detected but required |
+| `changeDir` | `string` | `change` | repo | directory where change files are stored (relative to repo root) |
+| `changelog` | [`ChangelogOptions`][2] | | repo | changelog rendering and grouping options |
+| `defaultNpmTag` | `string` | `'latest'` | repo, package | the default dist-tag used for NPM publish |
+| `disallowedChangeTypes` | `string[]` | | repo, package | what change types are disallowed |
+| `fetch` | `boolean` | `true` | repo | fetch from remote before doing diff comparisons |
+| `generateChangelog` | `boolean \| 'md' \| 'json'` | `true` | repo | whether to generate `CHANGELOG.md/json` (`'md'` or `'json'` to generate only that type) |
+| `gitTags` | `boolean` | `true` | repo, package | whether to create git tags for published packages (eg: foo_v1.0.1) |
+| `groups` | [`VersionGroupOptions[]`][3] | | repo | bump these packages together ([see details][3]) |
+| `groupChanges` | `boolean` | `false` | repo | write multiple changes to a single changefile |
+| `hooks` | [`HooksOptions`][4] | | repo | hooks for custom pre/post publish actions |
+| `ignorePatterns` | `string[]` | | repo | ignore changes in files matching these glob patterns ([see notes][6]) |
+| `package` | `string` | | repo | specifies which package the command relates to (overrides change detection based on `git diff`) |
+| `prereleasePrefix` | `string` | | repo | prerelease prefix, e.g. "beta"; note that if this is specified, packages with change type major/minor/patch will be bumped as prerelease instead |
+| `publish` | `boolean` | `true` | repo | whether to publish to npm registry |
+| `push` | `boolean` | `true` | repo | whether to push to the remote git branch |
+| `registry` | `string` | | repo | target NPM registry to publish |
+| `retries` | `number` | `3` | repo | number of retries for a package publish before failing |
+| `scope` | `string[]` | | repo | only consider package paths matching these patterns ([see details](#scoping)) |
+| `shouldPublish` | `false \| undefined` | | package | manually disable publishing of a package by beachball (does not work to force publishing) |
+| `tag` | `string` | `'latest'` | repo, package | dist-tag for npm when published |
+| `transform` | [`TransformOptions`][4] | | repo | transformations for change files |
 
 [1]: https://github.com/microsoft/beachball/blob/main/src/types/ChangeFilePrompt.ts
 [2]: https://github.com/microsoft/beachball/blob/main/src/types/ChangelogOptions.ts

--- a/src/bump/bumpPackageInfoVersion.ts
+++ b/src/bump/bumpPackageInfoVersion.ts
@@ -4,7 +4,7 @@ import type { BeachballOptions } from '../types/BeachballOptions';
 
 /**
  * Bumps an individual package version based on the change type.
- * **This mutates `info.version`!**
+ * **This mutates `info.version` and `bumpInfo.modifiedPackages`!**
  */
 export function bumpPackageInfoVersion(
   pkgName: string,
@@ -23,10 +23,7 @@ export function bumpPackageInfoVersion(
     console.log(`Skipping bumping private package "${pkgName}"`);
   } else {
     // Ensure we can bump the correct versions
-    let bumpAsPrerelease = false;
-    if (options.prereleasePrefix && !['premajor', 'preminor', 'prepatch'].includes(changeType)) {
-      bumpAsPrerelease = true;
-    }
+    const bumpAsPrerelease = !!options.prereleasePrefix && !['premajor', 'preminor', 'prepatch'].includes(changeType);
 
     // Version should be updated
     info.version = semver.inc(
@@ -36,6 +33,7 @@ export function bumpPackageInfoVersion(
       options.prereleasePrefix || undefined,
       options.identifierBase
     ) as string;
+
     modifiedPackages.add(pkgName);
   }
 }

--- a/src/bump/callHook.ts
+++ b/src/bump/callHook.ts
@@ -26,6 +26,7 @@ export async function callHook(
       await callHookInternal(packageInfos[pkg]);
     }
   } else {
+    // TODO: reuse the graph across hooks if possible (depends on if internal state is used)
     const packageGraph = getPackageGraph(affectedPackages, packageInfos, callHookInternal);
 
     await packageGraph.run({

--- a/src/changefile/getDisallowedChangeTypes.ts
+++ b/src/changefile/getDisallowedChangeTypes.ts
@@ -1,6 +1,11 @@
 import type { ChangeType } from '../types/ChangeInfo';
 import type { PackageGroups, PackageInfos } from '../types/PackageInfo';
 
+/**
+ * Get `disallowedChangeTypes` from the package's group if relevant.
+ * Otherwise, get it from the package's own config or the repo config.
+ */
+// TODO: merge this in getPackageInfosWithOptions instead
 export function getDisallowedChangeTypes(
   packageName: string,
   packageInfos: PackageInfos,

--- a/src/logging/singleLineStringify.ts
+++ b/src/logging/singleLineStringify.ts
@@ -3,5 +3,8 @@
  * (similar to `JSON.stringify(obj, null, 2)` but without the line breaks).
  */
 export function singleLineStringify(obj: unknown): string {
-  return JSON.stringify(obj, null, 2).replace(/\n\s*/g, ' ');
+  return JSON.stringify(obj, null, 2)
+    .replace(/\n\s*/g, ' ')
+    .replace(/: \[ /g, ': [')
+    .replace(/ \]([ ,])/g, ']$1');
 }

--- a/src/options/getPackageInfosWithOptions.ts
+++ b/src/options/getPackageInfosWithOptions.ts
@@ -47,6 +47,7 @@ export function getPackageInfosWithOptions(
     // (just the "beachball" key in package.json).
     // If the package has no specific options (most common), reuse the pre-merged object for performance.
     const packageOptions = packageJson.beachball as Partial<PackageOptions> | undefined;
+    // TODO: merge group options too (group disallowedChangeTypes currently override package)
     const combinedOptions = packageOptions
       ? _mergePackageOptions({ defaultOptions, repoOptions, cliOptions, packageOptions })
       : { ...preMergedOptions };

--- a/src/validation/isValidGroupOptions.ts
+++ b/src/validation/isValidGroupOptions.ts
@@ -7,7 +7,7 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]): boolean {
   // Values that violate types could happen in a user-provided object
   if (!Array.isArray(groups)) {
     console.error(
-      'ERROR: Expected "groups" configuration setting to be an array. Received:\n' + JSON.stringify(groups)
+      'ERROR: Expected "groups" configuration setting to be an array. Received:\n' + singleLineStringify(groups)
     );
     return false;
   }
@@ -20,6 +20,8 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]): boolean {
     );
     return false;
   }
+
+  // TODO: validate disallowedChangeTypes? (they're not currently validated anywhere)
 
   return true;
 }


### PR DESCRIPTION
Update `readChangeFiles` to cache the results of `statSync` while sorting by age. This usually won't make a difference, but it could matter in big repos with lots of change files (especially if not using grouped change files).

Improve formatting of arrays in stringified objects in errors.