### PR TITLE
Rename test fixtures: "multi-workspace" to "multi-project"

### DIFF
--- a/src/__e2e__/bump.test.ts
+++ b/src/__e2e__/bump.test.ts
@@ -113,27 +113,27 @@ describe('bump command', () => {
   });
 
   it('for multi-root monorepo, only bumps packages in the current root', async () => {
-    repositoryFactory = new RepositoryFactory('multi-workspace');
-    expect(Object.keys(repositoryFactory.fixtures)).toEqual(['workspace-a', 'workspace-b']);
+    repositoryFactory = new RepositoryFactory('multi-project');
+    expect(Object.keys(repositoryFactory.fixtures)).toEqual(['project-a', 'project-b']);
     repo = repositoryFactory.cloneRepository();
 
-    const workspaceARoot = repo.pathTo('workspace-a');
-    const workspaceBRoot = repo.pathTo('workspace-b');
-    const infoA = getOptions({ bumpDeps: true }, workspaceARoot);
+    const projectARoot = repo.pathTo('project-a');
+    const projectBRoot = repo.pathTo('project-b');
+    const infoA = getOptions({ bumpDeps: true }, projectARoot);
     const optionsA = infoA.options;
-    const infoB = getOptions({ bumpDeps: true }, workspaceBRoot);
+    const infoB = getOptions({ bumpDeps: true }, projectBRoot);
     const optionsB = infoB.options;
 
-    generateChangeFiles([{ packageName: '@workspace-a/foo' }], optionsA);
-    generateChangeFiles([{ packageName: '@workspace-a/foo', type: 'major' }], optionsB);
+    generateChangeFiles([{ packageName: '@project-a/foo' }], optionsA);
+    generateChangeFiles([{ packageName: '@project-a/foo', type: 'major' }], optionsB);
     repo.push();
 
     await bumpWrapper(infoA.parsedOptions);
 
     const packageInfosA = getPackageInfos(infoA.parsedOptions);
     const packageInfosB = getPackageInfos(infoB.parsedOptions);
-    expect(packageInfosA['@workspace-a/foo'].version).toBe('1.1.0');
-    expect(packageInfosB['@workspace-b/foo'].version).toBe('1.0.0');
+    expect(packageInfosA['@project-a/foo'].version).toBe('1.1.0');
+    expect(packageInfosB['@project-b/foo'].version).toBe('1.0.0');
 
     const changeFilesA = getChangeFiles(optionsA);
     const changeFilesB = getChangeFiles(optionsB);

--- a/src/__e2e__/getChangedPackages.test.ts
+++ b/src/__e2e__/getChangedPackages.test.ts
@@ -141,7 +141,7 @@ describe('getChangedPackages', () => {
   beforeAll(() => {
     singleFactory = new RepositoryFactory('single');
     monorepoFactory = new RepositoryFactory('monorepo');
-    multiFactory = new RepositoryFactory('multi-workspace');
+    multiFactory = new RepositoryFactory('multi-project');
   });
 
   afterEach(() => {
@@ -336,23 +336,23 @@ describe('getChangedPackages', () => {
       packageInfos: rootPackageInfos,
       scopedPackages: rootScopedPackages,
     } = getOptionsAndPackages();
-    expect(Object.keys(multiFactory.fixtures)).toEqual(['workspace-a', 'workspace-b']);
+    expect(Object.keys(multiFactory.fixtures)).toEqual(['project-a', 'project-b']);
 
-    const workspaceARoot = repo.pathTo('workspace-a');
-    const workspaceBRoot = repo.pathTo('workspace-b');
+    const projectARoot = repo.pathTo('project-a');
+    const projectBRoot = repo.pathTo('project-b');
 
     expect(getChangedPackages(rootOptions, rootPackageInfos, rootScopedPackages)).toStrictEqual([]);
 
-    repo.stageChange('workspace-a/packages/foo/test.js');
+    repo.stageChange('project-a/packages/foo/test.js');
 
-    const infoA = getOptionsAndPackages({ cwd: workspaceARoot });
-    const infoB = getOptionsAndPackages({ cwd: workspaceBRoot });
+    const infoA = getOptionsAndPackages({ cwd: projectARoot });
+    const infoB = getOptionsAndPackages({ cwd: projectBRoot });
     const changedPackagesA = getChangedPackages(infoA.options, infoA.packageInfos, infoA.scopedPackages);
     const changedPackagesB = getChangedPackages(infoB.options, infoB.packageInfos, infoB.scopedPackages);
     const changedPackagesRoot = getChangedPackages(rootOptions, rootPackageInfos, rootScopedPackages);
 
-    expect(changedPackagesA).toStrictEqual(['@workspace-a/foo']);
+    expect(changedPackagesA).toStrictEqual(['@project-a/foo']);
     expect(changedPackagesB).toStrictEqual([]);
-    expect(changedPackagesRoot).toStrictEqual(['@workspace-a/foo']);
+    expect(changedPackagesRoot).toStrictEqual(['@project-a/foo']);
   });
 });

--- a/src/__fixtures__/repositoryFactory.ts
+++ b/src/__fixtures__/repositoryFactory.ts
@@ -13,7 +13,7 @@ import { writeJson } from '../object/writeJson';
  * Standard fixture options. See {@link getSinglePackageFixture}, {@link getMonorepoFixture} and
  * {@link getMultiWorkspaceFixture} for details about the structure and included files.
  */
-export type FixtureType = 'single' | 'monorepo' | 'multi-workspace';
+export type FixtureType = 'single' | 'monorepo' | 'multi-project';
 
 export type RootPackageJsonFixture = PackageJson & {
   /** Monorepo workspaces. These will be automatically filled in if `RepoFixture.folders` is provided. */
@@ -129,26 +129,26 @@ function getMonorepoFixture(parentFolder?: string): RepoFixture {
 
 /**
  * Get a fixture for a repo containing multiple workspaces ("monorepos").
- * The two workspaces are under subfolders `workspace-a` and `workspace-b`, and the packages in each
- * workspace use scoped names `@workspace-a/*` and `@workspace-b/*`.
+ * The two workspaces are under subfolders `project-a` and `project-b`, and the packages in each
+ * workspace use scoped names `@project-a/*` and `@project-b/*`.
  */
-function getMultiWorkspaceFixture(): { 'workspace-a': RepoFixture; 'workspace-b': RepoFixture } {
+function getMultiWorkspaceFixture(): { 'project-a': RepoFixture; 'project-b': RepoFixture } {
   return {
-    'workspace-a': getMonorepoFixture('workspace-a'),
-    'workspace-b': getMonorepoFixture('workspace-b'),
+    'project-a': getMonorepoFixture('project-a'),
+    'project-b': getMonorepoFixture('project-b'),
   };
 }
 
 /** Provides setup, cloning, and teardown for repository factories */
 export class RepositoryFactory {
   /**
-   * Primary fixture for the test *(do not use for multi-workspace)*.
+   * Primary fixture for the test *(do not use for multi-project)*.
    * This is public to potentially reduce hardcoded values (such as versions) in tests.
    */
   public readonly fixture: FullRepoFixture;
 
   /**
-   * Mapping from parent folder to fixture repo (only relevant for multi-workspace).
+   * Mapping from parent folder to fixture repo (only relevant for multi-project).
    * Paths within each fixture will be relative to `parentFolder`.
    * For a single-repo or single monorepo fixture, its `parentFolder` will be `'.'`.
    */
@@ -166,12 +166,12 @@ export class RepositoryFactory {
    * Create the "origin" repo and create+commit fixture files.
    * If `fixture` is a string, the corresponding default fixture is used.
    *
-   * (Note that there's currently no way to create a custom multi-workspace fixture,
+   * (Note that there's currently no way to create a custom multi-project fixture,
    * because that hasn't been needed so far.)
    */
   constructor(fixtureParam: FixtureType | RepoFixture) {
     let initialFixtures: { [parentFolder: string]: RepoFixture };
-    if (fixtureParam === 'multi-workspace') {
+    if (fixtureParam === 'multi-project') {
       initialFixtures = getMultiWorkspaceFixture();
     } else {
       initialFixtures = {


### PR DESCRIPTION
Usage of the term "workspace" should be consistent with yarn and pnpm (referring to a single package within a monorepo). Potentially the term "project" is better for multiple large "monorepos" within a single git repo.