### PR TITLE
Fix double bump issue

### DIFF
--- a/change/beachball-c16d514c-bb1d-4382-a4a7-b9fc62137db4.json
+++ b/change/beachball-c16d514c-bb1d-4382-a4a7-b9fc62137db4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix double bump issue",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -6,11 +6,14 @@ import type { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import type { PackageInfos } from '../types/PackageInfo';
 import { getPackageGroups } from '../monorepo/getPackageGroups';
+import { cloneObject } from '../object/cloneObject';
 
 /**
  * Gather bump info and bump versions in memory.
+ * Does NOT mutate the given `originalPackageInfos`.
  */
-export function gatherBumpInfo(options: BeachballOptions, packageInfos: PackageInfos): BumpInfo {
+export function gatherBumpInfo(options: BeachballOptions, originalPackageInfos: PackageInfos): BumpInfo {
+  const packageInfos = cloneObject(originalPackageInfos);
   const changes = readChangeFiles(options, packageInfos);
 
   // Determine base change types for each package (not considering disallowedChangeTypes or groups)

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -30,7 +30,7 @@ export async function bumpAndPush(bumpInfo: BumpInfo, publishBranch: string, opt
     console.log('-'.repeat(80));
     console.log(`Bumping versions and pushing to git (attempt ${tryNumber}/${BUMP_PUSH_RETRIES})`);
     console.log('Reverting');
-    revertLocalChanges(cwd);
+    revertLocalChanges({ cwd });
 
     // pull in latest from origin branch
     if (options.fetch !== false) {


### PR DESCRIPTION
#1087 introduced an issue where `validate()` would call `gatherBumpInfo()` on the same set of `packageInfos` which was then reused by bump/publish. This caused double version bumps.

Fix is to clone the package infos in `gatherBumpInfo`.