### PR TITLE
Remove fs-extra usage

### DIFF
--- a/change/beachball-857252f9-29e7-4cee-8792-9287a470db83.json
+++ b/change/beachball-857252f9-29e7-4cee-8792-9287a470db83.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove fs-extra usage",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "cosmiconfig": "^9.0.0",
     "execa": "^5.0.0",
-    "fs-extra": "^11.1.1",
     "minimatch": "^3.0.4",
     "p-graph": "^1.1.2",
     "p-limit": "^3.0.2",
@@ -63,7 +62,6 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.0.0",
-    "@types/fs-extra": "^11.0.0",
     "@types/minimatch": "^5.0.0",
     "@types/node": "^14.0.0",
     "@types/prompts": "^2.4.2",
@@ -77,7 +75,6 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-etc": "^2.0.3",
-    "find-free-port": "^2.0.0",
     "get-port": "^5.0.0",
     "husky": "^8.0.0",
     "jest": "^29.0.0",

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, afterEach, jest } from '@jest/globals';
-import fs from 'fs-extra';
 import path from 'path';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { readChangelogJson } from '../__fixtures__/changelog';
@@ -12,6 +11,7 @@ import type { Repository } from '../__fixtures__/repository';
 import type { PackageJson } from '../types/PackageInfo';
 import { getParsedOptions } from '../options/getOptions';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
+import { readJson } from '../object/readJson';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -746,7 +746,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect((fs.readJSONSync(jsonPath) as PackageJson).version).toBe('1.0.0');
+          expect(readJson<PackageJson>(jsonPath).version).toBe('1.0.0');
         }),
       },
     });
@@ -776,7 +776,8 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect(((await fs.readJSON(jsonPath)) as PackageJson).version).toBe('1.0.0');
+          await new Promise(resolve => setTimeout(resolve, 0)); // simulate async work
+          expect(readJson<PackageJson>(jsonPath).version).toBe('1.0.0');
         }),
       },
     });
@@ -830,7 +831,7 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect((fs.readJSONSync(jsonPath) as PackageJson).version).toBe('1.1.0');
+          expect(readJson<PackageJson>(jsonPath).version).toBe('1.1.0');
         }),
       },
     });
@@ -860,7 +861,8 @@ describe('version bumping', () => {
           expect(version).toBe('1.1.0');
 
           const jsonPath = path.join(packagePath, 'package.json');
-          expect(((await fs.readJSON(jsonPath)) as PackageJson).version).toBe('1.1.0');
+          await new Promise(resolve => setTimeout(resolve, 0)); // simulate async work
+          expect(readJson<PackageJson>(jsonPath).version).toBe('1.1.0');
         }),
       },
     });

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, afterEach, jest, beforeEach } from '@jest/globals';
-import fs from 'fs-extra';
 import type prompts from 'prompts';
 import { getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
@@ -13,6 +12,7 @@ import type { ChangeFileInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
 import type { Repository } from '../__fixtures__/repository';
 import { getParsedOptions } from '../options/getOptions';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
+import { readJson } from '../object/readJson';
 
 // prompts writes to stdout (not console) in a way that can't really be mocked with spies,
 // so instead we inject a custom mock stdout stream, as well as stdin for entering answers
@@ -128,7 +128,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
-    expect(fs.readJSONSync(changeFiles[0])).toMatchObject({
+    expect(readJson(changeFiles[0])).toMatchObject({
       comment: 'stage me please',
       packageName: 'foo',
       type: 'patch',
@@ -155,7 +155,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
-    expect(fs.readJSONSync(changeFiles[0])).toMatchObject({
+    expect(readJson(changeFiles[0])).toMatchObject({
       comment: 'commit me please',
       packageName: 'foo',
       type: 'patch',
@@ -186,7 +186,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
-    expect(fs.readJSONSync(changeFiles[0])).toMatchObject({
+    expect(readJson(changeFiles[0])).toMatchObject({
       comment: 'commit me please',
       packageName: 'foo',
       type: 'patch',
@@ -247,7 +247,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(2);
-    const changeFileContents = changeFiles.map(changeFile => fs.readJSONSync(changeFile) as ChangeFileInfo);
+    const changeFileContents = changeFiles.map(changeFile => readJson<ChangeFileInfo>(changeFile));
     expect(changeFileContents).toContainEqual(
       expect.objectContaining({ comment: 'custom', packageName: 'pkg-1', type: 'minor' })
     );
@@ -283,7 +283,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
-    const contents = fs.readJSONSync(changeFiles[0]) as ChangeInfoMultiple;
+    const contents = readJson<ChangeInfoMultiple>(changeFiles[0]);
     expect(contents.changes).toEqual([
       expect.objectContaining({ comment: 'custom', packageName: 'pkg-1', type: 'minor' }),
       expect.objectContaining({ comment: 'commit 2', packageName: 'pkg-2', type: 'patch' }),
@@ -330,7 +330,7 @@ describe('change command', () => {
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
-    const contents = fs.readJSONSync(changeFiles[0]) as ChangeInfoMultiple;
+    const contents = readJson<ChangeInfoMultiple>(changeFiles[0]);
     expect(contents.changes).toEqual([
       expect.objectContaining({ packageName: 'pkg-1', type: 'patch', comment: 'commit 2' }),
       expect.objectContaining({ packageName: 'pkg-2', type: 'patch', comment: 'commit 2', custom: 'stuff' }),

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
 import { initMockLogs } from '../__fixtures__/mockLogs';
@@ -12,6 +11,7 @@ import type { ChangeFileInfo } from '../types/ChangeInfo';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import type { PackageJson } from '../types/PackageInfo';
 import { getParsedOptions } from '../options/getOptions';
+import { readJson } from '../object/readJson';
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory;
@@ -58,7 +58,7 @@ describe('publish command (git)', () => {
 
     const newRepo = repositoryFactory.cloneRepository();
 
-    const packageJson = fs.readJSONSync(newRepo.pathTo('package.json')) as PackageJson;
+    const packageJson = readJson<PackageJson>(newRepo.pathTo('package.json'));
 
     expect(packageJson.version).toBe('1.1.0');
   });
@@ -88,7 +88,7 @@ describe('publish command (git)', () => {
     const newRepo = repositoryFactory.cloneRepository();
     const changeFiles = getChangeFiles({ ...options1, path: newRepo.rootPath });
     expect(changeFiles).toHaveLength(1);
-    const changeFileContent = fs.readJSONSync(changeFiles[0]) as ChangeFileInfo;
+    const changeFileContent = readJson<ChangeFileInfo>(changeFiles[0]);
     expect(changeFileContent.packageName).toBe('foo2');
   });
 });

--- a/src/__e2e__/syncE2E.test.ts
+++ b/src/__e2e__/syncE2E.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, afterEach, jest } from '@jest/globals';
-import fs from 'fs-extra';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import type { Repository } from '../__fixtures__/repository';
@@ -10,6 +9,7 @@ import type { packagePublish } from '../packageManager/packagePublish';
 import type { RepoOptions } from '../types/BeachballOptions';
 import { initNpmMock } from '../__fixtures__/mockNpm';
 import { getParsedOptions } from '../options/getOptions';
+import { removeTempDir } from '../__fixtures__/tmpdir';
 
 // Spawning actual npm to run commands against a fake registry is extremely slow, so mock it for
 // this test (packagePublish covers the more complete npm registry scenario).
@@ -59,7 +59,7 @@ describe('sync command (e2e)', () => {
       repositoryFactory.cleanUp();
       repositoryFactory = undefined;
     }
-    tempDirs.forEach(dir => fs.removeSync(dir));
+    tempDirs.forEach(dir => removeTempDir(dir));
     tempDirs.splice(0, tempDirs.length);
   });
 

--- a/src/__fixtures__/changelog.ts
+++ b/src/__fixtures__/changelog.ts
@@ -1,7 +1,8 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import type { ChangelogJson } from '../types/ChangeLog';
 import { markerComment } from '../changelog/renderChangelog';
+import { readJson } from '../object/readJson';
 
 /** Placeholder commit as replaced by cleanChangelogJson */
 export const fakeCommit = '(sha1)';
@@ -38,7 +39,7 @@ export function readChangelogJson(packagePath: string, filename?: string, noClea
     return null;
   }
 
-  const changelog = fs.readJSONSync(changelogJsonFile, { encoding: 'utf-8' }) as ChangelogJson;
+  const changelog = readJson<ChangelogJson>(changelogJsonFile);
   if (noClean) {
     return changelog;
   }

--- a/src/__fixtures__/createTestFileStructure.ts
+++ b/src/__fixtures__/createTestFileStructure.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import { tmpdir } from './tmpdir';
 import path from 'path';
 
@@ -12,7 +12,7 @@ export function createTestFileStructure(files: Record<string, string | object>):
 
   for (const [filename, content] of Object.entries(files)) {
     const filePath = path.join(testFolderPath, filename);
-    fs.ensureDirSync(path.dirname(filePath));
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, typeof content === 'string' ? content : JSON.stringify(content));
   }
 

--- a/src/__fixtures__/mockNpm.test.ts
+++ b/src/__fixtures__/mockNpm.test.ts
@@ -3,7 +3,7 @@
 // dependency on actual npm CLI calls and a fake registry (which are very slow).
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { type NpmResult, npm } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
 import {
@@ -14,8 +14,10 @@ import {
   _mockNpmShow,
   type MockNpmResult,
 } from './mockNpm';
+import * as readJsonModule from '../object/readJson';
 
-jest.mock('fs-extra');
+jest.mock('fs');
+jest.mock('../object/readJson');
 jest.mock('../packageManager/npm');
 
 describe('_makeRegistryData', () => {
@@ -193,10 +195,10 @@ describe('_mockNpmPublish', () => {
   let packageJson: PackageJson | undefined;
 
   beforeAll(() => {
-    (fs.readJsonSync as jest.MockedFunction<typeof fs.readJsonSync>).mockImplementation(() => {
+    (readJsonModule.readJson as jest.MockedFunction<typeof readJsonModule.readJson>).mockImplementation((() => {
       if (!packageJson) throw new Error('packageJson not set');
       return packageJson;
-    });
+    }) as typeof readJsonModule.readJson);
   });
 
   afterEach(() => {
@@ -289,10 +291,10 @@ describe('_mockNpmPack', () => {
   let writtenFiles: (fs.PathLike | number)[] = [];
 
   beforeAll(() => {
-    (fs.readJsonSync as jest.MockedFunction<typeof fs.readJsonSync>).mockImplementation(() => {
+    (readJsonModule.readJson as jest.MockedFunction<typeof readJsonModule.readJson>).mockImplementation((() => {
       if (!packageJson) throw new Error('packageJson not set');
       return packageJson;
-    });
+    }) as typeof readJsonModule.readJson);
     (fs.writeFileSync as jest.MockedFunction<typeof fs.writeFileSync>).mockImplementation(filePath => {
       writtenFiles.push(String(filePath).replace(/\\/g, '/'));
     });
@@ -352,10 +354,10 @@ describe('mockNpm', () => {
   let packageJson: PackageJson | undefined;
 
   beforeAll(() => {
-    (fs.readJsonSync as jest.MockedFunction<typeof fs.readJsonSync>).mockImplementation(() => {
+    (readJsonModule.readJson as jest.MockedFunction<typeof readJsonModule.readJson>).mockImplementation((() => {
       if (!packageJson) throw new Error('packageJson not set');
       return packageJson;
-    });
+    }) as typeof readJsonModule.readJson);
   });
 
   afterEach(() => {

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, beforeAll, type jest } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 import { npmShowProperties, type NpmShowResult } from '../packageManager/listPackageVersions';
 import { npm, NpmResult } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
 import type { PackageManagerOptions } from '../packageManager/packageManager';
+import { readJson } from '../object/readJson';
 
 /** Published versions and dist-tags for a package */
 type NpmPackageVersionsData = Pick<NpmShowResult, 'versions' | 'dist-tags'>;
@@ -210,7 +211,7 @@ export const _mockNpmPublish: MockNpmCommand = async (registryData, args, opts) 
 
   // Read package.json from cwd to find the published package name and version.
   // (If this fails, let the exception propagate for easier debugging.)
-  const packageJson = fs.readJsonSync(path.join(opts.cwd, 'package.json')) as PackageJson;
+  const packageJson = readJson<PackageJson>(path.join(opts.cwd, 'package.json'));
 
   const tag = args.includes('--tag') ? args[args.indexOf('--tag') + 1] : 'latest';
 
@@ -258,7 +259,7 @@ export const _mockNpmPack: MockNpmCommand = async (registryData, args, opts) => 
 
   // Read package.json from cwd to find the package name and version.
   // (If this fails, let the exception propagate for easier debugging.)
-  const packageJson = fs.readJsonSync(path.join(opts.cwd, 'package.json')) as PackageJson;
+  const packageJson = readJson<PackageJson>(path.join(opts.cwd, 'package.json'));
 
   // Create a fake ".tgz" file with npm's naming scheme (contents don't matter).
   const packFileName = getMockNpmPackName(packageJson);

--- a/src/__fixtures__/registry.ts
+++ b/src/__fixtures__/registry.ts
@@ -1,7 +1,7 @@
 import { ConfigBuilder } from '@verdaccio/config';
 import { fork, type ChildProcess } from 'child_process';
 import execa from 'execa';
-import fs from 'fs-extra';
+import fs from 'fs';
 import getPort from 'get-port';
 import path from 'path';
 import { removeTempDir, tmpdir } from './tmpdir';
@@ -48,7 +48,7 @@ export class Registry {
       return this.startWithPort(this.port);
     }
 
-    // find-free-port will throw an error if none are free.
+    // get-port will throw an error if none are free.
     // If this is consistently having problems, probably it's best to increase portRange.
     const maxPort = this.startPort + portRange;
     console.log(`Looking for free ports in range ${this.startPort} to ${maxPort}`);

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import type { PackageJson } from '../types/PackageInfo';
 import { Repository, type RepositoryCloneOptions } from './repository';
@@ -7,6 +7,7 @@ import { removeTempDir, tmpdir } from './tmpdir';
 import { gitFailFast } from 'workspace-tools';
 import { setDefaultBranchName } from './gitDefaults';
 import { cloneObject } from '../object/cloneObject';
+import { writeJson } from '../object/writeJson';
 
 /**
  * Standard fixture options. See {@link getSinglePackageFixture}, {@link getMonorepoFixture} and
@@ -203,7 +204,7 @@ export class RepositoryFactory {
         throw new Error('`fixtures` must define `rootPackage` and/or `folders`');
       }
 
-      fs.ensureDirSync(tmpRepo.pathTo(parentFolder));
+      fs.mkdirSync(tmpRepo.pathTo(parentFolder), { recursive: true });
 
       // fill out the root package and an empty folders object if not provided
       const rootPackage = fixture.rootPackage || getMonorepoRootPackage();
@@ -218,7 +219,7 @@ export class RepositoryFactory {
         rootPackage.workspaces = folderNames.map(folder => `${folder}/*`);
       }
       // create the root package.json
-      fs.writeJSONSync(tmpRepo.pathTo(parentFolder, 'package.json'), rootPackage, { spaces: 2 });
+      writeJson(tmpRepo.pathTo(parentFolder, 'package.json'), rootPackage);
 
       // create the lock file
       // (an option could be added to disable or customize this in the future if needed)
@@ -230,8 +231,8 @@ export class RepositoryFactory {
           // save the name if not already set
           packageJson.name ??= name;
           const pkgFolder = tmpRepo.pathTo(parentFolder, folder, name);
-          fs.ensureDirSync(pkgFolder);
-          fs.writeJSONSync(path.join(pkgFolder, 'package.json'), packageJson, { spaces: 2 });
+          fs.mkdirSync(pkgFolder, { recursive: true });
+          writeJson(path.join(pkgFolder, 'package.json'), packageJson);
         }
       }
 

--- a/src/__fixtures__/tmpdir.ts
+++ b/src/__fixtures__/tmpdir.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import * as tmp from 'tmp';
 import { normalizedTmpdir } from 'normalized-tmpdir';
 // import console to ensure that warnings are always logged if needed (no mocking)
@@ -38,7 +38,7 @@ export function removeTempDir(dir: string | undefined): void {
   try {
     // This occasionally throws on Windows with "resource busy"
     if (dir && !env.isCI) {
-      fs.removeSync(dir);
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   } catch (err) {
     // This is non-fatal since the temp dir will eventually be cleaned up automatically

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { generateChangeFiles, getChangeFiles } from '../../__fixtures__/changeFiles';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
@@ -13,6 +13,8 @@ import { getParsedOptions } from '../../options/getOptions';
 import { removeTempDir } from '../../__fixtures__/tmpdir';
 import path from 'path';
 import { createTestFileStructureType } from '../../__fixtures__/createTestFileStructure';
+import { readJson } from '../../object/readJson';
+import { writeJson } from '../../object/writeJson';
 
 describe('readChangeFiles', () => {
   /** Non-git temp directory root, for tests that don't need git */
@@ -34,9 +36,9 @@ describe('readChangeFiles', () => {
 
   function updateJsonFile(relativePath: string, json: Record<string, unknown>) {
     const fullPath = path.join(tempRoot!, relativePath);
-    const diskJson = fs.readJSONSync(fullPath) as Record<string, unknown>;
+    const diskJson = readJson<Record<string, unknown>>(fullPath);
     Object.assign(diskJson, json);
-    fs.writeJSONSync(fullPath, diskJson, { spaces: 2 });
+    writeJson(fullPath, diskJson);
   }
 
   afterEach(() => {

--- a/src/__functional__/changefile/unlinkChangeFiles.test.ts
+++ b/src/__functional__/changefile/unlinkChangeFiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import type { ChangeSet } from '../../types/ChangeInfo';
@@ -9,6 +9,7 @@ import type { BeachballOptions } from '../../types/BeachballOptions';
 import { getChangePath } from '../../paths';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
 import { getChange } from '../../__fixtures__/changeFiles';
+import { writeJson } from '../../object/writeJson';
 
 describe('unlinkChangeFiles', () => {
   const logs = initMockLogs();
@@ -36,13 +37,13 @@ describe('unlinkChangeFiles', () => {
     };
 
     const changePath = getChangePath(options);
-    fs.mkdirpSync(changePath);
+    fs.mkdirSync(changePath, { recursive: true });
 
     const changeSet: ChangeSet = [];
     for (const changeFile of changeFileNames) {
       // The change content doesn't matter here
       const change = getChange('fake');
-      fs.writeJsonSync(path.join(changePath, changeFile), change);
+      writeJson(path.join(changePath, changeFile), change);
       if (inChangeSet.includes(changeFile)) {
         changeSet.push({ changeFile, change });
       }
@@ -123,8 +124,8 @@ describe('unlinkChangeFiles', () => {
     });
     // Also create the default change path to ensure it doesn't get deleted
     const defaultChangePath = getChangePath({ ...getDefaultOptions(), path: root });
-    fs.mkdirpSync(defaultChangePath);
-    fs.writeJsonSync(path.join(defaultChangePath, 'change1.json'), {});
+    fs.mkdirSync(defaultChangePath, { recursive: true });
+    writeJson(path.join(defaultChangePath, 'change1.json'), {});
 
     unlinkChangeFiles(changeSet, options);
 

--- a/src/__functional__/changefile/writeChangeFiles.test.ts
+++ b/src/__functional__/changefile/writeChangeFiles.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeAll, afterAll, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 
@@ -10,6 +9,7 @@ import { listAllTrackedFiles } from 'workspace-tools';
 import type { BeachballOptions } from '../../types/BeachballOptions';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
 import type { Repository } from '../../__fixtures__/repository';
+import { readJson } from '../../object/readJson';
 
 const uuidRegex = /[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}/;
 const uuidGeneric = '00000000-0000-0000-0000-000000000000';
@@ -71,7 +71,7 @@ describe('writeChangeFiles', () => {
     expect(repo.getCurrentHash()).not.toEqual(previousHead);
 
     // also verify contents of one file
-    const changeFileContents = fs.readJSONSync(changeFiles[0]) as ChangeFileInfo;
+    const changeFileContents = readJson<ChangeFileInfo>(changeFiles[0]);
     expect(changeFileContents).toEqual({ packageName: 'bar' });
   });
 
@@ -128,7 +128,7 @@ describe('writeChangeFiles', () => {
     const trackedFiles = listAllTrackedFiles({ patterns: ['change/*'], cwd: repo.rootPath });
     expect(cleanChangeFilePaths(repo.rootPath, trackedFiles)).toEqual(expectedFile);
 
-    const changeFileContents = fs.readJSONSync(changeFiles[0]) as ChangeInfoMultiple;
+    const changeFileContents = readJson<ChangeInfoMultiple>(changeFiles[0]);
     expect(changeFileContents).toEqual({
       changes: [{ packageName: 'foo' }, { packageName: 'bar' }],
     });

--- a/src/__functional__/monorepo/getPackageInfos.test.ts
+++ b/src/__functional__/monorepo/getPackageInfos.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, beforeAll, afterAll, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { gitFailFast } from 'workspace-tools';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
-import { tmpdir } from '../../__fixtures__/tmpdir';
+import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
 import { getPackageInfos } from '../../monorepo/getPackageInfos';
 import type { PackageInfos, PackageInfo } from '../../types/PackageInfo';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
@@ -11,6 +11,7 @@ import type { PackageOptions } from '../../types/BeachballOptions';
 import { cloneObject } from '../../object/cloneObject';
 import { getParsedOptions } from '../../options/getOptions';
 import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { writeJson } from '../../object/writeJson';
 
 const defaultOptions = getDefaultOptions();
 
@@ -77,7 +78,7 @@ describe('getPackageInfos', () => {
   });
 
   afterEach(() => {
-    tempDir && fs.removeSync(tempDir);
+    removeTempDir(tempDir);
     tempDir = undefined;
   });
 
@@ -199,7 +200,7 @@ describe('getPackageInfos', () => {
 
   it('works in pnpm monorepo', () => {
     const repo = monorepoFactory.cloneRepository();
-    fs.writeJSONSync(repo.pathTo('package.json'), { name: 'pnpm-monorepo', version: '1.0.0', private: true });
+    writeJson(repo.pathTo('package.json'), { name: 'pnpm-monorepo', version: '1.0.0', private: true });
     fs.writeFileSync(repo.pathTo('pnpm-lock.yaml'), '');
     fs.writeFileSync(repo.pathTo('pnpm-workspace.yaml'), 'packages: ["packages/*", "packages/grouped/*"]');
     const parsedOptions = getOptions(repo.rootPath);
@@ -217,8 +218,8 @@ describe('getPackageInfos', () => {
 
   it('works in rush monorepo', () => {
     const repo = monorepoFactory.cloneRepository();
-    fs.writeJSONSync(repo.pathTo('package.json'), { name: 'rush-monorepo', version: '1.0.0', private: true });
-    fs.writeJSONSync(repo.pathTo('rush.json'), {
+    writeJson(repo.pathTo('package.json'), { name: 'rush-monorepo', version: '1.0.0', private: true });
+    writeJson(repo.pathTo('rush.json'), {
       projects: [{ projectFolder: 'packages' }, { projectFolder: 'packages/grouped' }],
     });
     const parsedOptions = getOptions(repo.rootPath);
@@ -236,8 +237,8 @@ describe('getPackageInfos', () => {
 
   it('works in lerna monorepo', () => {
     const repo = monorepoFactory.cloneRepository();
-    fs.writeJSONSync(repo.pathTo('package.json'), { name: 'lerna-monorepo', version: '1.0.0', private: true });
-    fs.writeJSONSync(repo.pathTo('lerna.json'), { packages: ['packages/*', 'packages/grouped/*'] });
+    writeJson(repo.pathTo('package.json'), { name: 'lerna-monorepo', version: '1.0.0', private: true });
+    writeJson(repo.pathTo('lerna.json'), { packages: ['packages/*', 'packages/grouped/*'] });
     const parsedOptions = getOptions(repo.rootPath);
 
     const rootPackageInfos = getPackageInfos(parsedOptions);

--- a/src/__functional__/options/getOptions.test.ts
+++ b/src/__functional__/options/getOptions.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, beforeAll, afterAll, jest } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { getOptions, getParsedOptions } from '../../options/getOptions';
 import type { RepoOptions } from '../../types/BeachballOptions';
+import { writeJson } from '../../object/writeJson';
 
 describe('getOptions (deprecated)', () => {
   let repositoryFactory: RepositoryFactory;
@@ -45,7 +46,7 @@ describe('getOptions (deprecated)', () => {
   it('reads config from package.json', () => {
     const repo = repositoryFactory.cloneRepository();
     const config = inDirectory(repo.rootPath, () => {
-      fs.writeJsonSync('package.json', { beachball: { branch: 'origin/foo' } });
+      writeJson('package.json', { beachball: { branch: 'origin/foo' } });
       // eslint-disable-next-line etc/no-deprecated
       return getOptions(baseArgv());
     });
@@ -55,7 +56,7 @@ describe('getOptions (deprecated)', () => {
   it('finds a .beachballrc.json file', () => {
     const repo = repositoryFactory.cloneRepository();
     const config = inDirectory(repo.rootPath, () => {
-      fs.writeJsonSync('.beachballrc.json', { branch: 'origin/foo' });
+      writeJson('.beachballrc.json', { branch: 'origin/foo' });
       // eslint-disable-next-line etc/no-deprecated
       return getOptions(baseArgv());
     });
@@ -135,7 +136,7 @@ describe('getParsedOptions', () => {
 
   it('reads config from package.json', () => {
     const repo = repositoryFactory.cloneRepository();
-    fs.writeJsonSync(path.join(repo.rootPath, 'package.json'), { beachball: { branch: 'origin/foo' } });
+    writeJson(path.join(repo.rootPath, 'package.json'), { beachball: { branch: 'origin/foo' } });
 
     const parsedOptions = getParsedOptions({ argv: baseArgv(), cwd: repo.rootPath });
     expect(parsedOptions).toEqual({
@@ -147,7 +148,7 @@ describe('getParsedOptions', () => {
 
   it('finds a .beachballrc.json file', () => {
     const repo = repositoryFactory.cloneRepository();
-    fs.writeJsonSync(path.join(repo.rootPath, '.beachballrc.json'), { branch: 'origin/foo' });
+    writeJson(path.join(repo.rootPath, '.beachballrc.json'), { branch: 'origin/foo' });
 
     const parsedOptions = getParsedOptions({ argv: baseArgv(), cwd: repo.rootPath });
     expect(parsedOptions.options.branch).toEqual('origin/foo');

--- a/src/__functional__/packageManager/packPackage.test.ts
+++ b/src/__functional__/packageManager/packPackage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, jest, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
@@ -8,6 +8,7 @@ import type { NpmResult } from '../../packageManager/npm';
 import { packPackage } from '../../packageManager/packPackage';
 import { PackageInfo } from '../../types/PackageInfo';
 import { getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
+import { writeJson } from '../../object/writeJson';
 
 // Spawning actual npm is slow, so mock it for most of these tests.
 // A couple tests also use the real npm command.
@@ -56,7 +57,7 @@ describe('packPackage', () => {
 
   it('packs package', async () => {
     const testPkg = getTestPackage('testpkg');
-    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+    writeJson(tempPackageJsonPath, testPkg.json);
 
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
     expect(packResult).toEqual(true);
@@ -76,7 +77,7 @@ describe('packPackage', () => {
 
   it('packs scoped package', async () => {
     const testPkg = getTestPackage('@foo/bar');
-    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+    writeJson(tempPackageJsonPath, testPkg.json);
 
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
     expect(packResult).toEqual(true);
@@ -96,7 +97,7 @@ describe('packPackage', () => {
 
   it('packs package with correct longer prefix', async () => {
     const testPkg = getTestPackage('testpkg');
-    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+    writeJson(tempPackageJsonPath, testPkg.json);
 
     // There are 100 packages to pack, so index 1 should be prefixed with "002-"
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 1, total: 100 });
@@ -168,9 +169,8 @@ describe('packPackage', () => {
 
   it('handles failure moving file', async () => {
     const testPkg = getTestPackage('testpkg');
-    fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+    writeJson(tempPackageJsonPath, testPkg.json);
 
-    // create a file with the same name to simulate a move failure
     fs.writeFileSync(path.join(tempPackPath, '1-' + testPkg.packName), 'other content');
 
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
@@ -200,7 +200,7 @@ describe('packPackage', () => {
 
     it('packs scoped package', async () => {
       const testPkg = getTestPackage('@foo/bar');
-      fs.writeJSONSync(tempPackageJsonPath, testPkg.json);
+      writeJson(tempPackageJsonPath, testPkg.json);
 
       const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
       expect(packResult).toEqual(true);

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it, beforeAll, afterAll, beforeEach, jest, afterEach } from '@jest/globals';
-import fs from 'fs-extra';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { npmShow } from '../../__fixtures__/npmShow';
 import { Registry } from '../../__fixtures__/registry';
-import { tmpdir } from '../../__fixtures__/tmpdir';
+import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
 import * as npmModule from '../../packageManager/npm';
 import { packagePublish } from '../../packageManager/packagePublish';
 import type { PackageInfo } from '../../types/PackageInfo';
 import type { npm, NpmResult } from '../../packageManager/npm';
 import type { PackageOptions } from '../../types/BeachballOptions';
+import { writeJson } from '../../object/writeJson';
 
 const testTag = 'testbeachballtag';
 const testName = 'testbeachballpackage';
@@ -67,7 +67,7 @@ describe('packagePublish', () => {
     // Create a test package.json in a temporary location for use in tests.
     tempRoot = tmpdir();
     tempPackageJsonPath = path.join(tempRoot, 'package.json');
-    fs.writeJSONSync(tempPackageJsonPath, testPackage, { spaces: 2 });
+    writeJson(tempPackageJsonPath, testPackage);
   });
 
   beforeEach(() => {
@@ -81,7 +81,7 @@ describe('packagePublish', () => {
   afterAll(() => {
     registry.stop();
     registry.cleanUp();
-    fs.removeSync(tempRoot);
+    removeTempDir(tempRoot);
   });
 
   it('can publish', async () => {

--- a/src/__functional__/validation/areChangeFilesDeleted.test.ts
+++ b/src/__functional__/validation/areChangeFilesDeleted.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, beforeEach, afterAll } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { generateChangeFiles } from '../../__fixtures__/changeFiles';
 import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
@@ -50,7 +50,7 @@ describe('areChangeFilesDeleted', () => {
 
     const options = getOptions();
     const changeDirPath = getChangePath(options);
-    fs.removeSync(changeDirPath);
+    fs.rmSync(changeDirPath, { recursive: true, force: true });
 
     repository.commitAll();
 
@@ -67,7 +67,7 @@ describe('areChangeFilesDeleted', () => {
     repository.checkout('-b', 'feature-0');
 
     const changeDirPath = getChangePath(options);
-    fs.removeSync(changeDirPath);
+    fs.rmSync(changeDirPath, { recursive: true, force: true });
 
     repository.commitAll();
 

--- a/src/__tests__/bump/updateLockFile.test.ts
+++ b/src/__tests__/bump/updateLockFile.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, jest, afterAll, afterEach, beforeAll, beforeEach } from '@jest/globals';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { updateLockFile } from '../../bump/updateLockFile';
 import { packageManager, type PackageManagerResult } from '../../packageManager/packageManager';
 
-jest.mock('fs-extra');
+jest.mock('fs');
 jest.mock('../../packageManager/packageManager');
 jest.mock('../../env', () => ({
   env: {

--- a/src/bump/updateLockFile.ts
+++ b/src/bump/updateLockFile.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { packageManager } from '../packageManager/packageManager';
 import { env } from '../env';

--- a/src/bump/updatePackageJsons.ts
+++ b/src/bump/updatePackageJsons.ts
@@ -1,5 +1,7 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import { type PackageInfos, type PackageJson, consideredDependencies } from '../types/PackageInfo';
+import { readJson } from '../object/readJson';
+import { writeJson } from '../object/writeJson';
 
 /**
  * Update package.json files for modified packages after bumping.
@@ -12,7 +14,7 @@ export function updatePackageJsons(modifiedPackages: Set<string>, packageInfos: 
       console.warn(`Skipping ${pkgName} since package.json does not exist`);
       continue;
     }
-    const packageJson = fs.readJSONSync(info.packageJsonPath) as PackageJson;
+    const packageJson = readJson<PackageJson>(info.packageJsonPath);
 
     if (!info.private) {
       packageJson.version = info.version;
@@ -33,6 +35,6 @@ export function updatePackageJsons(modifiedPackages: Set<string>, packageInfos: 
       }
     }
 
-    fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
+    writeJson(info.packageJsonPath, packageJson);
   }
 }

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import minimatch from 'minimatch';
 import type { ChangeFileInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
@@ -8,6 +8,7 @@ import { getScopedPackages } from '../monorepo/getScopedPackages';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { PackageInfos, PackageInfo } from '../types/PackageInfo';
 import { ensureSharedHistory } from '../git/ensureSharedHistory';
+import { readJson } from '../object/readJson';
 
 const count = (n: number, str: string) => `${n} ${str}${n === 1 ? '' : 's'}`;
 
@@ -155,7 +156,7 @@ export function getChangedPackages(options: BeachballOptions, packageInfos: Pack
   // Loop through the change files, building up a set of packages that we can skip
   for (const file of changeFiles) {
     try {
-      const changeInfo = fs.readJSONSync(path.join(cwd, file)) as ChangeFileInfo | ChangeInfoMultiple;
+      const changeInfo = readJson<ChangeFileInfo | ChangeInfoMultiple>(path.join(cwd, file));
       const changes = (changeInfo as ChangeInfoMultiple).changes || [changeInfo];
 
       for (const change of changes) {

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -1,11 +1,12 @@
 import type { ChangeSet, ChangeInfo, ChangeInfoMultiple } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { getScopedPackages } from '../monorepo/getScopedPackages';
 import { getChangesBetweenRefs } from 'workspace-tools';
 import type { PackageInfos } from '../types/PackageInfo';
+import { readJson } from '../object/readJson';
 
 /**
  * Read change files, excluding any changes for packages that are:
@@ -58,7 +59,7 @@ export function readChangeFiles(options: BeachballOptions, packageInfos: Package
 
     let changeInfo: ChangeInfo | ChangeInfoMultiple;
     try {
-      changeInfo = fs.readJSONSync(changeFilePath) as ChangeInfo | ChangeInfoMultiple;
+      changeInfo = readJson<ChangeInfo | ChangeInfoMultiple>(changeFilePath);
     } catch (e) {
       console.warn(`Error reading or parsing change file ${changeFilePath}: ${e}`);
       continue;

--- a/src/changefile/unlinkChangeFiles.ts
+++ b/src/changefile/unlinkChangeFiles.ts
@@ -1,6 +1,6 @@
 import type { ChangeSet } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { DeepReadonly } from '../types/DeepReadonly';
@@ -24,11 +24,11 @@ export function unlinkChangeFiles(
   for (const { changeFile } of changeSet) {
     if (changeFile) {
       console.log(`- ${changeFile}`);
-      fs.removeSync(path.join(changePath, changeFile));
+      fs.rmSync(path.join(changePath, changeFile), { force: true });
     }
   }
   if (fs.existsSync(changePath) && fs.readdirSync(changePath).length === 0) {
     console.log(`Removing empty ${options.changeDir} folder`);
-    fs.removeSync(changePath);
+    fs.rmSync(changePath, { recursive: true, force: true });
   }
 }

--- a/src/changefile/writeChangeFiles.ts
+++ b/src/changefile/writeChangeFiles.ts
@@ -2,9 +2,10 @@ import type { ChangeFileInfo } from '../types/ChangeInfo';
 import { getChangePath } from '../paths';
 import { getBranchName, stage, commit } from 'workspace-tools';
 import crypto from 'crypto';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import type { BeachballOptions } from '../types/BeachballOptions';
+import { writeJson } from '../object/writeJson';
 
 /**
  * Loops through the `changes` and writes out a list of change files
@@ -23,7 +24,7 @@ export function writeChangeFiles(
   }
 
   if (!fs.existsSync(changePath)) {
-    fs.mkdirpSync(changePath);
+    fs.mkdirSync(changePath, { recursive: true });
   }
 
   const getChangeFile = (prefix: string) => path.join(changePath, `${prefix}-${crypto.randomUUID()}.json`);
@@ -38,7 +39,7 @@ export function writeChangeFiles(
   } else {
     changeFiles = changes.map(change => {
       const changeFile = getChangeFile(change.packageName.replace(/[^\w@]/g, '-'));
-      fs.writeJSONSync(changeFile, change, { spaces: 2 });
+      writeJson(changeFile, change);
       return changeFile;
     });
   }

--- a/src/changelog/writeChangelog.ts
+++ b/src/changelog/writeChangelog.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs from 'fs-extra';
+import fs from 'fs';
 import type { PackageInfo } from '../types/PackageInfo';
 import { getPackageChangelogs } from './getPackageChangelogs';
 import { renderChangelog } from './renderChangelog';
@@ -10,6 +10,8 @@ import { isPathIncluded } from '../monorepo/isPathIncluded';
 import type { PackageChangelog, ChangelogJson } from '../types/ChangeLog';
 import { mergeChangelogs } from './mergeChangelogs';
 import { prepareChangelogPaths } from './prepareChangelogPaths';
+import { readJson } from '../object/readJson';
+import { writeJson } from '../object/writeJson';
 
 export async function writeChangelog(
   bumpInfo: Pick<BumpInfo, 'changeFileChangeInfos' | 'calculatedChangeTypes' | 'dependentChangedBy' | 'packageInfos'>,
@@ -132,9 +134,7 @@ async function writeChangelogFiles(params: {
   // (changelogPaths.json will only be set if generateChangelog is true or 'json')
   if (changelogPaths.json) {
     try {
-      previousJson = fs.existsSync(changelogPaths.json)
-        ? (fs.readJSONSync(changelogPaths.json) as ChangelogJson)
-        : undefined;
+      previousJson = fs.existsSync(changelogPaths.json) ? readJson<ChangelogJson>(changelogPaths.json) : undefined;
     } catch (e) {
       console.warn(`${changelogPaths.json} is invalid: ${e}`);
     }
@@ -144,7 +144,7 @@ async function writeChangelogFiles(params: {
         previousChangelog: previousJson,
         maxVersions: options.changelog?.maxVersions,
       });
-      fs.writeJSONSync(changelogPaths.json, nextJson, { spaces: 2 });
+      writeJson(changelogPaths.json, nextJson);
     } catch (e) {
       console.warn(`Problem writing to ${changelogPaths.json}: ${e}`);
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,9 +1,10 @@
 import type { BeachballOptions } from '../types/BeachballOptions';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import * as path from 'path';
 import { findGitRoot } from 'workspace-tools';
 import { npm } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
+import { readJson } from '../object/readJson';
 
 // TODO: consider modifying this to propagate up
 function errorExit(message: string): void {
@@ -45,7 +46,7 @@ export async function init(options: Pick<BeachballOptions, 'path'>): Promise<voi
 
   let packageJson = {} as PackageJson;
   try {
-    packageJson = fs.readJSONSync(packageJsonFilePath, 'utf-8') as PackageJson;
+    packageJson = readJson<PackageJson>(packageJsonFilePath);
   } catch {
     errorExit(`Failed to read package.json at ${packageJsonFilePath}`);
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,9 +1,9 @@
-import fs from 'fs-extra';
 import path from 'path';
 import type { PackageJson } from './types/PackageInfo';
+import { readJson } from './object/readJson';
 
 export function showVersion(): void {
-  const packageJson = fs.readJSONSync(path.resolve(__dirname, '../package.json')) as PackageJson;
+  const packageJson = readJson<PackageJson>(path.resolve(__dirname, '../package.json'));
   console.log(`beachball v${packageJson.version} - the sunniest version bumping tool`);
 }
 

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -1,4 +1,3 @@
-import fs from 'fs-extra';
 import path from 'path';
 import {
   getWorkspaces as getWorkspacePackages,
@@ -11,6 +10,7 @@ import {
 import type { PackageInfos } from '../types/PackageInfo';
 import { getPackageInfosWithOptions } from '../options/getPackageInfosWithOptions';
 import type { ParsedOptions } from '../types/BeachballOptions';
+import { readJson } from '../object/readJson';
 
 /**
  * Get a mapping from package name to package info for all packages in the workspace
@@ -102,7 +102,7 @@ function readWsPackageInfo(packageJsonPath: string): WSPackageInfo {
   return {
     // this is actually the properties of WSPackageInfo except the packageJsonPath, but using omit
     // messes things up due to the index signature...
-    ...(fs.readJSONSync(packageJsonPath) as WSPackageInfo),
+    ...readJson<WSPackageInfo>(packageJsonPath),
     packageJsonPath,
   };
 }

--- a/src/object/readJson.ts
+++ b/src/object/readJson.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+/**
+ * Read a JSON file. Throws an informative error if parsing fails.
+ */
+export function readJson<T>(filePath: string): T {
+  const fileContents = fs.readFileSync(filePath, 'utf-8');
+  try {
+    return JSON.parse(fileContents) as T;
+  } catch {
+    throw new Error(`Error parsing JSON file at ${filePath}. Contents:\n${fileContents}`);
+  }
+}

--- a/src/object/writeJson.ts
+++ b/src/object/writeJson.ts
@@ -1,0 +1,6 @@
+import fs from 'fs';
+
+export function writeJson(filePath: string, data: unknown): void {
+  const fileContents = JSON.stringify(data, null, 2) + '\n';
+  fs.writeFileSync(filePath, fileContents, 'utf-8');
+}

--- a/src/packageManager/packPackage.ts
+++ b/src/packageManager/packPackage.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { PackageInfo } from '../types/PackageInfo';
 import { BeachballOptions } from '../types/BeachballOptions';
@@ -52,13 +52,16 @@ export async function packPackage(
   const packPrefix = String(index + 1).padStart(String(total).length, '0') + '-';
   const finalPackFilePath = path.join(packToPath, packPrefix + packFile);
   try {
-    fs.ensureDirSync(packToPath);
-    fs.moveSync(packFilePath, finalPackFilePath);
+    if (fs.existsSync(finalPackFilePath)) {
+      throw new Error('Target path already exists');
+    }
+    fs.mkdirSync(packToPath, { recursive: true });
+    fs.renameSync(packFilePath, finalPackFilePath);
   } catch (err) {
     console.error(`\nFailed to move ${packFilePath} to ${finalPackFilePath}: ${err}`);
     try {
       // attempt to clean up the pack file (ignore any failures)
-      fs.removeSync(packFilePath);
+      fs.rmSync(packFilePath);
     } catch {
       // ignore
     }

--- a/src/publish/performPublishOverrides.ts
+++ b/src/publish/performPublishOverrides.ts
@@ -1,6 +1,7 @@
-import * as fs from 'fs-extra';
 import { getWorkspaceRange } from '../packageManager/getWorkspaceRange';
 import { consideredDependencies, type PackageInfos, type PackageJson, type PublishConfig } from '../types/PackageInfo';
+import { readJson } from '../object/readJson';
+import { writeJson } from '../object/writeJson';
 
 const acceptedKeys: (keyof PublishConfig)[] = [
   'types',
@@ -17,12 +18,12 @@ const acceptedKeys: (keyof PublishConfig)[] = [
 export function performPublishOverrides(packagesToPublish: string[], packageInfos: PackageInfos): void {
   for (const pkgName of packagesToPublish) {
     const info = packageInfos[pkgName];
-    const packageJson = fs.readJSONSync(info.packageJsonPath) as PackageJson;
+    const packageJson = readJson<PackageJson>(info.packageJsonPath);
 
     performWorkspaceVersionOverrides(packageJson, packageInfos);
     performPublishConfigOverrides(packageJson);
 
-    fs.writeJSONSync(info.packageJsonPath, packageJson, { spaces: 2 });
+    writeJson(info.packageJsonPath, packageJson);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,14 +672,6 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
-"@types/fs-extra@^11.0.0":
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.4.tgz#e16a863bb8843fba8c5004362b5a73e17becca45"
-  integrity sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==
-  dependencies:
-    "@types/jsonfile" "*"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
@@ -710,13 +702,6 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-
-"@types/jsonfile@*":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.4.tgz#614afec1a1164e7d670b4a7ad64df3e7beb7b702"
-  integrity sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/lodash@^4.14.175":
   version "4.17.21"
@@ -2227,11 +2212,6 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-find-free-port@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-free-port/-/find-free-port-2.0.0.tgz#4b22e5f6579eb1a38c41ac6bcb3efed1b6da9b1b"
-  integrity sha512-J1j8gfEVf5FN4PR5w5wrZZ7NYs2IvqsHcd03cAeQx3Ec/mo+lKceaVNhpsRKoZpZKbId88o8qh+dwUwzBV6WCg==
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -2285,15 +2265,6 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
-
-fs-extra@^11.1.1:
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.2.tgz#c838aeddc6f4a8c74dd15f85e11fe5511bfe02a4"
-  integrity sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2442,7 +2413,7 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.1.3, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3175,15 +3146,6 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonfile@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.0.tgz#7c265bd1b65de6977478300087c99f1c84383f62"
-  integrity sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -4681,11 +4643,6 @@ universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
-universalify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
-  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unix-crypt-td-js@1.1.4:
   version "1.1.4"


### PR DESCRIPTION
`fs-extra` is not really needed and can be replaced with native FS calls + custom `readJson` and `writeJson` wrappers.