### PR TITLE
bumpMinSemverRange improvements

### DIFF
--- a/change/beachball-0a61708f-627a-4aaf-b8e0-0ca88cd9815a.json
+++ b/change/beachball-0a61708f-627a-4aaf-b8e0-0ca88cd9815a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Properly handle bumping more types of semver ranges",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/bump/bumpMinSemverRange.test.ts
+++ b/src/__tests__/bump/bumpMinSemverRange.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { bumpMinSemverRange } from '../../bump/bumpMinSemverRange';
 
 describe('bumpMinSemverRange', () => {
-  it('bumps * to *', () => {
+  it('preserves *', () => {
     const result = bumpMinSemverRange('1.0.0', '*');
     expect(result).toBe('*');
   });
@@ -17,43 +17,60 @@ describe('bumpMinSemverRange', () => {
     expect(result).toBe('file:/absolute/path/to/package');
   });
 
-  it('attaches ~ to semver range', () => {
-    const result = bumpMinSemverRange('1.3.0', '~1.2.0');
-    expect(result).toBe('~1.3.0');
+  it('preserves catalog: protocol', () => {
+    let result = bumpMinSemverRange('1.0.0', 'catalog:');
+    expect(result).toBe('catalog:');
+    result = bumpMinSemverRange('1.0.0', 'catalog:foo');
+    expect(result).toBe('catalog:foo');
   });
 
-  it('bumps ^ to semver range', () => {
-    const result = bumpMinSemverRange('1.3.0', '^1.2.0');
-    expect(result).toBe('^1.3.0');
+  it.each(['~', '^'])('preserves %s and bumps to new version', prefix => {
+    const result = bumpMinSemverRange('1.3.0', `${prefix}1.2.0`);
+    expect(result).toBe(`${prefix}1.3.0`);
   });
 
-  it('will return the min version if unknown format', () => {
-    const result = bumpMinSemverRange('1.3.0', '#1.2.0');
-    expect(result).toBe('1.3.0');
-  });
-
-  it('will return a minor range generally if a range is specified with >= or >', () => {
+  it('returns range from new version to next major with >=', () => {
     const result = bumpMinSemverRange('1.3.0', '>=1.2.0 <2.0.0');
     expect(result).toBe('>=1.3.0 <2.0.0');
   });
 
-  it('will return a minor range generally if a range is specified with x - y', () => {
+  it('returns range from new version to next major with >', () => {
+    const result = bumpMinSemverRange('1.3.0', '>1.2.0 <2.0.0');
+    expect(result).toBe('>=1.3.0 <2.0.0');
+  });
+
+  it('returns range from new version to next major with -', () => {
     const result = bumpMinSemverRange('1.3.0', '1.2.0 - 2.0.0');
     expect(result).toBe('1.3.0 - 2.0.0');
   });
 
-  it.each(['workspace:*', 'workspace:~', 'workspace:^'])('will preserve %s', workspaceVersion => {
+  it.each(['workspace:*', 'workspace:~', 'workspace:^'])('preserves %s', workspaceVersion => {
     const result = bumpMinSemverRange('1.3.0', workspaceVersion);
     expect(result).toBe(workspaceVersion);
   });
 
-  it('bumps workspace:~1.2.0 to workspace semver range', () => {
+  it('bumps workspace:~x.y.z to workspace range with new version', () => {
     const result = bumpMinSemverRange('1.2.1', 'workspace:~1.2.0');
     expect(result).toBe('workspace:~1.2.1');
   });
 
-  it('bumps workspace:^1.2.0 to workspace semver range', () => {
+  it('bumps workspace:^x.y.z to workspace range with new version', () => {
     const result = bumpMinSemverRange('1.3.0', 'workspace:^1.2.0');
     expect(result).toBe('workspace:^1.3.0');
+  });
+
+  it('uses the new version for exact version match', () => {
+    const result = bumpMinSemverRange('1.3.0', '1.2.0');
+    expect(result).toBe('1.3.0');
+  });
+
+  it('uses the new version if unknown non-semver format', () => {
+    const result = bumpMinSemverRange('1.3.0', '#1.2.0');
+    expect(result).toBe('1.3.0');
+  });
+
+  it('preserves unrecognized range if new version satisfies it', () => {
+    const result = bumpMinSemverRange('1.3.0', '1');
+    expect(result).toBe('1');
   });
 });

--- a/src/bump/bumpMinSemverRange.ts
+++ b/src/bump/bumpMinSemverRange.ts
@@ -1,37 +1,56 @@
 import semver from 'semver';
 import { getWorkspaceRange } from '../packageManager/getWorkspaceRange';
 
-export function bumpMinSemverRange(minVersion: string, semverRange: string): string {
-  if (semverRange === '*' || semverRange.startsWith('file:')) {
-    return semverRange;
+/**
+ * Bump the semver range for a dependency to match the new version of a package.
+ * @param newVersion The new version of the package
+ * @param currentRange Current version range for the dependency.
+ * @returns New semver range for the dependency
+ */
+export function bumpMinSemverRange(newVersion: string, currentRange: string): string {
+  if (currentRange === '*' || currentRange.startsWith('file:') || currentRange.startsWith('catalog:')) {
+    return currentRange;
   }
 
-  const workspaceRange = getWorkspaceRange(semverRange);
+  if (currentRange[0] === '~' || currentRange[0] === '^') {
+    // ~1.0.0
+    // ^1.0.0
+    return currentRange[0] + newVersion;
+  }
 
+  const workspaceRange = getWorkspaceRange(currentRange);
   if (workspaceRange === '*' || workspaceRange === '~' || workspaceRange === '^') {
     // For basic workspace ranges we can just preserve current value and replace during publish
     // https://pnpm.io/workspaces#workspace-protocol-workspace
-    return semverRange;
-  }
-  if (semverRange[0] === '~' || semverRange[0] === '^') {
-    // ~1.0.0
-    // ^1.0.0
-    return semverRange[0] + minVersion;
+    return currentRange;
   }
   if (workspaceRange && (workspaceRange[0] === '~' || workspaceRange[0] === '^')) {
     // workspace:~1.0.0
     // workspace:^1.0.0
-    return `workspace:${workspaceRange[0]}${minVersion}`;
+    return `workspace:${workspaceRange[0]}${newVersion}`;
   }
-  if (semverRange.includes('>')) {
-    // Less frequently used, but we treat any of these kinds of ranges to be within a minor band for now:
+
+  if (currentRange.includes('>')) {
+    // Less frequently used, but use the new version as a minimum for this kind of range.
     // more complex understanding of the semver range utility is needed to do more
     // >=1.0.0 <2.0.0
-    return `>=${minVersion} <${semver.inc(minVersion, 'major')}`;
+    return `>=${newVersion} <${semver.inc(newVersion, 'major')}`;
   }
-  if (semverRange.includes(' - ')) {
+  if (currentRange.includes(' - ')) {
     // 1.0.0 - 2.0.0
-    return `${minVersion} - ${semver.inc(minVersion, 'major')}`;
+    return `${newVersion} - ${semver.inc(newVersion, 'major')}`;
   }
-  return minVersion;
+
+  if (semver.valid(currentRange)) {
+    // Exact version match, e.g. 1.0.0
+    return newVersion;
+  }
+
+  // For unrecognized valid semver ranges: if the new version satisfies the current range, keep it
+  if (semver.validRange(currentRange) && semver.satisfies(newVersion, currentRange)) {
+    return currentRange;
+  }
+
+  // Fallback: return the exact new version
+  return newVersion;
 }


### PR DESCRIPTION
- Add very very basic handling of `catalog:` versions in this utility only (preserve as-is; note this doesn't include proper handling for publishing)
- Preserve valid unrecognized ranges if the new version satisfies the existing range