### PR TITLE
Simplify scopedPackages short circuit logic

### DIFF
--- a/change/beachball-14f0094f-a017-4b4e-856e-726bd0288542.json
+++ b/change/beachball-14f0094f-a017-4b4e-856e-726bd0288542.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Simplify internal handling of determining in-scope packages",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/object/cloneObject.test.ts
+++ b/src/__tests__/object/cloneObject.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import type { BumpInfo } from '../../types/BumpInfo';
 import { cloneObject } from '../../object/cloneObject';
-import { makePackageInfos } from '../../__fixtures__/packageInfos';
-import { getChange } from '../../__fixtures__/changeFiles';
 
 describe('cloneObject', () => {
   it.each<[string, object | unknown[]]>([
@@ -12,8 +9,6 @@ describe('cloneObject', () => {
     ['object with null prototype', Object.assign(Object.create(null), { a: 1, b: '2', c: true })],
     ['empty array', []],
     ['array', [1, '2', true]],
-    ['set', new Set([1, 2, 3])],
-    ['object of sets', { a: new Set([1, 2, 3]), b: new Set(['a', 'b', 'c']) }],
   ])('clones %s', (desc, val) => {
     const cloned = cloneObject(val);
     expect(cloned).toEqual(val);
@@ -44,35 +39,6 @@ describe('cloneObject', () => {
     expect(() => cloneObject(new Map())).toThrow('Unsupported object type found while cloning bump info: Map');
     class Foo {}
     expect(() => cloneObject(new Foo())).toThrow('Unsupported object type found while cloning bump info: Foo');
-  });
-
-  it('clones bump info structure', () => {
-    const original: BumpInfo = {
-      // There's no attempt at consistency because it doesn't matter here
-      calculatedChangeTypes: { pkgA: 'minor', pkgB: 'patch' },
-      packageInfos: makePackageInfos({ a: { dependencies: { b: '^1.0.0' } }, b: {} }),
-      changeFileChangeInfos: [
-        { change: getChange('a'), changeFile: '' },
-        { change: getChange('b'), changeFile: '' },
-      ],
-      packageGroups: { group1: { packageNames: ['a', 'b'], disallowedChangeTypes: null } },
-      dependentChangedBy: { a: new Set(['b']) },
-      modifiedPackages: new Set(['a']),
-      scopedPackages: new Set(['a', 'b']),
-    };
-
-    const cloned = cloneObject(original);
-    expect(cloned).toEqual(original);
-    expect(cloned).not.toBe(original);
-    expect(cloned.packageInfos).not.toBe(original.packageInfos);
-    expect(cloned.packageInfos.a).not.toBe(original.packageInfos.a);
-    expect(cloned.changeFileChangeInfos).not.toBe(original.changeFileChangeInfos);
-    expect(cloned.changeFileChangeInfos[0]).not.toBe(original.changeFileChangeInfos[0]);
-    expect(cloned.changeFileChangeInfos[0].change).not.toBe(original.changeFileChangeInfos[0].change);
-    expect(cloned.packageGroups).not.toBe(original.packageGroups);
-    expect(cloned.dependentChangedBy).not.toBe(original.dependentChangedBy);
-    expect(cloned.dependentChangedBy.a).not.toBe(original.dependentChangedBy.a);
-    expect(cloned.modifiedPackages).not.toBe(original.modifiedPackages);
-    expect(cloned.scopedPackages).not.toBe(original.scopedPackages);
+    expect(() => cloneObject(new Set())).toThrow('Unsupported object type found while cloning bump info: Set');
   });
 });

--- a/src/bump/setDependentVersions.ts
+++ b/src/bump/setDependentVersions.ts
@@ -20,7 +20,7 @@ export function setDependentVersions(
   const dependentChangedBy: BumpInfo['dependentChangedBy'] = {};
 
   for (const [pkgName, info] of Object.entries(packageInfos)) {
-    if (!scopedPackages.allInScope && !scopedPackages.has(pkgName)) {
+    if (!scopedPackages.has(pkgName)) {
       continue; // out of scope
     }
 

--- a/src/changefile/getChangedPackages.ts
+++ b/src/changefile/getChangedPackages.ts
@@ -48,7 +48,7 @@ function isPackageIncluded(
     : // This is a package-only option (can't be set at repo level or via CLI)
     packageInfo.packageOptions?.shouldPublish === false
     ? `${packageInfo.name} has beachball.shouldPublish=false`
-    : !scopedPackages.allInScope && !scopedPackages.has(packageInfo.name)
+    : !scopedPackages.has(packageInfo.name)
     ? `${packageInfo.name} is out of scope`
     : ''; // not ignored
 

--- a/src/changefile/readChangeFiles.ts
+++ b/src/changefile/readChangeFiles.ts
@@ -103,7 +103,7 @@ export function readChangeFiles(
       }
 
       // Add the change to the final list if it's valid and in scope
-      if (!warningType && (scopedPackages.allInScope || scopedPackages.has(change.packageName))) {
+      if (!warningType && scopedPackages.has(change.packageName)) {
         changeSet.push({ changeFile, change });
       }
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -21,11 +21,7 @@ export async function sync(options: BeachballOptions, context?: SyncCommandConte
   const packageInfos = context?.originalPackageInfos ?? getPackageInfos(options.path);
   const scopedPackages = context?.scopedPackages ?? getScopedPackages(options, packageInfos);
 
-  const infos = new Map(
-    Object.entries(packageInfos).filter(
-      ([pkg, info]) => !info.private && (scopedPackages.allInScope || scopedPackages.has(pkg))
-    )
-  );
+  const infos = new Map(Object.entries(packageInfos).filter(([pkg, info]) => !info.private && scopedPackages.has(pkg)));
 
   console.log(`Getting versions from registry for ${infos.size} package(s)...`);
 

--- a/src/object/cloneObject.ts
+++ b/src/object/cloneObject.ts
@@ -1,8 +1,6 @@
-import type { ScopedPackages } from '../types/PackageInfo';
-
 /**
- * Clone an object, fast.
- * Currently only handles data types expected in `BumpInfo` but could be expanded if needed.
+ * Clone an object, fast. Currently only handles JSON-like objects (not class instances)
+ * but could be expanded if needed.
  *
  * This is decently faster than `structuredClone` or `JSON.parse(JSON.stringify())` on a
  * very large object (bump info can be huge in certain repos). https://jsperf.app/rugosa/5
@@ -27,18 +25,6 @@ export function cloneObject<T extends object>(obj: T): T {
       clone[i] = val && typeof val === 'object' ? cloneObject(val) : val;
     }
     return clone;
-  }
-
-  if (obj instanceof Set) {
-    const cloned = new Set(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      Array.from(obj).map(item => (item && typeof item === 'object' ? cloneObject(item) : item))
-    ) as T;
-    // special logic to clone a custom set property
-    if ((obj as ScopedPackages).allInScope) {
-      (cloned as ScopedPackages).allInScope = true;
-    }
-    return cloned;
   }
 
   if (obj.constructor?.name && obj.constructor.name !== 'Object') {

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -37,7 +37,7 @@ export function getPackagesToPublish(
       skipReason = 'has change type none';
     } else if (packageInfo.private) {
       skipReason = 'is private';
-    } else if (!scopedPackages.allInScope && !scopedPackages.has(pkg)) {
+    } else if (!scopedPackages.has(pkg)) {
       skipReason = 'is out-of-scope';
     } else if (!changeType && !newPackages?.includes(pkg)) {
       skipReason = 'is not bumped (no calculated change type)';

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -95,10 +95,7 @@ export const consideredDependencies = [
 ] as const;
 
 /**
- * In-scope package names, with an extra property if all packages are in scope.
+ * In-scope package names. If returned by `getScopedPackages`, this has extra logic to return true
+ * without a full lookup when all packages are in scope. (A plain `Set<string>` works for tests.)
  */
-// This is a Set with an extra property to avoid compatibility issues with code using private APIs
-export type ScopedPackages = ReadonlySet<string> & {
-  /** No `scope` option was specified, so all packages are in scope. */
-  allInScope?: true;
-};
+export type ScopedPackages = ReadonlySet<string>;


### PR DESCRIPTION
Instead of adding an `allInScope` property to `scopedPackages` which must be manually checked by all consuming code, override `Set.prototype.has` if all packages are in scope. This is completely transparent to the consuming code and works identically to unmodified `Set<string>` for jest tests.