### PR TITLE
Skip writing changelogs for packages not being bumped

### DIFF
--- a/change/beachball-7851a983-f6b1-4607-9bda-48f2cdefdd42.json
+++ b/change/beachball-7851a983-f6b1-4607-9bda-48f2cdefdd42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Skip adding changelog entries for packages without a calculated change type",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -64,8 +64,7 @@ describe('version bumping', () => {
 
     // Only pkg-1 actually gets bumped
     expect(bumpInfo?.calculatedChangeTypes).toEqual({ 'pkg-1': 'minor' });
-    // But currently, pkg-2 ends up in the modified list and dependentChangedBy via setDependentVersions.
-    // It's debatable whether this is correct: https://github.com/microsoft/beachball/issues/620#issuecomment-3609264966
+    // Currently, pkg-2 ends up included due to https://github.com/microsoft/beachball/issues/1123
     expect(bumpInfo?.modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2']));
     expect(bumpInfo?.dependentChangedBy).toEqual({ 'pkg-2': new Set(['pkg-1']) });
 
@@ -89,6 +88,10 @@ describe('version bumping', () => {
 
     const pkg1Changelog = readChangelogJson(repo.pathTo('packages/pkg-1'));
     expect(pkg1Changelog!.entries[0].comments.minor![0].comment).toBe(comment);
+    // There's a check in writeChangeFiles to prevent writing changelogs for packages in
+    // dependentChangedBy with no changeType
+    const pkg2Changelog = readChangelogJson(repo.pathTo('packages/pkg-2'));
+    expect(pkg2Changelog).toBeNull();
   });
 
   it('for multi-root monorepo, only bumps packages in the current root', async () => {

--- a/src/changelog/getPackageChangelogs.ts
+++ b/src/changelog/getPackageChangelogs.ts
@@ -57,9 +57,14 @@ export function getPackageChangelogs(
       continue;
     }
 
-    changelogs[dependent] ??= createPackageChangelog(packageInfos[dependent]);
-
     const changeType = calculatedChangeTypes[dependent];
+    if (!changeType) {
+      // Either bumpDeps is false, or the dependent is out of scope, so skip writing changelogs.
+      // (Related issue for why the package ends up in dependentChangedBy at all: https://github.com/microsoft/beachball/issues/1123)
+      continue;
+    }
+
+    changelogs[dependent] ??= createPackageChangelog(packageInfos[dependent]);
 
     changelogs[dependent].comments ??= {};
     changelogs[dependent].comments[changeType] ??= [];
@@ -73,6 +78,7 @@ export function getPackageChangelogs(
           // This change will be made in the commit that is currently being created, so unless we
           // split publishing into two commits (one for bumps and one for changelog updates),
           // there's no way to know the hash yet. It's better to record nothing than incorrect info.
+          // TODO: switch to actually writing nothing at all
           // https://github.com/microsoft/beachball/issues/901
           ...(includeCommitHashes && { commit: commitNotAvailable }),
         });

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -24,7 +24,8 @@ export type BumpInfo = {
   calculatedChangeTypes: { [pkgName: string]: ChangeType };
 
   /**
-   * Package version groups (not changelog groups) derived from `BeachballOptions.groups` (`VersionGroupOptions`).
+   * Package version groups (not changelog groups) derived from `BeachballOptions.groups`
+   * (`VersionGroupOptions`).
    */
   packageGroups: DeepReadonly<PackageGroups>;
 
@@ -39,6 +40,10 @@ export type BumpInfo = {
   /**
    * Map from package name to its internal dependency names that were bumped.
    * This is just used for changelog generation.
+   *
+   * Note: due to [this issue](https://github.com/microsoft/beachball/issues/1123), there may be
+   * packages here that don't have a `calculatedChangeTypes` entry, and those should be ignored
+   * when generating changelogs.
    */
   dependentChangedBy: { [pkgName: string]: Set<string> };
 


### PR DESCRIPTION
For reasons outlined in #1123, packages may end up in `dependentChangedBy` even if they're not being bumped. Previously this would cause entries for `undefined` change type in CHANGELOG.json, and possibly other effects.

This PR updates `getPackageChangelogs` (part of `writeChangelogs`) to skip any packages without a `calculatedChangeTypes` entry. This means only packages being bumped will have changelogs written.