### PR TITLE
Improve validation when bumping semver

### DIFF
--- a/change/beachball-6d8d2d71-d22d-4e03-bbc8-ec0adedc5d84.json
+++ b/change/beachball-6d8d2d71-d22d-4e03-bbc8-ec0adedc5d84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve validation when bumping semver",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/bump/bumpPackageInfoVersion.test.ts
+++ b/src/__tests__/bump/bumpPackageInfoVersion.test.ts
@@ -1,64 +1,77 @@
-import { describe, it, expect, jest, afterEach, beforeAll, afterAll } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import { bumpPackageInfoVersion } from '../../bump/bumpPackageInfoVersion';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import type { ChangeType } from '../../types/ChangeInfo';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import type { PackageInfo } from '../../types/PackageInfo';
+import type { BeachballOptions } from '../../types/BeachballOptions';
 
 type PartialBumpInfo = Parameters<typeof bumpPackageInfoVersion>[1];
 
 describe('bumpPackageInfoVersion', () => {
-  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  const logs = initMockLogs();
+  /** Reused package name */
+  const name = 'pkg';
 
-  beforeAll(() => {
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('logs and skips when package info is not found', () => {
+  /**
+   * Bump `pkg` (default version `1.0.0`) with given params and return the `bumpInfo`.
+   */
+  function bumpPackageInfoVersionWrapper(params: {
+    /** Extra info (defaults to version 1.0.0), or null for nonexistent package */
+    packageInfo?: Partial<PackageInfo> | null;
+    changeType: ChangeType | undefined;
+    options?: Parameters<typeof bumpPackageInfoVersion>[2];
+  }) {
+    const { changeType, packageInfo } = params;
     const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': 'patch' },
-      packageInfos: {},
-      modifiedPackages: new Set<string>(),
+      calculatedChangeTypes: changeType ? { [name]: changeType } : {},
+      packageInfos: packageInfo === null ? {} : makePackageInfos({ [name]: packageInfo || {} }),
+      modifiedPackages: new Set(),
     };
 
-    bumpPackageInfoVersion('pkg-a', bumpInfo, {});
+    bumpPackageInfoVersion(name, bumpInfo, params.options || {});
 
-    expect(consoleLogSpy).toHaveBeenCalledWith('Unknown package named "pkg-a" detected from change files, skipping!');
+    return bumpInfo;
+  }
+
+  it('warns and skips when package info is not found', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      packageInfo: null,
+      changeType: 'patch',
+    });
+    expect(logs.mocks.warn).toHaveBeenCalledWith('Unknown package named "pkg" detected from change files, skipping!');
+    expect(bumpInfo.modifiedPackages.size).toBe(0);
+  });
+
+  it('warns and skips when no change type is found', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: undefined,
+    });
+    expect(logs.mocks.warn).toHaveBeenCalledWith(
+      'No change type found when bumping "pkg" (this may be a beachball bug)'
+    );
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.0');
     expect(bumpInfo.modifiedPackages.size).toBe(0);
   });
 
   it('logs and skips when change type is "none"', () => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': 'none' },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-      modifiedPackages: new Set<string>(),
-    };
-
-    // prereleasePrefix should be ignored here
-    bumpPackageInfoVersion('pkg-a', bumpInfo, { prereleasePrefix: 'beta' });
-
-    expect(consoleLogSpy).toHaveBeenCalledWith('"pkg-a" has a "none" change type, no version bump is required.');
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe('1.0.0');
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'none',
+      // prereleasePrefix should be ignored here
+      options: { prereleasePrefix: 'beta' },
+    });
+    expect(logs.mocks.log).toHaveBeenCalledWith('"pkg" has a "none" change type, so no version bump is required.');
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.0');
     expect(bumpInfo.modifiedPackages.size).toBe(0);
   });
 
-  it('logs and skips when package is private', () => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': 'patch' },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0', private: true } }),
-      modifiedPackages: new Set<string>(),
-    };
-
-    bumpPackageInfoVersion('pkg-a', bumpInfo, {});
-
-    expect(consoleLogSpy).toHaveBeenCalledWith('Skipping bumping private package "pkg-a"');
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe('1.0.0');
+  it('warns and skips when package is private', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'patch',
+      packageInfo: { private: true },
+    });
+    expect(logs.mocks.warn).toHaveBeenCalledWith('Skipping bumping private package "pkg"');
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.0');
     expect(bumpInfo.modifiedPackages.size).toBe(0);
   });
 
@@ -71,16 +84,11 @@ describe('bumpPackageInfoVersion', () => {
     ['preminor', '1.1.0-0'],
     ['prepatch', '1.0.1-0'],
   ])('bumps %s version', (changeType, expectedVersion) => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': changeType },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-      modifiedPackages: new Set<string>(),
-    };
-
-    bumpPackageInfoVersion('pkg-a', bumpInfo, {});
-
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe(expectedVersion);
-    expect(bumpInfo.modifiedPackages).toContain('pkg-a');
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType,
+    });
+    expect(bumpInfo.packageInfos[name].version).toBe(expectedVersion);
+    expect(bumpInfo.modifiedPackages).toContain(name);
   });
 
   // This should probably be changed, but documenting it for now
@@ -88,16 +96,12 @@ describe('bumpPackageInfoVersion', () => {
   it.each<ChangeType>(['major', 'minor', 'patch'])(
     'bumps as prerelease when prereleasePrefix is set and changeType is %s',
     changeType => {
-      const bumpInfo: PartialBumpInfo = {
-        calculatedChangeTypes: { 'pkg-a': changeType },
-        packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-        modifiedPackages: new Set<string>(),
-      };
-
-      bumpPackageInfoVersion('pkg-a', bumpInfo, { prereleasePrefix: 'beta' });
-
-      expect(bumpInfo.packageInfos['pkg-a'].version).toBe('1.0.1-beta.0');
-      expect(bumpInfo.modifiedPackages).toContain('pkg-a');
+      const bumpInfo = bumpPackageInfoVersionWrapper({
+        changeType,
+        options: { prereleasePrefix: 'beta' },
+      });
+      expect(bumpInfo.packageInfos[name].version).toBe('1.0.1-beta.0');
+      expect(bumpInfo.modifiedPackages).toContain(name);
     }
   );
 
@@ -107,41 +111,77 @@ describe('bumpPackageInfoVersion', () => {
     ['preminor', '1.1.0-beta.0'],
     ['prepatch', '1.0.1-beta.0'],
   ])('uses prereleasePrefix for changeType %s', (changeType, expectedVersion) => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': changeType },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-      modifiedPackages: new Set<string>(),
-    };
-
-    bumpPackageInfoVersion('pkg-a', bumpInfo, { prereleasePrefix: 'beta' });
-
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe(expectedVersion);
-    expect(bumpInfo.modifiedPackages).toContain('pkg-a');
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType,
+      options: { prereleasePrefix: 'beta' },
+    });
+    expect(bumpInfo.packageInfos[name].version).toBe(expectedVersion);
+    expect(bumpInfo.modifiedPackages).toContain(name);
   });
 
-  it('uses identifierBase for prerelease when provided', () => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': 'prerelease' },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-      modifiedPackages: new Set<string>(),
-    };
+  it('bumps to subsequent prerelease version with existing prefix', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'prerelease',
+      packageInfo: { version: '1.0.1-beta.2' },
+    });
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.1-beta.3');
+    expect(bumpInfo.modifiedPackages).toContain(name);
+  });
 
-    bumpPackageInfoVersion('pkg-a', bumpInfo, { identifierBase: '1' });
-
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe('1.0.1-1');
-    expect(bumpInfo.modifiedPackages).toContain('pkg-a');
+  it.each<[BeachballOptions['identifierBase'], string]>([
+    [undefined, '1.0.1-beta.0'], // default
+    ['0', '1.0.1-beta.0'],
+    ['1', '1.0.1-beta.1'],
+    [false, '1.0.1-beta'], // disable numeric identifier
+  ])('uses identifierBase %s for prerelease', (identifierBase, expectedVersion) => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'prerelease',
+      options: { identifierBase, prereleasePrefix: 'beta' },
+    });
+    expect(bumpInfo.packageInfos[name].version).toBe(expectedVersion);
+    expect(bumpInfo.modifiedPackages).toContain(name);
   });
 
   it('uses both prereleasePrefix and identifierBase when provided', () => {
-    const bumpInfo: PartialBumpInfo = {
-      calculatedChangeTypes: { 'pkg-a': 'prerelease' },
-      packageInfos: makePackageInfos({ 'pkg-a': { version: '1.0.0' } }),
-      modifiedPackages: new Set<string>(),
-    };
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'prerelease',
+      options: { prereleasePrefix: 'beta', identifierBase: '1' },
+    });
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.1-beta.1');
+    expect(bumpInfo.modifiedPackages).toContain(name);
+  });
 
-    bumpPackageInfoVersion('pkg-a', bumpInfo, { prereleasePrefix: 'beta', identifierBase: '1' });
+  it('warns and skips if change type is not valid semver', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'invalid-type' as ChangeType,
+    });
+    expect(logs.mocks.warn).toHaveBeenCalledWith(
+      'Invalid version bump requested for "pkg": from version "1.0.0", change type "invalid-type"'
+    );
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.0');
+    expect(bumpInfo.modifiedPackages.size).toBe(0);
+  });
 
-    expect(bumpInfo.packageInfos['pkg-a'].version).toBe('1.0.1-beta.1');
-    expect(bumpInfo.modifiedPackages).toContain('pkg-a');
+  it('warns and skips if prereleasePrefix is invalid', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'prerelease',
+      options: { prereleasePrefix: '!!!' },
+    });
+    expect(logs.mocks.warn).toHaveBeenCalledWith(
+      'Invalid version bump requested for "pkg": from version "1.0.0", change type "prerelease", prerelease prefix "!!!"'
+    );
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.0');
+    expect(bumpInfo.modifiedPackages.size).toBe(0);
+  });
+
+  // documenting semver package behavior
+  it('ignores invalid identifierBase', () => {
+    const bumpInfo = bumpPackageInfoVersionWrapper({
+      changeType: 'prerelease',
+      options: { prereleasePrefix: 'beta', identifierBase: 'nope' as BeachballOptions['identifierBase'] },
+    });
+    expect(logs.mocks.warn).not.toHaveBeenCalled();
+    expect(bumpInfo.packageInfos[name].version).toBe('1.0.1-beta.0');
+    expect(bumpInfo.modifiedPackages).toContain(name);
   });
 });

--- a/src/changefile/changeTypes.ts
+++ b/src/changefile/changeTypes.ts
@@ -26,7 +26,9 @@ const ChangeTypeWeights = Object.fromEntries(SortedChangeTypes.map((t, i) => [t,
 
 /**
  * Get initial package change types based on the greatest change type set for each package in any
- * change file, accounting for any disallowed change types or nonexistent packages.
+ * change file, accounting for any disallowed change types. (Nonexistent or private packages were
+ * already filtered out by `readChangeFiles`.)
+ *
  * Anything with change type "none" will be ignored.
  */
 export function initializePackageChangeTypes(changeSet: ChangeSet): BumpInfo['calculatedChangeTypes'] {

--- a/src/types/BeachballOptions.ts
+++ b/src/types/BeachballOptions.ts
@@ -193,9 +193,10 @@ export interface RepoOptions {
   path: string;
   /** Prerelease prefix for packages that are specified to receive a prerelease bump */
   prereleasePrefix?: string | null;
-  /** This is for prerelease. Set it to "0" for zero-based or "1" for one-based.
-   *  Set it to false to omit the prerelease number.
-   *  @default "0"
+  /**
+   * This is for prerelease. Set it to "0" for zero-based or "1" for one-based.
+   * Set it to false to omit the prerelease number.
+   * @default "0"
    */
   identifierBase?: '0' | '1' | false;
   /**


### PR DESCRIPTION
When bumping the version in package.json using `semver.inc()`, there was some missing validation:
- package change type is somehow unknown
- semver bump type (`changeType`) is invalid
- `prereleasePrefix` is invalid