### PR TITLE
Share bump info between validate and actual commands

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,10 +1,11 @@
 // @ts-check
-/** @type {import('./src/types/BeachballOptions').RepoOptions}*/
-module.exports = {
+/** @type {Partial<import('./src/types/BeachballOptions').RepoOptions>}*/
+const config = {
   disallowedChangeTypes: ['major'],
   ignorePatterns: [
     '.*ignore',
     '*.yml',
+    '.eslintrc.js',
     '.github/**',
     '.prettierrc.json5',
     '.vscode/**',
@@ -18,3 +19,5 @@ module.exports = {
     'yarn.lock',
   ],
 };
+
+module.exports = config;

--- a/change/beachball-21c46d28-8e4a-4355-a59a-dc68058e6b11.json
+++ b/change/beachball-21c46d28-8e4a-4355-a59a-dc68058e6b11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Share bump info between validate and actual commands. This should be a significant performance improvement in large repos.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -12,6 +12,7 @@ import type { PackageJson } from '../types/PackageInfo';
 import { getParsedOptions } from '../options/getOptions';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { readJson } from '../object/readJson';
+import { validate } from '../validation/validate';
 
 describe('version bumping', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -56,7 +57,10 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options, originalPackageInfos);
+    // For this test, use validate() similar to the CLI to ensure it works
+    const { bumpInfo } = validate(options, { checkDependencies: true }, originalPackageInfos);
+
+    await bump(options, originalPackageInfos, bumpInfo);
 
     const packageInfos = getPackageInfos(parsedOptions);
 
@@ -191,7 +195,10 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
-    await bump(options, originalPackageInfos);
+    // For this test, use validate() similar to the CLI to ensure it works
+    const { bumpInfo } = validate(options, { checkDependencies: true }, originalPackageInfos);
+
+    await bump(options, originalPackageInfos, bumpInfo);
 
     const packageInfos = getPackageInfos(parsedOptions);
 

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -6,7 +6,7 @@ import type { Repository } from '../__fixtures__/repository';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { bumpAndPush } from '../publish/bumpAndPush';
 import { publish } from '../commands/publish';
-import { gatherBumpInfo } from '../bump/gatherBumpInfo';
+import { bumpInMemory } from '../bump/bumpInMemory';
 import type { ChangeFileInfo } from '../types/ChangeInfo';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import type { PackageJson } from '../types/PackageInfo';
@@ -54,7 +54,7 @@ describe('publish command (git)', () => {
     generateChangeFiles(['foo'], options);
     repo.push();
 
-    await publish(options, packageInfos);
+    await publish(options, packageInfos, undefined);
 
     const newRepo = repositoryFactory.cloneRepository();
 
@@ -74,7 +74,7 @@ describe('publish command (git)', () => {
     const publishBranch = 'publish_test';
     repo1.checkout('-b', publishBranch);
 
-    const bumpInfo = gatherBumpInfo(options1, packageInfos1);
+    const bumpInfo = bumpInMemory(options1, packageInfos1);
 
     // 3. Meanwhile, in repo2, also create a new change file
     const repo2 = repositoryFactory.cloneRepository();

--- a/src/bump/bumpInMemory.ts
+++ b/src/bump/bumpInMemory.ts
@@ -1,0 +1,35 @@
+import { initializePackageChangeTypes } from '../changefile/changeTypes';
+import { readChangeFiles } from '../changefile/readChangeFiles';
+import type { BumpInfo } from '../types/BumpInfo';
+import { bumpInPlace } from './bumpInPlace';
+import type { BeachballOptions } from '../types/BeachballOptions';
+import { getScopedPackages } from '../monorepo/getScopedPackages';
+import type { PackageInfos } from '../types/PackageInfo';
+import { getPackageGroups } from '../monorepo/getPackageGroups';
+import { cloneObject } from '../object/cloneObject';
+
+/**
+ * Gather bump info and bump versions in memory.
+ * Does NOT mutate the given `originalPackageInfos`.
+ */
+export function bumpInMemory(options: BeachballOptions, originalPackageInfos: PackageInfos): BumpInfo {
+  const packageInfos = cloneObject(originalPackageInfos);
+  const changes = readChangeFiles(options, packageInfos);
+
+  // Determine base change types for each package (not considering disallowedChangeTypes or groups)
+  const calculatedChangeTypes = initializePackageChangeTypes(changes);
+
+  const bumpInfo: BumpInfo = {
+    calculatedChangeTypes,
+    packageInfos,
+    packageGroups: getPackageGroups(packageInfos, options.path, options.groups),
+    changeFileChangeInfos: changes,
+    modifiedPackages: new Set<string>(),
+    scopedPackages: new Set(getScopedPackages(options, packageInfos)),
+    dependentChangedBy: {},
+  };
+
+  bumpInPlace(bumpInfo, options);
+
+  return bumpInfo;
+}

--- a/src/bump/gatherBumpInfo.ts
+++ b/src/bump/gatherBumpInfo.ts
@@ -1,35 +1,11 @@
-import { initializePackageChangeTypes } from '../changefile/changeTypes';
-import { readChangeFiles } from '../changefile/readChangeFiles';
 import type { BumpInfo } from '../types/BumpInfo';
-import { bumpInPlace } from './bumpInPlace';
 import type { BeachballOptions } from '../types/BeachballOptions';
-import { getScopedPackages } from '../monorepo/getScopedPackages';
 import type { PackageInfos } from '../types/PackageInfo';
-import { getPackageGroups } from '../monorepo/getPackageGroups';
-import { cloneObject } from '../object/cloneObject';
+import { bumpInMemory } from './bumpInMemory';
 
 /**
- * Gather bump info and bump versions in memory.
- * Does NOT mutate the given `originalPackageInfos`.
+ * @deprecated Use `bumpInMemory` instead.
  */
 export function gatherBumpInfo(options: BeachballOptions, originalPackageInfos: PackageInfos): BumpInfo {
-  const packageInfos = cloneObject(originalPackageInfos);
-  const changes = readChangeFiles(options, packageInfos);
-
-  // Determine base change types for each package (not considering disallowedChangeTypes or groups)
-  const calculatedChangeTypes = initializePackageChangeTypes(changes);
-
-  const bumpInfo: BumpInfo = {
-    calculatedChangeTypes,
-    packageInfos,
-    packageGroups: getPackageGroups(packageInfos, options.path, options.groups),
-    changeFileChangeInfos: changes,
-    modifiedPackages: new Set<string>(),
-    scopedPackages: new Set(getScopedPackages(options, packageInfos)),
-    dependentChangedBy: {},
-  };
-
-  bumpInPlace(bumpInfo, options);
-
-  return bumpInfo;
+  return bumpInMemory(options, originalPackageInfos);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,25 +37,25 @@ import { validate } from './validation/validate';
 
     case 'publish': {
       const packageInfos = getPackageInfos(parsedOptions);
-      validate(options, { checkDependencies: true }, packageInfos);
+      const { bumpInfo } = validate(options, { checkDependencies: true }, packageInfos);
 
       // set a default publish message
       options.message = options.message || 'applying package updates';
-      await publish(options, packageInfos);
+      await publish(options, packageInfos, bumpInfo);
       break;
     }
 
     case 'bump': {
       const packageInfos = getPackageInfos(parsedOptions);
-      validate(options, { checkDependencies: true }, packageInfos);
-      await bump(options, packageInfos);
+      const { bumpInfo } = validate(options, { checkDependencies: true }, packageInfos);
+      await bump(options, packageInfos, bumpInfo);
       break;
     }
 
     case 'canary': {
       const packageInfos = getPackageInfos(parsedOptions);
-      validate(options, { checkDependencies: true }, packageInfos);
-      await canary(options, packageInfos);
+      const { bumpInfo } = validate(options, { checkDependencies: true }, packageInfos);
+      await canary(options, packageInfos, bumpInfo);
       break;
     }
 

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -1,4 +1,4 @@
-import { gatherBumpInfo } from '../bump/gatherBumpInfo';
+import { bumpInMemory } from '../bump/bumpInMemory';
 import { performBump } from '../bump/performBump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
 import type { BeachballOptions } from '../types/BeachballOptions';
@@ -7,13 +7,23 @@ import type { PackageInfos } from '../types/PackageInfo';
 
 /**
  * Bump versions and update changelogs, but don't commit, push, or publish.
+ * @param oldPackageInfo Pre-read package info prior to version bumps
+ * @param bumpInfo Pre-calculated bump info from `validate()` (can be undefined for tests)
  */
-export async function bump(options: BeachballOptions, packageInfos: PackageInfos): Promise<BumpInfo>;
+export async function bump(
+  options: BeachballOptions,
+  oldPackageInfo: PackageInfos,
+  bumpInfo?: BumpInfo
+): Promise<BumpInfo>;
 /** @deprecated Must provide the package infos */
 export async function bump(options: BeachballOptions): Promise<BumpInfo>;
-export async function bump(options: BeachballOptions, packageInfos?: PackageInfos): Promise<BumpInfo> {
+export async function bump(
+  options: BeachballOptions,
+  oldPackageInfo?: PackageInfos,
+  bumpInfo?: BumpInfo
+): Promise<BumpInfo> {
   // eslint-disable-next-line etc/no-deprecated
-  const bumpInfo = gatherBumpInfo(options, packageInfos || getPackageInfos(options.path));
+  bumpInfo ||= bumpInMemory(options, oldPackageInfo || getPackageInfos(options.path));
   // The bumpInfo is returned for testing
   return performBump(bumpInfo, options);
 }

--- a/src/commands/canary.ts
+++ b/src/commands/canary.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { gatherBumpInfo } from '../bump/gatherBumpInfo';
+import { bumpInMemory } from '../bump/bumpInMemory';
 import { performBump } from '../bump/performBump';
 import { setDependentVersions } from '../bump/setDependentVersions';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
@@ -7,15 +7,29 @@ import { listPackageVersions } from '../packageManager/listPackageVersions';
 import { publishToRegistry } from '../publish/publishToRegistry';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { PackageInfos } from '../types/PackageInfo';
+import type { BumpInfo } from '../types/BumpInfo';
 
-export async function canary(options: BeachballOptions, oldPackageInfo: PackageInfos): Promise<void>;
+/**
+ * Bump and publish a "canary" prerelease version.
+ * @param oldPackageInfo Pre-read package info prior to version bumps
+ * @param bumpInfo Pre-calculated bump info from `validate()` (can be undefined for tests)
+ */
+export async function canary(
+  options: BeachballOptions,
+  oldPackageInfo: PackageInfos,
+  bumpInfo: BumpInfo | undefined
+): Promise<void>;
 /** @deprecated Must provide the package infos */
 export async function canary(options: BeachballOptions): Promise<void>;
-export async function canary(options: BeachballOptions, oldPackageInfo?: PackageInfos): Promise<void> {
+export async function canary(
+  options: BeachballOptions,
+  oldPackageInfo?: PackageInfos,
+  bumpInfo?: BumpInfo
+): Promise<void> {
   // eslint-disable-next-line etc/no-deprecated
   oldPackageInfo = oldPackageInfo || getPackageInfos(options.path);
 
-  const bumpInfo = gatherBumpInfo(options, oldPackageInfo);
+  bumpInfo ||= bumpInMemory(options, oldPackageInfo);
 
   options.keepChangeFiles = true;
   options.generateChangelog = false;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,4 +1,4 @@
-import { gatherBumpInfo } from '../bump/gatherBumpInfo';
+import { bumpInMemory } from '../bump/bumpInMemory';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { gitFailFast, getBranchName, getCurrentHash, git } from 'workspace-tools';
 import prompts from 'prompts';
@@ -12,11 +12,21 @@ import type { PackageInfos } from '../types/PackageInfo';
 
 /**
  * Potentially bump, publish, and push package changes depending on options.
+ * @param oldPackageInfos Pre-read package info prior to version bumps
+ * @param bumpInfo Pre-calculated bump info from `validate()` (can be undefined for tests)
  */
-export async function publish(options: BeachballOptions, oldPackageInfos: PackageInfos): Promise<void>;
+export async function publish(
+  options: BeachballOptions,
+  oldPackageInfos: PackageInfos,
+  bumpInfo?: PublishBumpInfo
+): Promise<void>;
 /** @deprecated Must provide the package infos */
 export async function publish(options: BeachballOptions): Promise<void>;
-export async function publish(options: BeachballOptions, oldPackageInfos?: PackageInfos): Promise<void> {
+export async function publish(
+  options: BeachballOptions,
+  oldPackageInfos?: PackageInfos,
+  bumpInfo?: PublishBumpInfo
+): Promise<void> {
   console.log('\nPreparing to publish');
 
   const { path: cwd, branch, registry, tag } = options;
@@ -66,7 +76,7 @@ export async function publish(options: BeachballOptions, oldPackageInfos?: Packa
   gitFailFast(['checkout', '-b', publishBranch], { cwd });
 
   console.log(`\nGathering info ${options.bump ? 'to bump versions' : 'about versions and changes'}`);
-  const bumpInfo: PublishBumpInfo = gatherBumpInfo(options, oldPackageInfos);
+  bumpInfo ||= bumpInMemory(options, oldPackageInfos);
 
   // eslint-disable-next-line etc/no-deprecated
   if (options.new) {

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -18,7 +18,7 @@ export type BumpInfo = {
   /**
    * Mapping from package name to change type.
    *
-   * Initially (after `gatherBumpInfo`), this just has change types based on the change files.
+   * Initially (after `bumpInMemory`), this just has change types based on the change files.
    * It's updated by the early steps of `bumpInPlace` to consider groups and `disallowedChangeTypes`.
    */
   calculatedChangeTypes: { [pkgName: string]: ChangeType };
@@ -36,7 +36,10 @@ export type BumpInfo = {
    */
   modifiedPackages: Set<string>;
 
-  /** Map from package name to its internal dependency names that were bumped. */
+  /**
+   * Map from package name to its internal dependency names that were bumped.
+   * This is just used for changelog generation.
+   */
   dependentChangedBy: { [pkgName: string]: Set<string> };
 
   /** Set of packages that are in scope for this bump */


### PR DESCRIPTION
Update `validate()` to return the bump info it calculated (if relevant) so that it can be reused by the main `bump()`/`publish()` implementations instead of calculating it twice. This should be a significant performance improvement in large repos, where calculating the bump info can be extremely slow.

Rename `gatherBumpInfo` to `bumpInMemory` to better reflect what it does. The file `gatherBumpInfo.ts` is preserved since it's directly imported by some consumers (which has never been supported, but shouldn't be broken in this case outside a major version).