### PR TITLE
Changed packages and change files improvements

### DIFF
--- a/change/beachball-89d46089-07d0-49ef-ac3d-9e171bc0e781.json
+++ b/change/beachball-89d46089-07d0-49ef-ac3d-9e171bc0e781.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve approach and error handling for getting changed packages",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -16,7 +16,12 @@ import { addGitObserver, clearGitObservers } from 'workspace-tools';
 describe('getChangedPackages (basic)', () => {
   /** Factory reused for all the tests */
   let repositoryFactory: RepositoryFactory;
-  /** Clone from the factory reused for multiple tests where it's safe */
+  /**
+   * Clone from the factory reused for multiple tests where it's safe.
+   * DO NOT:
+   * - push changes
+   * - create uncommitted files or directories
+   */
   let reusedRepo: Repository;
   const gitObserver = jest.fn();
   initMockLogs();
@@ -168,16 +173,18 @@ describe('getChangedPackages', () => {
       extraArgv: ['--verbose'],
     });
 
-    repo.stageChange('src/foo.test.js');
-    repo.stageChange('tests/stuff.js');
-    repo.stageChange('yarn.lock');
+    repo.writeFile('src/foo.test.js');
+    repo.writeFile('src/foo.test.js');
+    repo.writeFile('tests/stuff.js');
+    repo.writeFile('yarn.lock');
+    repo.git(['add', '-A']); // stage in one git operation
 
     expect(getChangedPackages(options, packageInfos, scopedPackages)).toStrictEqual([]);
     const logLines = logs.getMockLines('all');
     expect(logLines).toMatch('ignored by pattern');
     expect(logLines).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
-      [log] Found 2 changed files in branch "origin/master" (before filtering)
+      [log] Found 2 changed files in current branch (before filtering)
       [log]   - ~~src/foo.test.js~~ (ignored by pattern "*.test.js")
       [log]   - ~~tests/stuff.js~~ (ignored by pattern "tests/**")
       [log] All files were ignored"
@@ -208,11 +215,11 @@ describe('getChangedPackages', () => {
 
     // foo is not included in changed packages
     let changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
-    const logLines = logs.getMockLines('all', true);
+    const logLines = logs.getMockLines('all', { guids: true });
     expect(logLines).toMatch(/Your local repository already has change files for these packages:\s+• foo/);
     expect(logLines).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
-      [log] Found 2 changed files in branch "origin/master" (before filtering)
+      [log] Found 2 changed files in current branch (before filtering)
       [log]   - ~~change/foo-<guid>.json~~ (ignored by pattern "change/*.json")
       [log]   - packages/foo/test.js
       [log] Found 1 file in 1 package that should be published
@@ -225,9 +232,9 @@ describe('getChangedPackages', () => {
     // change bar => bar is the only changed package returned
     repo.stageChange('packages/bar/test.js');
     changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
-    expect(logs.getMockLines('all', true)).toMatchInlineSnapshot(`
+    expect(logs.getMockLines('all', { guids: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
-      [log] Found 3 changed files in branch "origin/master" (before filtering)
+      [log] Found 3 changed files in current branch (before filtering)
       [log]   - ~~change/foo-<guid>.json~~ (ignored by pattern "change/*.json")
       [log]   - packages/foo/test.js
       [log]   - packages/bar/test.js
@@ -236,6 +243,36 @@ describe('getChangedPackages', () => {
         • foo"
     `);
     expect(changedPackages).toStrictEqual(['bar']);
+  });
+
+  it('ignores change files that exist in target remote branch', () => {
+    // This needs a separate factory since it pushes changes
+    const repositoryFactory = new RepositoryFactory('single');
+    extraFactories.push(repositoryFactory);
+    repo = repositoryFactory.cloneRepository();
+    const { packageInfos, scopedPackages, options } = getOptionsAndPackages({ extraArgv: ['--verbose'] });
+    expect(options.commit).toBe(true);
+
+    // create and push a change file in master
+    generateChangeFiles(['foo'], options);
+    repo.push();
+
+    // create a new branch and stage a new file + changes to existing file
+    repo.checkout('-b', 'test');
+    repo.writeFile('test.js');
+    repo.writeFile('yarn.lock', 'hi'); // this should already exist
+    repo.git(['add', '-A']);
+    logs.clear();
+
+    const changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
+    expect(changedPackages).toStrictEqual(['foo']);
+    expect(logs.getMockLines('all', { guids: true })).toMatchInlineSnapshot(`
+      "[log] Checking for changes against "origin/master"
+      [log] Found 2 changed files in current branch (before filtering)
+      [log]   - test.js
+      [log]   - yarn.lock
+      [log] Found 2 files in 1 package that should be published"
+    `);
   });
 
   it('ignores package changes as appropriate', () => {
@@ -279,7 +316,7 @@ describe('getChangedPackages', () => {
     // and overall output
     expect(logLines).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
-      [log] Found 6 changed files in branch "origin/master" (before filtering)
+      [log] Found 6 changed files in current branch (before filtering)
       [log]   - ~~packages/ignore-pkg/CHANGELOG.md~~ (ignored by pattern "CHANGELOG.{md,json}")
       [log]   - ~~packages/ignore-pkg/jest.config.js~~ (ignored by pattern "**/jest.config.js")
       [log]   - ~~packages/no-publish/test.js~~ (no-publish has beachball.shouldPublish=false)

--- a/src/__fixtures__/changeFiles.ts
+++ b/src/__fixtures__/changeFiles.ts
@@ -30,7 +30,7 @@ export function getChange(
 
 /**
  * Generates and writes change files for the given packages.
- * Also commits if `options.commit` is true and the context is a git repo.
+ * Also commits if `options.commit` is true (the default with full options) and the context is a git repo.
  * @param changes Array of package names or partial change files (which must include `packageName`).
  * Default values:
  * - `type: 'minor'`

--- a/src/__fixtures__/repository.ts
+++ b/src/__fixtures__/repository.ts
@@ -128,25 +128,31 @@ ${gitResult.stderr.toString()}`);
   }
 
   /**
+   * Create (or update) a file, creating the intermediate directories if necessary.
+   * Automatically uses root path; do not pass absolute paths here.
+   */
+  writeFile(relativePath: string, content: string | object = ''): void {
+    const filePath = this.pathTo(relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, typeof content === 'string' ? content : JSON.stringify(content));
+  }
+
+  /**
    * Create (or update) and stage a file, creating the intermediate directories if necessary.
    * Automatically uses root path; do not pass absolute paths here.
    */
-  stageChange(newFilename: string, content: string | object = ''): void {
-    const filePath = this.pathTo(newFilename);
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-    fs.writeFileSync(filePath, typeof content === 'string' ? content : JSON.stringify(content));
-
-    this.git(['add', newFilename]);
+  stageChange(relativePath: string, content?: string | object): void {
+    this.writeFile(relativePath, content);
+    this.git(['add', relativePath]);
   }
 
   /**
    * Commit a change, creating the intermediate directories if necessary.
    * Automatically uses root path; do not pass absolute paths here.
    */
-  commitChange(newFilename: string, content?: string | object): void {
-    this.stageChange(newFilename, content);
-    this.git(['commit', '-m', `"${newFilename}"`]);
+  commitChange(relativePath: string, content?: string | object): void {
+    this.stageChange(relativePath, content);
+    this.git(['commit', '-m', `"${relativePath}"`]);
   }
 
   /** Commit all changes to tracked and untracked files. */

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -63,6 +63,10 @@ export function readChangeFiles(
     let changeInfo: ChangeInfo | ChangeInfoMultiple;
     try {
       changeInfo = readJson<ChangeInfo | ChangeInfoMultiple>(changeFilePath);
+      if (!(changeInfo as ChangeInfo).packageName && !(changeInfo as ChangeInfoMultiple).changes) {
+        console.warn(`${changeFilePath} does not appear to be a change file`);
+        continue;
+      }
     } catch (e) {
       console.warn(`Error reading or parsing change file ${changeFilePath}: ${e}`);
       continue;
@@ -94,10 +98,7 @@ export function readChangeFiles(
       if (warningType) {
         const resolution = options.groupChanges ? 'remove the entry from this file' : 'delete this file';
         console.warn(
-          `Change detected for ${warningType} package ${change.packageName}; ${resolution}: "${path.resolve(
-            changePath,
-            changeFile
-          )}"`
+          `Change detected for ${warningType} package ${change.packageName}; ${resolution}: ${changeFilePath}`
         );
       }
 


### PR DESCRIPTION
#1119 introduced an issue (not published) where if the `change` directory existed but had no files unique to the current branch, git output wasn't handled correctly and it would attempt to read the change dir as a file.

Switch `getChangedPackages` to use the `getChangesBetweenRefs` helper to ensure git output is correctly handled.

In both `getChangedPackages` and `readChangeFiles`, skip anything that's definitely not a change file (no `packageName` for single and no `changes` for multiple).