### PR TITLE
Use `import type` internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,8 @@ const config = {
   rules: {
     '@typescript-eslint/consistent-generic-constructors': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-exports': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/naming-convention': [
       'error',

--- a/change/beachball-41e15715-39f5-4e08-b9fb-15190803a8af.json
+++ b/change/beachball-41e15715-39f5-4e08-b9fb-15190803a8af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use `import type` internally",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/change.test.ts
+++ b/src/__e2e__/change.test.ts
@@ -38,6 +38,7 @@ let mockBeachballOptions: Partial<BeachballOptions> | undefined;
 jest.mock('../options/getDefaultOptions', () => ({
   getDefaultOptions: () => ({
     ...jest
+      // eslint-disable-next-line @typescript-eslint/consistent-type-imports
       .requireActual<typeof import('../options/getDefaultOptions')>('../options/getDefaultOptions')
       .getDefaultOptions(),
     ...mockBeachballOptions,

--- a/src/__fixtures__/mockNpm.ts
+++ b/src/__fixtures__/mockNpm.ts
@@ -1,9 +1,10 @@
-import { afterAll, afterEach, beforeAll, jest } from '@jest/globals';
+import type { jest } from '@jest/globals';
+import { afterAll, afterEach, beforeAll } from '@jest/globals';
 import fs from 'fs';
 import fetch from 'npm-registry-fetch';
 import path from 'path';
 import semver from 'semver';
-import { npm, NpmResult } from '../packageManager/npm';
+import { npm, type NpmResult } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
 import type { PackageManagerOptions } from '../packageManager/packageManager';
 import { readJson } from '../object/readJson';

--- a/src/__functional__/packageManager/packPackage.test.ts
+++ b/src/__functional__/packageManager/packPackage.test.ts
@@ -3,10 +3,10 @@ import fs from 'fs';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
-import * as npmModuleType from '../../packageManager/npm';
+import type * as npmModuleType from '../../packageManager/npm';
 import type { NpmResult } from '../../packageManager/npm';
 import { packPackage } from '../../packageManager/packPackage';
-import { PackageInfo } from '../../types/PackageInfo';
+import type { PackageInfo } from '../../types/PackageInfo';
 import { getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
 import { writeJson } from '../../object/writeJson';
 

--- a/src/__functional__/packageManager/packagePublish.test.ts
+++ b/src/__functional__/packageManager/packagePublish.test.ts
@@ -6,7 +6,7 @@ import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
 import * as npmModule from '../../packageManager/npm';
 import { packagePublish } from '../../packageManager/packagePublish';
 import type { PackageInfo } from '../../types/PackageInfo';
-import { npm, NpmResult } from '../../packageManager/npm';
+import type { npm, NpmResult } from '../../packageManager/npm';
 import { writeJson } from '../../object/writeJson';
 import { getNpmPackageInfo, type NpmPackageVersionsData } from '../../packageManager/getNpmPackageInfo';
 import { env } from '../../env';

--- a/src/__tests__/bump/performBump.test.ts
+++ b/src/__tests__/bump/performBump.test.ts
@@ -7,7 +7,7 @@ import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/p
 import type { BumpInfo } from '../../types/BumpInfo';
 import { getParsedOptions } from '../../options/getOptions';
 import { performBump } from '../../bump/performBump';
-import { ChangeSet, type ChangeFileInfo } from '../../types/ChangeInfo';
+import type { ChangeSet, ChangeFileInfo } from '../../types/ChangeInfo';
 import { consideredDependencies, type PackageInfos, type PackageJson } from '../../types/PackageInfo';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { updateLockFile as _updateLockFile } from '../../bump/updateLockFile';

--- a/src/__tests__/bump/updateLockFile.test.ts
+++ b/src/__tests__/bump/updateLockFile.test.ts
@@ -8,6 +8,7 @@ jest.mock('fs');
 jest.mock('../../packageManager/packageManager');
 jest.mock('../../env', () => ({
   env: {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     ...jest.requireActual<typeof import('../../env')>('../../env').env,
     isJest: false,
   },

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import { updateRelatedChangeType } from '../../bump/updateRelatedChangeType';
 import type { ChangeFileInfo, ChangeInfo, ChangeType } from '../../types/ChangeInfo';
-import { PartialPackageInfos, makePackageInfos } from '../../__fixtures__/packageInfos';
-import { PackageGroups } from '../../types/PackageInfo';
+import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
+import type { PackageGroups } from '../../types/PackageInfo';
 import { getDependentsForPackages } from '../../bump/getDependentsForPackages';
 import type { BeachballOptions } from '../../types/BeachballOptions';
 

--- a/src/bump/updateRelatedChangeType.ts
+++ b/src/bump/updateRelatedChangeType.ts
@@ -2,7 +2,7 @@ import { getMaxChangeType } from '../changefile/changeTypes';
 import { getPackageOption } from '../options/getPackageOption';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { BumpInfo, PackageDependents } from '../types/BumpInfo';
-import { ChangeFileInfo } from '../types/ChangeInfo';
+import type { ChangeFileInfo } from '../types/ChangeInfo';
 
 /**
  * This is the core of the `bumpInfo` dependency bumping logic - done once per change info.

--- a/src/changefile/changeTypes.ts
+++ b/src/changefile/changeTypes.ts
@@ -1,4 +1,4 @@
-import { BumpInfo } from '../types/BumpInfo';
+import type { BumpInfo } from '../types/BumpInfo';
 import type { ChangeSet, ChangeType } from '../types/ChangeInfo';
 
 /**

--- a/src/packageManager/packPackage.ts
+++ b/src/packageManager/packPackage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { PackageInfo } from '../types/PackageInfo';
-import { BeachballOptions } from '../types/BeachballOptions';
+import type { PackageInfo } from '../types/PackageInfo';
+import type { BeachballOptions } from '../types/BeachballOptions';
 import { npm } from './npm';
 import { getNpmLogLevelArgs } from './npmArgs';
 

--- a/src/validation/isValidDependentChangeType.ts
+++ b/src/validation/isValidDependentChangeType.ts
@@ -1,5 +1,5 @@
 import { SortedChangeTypes } from '../changefile/changeTypes';
-import { ChangeType } from '../types/ChangeInfo';
+import type { ChangeType } from '../types/ChangeInfo';
 
 /**
  * Returns whether `dependentChangeType` is valid and not disallowed.


### PR DESCRIPTION
`import type` was already being used in some places, but PR enables the `@typescript-eslint/explicit-type-imports` rule and updates the remaining usage.