### PR TITLE
Add more tests for bump and publish

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,28 @@
       "processId": "${command:PickProcess}",
       "sourceMaps": true,
       "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      // Debug configuration for Jest extension
+      "name": "vscode-jest-tests.v2",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "cwd": "${workspaceFolder}",
+      "runtimeArgs": ["run-script", "test"],
+      "args": [
+        "--",
+        "--runInBand",
+        "--watch",
+        "--testTimeout=1000000",
+        "--no-coverage",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ],
+      "console": "integratedTerminal",
+      "runtimeVersion": "14"
     }
   ]
 }

--- a/change/beachball-16f366fb-0faa-4ab5-8ff0-7528df9476b7.json
+++ b/change/beachball-16f366fb-0faa-4ab5-8ff0-7528df9476b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add validation of package names in callHook. Update internal handling of dependent modified packages (behavior is the same).",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,14 @@ const commonOptions = {
 const config = {
   reporters: ['default', 'github-actions'],
   testTimeout: 60000,
+  // Enable to locally test with coverage info (will only work properly with `yarn test`, not
+  // `test:all` or individual projects). This would be tricky to enable in CI due to the multiple
+  // test projects that run in sequence. Coverage also doesn't alone capture tricky scenarios.
+  // collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '__fixtures__'],
+  coverageThreshold: {
+    global: { branches: 80, functions: 100, lines: 90, statements: 90 },
+  },
   projects: [
     {
       displayName: 'unit',

--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, afterEach, jest } from '@jest/globals';
 import path from 'path';
 import { generateChangeFiles, getChangeFiles } from '../__fixtures__/changeFiles';
-import { readChangelogJson } from '../__fixtures__/changelog';
+import { readChangelogJson, readChangelogMd } from '../__fixtures__/changelog';
 import { initMockLogs } from '../__fixtures__/mockLogs';
 import { type RepoFixture, RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { bump } from '../commands/bump';
 import { getPackageInfos } from '../monorepo/getPackageInfos';
-import type { HooksOptions, RepoOptions } from '../types/BeachballOptions';
+import type { HooksOptions, ParsedOptions, RepoOptions } from '../types/BeachballOptions';
 import type { Repository } from '../__fixtures__/repository';
 import type { PackageJson } from '../types/PackageInfo';
 import { getParsedOptions } from '../options/getOptions';
@@ -14,20 +14,46 @@ import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { readJson } from '../object/readJson';
 import { validate } from '../validation/validate';
 import { createCommandContext } from '../monorepo/createCommandContext';
+import type { CommandContext } from '../types/CommandContext';
+import type { BumpInfo } from '../types/BumpInfo';
+import { deepFreeze } from '../__fixtures__/object';
 
-describe('version bumping', () => {
+//
+// These tests use git repos and are slow, so besides a few basic scenarios, this file should
+// only contain cases that can't be realistically tested in memory only.
+// Most scenarios for version bumps should be tested in bumpInMemory.test.ts instead.
+//
+describe('bump command', () => {
   let repositoryFactory: RepositoryFactory | undefined;
   let repo: Repository | undefined;
 
   initMockLogs();
 
+  /**
+   * Get options. Defaults to the repository root as cwd.
+   * Defaults to `fetch: false` since fetching is rarely relevant for these tests and is slow.
+   */
   function getOptions(repoOptions?: Partial<RepoOptions>, cwd?: string) {
     const parsedOptions = getParsedOptions({
       cwd: cwd || repo?.rootPath || '',
       argv: [],
-      testRepoOptions: { branch: defaultRemoteBranchName, ...repoOptions },
+      testRepoOptions: { branch: defaultRemoteBranchName, fetch: false, ...repoOptions },
     });
     return { options: parsedOptions.options, parsedOptions };
+  }
+
+  /**
+   * For more realistic testing, call `validate()` like the CLI command does, then call `bump()`.
+   * This helps catch any new issues with double bumps or context mutation.
+   * @returns the context containing the bump info
+   */
+  async function bumpWrapper(parsedOptions: ParsedOptions) {
+    // This does an initial bump
+    const { context } = validate(parsedOptions, { checkDependencies: true });
+    // Ensure the later bump process does not modify the context
+    deepFreeze(context);
+    await bump(parsedOptions.options, context);
+    return context as CommandContext & { bumpInfo: BumpInfo };
   }
 
   afterEach(() => {
@@ -43,9 +69,7 @@ describe('version bumping', () => {
       packages: {
         'pkg-1': { version: '1.0.0' },
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
+        'pkg-3': { version: '1.0.0', dependencies: { 'pkg-2': '1.0.0' } },
       },
     };
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
@@ -58,9 +82,7 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', comment, type: 'minor' }], options);
     repo.push();
 
-    // For this test, use validate() similar to the CLI to ensure it works
-    const { context } = validate(parsedOptions, { checkDependencies: true });
-    const { bumpInfo } = context;
+    const { bumpInfo } = await bumpWrapper(parsedOptions);
 
     // Only pkg-1 actually gets bumped
     expect(bumpInfo?.calculatedChangeTypes).toEqual({ 'pkg-1': 'minor' });
@@ -68,20 +90,15 @@ describe('version bumping', () => {
     expect(bumpInfo?.modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2']));
     expect(bumpInfo?.dependentChangedBy).toEqual({ 'pkg-2': new Set(['pkg-1']) });
 
-    await bump(options, context);
-
     const packageInfos = getPackageInfos(parsedOptions);
 
     const pkg1NewVersion = '1.1.0';
     expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
     expect(packageInfos['pkg-2'].version).toBe('1.0.0');
     expect(packageInfos['pkg-3'].version).toBe('1.0.0');
-    expect(packageInfos['pkg-4'].version).toBe('1.0.0');
 
     expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(monorepo['packages']['pkg-2'].version);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(monorepo['packages']['pkg-3'].version);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(monorepo['packages']['pkg-4'].version);
+    expect(packageInfos['pkg-3'].dependencies!['pkg-2']).toBe(monorepo['packages']['pkg-2'].version);
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(0);
@@ -110,7 +127,7 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: '@workspace-a/foo', type: 'major' }], optionsB);
     repo.push();
 
-    await bump(optionsA, createCommandContext(infoA.parsedOptions));
+    await bumpWrapper(infoA.parsedOptions);
 
     const packageInfosA = getPackageInfos(infoA.parsedOptions);
     const packageInfosB = getPackageInfos(infoB.parsedOptions);
@@ -136,35 +153,44 @@ describe('version bumping', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    // generate an initial set of change files
     const { options, parsedOptions } = getOptions({
       bumpDeps: false,
+      // Incidentally use this to verify generateChangelog: false is respected
+      generateChangelog: false,
     });
+    // generate an initial set of change files
     generateChangeFiles(['pkg-1'], options);
     // set the initial change files commit as fromRef
-    options.fromRef = repo.getCurrentHash();
+    options.fromRef = parsedOptions.repoOptions.fromRef = repo.getCurrentHash();
 
     // generate a new set of change files
     generateChangeFiles(['pkg-3'], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    const { bumpInfo, originalPackageInfos } = await bumpWrapper(parsedOptions);
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({ 'pkg-3': 'minor' });
+    expect(bumpInfo.modifiedPackages).toEqual(new Set(['pkg-3']));
 
     const packageInfos = getPackageInfos(parsedOptions);
 
-    expect(packageInfos['pkg-1'].version).toBe(monorepo['packages']['pkg-1'].version);
-    expect(packageInfos['pkg-2'].version).toBe(monorepo['packages']['pkg-2'].version);
+    expect(packageInfos['pkg-1']).toEqual(originalPackageInfos['pkg-1']);
+    expect(packageInfos['pkg-2']).toEqual(originalPackageInfos['pkg-2']);
     expect(packageInfos['pkg-3'].version).toBe('1.1.0');
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(monorepo['packages']['pkg-1'].version);
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
+
+    // Verify generateChangelog: false
+    expect(readChangelogJson(repo.pathTo('packages/pkg-3'))).toBeNull();
+    expect(readChangelogMd(repo.pathTo('packages/pkg-3'))).toBeNull();
   });
 
   it('bumps all dependent packages with bumpDeps: true (default)', async () => {
     const monorepo: RepoFixture['folders'] = {
       packages: {
         'pkg-1': { version: '1.0.0' },
+        // check all dependency types
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
         'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
         'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
@@ -182,12 +208,9 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'pkg-1', type: 'minor', comment }], options);
     repo.push();
 
-    // For this test, use validate() similar to the CLI to ensure it works
-    const { context } = validate(parsedOptions, { checkDependencies: true });
-    const { bumpInfo } = context;
-    expect(bumpInfo?.modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2', 'pkg-3', 'pkg-4', 'pkg-5']));
+    const { bumpInfo } = await bumpWrapper(parsedOptions);
 
-    await bump(options, context);
+    expect(bumpInfo.modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2', 'pkg-3', 'pkg-4', 'pkg-5']));
 
     const packageInfos = getPackageInfos(parsedOptions);
 
@@ -213,87 +236,8 @@ describe('version bumping', () => {
     expect(pkg3Changelog!.entries[0].comments.patch![0].comment).toBe(`Bump pkg-2 to v${dependentNewVersion}`);
   });
 
-  // TODO: move to bumpInMemory tests
-  it('bumps all grouped packages', async () => {
-    const monorepo: RepoFixture['folders'] = {
-      packages: {
-        'pkg-1': { version: '1.0.0' },
-        'pkg-2': { version: '1.0.0' },
-        'pkg-3': { version: '1.0.0' },
-      },
-      unrelated: {
-        'pkg-4': { version: '1.0.0' },
-      },
-    };
-    repositoryFactory = new RepositoryFactory({ folders: monorepo });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      groups: [{ include: 'packages/*', name: 'testgroup', disallowedChangeTypes: [] }],
-    });
-    generateChangeFiles(['pkg-1'], options);
-
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    const newVersion = '1.1.0';
-    expect(packageInfos['pkg-1'].version).toBe(newVersion);
-    expect(packageInfos['pkg-2'].version).toBe(newVersion);
-    expect(packageInfos['pkg-3'].version).toBe(newVersion);
-    expect(packageInfos['pkg-4'].version).toBe(monorepo['unrelated']['pkg-4'].version);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
-  });
-
-  // TODO: move to bumpInMemory tests
-  it('bumps all grouped packages to the greatest change type in the group, regardless of change file order', async () => {
-    repositoryFactory = new RepositoryFactory('monorepo');
-    repo = repositoryFactory.cloneRepository();
-
-    repo.commitChange('packages/commonlib/package.json', {
-      // The prefix z- here ensures commonlib's change file is loaded AFTER its dependents.
-      // This makes sure we set the group's version bumps based on ChangeType order and not in
-      // the sort order the filesystem gives us.
-      name: 'z-commonlib',
-      version: '1.0.0',
-    });
-    repo.commitChange('packages/pkg-1/package.json', {
-      name: 'pkg-1',
-      version: '1.0.0',
-      dependencies: {
-        'z-commonlib': '1.0.0',
-      },
-    });
-
-    const { options, parsedOptions } = getOptions({
-      groups: [{ include: 'packages/*', disallowedChangeTypes: null, name: 'grp' }],
-      bumpDeps: true,
-      commit: true,
-    });
-    generateChangeFiles(
-      [
-        { packageName: 'z-commonlib', type: 'none', dependentChangeType: 'none' },
-        { packageName: 'pkg-1', type: 'minor', dependentChangeType: 'minor' },
-      ],
-      options
-    );
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
-    expect(packageInfos['z-commonlib'].version).toBe('1.1.0');
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
-  });
-
+  // Most grouped package scenarios are covered in bumpInMemory.test.ts.
+  // Test this complicated scenario E2E too to verify all the pieces work together.
   it('bumps all grouped AND dependent packages', async () => {
     const monorepo: RepoFixture['folders'] = {
       'packages/grp': {
@@ -315,11 +259,15 @@ describe('version bumping', () => {
       groups: [{ include: 'packages/grp/*', name: 'grp', disallowedChangeTypes: [] }],
       bumpDeps: true,
     });
+    // Bump commonlib, which is not in the group, but triggers a dependent bump of pkg-3,
+    // which triggers bump of the whole group and then the app.
+    // Also verify the non-default dependentChangeType passes through.
     generateChangeFiles([{ packageName: 'commonlib', dependentChangeType: 'minor' }], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    const { originalPackageInfos } = await bumpWrapper(parsedOptions);
 
+    // This scenario is also covered in bumpInMemory, so focus on the filesystem parts
     const packageInfos = getPackageInfos(parsedOptions);
 
     const groupNewVersion = '1.1.0';
@@ -328,12 +276,21 @@ describe('version bumping', () => {
     expect(packageInfos['pkg-3'].version).toBe(groupNewVersion);
     expect(packageInfos['commonlib'].version).toBe('1.1.0');
     expect(packageInfos['app'].version).toBe('1.1.0');
-    expect(packageInfos['unrelated'].version).toBe(monorepo['packages'].unrelated.version);
+    expect(packageInfos['unrelated']).toEqual(originalPackageInfos['unrelated']);
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(0);
 
-    // TODO check changelogs
+    // Current behavior: group bumps don't generate changelog entries
+    // (not sure if this is good or bad)
+    expect(readChangelogJson(repo.pathTo('packages/grp/pkg-1'))).toBeNull();
+    expect(readChangelogJson(repo.pathTo('packages/grp/pkg-2'))).toBeNull();
+    // The original dependent bump gets an entry
+    const pkg3Changelog = readChangelogJson(repo.pathTo('packages/grp/pkg-3'));
+    expect(pkg3Changelog!.entries[0].comments.minor![0].comment).toBe('Bump commonlib to v1.1.0');
+    // As does bumping pkg-1 in app
+    const appChangelog = readChangelogJson(repo.pathTo('packages/app'));
+    expect(appChangelog!.entries[0].comments.minor![0].comment).toBe('Bump pkg-1 to v1.1.0');
   });
 
   // Scope filtering of changes happens in readChangesFiles, not the actual bump logic,
@@ -341,31 +298,42 @@ describe('version bumping', () => {
   // (Scope filtering of dependents happens in the bump step.)
   it('should not bump out-of-scope package even if package has change', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
-    const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
       scope: ['!packages/bar'],
     });
-    generateChangeFiles(['bar'], options);
+    // bar depends on baz, so that gives bar an extra chance to get a dependent bump
+    generateChangeFiles(['bar', 'baz'], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    const { bumpInfo, originalPackageInfos } = await bumpWrapper(parsedOptions);
+
+    // Verify the in-memory part of the bump
+    expect(bumpInfo.calculatedChangeTypes).toEqual({ baz: 'minor' });
+    expect(bumpInfo.modifiedPackages).toEqual(new Set(['baz']));
+    expect(bumpInfo.dependentChangedBy).toEqual({});
+    expect(bumpInfo.scopedPackages).toEqual(new Set(['baz', 'foo', 'a', 'b']));
+    expect(bumpInfo.changeFileChangeInfos).toHaveLength(1);
+    expect(bumpInfo.changeFileChangeInfos[0].change.packageName).toBe('baz');
 
     const packageInfos = getPackageInfos(parsedOptions);
-    expect(packageInfos['bar'].version).toBe(monorepo['packages']['bar'].version);
-    expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
+    expect(packageInfos['bar']).toEqual(originalPackageInfos['bar']);
+    expect(packageInfos['foo']).toEqual(originalPackageInfos['foo']);
+    expect(packageInfos['baz'].version).toBe('1.4.0');
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(1);
+
+    expect(readChangelogJson(repo.pathTo('packages/bar'))).toBeNull();
+    expect(readChangelogJson(repo.pathTo('packages/baz'))).not.toBeNull();
   });
 
   // Scope filtering of dependents currently happens in the bump step and can be tested in bumpInMemory,
   // but probably also good to have E2E coverage of this scenario in case that changes in the future.
   it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
-    const monorepo = repositoryFactory.fixture.folders;
     repo = repositoryFactory.cloneRepository();
 
     const { options, parsedOptions } = getOptions({
@@ -375,18 +343,21 @@ describe('version bumping', () => {
     generateChangeFiles([{ packageName: 'bar', type: 'patch' }], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    // bumpInMemory already tests the in-memory part of this scenario
+    const { originalPackageInfos } = await bumpWrapper(parsedOptions);
 
     const packageInfos = getPackageInfos(parsedOptions);
-    expect(packageInfos['foo'].version).toBe(monorepo['packages']['foo'].version);
     expect(packageInfos['bar'].version).toBe('1.3.5');
     // Since foo is out of scope, currently its dep on bar is not bumped.
     // This is usually fine, but could be an issue if bar is bumped to an incompatible version.
     // Somewhat related: https://github.com/microsoft/beachball/issues/620#issuecomment-3609264966
-    expect(packageInfos['foo'].dependencies!['bar']).toBe(monorepo['packages']['foo'].dependencies!['bar']);
+    expect(packageInfos['foo']).toEqual(originalPackageInfos['foo']);
 
     const changeFiles = getChangeFiles(options);
     expect(changeFiles).toHaveLength(0);
+
+    expect(readChangelogJson(repo.pathTo('packages/bar'))).not.toBeNull();
+    expect(readChangelogJson(repo.pathTo('packages/foo'))).toBeNull();
   });
 
   // This is mostly covered by bumpInMemory.test.ts, but the current changelog behavior is probably
@@ -410,9 +381,7 @@ describe('version bumping', () => {
 
     repo.push();
 
-    const context = createCommandContext(parsedOptions);
-    const { originalPackageInfos } = context;
-    await bump(options, context);
+    const { originalPackageInfos } = await bumpWrapper(parsedOptions);
 
     const packageInfos = getPackageInfos(parsedOptions);
 
@@ -434,176 +403,7 @@ describe('version bumping', () => {
     expect(changelogJson3).toBeNull();
   });
 
-  // TODO: move to bumpInMemory tests
-  it('bumps all packages and keeps change files with `keep-change-files` flag', async () => {
-    const monorepo: RepoFixture['folders'] = {
-      packages: {
-        'pkg-1': { version: '1.0.0' },
-        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
-      },
-    };
-    repositoryFactory = new RepositoryFactory({ folders: monorepo });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      bumpDeps: false,
-      keepChangeFiles: true,
-    });
-    generateChangeFiles(['pkg-1'], options);
-
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    const pkg1NewVersion = '1.1.0';
-    expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
-    expect(packageInfos['pkg-2'].version).toBe(monorepo['packages']['pkg-2'].version);
-    expect(packageInfos['pkg-3'].version).toBe(monorepo['packages']['pkg-3'].version);
-    expect(packageInfos['pkg-4'].version).toBe(monorepo['packages']['pkg-4'].version);
-    expect(packageInfos['pkg-5'].version).toBe(monorepo['packages']['pkg-5'].version);
-
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(monorepo['packages']['pkg-2'].version);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(monorepo['packages']['pkg-3'].version);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(monorepo['packages']['pkg-4'].version);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(1);
-  });
-
-  // TODO: move to bumpInMemory tests
-  it('bumps all packages and uses prefix in the version with default identifier base', async () => {
-    const monorepo: RepoFixture['folders'] = {
-      packages: {
-        'pkg-1': { version: '1.0.0' },
-        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
-      },
-    };
-    repositoryFactory = new RepositoryFactory({ folders: monorepo });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      bumpDeps: true,
-      keepChangeFiles: false,
-      prereleasePrefix: 'beta',
-    });
-    generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    const newVersion = '1.0.1-beta.0';
-    expect(packageInfos['pkg-1'].version).toBe(newVersion);
-    expect(packageInfos['pkg-2'].version).toBe(newVersion);
-    expect(packageInfos['pkg-3'].version).toBe(newVersion);
-    expect(packageInfos['pkg-4'].version).toBe(newVersion);
-    expect(packageInfos['pkg-5'].version).toBe(newVersion);
-
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(newVersion);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(newVersion);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(newVersion);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
-  });
-
-  // TODO: move to bumpInMemory tests
-  it('bumps all packages and uses prefix in the version with the right identifier base', async () => {
-    const monorepo: RepoFixture['folders'] = {
-      packages: {
-        'pkg-1': { version: '1.0.0' },
-        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
-      },
-    };
-    repositoryFactory = new RepositoryFactory({ folders: monorepo });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      bumpDeps: true,
-      keepChangeFiles: false,
-      prereleasePrefix: 'beta',
-      identifierBase: '1',
-    });
-    generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    const newVersion = '1.0.1-beta.1';
-    expect(packageInfos['pkg-1'].version).toBe(newVersion);
-    expect(packageInfos['pkg-2'].version).toBe(newVersion);
-    expect(packageInfos['pkg-3'].version).toBe(newVersion);
-    expect(packageInfos['pkg-4'].version).toBe(newVersion);
-    expect(packageInfos['pkg-5'].version).toBe(newVersion);
-
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(newVersion);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(newVersion);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(newVersion);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
-  });
-
-  // TODO: move to bumpInMemory tests
-  it('bumps all packages and uses prefix in the version with no identifier base', async () => {
-    const monorepo: RepoFixture['folders'] = {
-      packages: {
-        'pkg-1': { version: '1.0.0' },
-        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
-      },
-    };
-    repositoryFactory = new RepositoryFactory({ folders: monorepo });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      bumpDeps: true,
-      keepChangeFiles: false,
-      prereleasePrefix: 'beta',
-      identifierBase: false,
-    });
-    generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease' }], options);
-    repo.push();
-
-    await bump(options, createCommandContext(parsedOptions));
-
-    const packageInfos = getPackageInfos(parsedOptions);
-
-    const newVersion = '1.0.1-beta';
-    expect(packageInfos['pkg-1'].version).toBe(newVersion);
-    expect(packageInfos['pkg-2'].version).toBe(newVersion);
-    expect(packageInfos['pkg-3'].version).toBe(newVersion);
-    expect(packageInfos['pkg-4'].version).toBe(newVersion);
-    expect(packageInfos['pkg-5'].version).toBe(newVersion);
-
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(newVersion);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(newVersion);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(newVersion);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
-  });
-
+  // Prerelease scenarios are covered in more detail in bumpInMemory.test.ts
   it('bumps to prerelease and uses prerelease version for dependents', async () => {
     const monorepo: RepoFixture['folders'] = {
       packages: {
@@ -619,13 +419,12 @@ describe('version bumping', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
-      keepChangeFiles: false,
       prereleasePrefix: 'beta',
     });
     generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease', dependentChangeType: 'prerelease' }], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    await bumpWrapper(parsedOptions);
 
     const packageInfos = getPackageInfos(parsedOptions);
 
@@ -644,15 +443,13 @@ describe('version bumping', () => {
     expect(changeFiles).toHaveLength(0);
   });
 
-  // TODO: move to bumpInMemory tests
-  it('bumps all packages and increments prefixed versions in dependents', async () => {
+  it('bumps dependents with workspace: deps', async () => {
     const monorepo: RepoFixture['folders'] = {
       packages: {
-        'pkg-1': { version: '1.0.1-beta.0' },
-        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
-        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
-        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
-        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
+        'pkg-1': { version: '1.0.0' },
+        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': 'workspace:~' } },
+        // this workspace version will be updated
+        'pkg-3': { version: '1.0.0', dependencies: { 'pkg-2': 'workspace:^1.0.0' } },
       },
     };
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
@@ -660,33 +457,33 @@ describe('version bumping', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
-      keepChangeFiles: false,
-      prereleasePrefix: 'beta',
     });
-    generateChangeFiles([{ packageName: 'pkg-1', type: 'prerelease', dependentChangeType: 'prerelease' }], options);
+    generateChangeFiles([{ packageName: 'pkg-1', type: 'minor' }], options);
     repo.push();
 
-    await bump(options, createCommandContext(parsedOptions));
+    // The bumpInfo object is covered by the similar test in bumpInMemory.test.ts
+    const { originalPackageInfos } = await bumpWrapper(parsedOptions);
 
     const packageInfos = getPackageInfos(parsedOptions);
 
-    const pkg1NewVersion = '1.0.1-beta.1';
-    const othersNewVersion = '1.0.1-beta.0';
-    expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
-    expect(packageInfos['pkg-2'].version).toBe(othersNewVersion);
-    expect(packageInfos['pkg-3'].version).toBe(othersNewVersion);
-    expect(packageInfos['pkg-4'].version).toBe(othersNewVersion);
+    // All the dependent packages are bumped despite the workspace: dep specs
+    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
+    // workspace:~ range isn't changed
+    expect(packageInfos['pkg-2']).toEqual({ ...originalPackageInfos['pkg-2'], version: '1.0.1' });
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1');
+    // workspace: range with number is updated
+    expect(packageInfos['pkg-3'].dependencies).toEqual({ 'pkg-2': 'workspace:^1.0.1' });
 
-    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
-    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(othersNewVersion);
-    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(othersNewVersion);
-    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(othersNewVersion);
-
-    const changeFiles = getChangeFiles(options);
-    expect(changeFiles).toHaveLength(0);
+    expect(readChangelogJson(repo.pathTo('packages/pkg-1'))).not.toBeNull();
+    const pkg3Changelog = readChangelogJson(repo.pathTo('packages/pkg-3'));
+    // this gets a changelog entry since the workspace:^1.0.0 dep was updated
+    // (a little debatable whether the current text is correct)
+    expect(pkg3Changelog!.entries[0].comments.patch![0].comment).toBe('Bump pkg-2 to v1.0.1');
+    // Current behavior: dependentChangedBy misses deps like workspace:~ that don't change,
+    // so the bump of pkg-1 will be missing from pkg-2's changelog.
+    // https://github.com/microsoft/beachball/issues/981
+    expect(readChangelogJson(repo.pathTo('packages/pkg-2'))).toBeNull();
   });
-
-  // TODO test workspace versions
 
   // Explicit tests for sync/async hooks aren't necessary, especially since these are slow tests.
   // Async is slightly trickier, so test that.
@@ -704,6 +501,8 @@ describe('version bumping', () => {
         prebump: jest.fn<NonNullable<HooksOptions['prebump']>>(async (packagePath, name, version) => {
           expect(packagePath.endsWith('pkg-1')).toBeTruthy();
           expect(name).toBe('pkg-1');
+          // This is currently wrong--it should still be the old version
+          // https://github.com/microsoft/beachball/issues/1116
           expect(version).toBe('1.1.0');
 
           await new Promise(resolve => setTimeout(resolve, 0)); // simulate async work
@@ -725,58 +524,10 @@ describe('version bumping', () => {
     generateChangeFiles(['pkg-1'], options);
     repo.push();
 
+    // Skip validate for this test
     await bump(options, createCommandContext(parsedOptions));
 
     expect(options.hooks?.prebump).toHaveBeenCalled();
     expect(options.hooks?.postbump).toHaveBeenCalled();
-  });
-
-  // TODO: move to performBump test (no repo)
-  it('propagates prebump hook exceptions', async () => {
-    repositoryFactory = new RepositoryFactory({
-      folders: {
-        packages: { 'pkg-1': { version: '1.0.0' } },
-      },
-    });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      path: repo.rootPath,
-      bumpDeps: false,
-      hooks: {
-        prebump: (): Promise<void> => {
-          throw new Error('Foo');
-        },
-      },
-    });
-
-    generateChangeFiles(['pkg-1'], options);
-    repo.push();
-
-    await expect(() => bump(options, createCommandContext(parsedOptions))).rejects.toThrow('Foo');
-  });
-
-  // TODO: move to performBump test (no repo)
-  it('propagates postbump hook exceptions', async () => {
-    repositoryFactory = new RepositoryFactory({
-      folders: {
-        packages: { 'pkg-1': { version: '1.0.0' } },
-      },
-    });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      bumpDeps: false,
-      hooks: {
-        postbump: (): Promise<void> => {
-          throw new Error('Foo');
-        },
-      },
-    });
-
-    generateChangeFiles(['pkg-1'], options);
-    repo.push();
-
-    await expect(() => bump(options, createCommandContext(parsedOptions))).rejects.toThrow('Foo');
   });
 });

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -215,7 +215,7 @@ describe('getChangedPackages', () => {
 
     // foo is not included in changed packages
     let changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
-    const logLines = logs.getMockLines('all', { guids: true });
+    const logLines = logs.getMockLines('all', { sanitize: true });
     expect(logLines).toMatch(/Your local repository already has change files for these packages:\s+• foo/);
     expect(logLines).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
@@ -232,7 +232,7 @@ describe('getChangedPackages', () => {
     // change bar => bar is the only changed package returned
     repo.stageChange('packages/bar/test.js');
     changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
-    expect(logs.getMockLines('all', { guids: true })).toMatchInlineSnapshot(`
+    expect(logs.getMockLines('all', { sanitize: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
       [log] Found 3 changed files in current branch (before filtering)
       [log]   - ~~change/foo-<guid>.json~~ (ignored by pattern "change/*.json")
@@ -266,7 +266,7 @@ describe('getChangedPackages', () => {
 
     const changedPackages = getChangedPackages(options, packageInfos, scopedPackages);
     expect(changedPackages).toStrictEqual(['foo']);
-    expect(logs.getMockLines('all', { guids: true })).toMatchInlineSnapshot(`
+    expect(logs.getMockLines('all', { sanitize: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
       [log] Found 2 changed files in current branch (before filtering)
       [log]   - test.js

--- a/src/__e2e__/publishRegistry.test.ts
+++ b/src/__e2e__/publishRegistry.test.ts
@@ -6,11 +6,13 @@ import { initMockLogs } from '../__fixtures__/mockLogs';
 import type { Repository } from '../__fixtures__/repository';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { publish } from '../commands/publish';
-import type { RepoOptions } from '../types/BeachballOptions';
+import type { ParsedOptions, RepoOptions } from '../types/BeachballOptions';
 import { initNpmMock } from '../__fixtures__/mockNpm';
 import { removeTempDir, tmpdir } from '../__fixtures__/tmpdir';
 import { getParsedOptions } from '../options/getOptions';
 import { createCommandContext } from '../monorepo/createCommandContext';
+import { validate } from '../validation/validate';
+import { deepFreezeProperties } from '../__fixtures__/object';
 
 // Spawning actual npm to run commands against a fake registry is extremely slow, so mock it for
 // this test (packagePublish covers the more complete npm registry scenario).
@@ -27,9 +29,11 @@ describe('publish command (registry)', () => {
   let repo: Repository | undefined;
   let packToPath: string | undefined;
 
-  // show error logs for these tests
-  const logs = initMockLogs({ alsoLog: ['error'] });
+  const logs = initMockLogs();
 
+  /**
+   * Get options with defaults including skipping git stuff
+   */
   function getOptions(repoOptions?: Partial<RepoOptions>) {
     const parsedOptions = getParsedOptions({
       cwd: repo!.rootPath,
@@ -38,6 +42,7 @@ describe('publish command (registry)', () => {
         branch: defaultRemoteBranchName,
         registry: 'fake',
         message: 'apply package updates',
+        fetch: false,
         bumpDeps: false,
         push: false,
         gitTags: false,
@@ -47,6 +52,20 @@ describe('publish command (registry)', () => {
       },
     });
     return { options: parsedOptions.options, parsedOptions };
+  }
+
+  /**
+   * For more realistic testing, call `validate()` like the CLI command does, then call `publish()`.
+   * This helps catch any new issues with double bumps or context mutation.
+   */
+  async function publishWrapper(parsedOptions: ParsedOptions) {
+    logs.clear();
+    // This does an initial bump
+    const { context } = validate(parsedOptions, { checkDependencies: true });
+    // Ensure the later bump process does not modify the context
+    deepFreezeProperties(context.bumpInfo);
+    deepFreezeProperties(context.originalPackageInfos);
+    await publish(parsedOptions.options, context);
   }
 
   afterEach(() => {
@@ -64,15 +83,14 @@ describe('publish command (registry)', () => {
 
     const { options, parsedOptions } = getOptions({ packToPath });
     generateChangeFiles(['foo'], options);
-    repo.push();
-
-    await publish(options, createCommandContext(parsedOptions));
+    await publishWrapper(parsedOptions);
 
     expect(fs.readdirSync(packToPath)).toEqual(['1-foo-1.1.0.tgz']);
     expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
-  it('publishes in monorepo with mixed public and private packages', async () => {
+  it('skips publishing private package with change file', async () => {
     repositoryFactory = new RepositoryFactory({
       folders: {
         packages: {
@@ -86,36 +104,92 @@ describe('publish command (registry)', () => {
     const { options, parsedOptions } = getOptions();
     generateChangeFiles(['foopkg'], options);
 
-    repo.push();
-
-    await publish(options, createCommandContext(parsedOptions));
-
+    // If there's only the private package with a change file, nothing happens
+    await publishWrapper(parsedOptions);
     expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package foopkg'));
-
+    expect(logs.mocks.error).not.toHaveBeenCalled();
     expect(npmMock.getPublishedVersions('foopkg')).toBeUndefined();
+
+    // Now try with a public package change file
+    logs.clear();
+    generateChangeFiles(['publicpkg'], options);
+    await publishWrapper(parsedOptions);
+    // Should be published despite private package change also existing
+    expect(npmMock.getPublishedPackage('publicpkg')!.version).toEqual('1.1.0');
+    // This is also a good case to get a "visual regression" test of the logs
+    expect(logs.getMockLines('all', { root: repo.rootPath, sanitize: true })).toMatchInlineSnapshot(`
+      "[log]
+      Validating options and change files...
+      [warn] Change detected for private package foopkg; delete this file: <root>/change/foopkg-<guid>.json
+      [log]
+      Validating package dependencies...
+      [log] Validating no private package among package dependencies
+      [log]   OK!
+
+      [log]
+      [log]
+      Preparing to publish
+      [log]
+      Publishing with the following configuration:
+
+        registry: fake
+
+        current branch: master
+        current hash: <commit>
+        target branch: origin/master
+        npm dist-tag: latest
+
+        bumps versions before publishing: yes
+        publishes to npm registry: yes
+        pushes bumps and changelogs to remote git repo: no
+
+
+      [log] Creating temporary publish branch publish_<timestamp>
+      [log]
+      Bumping versions and publishing packages to npm registry
+
+      [log] Removing change files:
+      [log] - publicpkg-<guid>.json
+      [log]
+      Validating new package versions...
+      [log]
+      Package versions are OK to publish:
+        • publicpkg@1.1.0
+      [log] Validating no private package among package dependencies
+      [log]   OK!
+
+      [log]
+      Publishing - publicpkg@1.1.0 with tag latest
+      [log]   publish command: publish --registry fake --tag latest --loglevel warn
+      [log]   (cwd: <root>/packages/publicpkg)
+      [log] Published! - publicpkg@1.1.0
+      [log]
+      [log] Skipping git push and tagging
+      [log]
+      Cleaning up
+      [log] git checkout master
+      [log] deleting temporary publish branch publish_<timestamp>"
+    `);
   });
 
   it('publishes multiple changed packages', async () => {
-    repositoryFactory = new RepositoryFactory({
-      folders: {
-        packages: {
-          foopkg: { version: '1.0.0', dependencies: { barpkg: '^1.0.0' } },
-          barpkg: { version: '1.0.0' },
-        },
-      },
-    });
+    repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
+    // Simulate the current package versions already existing to test validatePackageVersions
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.foo);
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.bar);
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.baz);
 
     const { options, parsedOptions } = getOptions();
-    generateChangeFiles(['foopkg', 'barpkg'], options);
+    generateChangeFiles(['foo', 'bar'], options);
 
-    repo.push();
+    await publishWrapper(parsedOptions);
 
-    await publish(options, createCommandContext(parsedOptions));
-
-    expect(npmMock.getPublishedPackage('foopkg')!.version).toEqual('1.1.0');
-    expect(npmMock.getPublishedPackage('barpkg')!.version).toEqual('1.1.0');
+    expect(npmMock.getPublishedPackage('foo')!.version).toEqual('1.1.0');
+    expect(npmMock.getPublishedPackage('bar')!.version).toEqual('1.4.0');
+    expect(npmMock.mock).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('packs many packages', async () => {
@@ -136,14 +210,14 @@ describe('publish command (registry)', () => {
 
     const { options, parsedOptions } = getOptions({ packToPath, groupChanges: true });
     generateChangeFiles(packageNames, options);
-    repo.push();
-
+    // initial validate() isn't relevant here
     await publish(options, createCommandContext(parsedOptions));
 
     expect(fs.readdirSync(packToPath).sort()).toEqual(
       [...packageNames].reverse().map((name, i) => `${String(i + 1).padStart(2, '0')}-${name}-1.1.0.tgz`)
     );
     expect(npmMock.getPublishedVersions('pkg-1')).toBeUndefined();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('exits publishing early if only invalid change files exist', async () => {
@@ -155,8 +229,7 @@ describe('publish command (registry)', () => {
     const { options, parsedOptions } = getOptions();
     generateChangeFiles(['bar', 'fake'], options);
 
-    repo.push();
-
+    // initial validate() isn't relevant here
     await publish(options, createCommandContext(parsedOptions));
 
     expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
@@ -164,7 +237,35 @@ describe('publish command (registry)', () => {
     expect(logs.mocks.warn).toHaveBeenCalledWith(
       expect.stringContaining('Change detected for nonexistent package fake')
     );
+    expect(logs.mocks.error).not.toHaveBeenCalled();
 
     expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
+  });
+
+  it('errors if version already exists in registry', async () => {
+    repositoryFactory = new RepositoryFactory('monorepo');
+    repo = repositoryFactory.cloneRepository();
+    // Simulate the current package versions already existing to test validatePackageVersions
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.foo);
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.bar);
+    npmMock.publishPackage(repositoryFactory.fixture.folders.packages.baz);
+    // also say the bumped version of foo and bar already exist (baz is fine)
+    npmMock.publishPackage({ ...repositoryFactory.fixture.folders.packages.foo, version: '1.1.0' });
+    npmMock.publishPackage({ ...repositoryFactory.fixture.folders.packages.bar, version: '1.4.0' });
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo', 'bar', 'baz'], options);
+    await expect(() => publishWrapper(parsedOptions)).rejects.toThrow('process.exit');
+
+    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
+      "ERROR: Attempting to publish package versions that already exist in the registry:
+        • bar@1.4.0
+        • foo@1.1.0
+      Something went wrong with publishing! Manually update these package and versions:
+        • bar@1.4.0
+        • baz@1.4.0
+        • foo@1.1.0
+      No packages were published due to validation errors (see above for details)."
+    `);
   });
 });

--- a/src/__fixtures__/changeFiles.ts
+++ b/src/__fixtures__/changeFiles.ts
@@ -37,21 +37,36 @@ export function getChange(
  * - `dependentChangeType: 'patch'`
  * - `comment: '<packageName> comment'`
  * - `email: 'test@test.com'`
+ *
+ * @param changes Array of package names or partial change files (which must include `packageName`).
+ */
+export function generateChanges(changes: (string | PartialChangeFile)[]): ChangeFileInfo[] {
+  return changes.map(change => {
+    change = typeof change === 'string' ? { packageName: change } : change;
+    return {
+      ...getChange(change.packageName, undefined, 'minor'),
+      ...change,
+    };
+  });
+}
+
+/**
+ * Generates and writes change files for the given packages.
+ * Also commits if `options.commit` is true.
+ *
+ * Default change info values:
+ * - `type: 'minor'`
+ * - `dependentChangeType: 'patch'`
+ * - `comment: '<packageName> comment'`
+ * - `email: 'test@test.com'`
+ *
+ * @param changes Array of package names or partial change files (which must include `packageName`).
  */
 export function generateChangeFiles(
   changes: (string | PartialChangeFile)[],
   options: Parameters<typeof writeChangeFiles>[1]
 ): void {
-  writeChangeFiles(
-    changes.map(change => {
-      change = typeof change === 'string' ? { packageName: change } : change;
-      return {
-        ...getChange(change.packageName, undefined, 'minor'),
-        ...change,
-      };
-    }),
-    options
-  );
+  writeChangeFiles(generateChanges(changes), options);
 }
 
 /** Get full paths to existing change files under `cwd` */

--- a/src/__fixtures__/object.ts
+++ b/src/__fixtures__/object.ts
@@ -8,6 +8,8 @@ export function deepFreeze<T>(obj: T): Readonly<T> {
 }
 
 export function deepFreezeProperties<T>(obj: T): T {
+  if (!obj || typeof obj !== 'object') return obj;
+
   Object.getOwnPropertyNames(obj).forEach(prop => {
     // eslint-disable-next-line
     const value = (obj as any)[prop];

--- a/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/src/__functional__/changefile/readChangeFiles.test.ts
@@ -134,7 +134,7 @@ describe('readChangeFiles', () => {
     const changeSet = readChangeFiles(options, packageInfos, scopedPackages);
     expect(getPackages(changeSet)).toEqual(['foo']);
 
-    expect(logs.getMockLines('warn', { root: tempRoot, guids: true, sort: true })).toMatchInlineSnapshot(`
+    expect(logs.getMockLines('warn', { root: tempRoot, sanitize: true, sort: true })).toMatchInlineSnapshot(`
       "<root>/change/not-change.json does not appear to be a change file
       Change detected for nonexistent package fake; delete this file: <root>/change/fake-<guid>.json
       Change detected for private package bar; delete this file: <root>/change/bar-<guid>.json"
@@ -154,7 +154,7 @@ describe('readChangeFiles', () => {
     const changeSet = readChangeFiles(options, packageInfos, scopedPackages);
     expect(getPackages(changeSet)).toEqual(['foo']);
 
-    expect(logs.getMockLines('warn', { root: tempRoot, guids: true, sort: true })).toMatchInlineSnapshot(`
+    expect(logs.getMockLines('warn', { root: tempRoot, sanitize: true, sort: true })).toMatchInlineSnapshot(`
       "Change detected for nonexistent package fake; remove the entry from this file: <root>/change/change-<guid>.json
       Change detected for private package bar; remove the entry from this file: <root>/change/change-<guid>.json"
     `);

--- a/src/__functional__/changefile/unlinkChangeFiles.test.ts
+++ b/src/__functional__/changefile/unlinkChangeFiles.test.ts
@@ -11,6 +11,8 @@ import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
 import { getChange } from '../../__fixtures__/changeFiles';
 import { writeJson } from '../../object/writeJson';
 
+// These tests could be done with filesystem method mocks, but it's pretty complicated,
+// and testing with the filesystem is fast since it doesn't use git.
 describe('unlinkChangeFiles', () => {
   const logs = initMockLogs();
   let root = '';
@@ -156,5 +158,22 @@ describe('unlinkChangeFiles', () => {
       Removing empty change folder"
     `);
     expect(fs.existsSync(changePath)).toBe(false);
+  });
+
+  it('leaves extra files not in the changeSet', () => {
+    const { changeSet, options, changePath } = makeFixture({
+      changeFileNames: ['change1.json', 'extra.json'],
+      inChangeSet: ['change1.json'],
+    });
+
+    unlinkChangeFiles(changeSet, options);
+
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+      "Removing change files:
+      - change1.json"
+    `);
+    expect(fs.existsSync(changePath)).toBe(true);
+    const remainingFiles = fs.readdirSync(changePath);
+    expect(remainingFiles).toEqual(['extra.json']);
   });
 });

--- a/src/__tests__/bump/bumpInMemory.test.ts
+++ b/src/__tests__/bump/bumpInMemory.test.ts
@@ -1,0 +1,444 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import path from 'path';
+import { generateChanges, type PartialChangeFile } from '../../__fixtures__/changeFiles';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { mockProcessExit } from '../../__fixtures__/mockProcessExit';
+import { makePackageInfosByFolder, type PartialPackageInfo } from '../../__fixtures__/packageInfos';
+import { bumpInMemory } from '../../bump/bumpInMemory';
+import { getParsedOptions } from '../../options/getOptions';
+import type { RepoOptions } from '../../types/BeachballOptions';
+import type { ChangeSet } from '../../types/ChangeInfo';
+import { getScopedPackages } from '../../monorepo/getScopedPackages';
+import { getPackageGroups } from '../../monorepo/getPackageGroups';
+
+describe('bumpInMemory', () => {
+  const logs = initMockLogs();
+  const cwd = path.resolve('/fake-root');
+
+  function gatherBumpInfoWrapper(params: {
+    packageFolders: { [folder: string]: PartialPackageInfo };
+    repoOptions?: Partial<RepoOptions>;
+    changes: (string | PartialChangeFile)[];
+  }) {
+    const { cliOptions, repoOptions, options } = getParsedOptions({
+      cwd,
+      argv: [],
+      testRepoOptions: params.repoOptions,
+    });
+    const originalPackageInfos = makePackageInfosByFolder({
+      packages: params.packageFolders,
+      cwd,
+      repoOptions,
+      cliOptions,
+    });
+    const changeSet: ChangeSet = generateChanges(params.changes).map((change, i) => ({
+      change,
+      changeFile: `change${i}.json`,
+    }));
+    const scopedPackages = getScopedPackages(options, originalPackageInfos);
+    const packageGroups = getPackageGroups(originalPackageInfos, cwd, options.groups);
+
+    const bumpInfo = bumpInMemory(options, { originalPackageInfos, changeSet, scopedPackages, packageGroups });
+
+    return { bumpInfo, options, originalPackageInfos };
+  }
+
+  beforeAll(() => {
+    // getPackageGroups currently can call process.exit
+    mockProcessExit(logs);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('bumps only packages with change files with bumpDeps: false', () => {
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.0' },
+        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
+        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
+        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
+        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
+      },
+      repoOptions: { bumpDeps: false },
+      changes: [{ packageName: 'pkg-1', type: 'minor' }],
+    });
+    const { packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    // Only pkg-1 actually gets bumped
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'minor' });
+    // But currently, pkg-2 ends up in the modified list and dependentChangedBy via setDependentVersions.
+    // It's debatable whether this is correct: https://github.com/microsoft/beachball/issues/620#issuecomment-3609264966
+    expect(modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2']));
+    expect(dependentChangedBy).toEqual({ 'pkg-2': new Set(['pkg-1']) });
+
+    const pkg1NewVersion = '1.1.0';
+    expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
+    expect(packageInfos['pkg-2'].version).toBe(originalPackageInfos['pkg-2'].version);
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
+
+    // these have no direct dep on pkg-1, so are unaffected
+    expect(packageInfos['pkg-3']).toEqual(originalPackageInfos['pkg-3']);
+    expect(packageInfos['pkg-4']).toEqual(originalPackageInfos['pkg-4']);
+    expect(packageInfos['pkg-5']).toEqual(originalPackageInfos['pkg-5']);
+  });
+
+  it('bumps all dependent packages with bumpDeps: true', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.0' },
+        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
+        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
+        'pkg-4': { version: '1.0.0', peerDependencies: { 'pkg-3': '1.0.0' } },
+        'pkg-5': { version: '1.0.0', optionalDependencies: { 'pkg-4': '1.0.0' } },
+      },
+      repoOptions: { bumpDeps: true },
+      changes: [{ packageName: 'pkg-1', type: 'minor' }],
+    });
+    const { packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    expect(modifiedPackages).toEqual(new Set(Object.keys(packageInfos)));
+    expect(calculatedChangeTypes).toEqual({
+      'pkg-1': 'minor',
+      'pkg-2': 'patch',
+      'pkg-3': 'patch',
+      'pkg-4': 'patch',
+      'pkg-5': 'patch',
+    });
+    expect(dependentChangedBy).toEqual({
+      'pkg-2': new Set(['pkg-1']),
+      'pkg-3': new Set(['pkg-2']),
+      'pkg-4': new Set(['pkg-3']),
+      'pkg-5': new Set(['pkg-4']),
+    });
+
+    const pkg1NewVersion = '1.1.0';
+    const dependentNewVersion = '1.0.1';
+    expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
+    expect(packageInfos['pkg-2'].version).toBe(dependentNewVersion);
+    expect(packageInfos['pkg-3'].version).toBe(dependentNewVersion);
+    expect(packageInfos['pkg-4'].version).toBe(dependentNewVersion);
+    expect(packageInfos['pkg-5'].version).toBe(dependentNewVersion);
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(dependentNewVersion);
+    expect(packageInfos['pkg-4'].peerDependencies!['pkg-3']).toBe(dependentNewVersion);
+    expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(dependentNewVersion);
+  });
+
+  it('bumps all grouped packages', () => {
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'packages/pkg-1': { version: '1.0.0' },
+        'packages/pkg-2': { version: '1.0.0' },
+        'packages/pkg-3': { version: '1.0.0' },
+        unrelated: { version: '1.0.0' },
+      },
+      changes: [{ packageName: 'pkg-1', type: 'minor' }],
+      repoOptions: {
+        bumpDeps: true,
+        groups: [{ include: 'packages/*', name: 'testgroup', disallowedChangeTypes: [] }],
+      },
+    });
+    const { packageGroups, packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    expect(packageGroups).toEqual({
+      testgroup: { packageNames: ['pkg-1', 'pkg-2', 'pkg-3'], disallowedChangeTypes: [] },
+    });
+    expect(modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2', 'pkg-3']));
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'minor', 'pkg-2': 'minor', 'pkg-3': 'minor' });
+    // Not sure if this is correct?
+    expect(dependentChangedBy).toEqual({});
+
+    const newVersion = '1.1.0';
+    expect(packageInfos['pkg-1'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].version).toBe(newVersion);
+    expect(packageInfos['pkg-3'].version).toBe(newVersion);
+    expect(packageInfos['unrelated'].version).toBe(originalPackageInfos['unrelated'].version);
+  });
+
+  it('bumps all grouped packages to the greatest change type in the group, regardless of change file order', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'packages/commonlib': { name: 'commonlib' },
+        'packages/pkg-1': { version: '1.0.0', dependencies: { commonlib: '1.0.0' } },
+      },
+      changes: [
+        { packageName: 'pkg-1', type: 'minor', dependentChangeType: 'minor' },
+        // Process commonlib's change file after pkg-1's. This ensures we set the group's version
+        // based on the max change type, not the last one processed (previous bug).
+        { packageName: 'commonlib', type: 'none', dependentChangeType: 'none' },
+      ],
+      repoOptions: {
+        groups: [{ include: 'packages/*', name: 'grp', disallowedChangeTypes: null }],
+        bumpDeps: true,
+      },
+    });
+    const { packageInfos } = bumpInfo;
+
+    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
+    expect(packageInfos['commonlib'].version).toBe('1.1.0');
+  });
+
+  it('bumps all grouped AND dependent packages', () => {
+    // This is covered E2E in bump.test.ts too
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'packages/app': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
+        'packages/commonlib': { version: '1.0.0' },
+        'packages/unrelated': { version: '1.0.0' },
+        'packages/grp/pkg-1': { version: '1.0.0' },
+        'packages/grp/pkg-2': { version: '1.0.0' },
+        'packages/grp/pkg-3': { version: '1.0.0', dependencies: { commonlib: '1.0.0' } },
+      },
+      repoOptions: {
+        groups: [{ include: 'packages/grp/*', name: 'grp', disallowedChangeTypes: [] }],
+        bumpDeps: true,
+      },
+      // Bump commonlib, which is not in the group, but triggers a dependent bump of pkg-3,
+      // which triggers bump of the whole group and then the app.
+      // Also verify the non-default dependentChangeType passes through.
+      changes: [{ packageName: 'commonlib', type: 'major', dependentChangeType: 'minor' }],
+    });
+    const { packageGroups, packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    expect(packageGroups).toEqual({
+      grp: { packageNames: ['pkg-1', 'pkg-2', 'pkg-3'], disallowedChangeTypes: [] },
+    });
+    expect(modifiedPackages).toEqual(new Set(['commonlib', 'pkg-1', 'pkg-2', 'pkg-3', 'app']));
+    expect(calculatedChangeTypes).toEqual({
+      commonlib: 'major',
+      'pkg-1': 'minor',
+      'pkg-2': 'minor',
+      'pkg-3': 'minor',
+      app: 'minor',
+    });
+    expect(dependentChangedBy).toEqual({
+      'pkg-3': new Set(['commonlib']),
+      app: new Set(['pkg-1']),
+    });
+
+    const groupNewVersion = '1.1.0';
+    expect(packageInfos['pkg-1'].version).toBe(groupNewVersion);
+    expect(packageInfos['pkg-2'].version).toBe(groupNewVersion);
+    expect(packageInfos['pkg-3'].version).toBe(groupNewVersion);
+    expect(packageInfos['commonlib'].version).toBe('2.0.0');
+    expect(packageInfos['app'].version).toBe('1.1.0');
+    expect(packageInfos['unrelated'].version).toBe(originalPackageInfos['unrelated'].version);
+  });
+
+  // Scope filtering of original changes happens in the readChangeFiles step (so must be tested E2E),
+  // but scope filtering of *dependents* happens in the bump step.
+  it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', () => {
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'packages/foo': { name: 'foo', version: '1.0.0', dependencies: { bar: '^1.3.4' } },
+        'packages/bar': { name: 'bar', version: '1.3.4', dependencies: { baz: '^1.3.4' } },
+        'packages/baz': { name: 'baz', version: '1.3.4' },
+        'packages/grouped/a': { name: 'a', version: '3.1.2' },
+        'packages/grouped/b': { name: 'b', version: '3.1.2' },
+      },
+      repoOptions: {
+        bumpDeps: true,
+        scope: ['!packages/foo'],
+      },
+      changes: [{ packageName: 'bar', type: 'patch' }],
+    });
+    const { scopedPackages, packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    expect(scopedPackages).toEqual(new Set(['a', 'b', 'bar', 'baz']));
+    expect(modifiedPackages).toEqual(new Set(['bar']));
+    expect(calculatedChangeTypes).toEqual({ bar: 'patch' });
+    expect(dependentChangedBy).toEqual({});
+
+    expect(packageInfos['foo']).toEqual(originalPackageInfos['foo']);
+    expect(packageInfos['bar'].version).toBe('1.3.5');
+    // Since foo is out of scope, currently its dep on bar is not bumped.
+    // This is usually fine, but could be an issue if bar is bumped to an incompatible version.
+    // Somewhat related: https://github.com/microsoft/beachball/issues/620#issuecomment-3609264966
+    expect(packageInfos['foo'].dependencies!['bar']).toBe('^1.3.4');
+  });
+
+  it('bumps dependents with file: deps', () => {
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.0' },
+        'pkg-2': { version: '0.0.0', dependencies: { 'pkg-1': 'file:../pkg-1' } },
+        'pkg-3': { version: '0.0.0', devDependencies: { 'pkg-2': 'file:../pkg-2' } },
+      },
+      repoOptions: { bumpDeps: true },
+      changes: [{ packageName: 'pkg-1', type: 'minor' }],
+    });
+
+    const { packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+    expect(modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2', 'pkg-3']));
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'minor', 'pkg-2': 'patch', 'pkg-3': 'patch' });
+    // Current behavior: dependentChangedBy misses file: deps, so the packages won't be in the changelog.
+    // https://github.com/microsoft/beachball/issues/981
+    expect(dependentChangedBy).toEqual({});
+
+    // All the packages are bumped despite the file: dep specs.
+    // The dep specs are not modified, but the dependent versions are bumped.
+    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
+    expect(packageInfos['pkg-2']).toEqual({ ...originalPackageInfos['pkg-2'], version: '0.0.1' });
+    expect(packageInfos['pkg-3']).toEqual({ ...originalPackageInfos['pkg-3'], version: '0.0.1' });
+  });
+
+  it('bumps dependents with workspace: deps', () => {
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.0' },
+        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': 'workspace:~' } },
+        // this workspace version will be updated
+        'pkg-3': { version: '1.0.0', dependencies: { 'pkg-2': 'workspace:^1.0.0' } },
+      },
+      repoOptions: { bumpDeps: true },
+      changes: ['pkg-1'],
+    });
+
+    const { packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+    expect(modifiedPackages).toEqual(new Set(['pkg-1', 'pkg-2', 'pkg-3']));
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'minor', 'pkg-2': 'patch', 'pkg-3': 'patch' });
+    expect(dependentChangedBy).toEqual({
+      'pkg-3': new Set(['pkg-2']),
+      // Current behavior: dependentChangedBy misses deps like workspace:~ that don't change,
+      // so the bump of pkg-1 will be missing from pkg-2's changelog.
+      // https://github.com/microsoft/beachball/issues/981
+      // 'pkg-2': new Set(['pkg-1']),
+    });
+
+    // All the dependent packages are bumped despite the workspace: dep specs
+    expect(packageInfos['pkg-1'].version).toBe('1.1.0');
+    // workspace:~ range isn't changed
+    expect(packageInfos['pkg-2']).toEqual({ ...originalPackageInfos['pkg-2'], version: '1.0.1' });
+    expect(packageInfos['pkg-2'].version).toBe('1.0.1');
+    // workspace: range with number is updated
+    expect(packageInfos['pkg-3'].dependencies).toEqual({ 'pkg-2': 'workspace:^1.0.1' });
+  });
+
+  it('bumps to prerelease using prefix, and uses prerelease version for dependents', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': {},
+        'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
+        'pkg-3': { peerDependencies: { 'pkg-2': '1.0.0' } },
+      },
+      repoOptions: {
+        bumpDeps: true,
+        prereleasePrefix: 'beta',
+      },
+      changes: [{ packageName: 'pkg-1', type: 'prerelease' }],
+    });
+
+    const { packageInfos, calculatedChangeTypes } = bumpInfo;
+    // dependents are calculated as patch but later changed to prerelease
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'prerelease', 'pkg-2': 'patch', 'pkg-3': 'patch' });
+
+    const newVersion = '1.0.1-beta.0';
+    expect(packageInfos['pkg-1'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].version).toBe(newVersion);
+    expect(packageInfos['pkg-3'].version).toBe(newVersion);
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
+    expect(packageInfos['pkg-3'].peerDependencies!['pkg-2']).toBe(newVersion);
+  });
+
+  it('bumps to prerelease and uses the specified identifier base', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': {},
+        'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
+      },
+      repoOptions: {
+        bumpDeps: true,
+        prereleasePrefix: 'beta',
+        identifierBase: '1',
+      },
+      changes: [{ packageName: 'pkg-1', type: 'prerelease' }],
+    });
+
+    const { packageInfos, calculatedChangeTypes } = bumpInfo;
+    // dependents are calculated as patch but later changed to prerelease
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'prerelease', 'pkg-2': 'patch' });
+
+    const newVersion = '1.0.1-beta.1';
+    expect(packageInfos['pkg-1'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
+  });
+
+  it('bumps to prerelease with no identifier base', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': {},
+        'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
+      },
+      repoOptions: {
+        bumpDeps: true,
+        prereleasePrefix: 'beta',
+        identifierBase: false,
+      },
+      changes: [{ packageName: 'pkg-1', type: 'prerelease' }],
+    });
+
+    const { packageInfos, calculatedChangeTypes } = bumpInfo;
+    // dependents are calculated as patch but later changed to prerelease
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'prerelease', 'pkg-2': 'patch' });
+
+    const newVersion = '1.0.1-beta';
+    expect(packageInfos['pkg-1'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].version).toBe(newVersion);
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
+  });
+
+  it('bumps all packages and increments prefixed versions in dependents', () => {
+    const { bumpInfo } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.1-beta.0' },
+        'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
+        'pkg-3': { version: '1.0.0', devDependencies: { 'pkg-2': '1.0.0' } },
+      },
+      repoOptions: {
+        bumpDeps: true,
+        prereleasePrefix: 'beta',
+      },
+      changes: [{ packageName: 'pkg-1', type: 'prerelease', dependentChangeType: 'prerelease' }],
+    });
+    const { packageInfos, calculatedChangeTypes } = bumpInfo;
+
+    expect(calculatedChangeTypes).toEqual({ 'pkg-1': 'prerelease', 'pkg-2': 'prerelease', 'pkg-3': 'prerelease' });
+
+    const pkg1NewVersion = '1.0.1-beta.1';
+    const othersNewVersion = '1.0.1-beta.0';
+    expect(packageInfos['pkg-1'].version).toBe(pkg1NewVersion);
+    expect(packageInfos['pkg-2'].version).toBe(othersNewVersion);
+    expect(packageInfos['pkg-3'].version).toBe(othersNewVersion);
+
+    expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(pkg1NewVersion);
+    expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(othersNewVersion);
+  });
+
+  it('does not modify dependency ranges of packages that are not bumped', () => {
+    // This was probably the scenario from https://github.com/microsoft/beachball/issues/1033
+    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+      packageFolders: {
+        'pkg-1': { version: '1.0.0' },
+        // pkg-2 was bumped to 1.2.3 at some point (with a manual or scoped bump)
+        'pkg-2': { version: '1.2.3', dependencies: { 'pkg-1': '^1.0.0' } },
+        // but pkg-3's range of pkg-2 was not updated (though it's still satisfied)
+        'pkg-3': { version: '1.0.0', dependencies: { 'pkg-2': '^1.0.0' } },
+      },
+      repoOptions: { bumpDeps: true },
+      changes: ['pkg-3'],
+    });
+    const { packageInfos, modifiedPackages, calculatedChangeTypes, dependentChangedBy } = bumpInfo;
+
+    expect(modifiedPackages).toEqual(new Set(['pkg-3']));
+    expect(calculatedChangeTypes).toEqual({ 'pkg-3': 'minor' });
+    expect(dependentChangedBy).toEqual({});
+
+    // pkg-3's deps weren't modified because pkg-2 wasn't bumped
+    expect(packageInfos['pkg-3'].dependencies).toEqual(originalPackageInfos['pkg-3'].dependencies);
+  });
+});

--- a/src/__tests__/bump/callHook.test.ts
+++ b/src/__tests__/bump/callHook.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { callHook } from '../../bump/callHook';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import type { HooksOptions } from '../../types/BeachballOptions';
+import path from 'path';
+
+type AnyHook = NonNullable<HooksOptions['postbump']>;
+
+const root = path.resolve('/fake/root');
+
+describe('callHook', () => {
+  const packageInfos = makePackageInfos(
+    {
+      // This graph only has one possible ordering
+      pkg1: { dependencies: { pkg2: '*' } },
+      pkg2: { version: '2.0.0', peerDependencies: { pkg3: '*', pkg4: '*' } },
+      pkg3: { devDependencies: { pkg4: '*' } },
+      pkg4: { optionalDependencies: { pkg5: '*' } },
+      pkg5: {},
+    },
+    undefined,
+    { path: root }
+  );
+
+  /** Get hook calls without the final `packageInfos` param for simpler diffs */
+  function getHookCalls(hook: jest.Mock<AnyHook>) {
+    return hook.mock.calls.map(call => call.slice(0, 3));
+  }
+
+  /** Get package names from the list of hook calls */
+  function getHookCallNames(hook: jest.Mock<AnyHook>) {
+    return hook.mock.calls.map(call => call[1]);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does nothing if hook is undefined', async () => {
+    await callHook(undefined, ['pkg1'], packageInfos, 1);
+  });
+
+  it('does nothing if no affected packages', async () => {
+    const mockHook = jest.fn<AnyHook>();
+    await callHook(mockHook, [], packageInfos, 1);
+    expect(mockHook).not.toHaveBeenCalled();
+  });
+
+  // Currently there's no topological ordering for non-concurrent hooks
+  // (might make sense to either add here or remove for concurrent hooks)
+  it('calls hook for each affected package in order with concurrency=1', async () => {
+    const mockHook = jest.fn<AnyHook>();
+
+    await callHook(mockHook, ['pkg3', 'pkg2', 'pkg5'], packageInfos, 1);
+
+    // Verify the exact args of one call
+    expect(mockHook).toHaveBeenCalledWith(path.join(root, 'packages/pkg2'), 'pkg2', '2.0.0', packageInfos);
+
+    // Most of the tests omit the very large final packageInfos arg for better diffs on error
+    expect(getHookCalls(mockHook)).toEqual([
+      [expect.stringMatching(/pkg3$/), 'pkg3', '1.0.0'],
+      [expect.stringMatching(/pkg2$/), 'pkg2', '2.0.0'],
+      [expect.stringMatching(/pkg5$/), 'pkg5', '1.0.0'],
+    ]);
+  });
+
+  it('works with set of affected packages', async () => {
+    const mockHook = jest.fn<AnyHook>();
+
+    await callHook(mockHook, new Set(['pkg3', 'pkg2']), packageInfos, 1);
+
+    expect(getHookCallNames(mockHook)).toEqual(['pkg3', 'pkg2']);
+  });
+
+  // really should have been validated already
+  it('ignores nonexistent package with concurrency=1', async () => {
+    const mockHook = jest.fn<AnyHook>();
+
+    await callHook(mockHook, ['pkg1', 'nonexistent', 'pkg4'], packageInfos, 1);
+    expect(mockHook).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls hook sequentially when concurrency=1', async () => {
+    const callOrder: string[] = [];
+    const mockHook = jest.fn<AnyHook>(async (_, name) => {
+      callOrder.push(`start-${name}`);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      callOrder.push(`end-${name}`);
+    });
+
+    await callHook(mockHook, ['pkg1', 'pkg2'], packageInfos, 1);
+
+    // With concurrency=1, should be fully sequential
+    expect(callOrder).toEqual(['start-pkg1', 'end-pkg1', 'start-pkg2', 'end-pkg2']);
+  });
+
+  // sync/async shouldn't be any different here
+  it('propagates sync hook errors with concurrency=1', async () => {
+    const mockHook = jest.fn<AnyHook>((_, name) => {
+      if (name === 'pkg2') throw new Error('oh no');
+    });
+
+    await expect(() => callHook(mockHook, ['pkg1', 'pkg2', 'pkg3'], packageInfos, 1)).rejects.toThrow('oh no');
+    // failed on second call, does not continue
+    expect(mockHook).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates async hook errors with concurrency=1', async () => {
+    const mockHook = jest.fn<AnyHook>(async (_, name) => {
+      if (name === 'pkg2') {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        throw new Error('async oh no');
+      }
+    });
+
+    await expect(() => callHook(mockHook, ['pkg1', 'pkg2', 'pkg3'], packageInfos, 1)).rejects.toThrow('async oh no');
+    expect(mockHook).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls hook with concurrency > 1 in topological order', async () => {
+    const mockHook = jest.fn<AnyHook>();
+
+    await callHook(mockHook, ['pkg1', 'pkg5', 'pkg4', 'pkg2', 'pkg3'], packageInfos, 2);
+
+    expect(getHookCallNames(mockHook)).toEqual(['pkg5', 'pkg4', 'pkg3', 'pkg2', 'pkg1']);
+  });
+
+  it('ignores nonexistent packages with concurrency > 1', async () => {
+    const mockHook = jest.fn<AnyHook>();
+
+    await callHook(mockHook, ['pkg1', 'nonexistent', 'pkg2'], packageInfos, 3);
+
+    expect(getHookCallNames(mockHook)).toEqual(['pkg2', 'pkg1']);
+  });
+
+  it('calls hook for each affected package in order and respecting max concurrency', async () => {
+    const callOrder: string[] = [];
+    let currentConcurrency = 0;
+    let maxConcurrency = 0;
+    const mockHook = jest.fn<AnyHook>(async (_, name) => {
+      callOrder.push(`start-${name}`);
+      currentConcurrency++;
+      maxConcurrency = Math.max(maxConcurrency, currentConcurrency);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      currentConcurrency--;
+      callOrder.push(`end-${name}`);
+    });
+
+    await callHook(mockHook, ['pkg1', 'pkg2', 'pkg3', 'pkg4', 'pkg5'], packageInfos, 3);
+
+    expect(maxConcurrency).toBeLessThanOrEqual(3);
+
+    // Verify that dependencies are still respected in the call order
+    const pkg3Start = callOrder.indexOf('start-pkg3');
+    const pkg2Start = callOrder.indexOf('start-pkg2');
+    const pkg1Start = callOrder.indexOf('start-pkg1');
+    expect(pkg3Start).toBeLessThan(pkg2Start);
+    expect(pkg2Start).toBeLessThan(pkg1Start);
+  });
+
+  // this shouldn't be any different sync/async, but just in case...
+  it('propagates sync hook errors with concurrency > 1', async () => {
+    const mockHook = jest.fn<AnyHook>((_, name) => {
+      if (name === 'pkg2') {
+        throw new Error('oh no');
+      }
+    });
+
+    // this will be in topological order so pkg2 is the third call
+    await expect(() => callHook(mockHook, ['pkg1', 'pkg2', 'pkg3', 'pkg4'], packageInfos, 2)).rejects.toThrow('oh no');
+    // stops as soon as error is encountered
+    expect(mockHook).toHaveBeenCalledTimes(3);
+  });
+
+  it('propagates async hook errors with concurrency > 1', async () => {
+    const mockHook = jest.fn<AnyHook>(async (_, name) => {
+      if (name === 'pkg2') {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        throw new Error('oh no');
+      }
+    });
+
+    // this will be in topological order so pkg2 is the third call
+    await expect(() => callHook(mockHook, ['pkg1', 'pkg2', 'pkg3', 'pkg4'], packageInfos, 2)).rejects.toThrow('oh no');
+    // stops as soon as error is encountered
+    expect(mockHook).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/__tests__/bump/performBump.test.ts
+++ b/src/__tests__/bump/performBump.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, jest, afterEach, beforeAll } from '@jest/globals';
+import _fs from 'fs';
+import path from 'path';
+import type { RepoOptions } from '../../types/BeachballOptions';
+import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
+import type { BumpInfo } from '../../types/BumpInfo';
+import { getParsedOptions } from '../../options/getOptions';
+import { performBump } from '../../bump/performBump';
+import { ChangeSet, type ChangeFileInfo } from '../../types/ChangeInfo';
+import { consideredDependencies, type PackageInfos, type PackageJson } from '../../types/PackageInfo';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { updateLockFile as _updateLockFile } from '../../bump/updateLockFile';
+import { writeJson as _writeJson, writeJson } from '../../object/writeJson';
+import { writeChangelog as mockWriteChangelog } from '../../changelog/writeChangelog';
+
+jest.mock('fs');
+jest.mock('../../object/writeJson');
+// These tests don't cover writeChangelog
+jest.mock('../../changelog/writeChangelog');
+// Mock updateLockFile to verify it's called
+jest.mock('../../bump/updateLockFile');
+
+const mockFs = _fs as jest.Mocked<typeof _fs>;
+const mockWriteJson = _writeJson as jest.MockedFunction<typeof _writeJson>;
+const mockUpdateLockFile = _updateLockFile as jest.MockedFunction<typeof _updateLockFile>;
+
+type PrebumpHook = NonNullable<NonNullable<RepoOptions['hooks']>['prebump']>;
+type PostbumpHook = NonNullable<NonNullable<RepoOptions['hooks']>['postbump']>;
+
+//
+// Test basic in-memory scenarios for performBump.
+// These tests DO NOT cover changelog generation! (use writeChangelog.test.ts, or bump.test.ts for E2E)
+//
+describe('performBump', () => {
+  initMockLogs();
+
+  /** Fake root path in OS format */
+  const fakeRoot = path.resolve('/fake/root');
+
+  /** Package infos for current test */
+  let packageInfos: PackageInfos | undefined;
+
+  /** Get the package.json from `packageInfos` for the given package name */
+  function packageJsonFor(pkgName: string) {
+    const pkg = packageInfos?.[pkgName];
+    if (!pkg) {
+      throw new Error(`No package info for ${pkgName}`);
+    }
+    // remove beachball keys and undefined values
+    const includedKeys: (keyof PackageJson)[] = ['name', 'version', 'private', ...consideredDependencies];
+    return Object.fromEntries(
+      Object.entries(pkg).filter(
+        ([key, value]) => includedKeys.includes(key as keyof PackageJson) && value !== undefined
+      )
+    );
+  }
+
+  /**
+   * Call `performBump` with minimal mock params (omitting thing only needed for `writeChangelog`).
+   * Also populate the shared `packageInfos` used to mock `fs.readFileSync`.
+   *
+   * `modifiedPackages` defaults to all packages in `packageInfos`.
+   */
+  function performBumpWrapper(params: {
+    packageInfos: PartialPackageInfos;
+    modifiedPackages?: BumpInfo['modifiedPackages'];
+    /** Names to generate empty `changeFileChangeInfos` */
+    changeFileNames?: string[];
+    repoOptions?: Partial<RepoOptions>;
+  }) {
+    const opts = getParsedOptions({
+      cwd: fakeRoot,
+      argv: [],
+      testRepoOptions: { branch: defaultRemoteBranchName, ...params.repoOptions },
+    });
+
+    packageInfos = makePackageInfos(params.packageInfos, opts.repoOptions, opts.cliOptions);
+
+    return performBump(
+      {
+        // performBump only directly uses packageInfos, modifiedPackages, and names from changeFileChangeInfos.
+        packageInfos,
+        modifiedPackages: params.modifiedPackages || new Set(Object.keys(packageInfos)),
+        changeFileChangeInfos: (params.changeFileNames || []).map<ChangeSet[number]>(name => ({
+          changeFile: name,
+          change: {} as ChangeFileInfo,
+        })),
+        calculatedChangeTypes: {},
+        dependentChangedBy: {},
+        packageGroups: {},
+        scopedPackages: new Set(),
+      },
+      opts.options
+    );
+  }
+
+  /** Get hook calls without the final `packageInfos` param for simpler diffs */
+  function getHookCalls(hook: jest.Mock<PostbumpHook>) {
+    return hook.mock.calls.map(call => call.slice(0, 3));
+  }
+
+  beforeAll(() => {
+    // Only say package.json files exist
+    mockFs.existsSync.mockImplementation(filePath => String(filePath).endsWith('package.json'));
+
+    // Mock readFileSync to return package.json based on packageInfos
+    mockFs.readFileSync.mockImplementation((filePath => {
+      filePath = String(filePath);
+      if (!filePath.endsWith('package.json')) {
+        throw new Error(`readFileSync not mocked for ${filePath}`);
+      }
+      const packageJson = packageJsonFor(path.basename(path.dirname(filePath)));
+      return JSON.stringify(packageJson);
+    }) as typeof _fs.readFileSync);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    packageInfos = undefined;
+  });
+
+  it('updates package.json files for modified packages only', async () => {
+    await performBumpWrapper({
+      packageInfos: { pkg1: { version: '1.0.0' }, pkg2: { version: '2.0.0' }, pkg3: { version: '3.0.0' } },
+      modifiedPackages: new Set(['pkg2', 'pkg3']),
+    });
+
+    const mockCalls = mockWriteJson.mock.calls.filter(call => call[0].endsWith('package.json'));
+    expect(mockCalls).toEqual([
+      [packageInfos!.pkg2.packageJsonPath, packageJsonFor('pkg2')],
+      [packageInfos!.pkg3.packageJsonPath, packageJsonFor('pkg3')],
+    ]);
+
+    // other expected mocks
+    expect(mockWriteChangelog).toHaveBeenCalled();
+    expect(mockUpdateLockFile).toHaveBeenCalled();
+  });
+
+  it('respects generateChangelog: false', async () => {
+    await performBumpWrapper({
+      packageInfos: { pkg1: { version: '1.0.0' } },
+      repoOptions: { generateChangelog: false },
+    });
+
+    expect(mockWriteChangelog).not.toHaveBeenCalled();
+    expect(writeJson).toHaveBeenCalled(); // the package was updated
+  });
+
+  it('updates lock file after package.jsons', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await -- match signature
+    mockUpdateLockFile.mockImplementationOnce(async () => {
+      // verify package.json was updated first
+      expect(mockWriteJson).toHaveBeenCalledWith(expect.stringMatching(/package.json$/), expect.anything());
+    });
+
+    try {
+      await performBumpWrapper({ packageInfos: { pkg1: {} } });
+      expect(mockUpdateLockFile).toHaveBeenCalled();
+    } finally {
+      // Ensure the mock is cleaned up
+      mockUpdateLockFile.mockReset();
+    }
+  });
+
+  it('deletes change files after bump by default', async () => {
+    await performBumpWrapper({
+      packageInfos: { pkg1: {} },
+      changeFileNames: ['change1.json', 'change2.json'],
+    });
+    const changePath = path.join(fakeRoot, 'change');
+    expect(mockFs.rmSync).toHaveBeenCalledWith(path.join(changePath, 'change1.json'), expect.anything());
+    expect(mockFs.rmSync).toHaveBeenCalledWith(path.join(changePath, 'change2.json'), expect.anything());
+  });
+
+  it('keeps change files with keepChangeFiles option', async () => {
+    await performBumpWrapper({
+      packageInfos: { pkg1: {} },
+      changeFileNames: ['change1.json', 'change2.json'],
+      repoOptions: { keepChangeFiles: true },
+    });
+    expect(mockFs.rmSync).not.toHaveBeenCalled();
+  });
+
+  // Currently prebump is using the wrong version, so the test/mocks might need updating
+  // https://github.com/microsoft/beachball/issues/1116
+  it('calls prebump hook for each package before writing', async () => {
+    const hook = jest.fn<PrebumpHook>(() => {
+      expect(mockWriteJson).not.toHaveBeenCalled();
+      expect(mockWriteChangelog).not.toHaveBeenCalled();
+      expect(mockUpdateLockFile).not.toHaveBeenCalled();
+    });
+
+    await performBumpWrapper({
+      packageInfos: { pkg1: { version: '1.0.0' }, pkg2: { version: '2.0.0' }, pkg3: { version: '1.0.0' } },
+      modifiedPackages: new Set(['pkg2', 'pkg3']),
+      changeFileNames: ['change1', 'change2'],
+      repoOptions: { hooks: { prebump: hook } },
+    });
+
+    // currently this is getting the extra packageInfos arg even though it's not in signature
+    expect(getHookCalls(hook)).toEqual([
+      [expect.stringMatching(/pkg2$/), 'pkg2', '2.0.0'],
+      [expect.stringMatching(/pkg3$/), 'pkg3', '1.0.0'],
+    ]);
+  });
+
+  it('calls postbump hook for each package after writing', async () => {
+    const hook = jest.fn<PostbumpHook>(() => {
+      expect(mockWriteChangelog).toHaveBeenCalled();
+      expect(mockUpdateLockFile).toHaveBeenCalled();
+      expect(mockWriteJson).toHaveBeenCalledWith(packageInfos!.pkg2.packageJsonPath, expect.anything());
+      expect(mockWriteJson).toHaveBeenCalledWith(packageInfos!.pkg3.packageJsonPath, expect.anything());
+    });
+
+    await performBumpWrapper({
+      packageInfos: { pkg1: { version: '1.0.0' }, pkg2: { version: '2.0.0' }, pkg3: { version: '1.0.0' } },
+      modifiedPackages: new Set(['pkg2', 'pkg3']),
+      changeFileNames: ['change1', 'change2'],
+      repoOptions: { hooks: { postbump: hook } },
+    });
+
+    expect(getHookCalls(hook)).toEqual([
+      [expect.stringMatching(/pkg2$/), 'pkg2', '2.0.0'],
+      [expect.stringMatching(/pkg3$/), 'pkg3', '1.0.0'],
+    ]);
+  });
+
+  // Scenarios (including exceptions) with concurrency are covered in callHook.
+  // performBump just has to pass the required `concurrency` param through.
+  it.each(['prebump', 'postbump'] as const)('propagates %s hook exceptions', async hookName => {
+    const repoOptions: Partial<RepoOptions> = {
+      hooks: {
+        [hookName]: () => Promise.reject(new Error('oh no')),
+      },
+    };
+
+    await expect(() => performBumpWrapper({ packageInfos: { pkg1: {} }, repoOptions })).rejects.toThrow('oh no');
+  });
+});

--- a/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -9,7 +9,7 @@ describe('getPackageGraph', () => {
    * @returns all package names in the package graph
    */
   async function getPackageGraphPackageNames(
-    affectedPackages: Iterable<string>,
+    affectedPackages: string[],
     packageInfos: PackageInfos,
     runHook?: (packageInfo: PackageInfo) => Promise<void>
   ): Promise<string[]> {

--- a/src/bump/bumpInMemory.ts
+++ b/src/bump/bumpInMemory.ts
@@ -70,8 +70,10 @@ export function bumpInMemory(options: BeachballOptions, context: Omit<CommandCon
   }
 
   // step 5: Bump all the dependency version ranges and collect dependentChangedBy for the changelog.
-  // (also add any modifiedPackages not previously detected--this should only happen if bumpDeps was false)
   const dependentChangedBy = setDependentVersions(bumpInfo, options);
+  // For now, add any modifiedPackages not previously detected (due to bumpDeps: false or scopes).
+  // TODO: Rethink all of this... https://github.com/microsoft/beachball/issues/1123
+  Object.keys(dependentChangedBy).forEach(pkg => bumpInfo.modifiedPackages.add(pkg));
 
   return {
     ...bumpInfo,

--- a/src/bump/callHook.ts
+++ b/src/bump/callHook.ts
@@ -8,11 +8,17 @@ import { getPackageGraph } from '../monorepo/getPackageGraph';
  */
 export async function callHook(
   hook: HooksOptions['prebump' | 'postbump' | 'prepublish' | 'postpublish'],
-  affectedPackages: Iterable<string>,
+  affectedPackages: string[] | Set<string>,
   packageInfos: PackageInfos,
   concurrency: number
 ): Promise<void> {
   if (!hook) {
+    return;
+  }
+
+  // Filter out nonexistent packages in case of theoretical race conditions or something
+  affectedPackages = [...affectedPackages].filter(pkgName => pkgName in packageInfos);
+  if (!affectedPackages.length) {
     return;
   }
 

--- a/src/bump/performBump.ts
+++ b/src/bump/performBump.ts
@@ -16,6 +16,7 @@ import { updateLockFile } from './updateLockFile';
 export async function performBump(bumpInfo: Readonly<BumpInfo>, options: BeachballOptions): Promise<void> {
   const { modifiedPackages, packageInfos, changeFileChangeInfos } = bumpInfo;
 
+  // TODO: this uses the wrong version https://github.com/microsoft/beachball/issues/1116
   await callHook(options.hooks?.prebump, modifiedPackages, packageInfos, options.concurrency);
 
   updatePackageJsons(modifiedPackages, packageInfos);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -48,8 +48,11 @@ export async function sync(options: BeachballOptions, context?: SyncCommandConte
     }
   }
 
-  // Update modifiedPackages
-  setDependentVersions({ packageInfos, scopedPackages, modifiedPackages }, options);
+  // Update dependencies on the packages with updated versions
+  const dependentModifiedPackages = setDependentVersions({ packageInfos, scopedPackages, modifiedPackages }, options);
+  // Add the dependent modified packages to the list that needs to be updated on disk
+  // (this is a different purpose than other use of modifiedPackages)
+  Object.keys(dependentModifiedPackages).forEach(pkg => modifiedPackages.add(pkg));
 
   updatePackageJsons(modifiedPackages, packageInfos);
   await updateLockFile(options);

--- a/src/monorepo/getPackageGraph.ts
+++ b/src/monorepo/getPackageGraph.ts
@@ -6,7 +6,7 @@ import { getPackageDependencyGraph } from './getPackageDependencyGraph';
 type PGraph = ReturnType<typeof pGraph>;
 
 export function getPackageGraph(
-  affectedPackages: Iterable<string>,
+  affectedPackages: string[],
   packageInfos: PackageInfos,
   runHook: (packageInfo: PackageInfo) => Promise<void>
 ): PGraph {
@@ -17,10 +17,7 @@ export function getPackageGraph(
     });
   }
 
-  const dependencyGraph: [string | undefined, string][] = getPackageDependencyGraph(
-    Array.from(affectedPackages),
-    packageInfos
-  );
+  const dependencyGraph: [string | undefined, string][] = getPackageDependencyGraph(affectedPackages, packageInfos);
   const filteredDependencyGraph = filterDependencyGraph(dependencyGraph);
   return pGraph(nodeMap, filteredDependencyGraph);
 }

--- a/src/monorepo/getPackageInfos.ts
+++ b/src/monorepo/getPackageInfos.ts
@@ -18,7 +18,8 @@ import { readJson } from '../object/readJson';
  *
  * This looks for files relative to `parsedOptions.cliOptions.path` (the project root).
  * The options objects are needed so they can be properly merged with the package options
- * into `PackageInfo.combinedOptions`.
+ * into `PackageInfo.combinedOptions` without going back through the whole process of
+ * getting CLI and repo options.
  */
 export function getPackageInfos(parsedOptions: Pick<ParsedOptions, 'repoOptions' | 'cliOptions'>): PackageInfos;
 /** @deprecated Pass the pre-parsed options */

--- a/src/types/BumpInfo.ts
+++ b/src/types/BumpInfo.ts
@@ -30,10 +30,12 @@ export type BumpInfo = {
   packageGroups: DeepReadonly<PackageGroups>;
 
   /**
-   * Set of packages that had been modified.
+   * Set of packages that have been modified.
    *
-   * For the bump command, this is primarily populated by `bumpPackageInfoVersion` (which considers
-   * dependent bumps and groups). If `bumpDeps` is false, it might be updated by `setDependentVersions`.
+   * For bump/publish, this is primarily populated by `bumpInMemory -> bumpPackageInfoVersion`
+   * (which considers dependent bumps, groups, and scopes). Currently it's also updated with any
+   * new dependent packages from `bumpInMemory -> setDependentVersions` (if `bumpDeps: false` or
+   * certain other circumstances), but there are some [related issues](https://github.com/microsoft/beachball/issues/1123).
    */
   modifiedPackages: Set<string>;
 


### PR DESCRIPTION
Add a bunch more tests for bump and publish, including tests that work in-memory only where possible, and tests covering `workspace:` version bumps. Also convert some of the existing E2E tests into much faster in-memory tests where appropriate.

This is part of #1109, but there's a lot more to go. (All this started when trying to add catalog version support and discovering we don't even have coverage for workspace versions...)

A couple changes to the real code while working on adding tests:
- Update internal handling of adding dependents to `modifiedPackages` (partial revert of #1101 until a more complete solution to #1123 is found, though the overall behavior stays the same)
- Add validation of package names in `callHook`