### PR TITLE
Use same logic to filter tagged and published packages

### DIFF
--- a/change/beachball-3547e828-02f9-4d23-a286-125592135f3b.json
+++ b/change/beachball-3547e828-02f9-4d23-a286-125592135f3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "When determining which packages to tag in git, reuse the logic for determining which packages should be published (don't tag packages with no change type or out of scope)",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -4,7 +4,8 @@ import { toposortPackages } from './toposortPackages';
 
 /**
  * Determine which of the modified/new packages in bump info should actually be published
- * (based only on the bump info, not the registry).
+ * (based only on the bump info, not the registry). Removes packages that are private,
+ * out of scope, have change type "none", or have no calculated change type (unless they're new).
  */
 export function getPackagesToPublish(
   bumpInfo: Pick<


### PR DESCRIPTION
When determining which packages to tag in git, reuse the logic for determining which packages should be published (don't tag packages with no change type or out of scope).