### PR TITLE
Clarify some of the bumping logic

### DIFF
--- a/change/beachball-89f85253-2fbd-47da-923c-d3aad1d5f836.json
+++ b/change/beachball-89f85253-2fbd-47da-923c-d3aad1d5f836.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarify some of the bumping logic",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -37,7 +37,7 @@ describe('version bumping', () => {
     repo = undefined;
   });
 
-  it('bumps only packages with change files', async () => {
+  it('bumps only packages with change files with bumpDeps: false', async () => {
     const monorepo: RepoFixture['folders'] = {
       packages: {
         'pkg-1': { version: '1.0.0' },

--- a/src/__tests__/bump/setDependentVersions.test.ts
+++ b/src/__tests__/bump/setDependentVersions.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, afterEach, jest, beforeAll, afterAll } from '@jest/globals';
+import { setDependentVersions } from '../../bump/setDependentVersions';
+import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
+import { consideredDependencies } from '../../types/PackageInfo';
+
+type PartialBumpInfo = Parameters<typeof setDependentVersions>[0];
+
+describe('setDependentVersions', () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+
+  /**
+   * Make the bump info. Package versions should reflect any bumps applied.
+   *
+   * Unless otherwise specified, assumes all packages are in scope and have been modified.
+   * Realistically this would have been determined based on change types and `dependentChangeTypes`.
+   */
+  function makeBumpInfo(
+    params: { packageInfos: PartialPackageInfos } & Partial<Omit<PartialBumpInfo, 'packageInfos'>>
+  ): PartialBumpInfo {
+    const { packageInfos, ...rest } = params;
+    return {
+      packageInfos: makePackageInfos(packageInfos),
+      scopedPackages: new Set(Object.keys(packageInfos)),
+      modifiedPackages: new Set(Object.keys(packageInfos)),
+      ...rest,
+    };
+  }
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns empty object when no packages are in scope', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: { 'pkg-a': {} },
+      scopedPackages: new Set(),
+      // not sure if this would be included if out of scope, but check in case
+      modifiedPackages: new Set(['pkg-a']),
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(result).toEqual({});
+  });
+
+  it('returns empty object when no packages are modified', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: { 'pkg-a': {} },
+      modifiedPackages: new Set(),
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(result).toEqual({});
+  });
+
+  it('bumps dependency version range when dependency is bumped to unsatisfied range', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        // assume this had change type major
+        'pkg-a': { version: '2.0.0' },
+        // and this would be bumped for dependentChangeType patch
+        'pkg-b': { version: '1.0.1', dependencies: { 'pkg-a': '^1.0.0' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-b'].dependencies!['pkg-a']).toBe('^2.0.0');
+    expect(result).toEqual({ 'pkg-b': new Set(['pkg-a']) });
+  });
+
+  it('bumps dependency range even if already satisfied', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        // assume this had change type minor
+        'pkg-a': { version: '1.1.0' },
+        // and this would be bumped for dependentChangeType patch
+        'pkg-b': { version: '1.0.1', dependencies: { 'pkg-a': '^1.0.0' } },
+        'pkg-c': { version: '1.0.1', dependencies: { 'pkg-a': '~1.0.0' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-b'].dependencies!['pkg-a']).toBe('^1.1.0');
+    expect(bumpInfo.packageInfos['pkg-c'].dependencies!['pkg-a']).toBe('~1.1.0');
+    expect(result).toEqual({ 'pkg-b': new Set(['pkg-a']), 'pkg-c': new Set(['pkg-a']) });
+  });
+
+  it.each(consideredDependencies)('handles %s', depType => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        'pkg-a': { version: '1.1.0' },
+        'pkg-b': { version: '1.0.1', [depType]: { 'pkg-a': '^1.0.0' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-b'][depType]!['pkg-a']).toBe('^1.1.0');
+    expect(result).toEqual({ 'pkg-b': new Set(['pkg-a']) });
+
+    // doesn't log by default
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles (ignores) external dependencies', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        'pkg-a': { version: '1.0.0', dependencies: { external: '^1.0.0' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-a'].dependencies!['external']).toBe('^1.0.0');
+    expect(result).toEqual({});
+  });
+
+  it('handles multiple dependencies being bumped', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        'pkg-a': { version: '1.0.1' },
+        'pkg-b': { version: '1.1.0' },
+        'pkg-c': { version: '1.0.1', dependencies: { 'pkg-a': '^1.0.0' }, peerDependencies: { 'pkg-b': '^1.0.0' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-c'].dependencies!['pkg-a']).toBe('^1.0.1');
+    expect(bumpInfo.packageInfos['pkg-c'].peerDependencies!['pkg-b']).toBe('^1.1.0');
+    expect(result).toEqual({ 'pkg-c': new Set(['pkg-a', 'pkg-b']) });
+  });
+
+  it('logs when verbose is true', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        'pkg-a': { version: '2.0.0' },
+        'pkg-b': { version: '1.0.1', dependencies: { 'pkg-a': '^1.0.0' } },
+      },
+    });
+
+    setDependentVersions(bumpInfo, { verbose: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('pkg-b needs to be bumped because pkg-a ^1.0.0 -> ^2.0.0');
+  });
+
+  // Documenting this issue
+  // https://github.com/microsoft/beachball/issues/981
+  it('currently misses bumps of workspace: ranges', () => {
+    const bumpInfo = makeBumpInfo({
+      packageInfos: {
+        'pkg-a': { version: '1.1.0' },
+        // * means an exact dependency and should definitely cause a bump
+        'pkg-b': { version: '1.0.1', dependencies: { 'pkg-a': 'workspace:*' } },
+      },
+    });
+
+    const result = setDependentVersions(bumpInfo, {});
+
+    expect(bumpInfo.packageInfos['pkg-b'].dependencies!['pkg-a']).toBe('workspace:*');
+    expect(result).toEqual({}); // should have pkg-b depending on pkg-a
+  });
+});

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -5,14 +5,19 @@ import { bumpMinSemverRange } from './bumpMinSemverRange';
 
 /**
  * Go through the deps of each package and bump the version range for in-repo deps if needed.
+ * Prior to calling this, it's expected that:
+ * - package versions in `bumpInfo.packageInfos` have been bumped per change files and dependentChangeTypes
+ * - `bumpInfo.modifiedPackages` contains all packages whose version has been bumped
  *
- * **This mutates dep versions in `packageInfos`** as well as returning `dependentChangedBy`.
+ * **This mutates dependency versions in `packageInfos`** and might add to `bumpInfo.modifiedPackages`.
+ * Probably the only case where it will change `modifiedPackages` is if `BeachballOptions.bumpDeps` is false
+ * (or if this is being called by `sync` which didn't previously bump dependents).
  */
 export function setDependentVersions(
-  bumpInfo: Pick<BumpInfo, 'packageInfos' | 'scopedPackages'>,
+  bumpInfo: Pick<BumpInfo, 'packageInfos' | 'scopedPackages' | 'modifiedPackages'>,
   options: Pick<BeachballOptions, 'verbose'>
 ): BumpInfo['dependentChangedBy'] {
-  const { packageInfos, scopedPackages } = bumpInfo;
+  const { packageInfos, scopedPackages, modifiedPackages } = bumpInfo;
   const { verbose } = options;
   const dependentChangedBy: BumpInfo['dependentChangedBy'] = {};
 
@@ -26,8 +31,11 @@ export function setDependentVersions(
 
       for (const [dep, existingVersionRange] of Object.entries(deps)) {
         const depPackage = packageInfos[dep];
-        if (!depPackage) {
-          continue; // external dependency
+        // TODO: should this use the initial modifiedPackages rather than the possibly-updated one?
+        // (considering updates could introduce order sensitivity, though the old logic that didn't
+        // check modifiedPackages at all also had that issue)
+        if (!depPackage || !modifiedPackages.has(dep)) {
+          continue; // external dependency or not modified
         }
 
         const bumpedVersionRange = bumpMinSemverRange(depPackage.version, existingVersionRange);
@@ -38,6 +46,12 @@ export function setDependentVersions(
 
           dependentChangedBy[pkgName] ??= new Set<string>();
           dependentChangedBy[pkgName].add(dep);
+
+          // Unless bumpDeps was false, the package should have been added to modifiedPackages
+          // by updateRelatedChangeType plus bumpPackageInfoVersion, but to be safe we add it here too.
+          // TODO: fix behavior - https://github.com/microsoft/beachball/issues/620
+          modifiedPackages.add(pkgName);
+
           if (verbose) {
             console.log(
               `${pkgName} needs to be bumped because ${dep} ${existingVersionRange} -> ${bumpedVersionRange}`

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -68,14 +68,16 @@ export async function publish(options: BeachballOptions, oldPackageInfos?: Packa
   console.log(`\nGathering info ${options.bump ? 'to bump versions' : 'about versions and changes'}`);
   const bumpInfo: PublishBumpInfo = gatherBumpInfo(options, oldPackageInfos);
 
+  // eslint-disable-next-line etc/no-deprecated
   if (options.new) {
     // Publish newly created packages even if they don't have change files
     // (this is unlikely unless the packages were pushed without a PR that runs "beachball check")
     console.log(
       '\nFetching all unmodified packages from the registry to check if there are any ' +
         "newly-added packages that didn't have a change file...\n" +
-        '(If your PR build runs `beachball check`, it should be safe to disable this step by ' +
-        'removing `new: true` from your config or removing `--new` from your publish command.)'
+        '(NOTE: If your PR build runs `beachball check`, this step is unnecessarily slowing down ' +
+        "your publish process. In that case, it's recommended to remove `new: true` from your " +
+        'config or remove `--new` from your publish command.)'
     );
     bumpInfo.newPackages = await getNewPackages(bumpInfo, options);
   }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -39,8 +39,8 @@ export async function sync(options: BeachballOptions, packageInfos?: PackageInfo
     }
   }
 
-  const dependentModifiedPackages = setDependentVersions({ packageInfos, scopedPackages }, options);
-  Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
+  // Update modifiedPackages
+  setDependentVersions({ packageInfos, scopedPackages, modifiedPackages }, options);
 
   updatePackageJsons(modifiedPackages, packageInfos);
   await updateLockFile(options);

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -5,7 +5,7 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
   const errorLines: string[] = [];
   const succeededLines: string[] = [];
 
-  bumpInfo.modifiedPackages.forEach(pkg => {
+  for (const pkg of bumpInfo.modifiedPackages) {
     const packageInfo = bumpInfo.packageInfos[pkg];
     const entry = `${packageInfo.name}@${packageInfo.version}`;
     if (succeededPackages.has(packageInfo.name)) {
@@ -13,7 +13,7 @@ export function displayManualRecovery(bumpInfo: BumpInfo, succeededPackages: Set
     } else {
       errorLines.push(entry);
     }
-  });
+  }
 
   console.error(
     'Something went wrong with publishing! Manually update these package and versions:\n' +

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -250,9 +250,10 @@ export interface RepoOptions {
    * This is rarely needed since new packages *with change files* will always be published
    * regardless of this option.
    *
-   * (This has limited use unless you pushed new packages directly to the main branch, or
-   * your PR build doesn't run `beachball check`. Otherwise, `beachball check` will require
-   * change files to be created for the new packages.)
+   * @deprecated This option is not recommended because it will negatively impact perf (it requires
+   * checking the registry for ALL unmodified packages). It also has limited use unless you pushed
+   * new packages directly to the main branch, or your PR build doesn't run `beachball check`.
+   * Normally, `beachball check` will require change files to be created for the new packages.
    */
   new: boolean;
 }

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -28,7 +28,12 @@ export type BumpInfo = {
    */
   packageGroups: DeepReadonly<PackageGroups>;
 
-  /** Set of packages that had been modified */
+  /**
+   * Set of packages that had been modified.
+   *
+   * For the bump command, this is primarily populated by `bumpPackageInfoVersion` (which considers
+   * dependent bumps and groups). If `bumpDeps` is false, it might be updated by `setDependentVersions`.
+   */
   modifiedPackages: Set<string>;
 
   /** Map from package name to its internal dependency names that were bumped. */


### PR DESCRIPTION
Update some comments, operation ordering, and variable naming in some of the bumping logic to hopefully make it clearer.

Also improve perf of `setDependentVersions` by skipping any dependencies not listed in `modifiedPackages` (and add tests).

I realized while looking through this logic that the handling of `bumpDeps: false` is a bit of a mess, as documented in https://github.com/microsoft/beachball/issues/620#issuecomment-3609264966, but that shouldn't be changed outside a major bump.