### PR TITLE
publishToRegistry tests + logging improvements

### DIFF
--- a/change/beachball-9e8d59d7-6711-4665-a28b-89d3e8e176f1.json
+++ b/change/beachball-9e8d59d7-6711-4665-a28b-89d3e8e176f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve publish logging",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -28,6 +28,8 @@ export type MockLogs = {
     opts?: {
       /** Replace this path with `<root>` and normalize slashes */
       root?: string;
+      /** Mapping from path to placeholder text, e.g. `{ [packToPath]: '<packPath>' }` */
+      replacePaths?: Record<string, string>;
       /**
        * Sanitize GUIDs, full commit hashes, and publish branch timestamps.
        *
@@ -74,10 +76,15 @@ export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
         .join('\n')
         .trim();
 
-      if (opts.root) {
+      if (opts.root || opts.replacePaths) {
+        const replacePaths = { ...opts.replacePaths, ...(opts.root && { [opts.root]: '<root>' }) };
         // Normalize slashes first to ensure they're the same, then emulate replaceAll
-        lines = lines.replace(/\\/g, '/').split(opts.root.replace(/\\/g, '/')).join('<root>');
+        lines = lines.replace(/\\/g, '/');
+        for (const [key, value] of Object.entries(replacePaths)) {
+          lines = lines.split(key.replace(/\\/g, '/')).join(value);
+        }
       }
+
       if (opts.sanitize) {
         lines = lines
           // Replace GUIDs with <guid>

--- a/src/__functional__/packageManager/packPackage.test.ts
+++ b/src/__functional__/packageManager/packPackage.test.ts
@@ -64,12 +64,12 @@ describe('packPackage', () => {
       expect.objectContaining({ cwd: tempRoot })
     );
     // file is moved to correct location (not the package folder)
-    expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+    expect(fs.readdirSync(tempPackPath)).toEqual([`1-${testPkg.packName}`]);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
-    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, `1-${testPkg.packName}`)}`);
   });
 
   it('packs scoped package', async () => {
@@ -84,12 +84,12 @@ describe('packPackage', () => {
       expect.objectContaining({ cwd: tempRoot })
     );
     // file is moved to correct location (not the package folder)
-    expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+    expect(fs.readdirSync(tempPackPath)).toEqual([`1-${testPkg.packName}`]);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
-    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, `1-${testPkg.packName}`)}`);
   });
 
   it('packs package with correct longer prefix', async () => {
@@ -104,12 +104,12 @@ describe('packPackage', () => {
       ['pack', '--loglevel', 'warn'],
       expect.objectContaining({ cwd: tempRoot })
     );
-    expect(fs.existsSync(path.join(tempPackPath, '002-' + testPkg.packName))).toBe(true);
+    expect(fs.readdirSync(tempPackPath)).toEqual([`002-${testPkg.packName}`]);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
-    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '002-' + testPkg.packName)}`);
+    expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, `002-${testPkg.packName}`)}`);
   });
 
   it('handles failure packing', async () => {
@@ -122,8 +122,8 @@ describe('packPackage', () => {
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
     expect(packResult).toEqual(false);
     expect(npmMock.mock).toHaveBeenCalledTimes(1);
+    expect(fs.readdirSync(tempPackPath)).toEqual([]);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
-    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
@@ -140,7 +140,7 @@ describe('packPackage', () => {
     expect(packResult).toEqual(false);
     expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
-    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
+    expect(fs.readdirSync(tempPackPath)).toEqual([]);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
@@ -157,7 +157,7 @@ describe('packPackage', () => {
     expect(packResult).toEqual(false);
     expect(npmMock.mock).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
-    expect(fs.existsSync(path.join(tempPackPath, testPkg.packName))).toBe(false);
+    expect(fs.readdirSync(tempPackPath)).toEqual([]);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
@@ -168,7 +168,9 @@ describe('packPackage', () => {
     const testPkg = getTestPackage('testpkg');
     writeJson(tempPackageJsonPath, testPkg.json);
 
-    fs.writeFileSync(path.join(tempPackPath, '1-' + testPkg.packName), 'other content');
+    const destPath = path.join(tempPackPath, `1-${testPkg.packName}`);
+    fs.writeFileSync(destPath, 'other content');
+    const origPath = path.join(tempRoot, testPkg.packName);
 
     const packResult = await packPackage(testPkg.info, { packToPath: tempPackPath, index: 0, total: 1 });
     expect(packResult).toEqual(false);
@@ -176,15 +178,10 @@ describe('packPackage', () => {
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
-    expect(allLogs).toMatch(
-      `Failed to move ${path.join(tempRoot, testPkg.packName)} to ${path.join(
-        tempPackPath,
-        '1-' + testPkg.packName
-      )}: Error:`
-    );
+    expect(allLogs).toMatch(`Failed to move ${origPath} to ${destPath}: Error:`);
 
     // tgz file is cleaned up
-    expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
+    expect(fs.existsSync(origPath)).toBe(false);
   });
 
   // These tests are slow, so only cover minimal cases
@@ -207,12 +204,12 @@ describe('packPackage', () => {
         expect.objectContaining({ cwd: tempRoot })
       );
       // file is moved to correct location (not the package folder)
-      expect(fs.existsSync(path.join(tempPackPath, '1-' + testPkg.packName))).toBe(true);
+      expect(fs.readdirSync(tempPackPath)).toEqual([`1-${testPkg.packName}`]);
       expect(fs.existsSync(path.join(tempRoot, testPkg.packName))).toBe(false);
 
       const allLogs = logs.getMockLines('all');
       expect(allLogs).toMatch(`Packing - ${testPkg.spec}`);
-      expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, '1-' + testPkg.packName)}`);
+      expect(allLogs).toMatch(`Packed ${testPkg.spec} to ${path.join(tempPackPath, `1-${testPkg.packName}`)}`);
     });
   });
 });

--- a/src/__functional__/publish/__snapshots__/publishToRegistry.test.ts.snap
+++ b/src/__functional__/publish/__snapshots__/publishToRegistry.test.ts.snap
@@ -1,0 +1,258 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`publishToRegistry publishes multiple packages in dependency order 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • lib@1.0.0
+  • app@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - lib@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/lib)
+
+[log] Published! - lib@1.0.0
+
+[log] Publishing - app@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/app)
+
+[log] Published! - app@1.0.0"
+`;
+
+exports[`publishToRegistry skips private packages 1`] = `
+"[log] Skipping publishing the following packages:
+  • private-pkg is private
+
+[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • foo@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - foo@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/foo)
+
+[log] Published! - foo@1.0.0"
+`;
+
+exports[`publishToRegistry throws on publish failure 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • foo@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - foo@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/foo)
+
+[warn] Publishing foo@1.0.0 failed. Output:
+
+network error
+
+[log] Retrying... (1/3)
+
+[warn] Publishing foo@1.0.0 failed. Output:
+
+network error
+
+[log] Retrying... (2/3)
+
+[warn] Publishing foo@1.0.0 failed. Output:
+
+network error
+
+[log] Retrying... (3/3)
+
+[error] Publishing foo@1.0.0 failed. Output:
+
+network error
+
+[error] Something went wrong with publishing (see above for details). The following packages were NOT published:
+  • foo@1.0.0"
+`;
+
+exports[`publishToRegistry with concurrency > 1 publishes independent packages in parallel 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • foo@1.0.0
+  • bar@1.0.0
+  • baz@1.0.0
+  • qux@1.0.0
+  • quux@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - foo@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/foo)
+
+[log] Publishing - bar@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/bar)
+
+[log] Publishing - baz@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/baz)
+
+[log] Published! - foo@1.0.0
+
+[log] Publishing - qux@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/qux)
+
+[log] Published! - bar@1.0.0
+
+[log] Publishing - quux@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/quux)
+
+[log] Published! - baz@1.0.0
+
+[log] Published! - qux@1.0.0
+
+[log] Published! - quux@1.0.0"
+`;
+
+exports[`publishToRegistry with concurrency > 1 throws and shows recovery info on failure 2`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • pkg3@1.0.0
+  • pkg2@1.0.0
+  • pkg1@1.0.0
+  • pkg4@1.0.0
+  • pkg5@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - pkg3@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/pkg3)
+
+[log] Publishing - pkg4@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/pkg4)
+
+[log] Publishing - pkg5@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/pkg5)
+
+[warn] Publishing pkg5@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (1/3)
+
+[warn] Publishing pkg5@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (2/3)
+
+[warn] Publishing pkg5@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (3/3)
+
+[error] Publishing pkg5@1.0.0 failed. Output:
+
+oh no
+
+[log] Published! - pkg3@1.0.0
+
+[log] Publishing - pkg2@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/pkg2)
+
+[warn] Publishing pkg2@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (1/3)
+
+[warn] Publishing pkg2@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (2/3)
+
+[warn] Publishing pkg2@1.0.0 failed. Output:
+
+oh no
+
+[log] Retrying... (3/3)
+
+[error] Publishing pkg2@1.0.0 failed. Output:
+
+oh no
+
+[log] Published! - pkg4@1.0.0
+
+[error] Something went wrong with publishing (see above for details). The following packages were NOT published:
+  • pkg1@1.0.0
+  • pkg2@1.0.0
+  • pkg5@1.0.0
+
+[warn] These packages and versions were successfully published, but will NOT be reflected in your local package.json files:
+  • pkg3@1.0.0
+  • pkg4@1.0.0
+
+To recover from this, run "beachball sync" to synchronize local package.json files with the registry."
+`;
+
+exports[`publishToRegistry with packToPath packs packages 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • lib@1.0.0
+  • app@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Packing - lib@1.0.0
+[log]   (cwd: <root>/packages/lib)
+
+[log] lib-1.0.0.tgz
+
+[log] Packed lib@1.0.0 to <packPath>/1-lib-1.0.0.tgz
+[log] Packing - app@1.0.0
+[log]   (cwd: <root>/packages/app)
+
+[log] app-1.0.0.tgz
+
+[log] Packed app@1.0.0 to <packPath>/2-app-1.0.0.tgz"
+`;
+
+exports[`publishToRegistry with packToPath throws with packing error message on pack failure 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • foo@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Packing - foo@1.0.0
+[log]   (cwd: <root>/packages/foo)
+
+[log] pack error
+
+[error] Packing foo@1.0.0 failed (see above for details)
+
+[error] Something went wrong with packing packages! No packages were published, so you can address the issue and try again."
+`;

--- a/src/__functional__/publish/publishToRegistry.test.ts
+++ b/src/__functional__/publish/publishToRegistry.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { _mockNpmPublish, getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
+import { writeJson } from '../../object/writeJson';
+import { getDefaultOptions } from '../../options/getDefaultOptions';
+import { publishToRegistry } from '../../publish/publishToRegistry';
+import type { BeachballOptions, HooksOptions } from '../../types/BeachballOptions';
+import type { PublishBumpInfo } from '../../types/BumpInfo';
+import type { PackageJson } from '../../types/PackageInfo';
+
+// Mock npm calls (publish, pack, show)
+jest.mock('../../packageManager/npm');
+
+describe('publishToRegistry', () => {
+  const npmMock = initNpmMock();
+  const logs = initMockLogs();
+
+  let tempRoot: string;
+  let defaultOptions: BeachballOptions;
+
+  beforeEach(() => {
+    tempRoot = tmpdir();
+    defaultOptions = {
+      ...getDefaultOptions(),
+      path: tempRoot,
+      registry: 'http://localhost:99999',
+      bump: false,
+    };
+  });
+
+  afterEach(() => {
+    removeTempDir(tempRoot);
+  });
+
+  /** Create a minimal PublishBumpInfo where all packages are modified and in scope */
+  function makeBumpInfo(
+    partialPackageInfos: Parameters<typeof makePackageInfos>[0],
+    extra?: Partial<Pick<PublishBumpInfo, 'modifiedPackages' | 'calculatedChangeTypes' | 'scopedPackages'>>
+  ): PublishBumpInfo {
+    const packageInfos = makePackageInfos(partialPackageInfos, { path: tempRoot });
+
+    // Write package.json files to disk so mock npm publish can read them
+    for (const info of Object.values(packageInfos)) {
+      const { packageJsonPath, ...json } = info;
+      fs.mkdirSync(path.dirname(packageJsonPath), { recursive: true });
+      writeJson(packageJsonPath, json);
+    }
+
+    const names = Object.keys(packageInfos);
+    return {
+      changeFileChangeInfos: [],
+      packageInfos,
+      calculatedChangeTypes: Object.fromEntries(names.map(n => [n, 'patch' as const])),
+      packageGroups: {},
+      modifiedPackages: new Set(names),
+      dependentChangedBy: {},
+      scopedPackages: new Set(names),
+      ...extra,
+    };
+  }
+
+  it('publishes a single package', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {} });
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    const published = npmMock.getPublishedVersions('foo');
+    expect(published?.versions).toEqual(['1.0.0']);
+
+    // This is like a visual regression test for the log UX
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchInlineSnapshot(`
+      "[log] Validating new package versions...
+
+      [log] Package versions are OK to publish:
+        • foo@1.0.0
+
+      [log] Validating no private package among package dependencies
+      [log]   OK!
+
+      [log] Publishing - foo@1.0.0 with tag latest
+      [log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+      [log]   (cwd: <root>/packages/foo)
+
+      [log] Published! - foo@1.0.0"
+    `);
+  });
+
+  it('publishes multiple packages in dependency order', async () => {
+    const bumpInfo = makeBumpInfo({
+      app: { dependencies: { lib: '1.0.0' } },
+      lib: {},
+    });
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    // Both packages should be published
+    expect(npmMock.getPublishedVersions('lib')?.versions).toEqual(['1.0.0']);
+    expect(npmMock.getPublishedVersions('app')?.versions).toEqual(['1.0.0']);
+
+    // lib should be published before app (check npm call order)
+    const publishCalls = npmMock.mock.mock.calls.filter(([args]) => args[0] === 'publish');
+    const publishOrder = publishCalls.map(([, opts]) => path.basename(opts.cwd!));
+    expect(publishOrder).toEqual(['lib', 'app']);
+
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+  });
+
+  it('skips private packages', async () => {
+    const bumpInfo = makeBumpInfo({
+      foo: {},
+      'private-pkg': { private: true },
+    });
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    expect(npmMock.getPublishedVersions('foo')?.versions).toEqual(['1.0.0']);
+    expect(npmMock.getPublishedVersions('private-pkg')).toBeUndefined();
+
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+  });
+
+  it('returns early when no packages need publishing', async () => {
+    const bumpInfo = makeBumpInfo({ foo: { private: true } }, { calculatedChangeTypes: { foo: 'none' } });
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    // No npm calls should have been made
+    expect(npmMock.mock).not.toHaveBeenCalled();
+
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchInlineSnapshot(`
+      "[log] Skipping publishing the following packages:
+        • foo has change type none
+
+      [log] Nothing to publish"
+    `);
+  });
+
+  it('throws on publish failure', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {} });
+
+    // Make the publish command fail
+    npmMock.setCommandOverride('publish', () =>
+      Promise.resolve({ success: false, stdout: '', stderr: 'network error', all: 'network error', failed: true })
+    );
+
+    await expect(publishToRegistry(bumpInfo, defaultOptions)).rejects.toThrow('Error publishing');
+
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+  });
+
+  it('exits on validation failure when version already exists', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {} });
+
+    // Pre-populate registry so version 1.0.0 already exists
+    npmMock.setRegistryData({ foo: { versions: ['1.0.0'] } });
+
+    // process.exit is mocked in jestSetup.js to throw
+    await expect(publishToRegistry(bumpInfo, defaultOptions)).rejects.toThrow('process.exit called with code 1');
+
+    expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
+      "[log] Validating new package versions...
+
+      [error] ERROR: Attempting to publish package versions that already exist in the registry:
+        • foo@1.0.0
+
+      [error] Something went wrong with publishing (see above for details). The following packages were NOT published:
+        • foo@1.0.0"
+    `);
+  });
+
+  it('applies publishConfig overrides before publishing', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {} });
+    // Add main and publishConfig on disk (would be stripped by makePackageInfos)
+    const { packageJsonPath, ...json } = bumpInfo.packageInfos.foo;
+    const allJson: PackageJson = { ...json, main: 'src/index.js', publishConfig: { main: 'dist/index.js' } };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(allJson));
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    // performPublishOverrides should have replaced `main` from publishConfig
+    const packageJson = JSON.parse(fs.readFileSync(bumpInfo.packageInfos.foo.packageJsonPath, 'utf-8')) as PackageJson;
+    expect(packageJson).toMatchObject(allJson.publishConfig!);
+  });
+
+  it('calls prepublish and postpublish hooks', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {}, bar: {} });
+
+    const prepublish = jest.fn<Required<HooksOptions>['prepublish']>();
+    const postpublish = jest.fn<Required<HooksOptions>['postpublish']>();
+
+    await publishToRegistry(bumpInfo, { ...defaultOptions, hooks: { prepublish, postpublish } });
+
+    // Verify hook calls and arguments
+    const expectHookCalls = (hook: typeof prepublish) => {
+      expect(hook).toHaveBeenCalledTimes(2);
+      expect(hook).toHaveBeenCalledWith(expect.stringMatching(/packages[\\/]foo$/), 'foo', '1.0.0', expect.anything());
+      expect(hook).toHaveBeenCalledWith(expect.stringMatching(/packages[\\/]bar$/), 'bar', '1.0.0', expect.anything());
+    };
+    expectHookCalls(prepublish);
+    expectHookCalls(postpublish);
+  });
+
+  describe('with concurrency > 1', () => {
+    it('publishes independent packages in parallel', async () => {
+      const bumpInfo = makeBumpInfo({ foo: {}, bar: {}, baz: {}, qux: {}, quux: {} });
+
+      const concurrency = 3;
+      let currentConcurrency = 0;
+      let maxConcurrency = 0;
+
+      npmMock.setCommandOverride('publish', async (registryData, args, opts) => {
+        currentConcurrency++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const result = await _mockNpmPublish(registryData, args, opts);
+        maxConcurrency = Math.max(maxConcurrency, currentConcurrency);
+        currentConcurrency--;
+        return result;
+      });
+
+      await publishToRegistry(bumpInfo, { ...defaultOptions, concurrency });
+
+      // Verify that at most `concurrency` number of packages were published concurrently
+      expect(maxConcurrency).toBe(concurrency);
+
+      expect(npmMock.getPublishedVersions('foo')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('bar')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('baz')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('qux')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('quux')?.versions).toEqual(['1.0.0']);
+
+      // If this turns out to be unstable, it can be removed
+      expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+    });
+
+    // Just test postpublish (prepublish should have the same logic)
+    it('respects concurrency limit for publish hooks', async () => {
+      const bumpInfo = makeBumpInfo({ pkg1: {}, pkg2: {}, pkg3: {}, pkg4: {} });
+      const concurrency = 2;
+
+      let currentConcurrency = 0;
+      let maxConcurrency = 0;
+      const hookNames: string[] = [];
+
+      const postpublish = async (_packagePath: string, name: string) => {
+        currentConcurrency++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+        hookNames.push(name);
+        maxConcurrency = Math.max(maxConcurrency, currentConcurrency);
+        currentConcurrency--;
+      };
+
+      await publishToRegistry(bumpInfo, { ...defaultOptions, concurrency, hooks: { postpublish } });
+
+      expect(maxConcurrency).toBe(concurrency);
+      expect(hookNames.sort()).toEqual(['pkg1', 'pkg2', 'pkg3', 'pkg4']);
+    });
+
+    it('throws and shows recovery info on failure', async () => {
+      const bumpInfo = makeBumpInfo({
+        pkg1: { dependencies: { pkg2: '1.0.0' } },
+        pkg2: { dependencies: { pkg3: '1.0.0' } },
+        pkg3: {},
+        pkg4: {},
+        pkg5: {},
+      });
+
+      // Make publish fail for pkg2 and pkg5.
+      // pkg3 and pkg4 should succeed, and pkg1 should be skipped.
+      npmMock.setCommandOverride('publish', async (registryData, args, opts) => {
+        const packageName = path.basename(opts.cwd!);
+        if (packageName === 'pkg2' || packageName === 'pkg5') {
+          return { success: false, stdout: '', stderr: 'oh no', all: 'oh no', failed: true };
+        }
+        // Use a small delay to verify that the started tasks are awaited even if others fail
+        await new Promise(resolve => setTimeout(resolve, 20));
+        return _mockNpmPublish(registryData, args, opts);
+      });
+
+      // Set concurrency to 4 so pkg2-5 will start in parallel (leading to two failures)
+      await expect(publishToRegistry(bumpInfo, { ...defaultOptions, concurrency: 4 }))
+        .rejects // The message should be deduplicated since the same error is thrown for both failures
+        .toThrowErrorMatchingInlineSnapshot(
+          `"Error publishing! Refer to the previous logs for recovery instructions."`
+        );
+
+      expect(npmMock.getPublishedVersions('pkg1')).toBeUndefined();
+      expect(npmMock.getPublishedVersions('pkg2')).toBeUndefined();
+      expect(npmMock.getPublishedVersions('pkg3')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('pkg4')?.versions).toEqual(['1.0.0']);
+      expect(npmMock.getPublishedVersions('pkg5')).toBeUndefined();
+
+      // If this turns out to be unstable, it can be replaced with more granular tests
+      // (need to verify that all failed packages' logs are shown, and the final errors are aggregated
+      // in a reasonable manner)
+      expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+    });
+  });
+
+  describe('with packToPath', () => {
+    let packToPath: string;
+
+    beforeEach(() => {
+      packToPath = tmpdir();
+    });
+
+    afterEach(() => {
+      removeTempDir(packToPath);
+    });
+
+    it('packs packages', async () => {
+      const bumpInfo = makeBumpInfo({
+        app: { dependencies: { lib: '1.0.0' } },
+        lib: {},
+      });
+
+      await publishToRegistry(bumpInfo, { ...defaultOptions, packToPath });
+
+      // Nothing should be published to the registry
+      expect(npmMock.getPublishedVersions('lib')).toBeUndefined();
+      expect(npmMock.getPublishedVersions('app')).toBeUndefined();
+
+      // Tgz files should be in packToPath with numeric prefixes (toposorted: lib=1, app=2)
+      const files = fs.readdirSync(packToPath).sort();
+      expect(files).toEqual([
+        `1-${getMockNpmPackName(bumpInfo.packageInfos.lib)}`,
+        `2-${getMockNpmPackName(bumpInfo.packageInfos.app)}`,
+      ]);
+
+      expect(
+        logs.getMockLines('all', { replacePaths: { [tempRoot]: '<root>', [packToPath]: '<packPath>' } })
+      ).toMatchSnapshot();
+    });
+
+    it('throws with packing error message on pack failure', async () => {
+      const bumpInfo = makeBumpInfo({ foo: {} });
+
+      npmMock.setCommandOverride('pack', () =>
+        Promise.resolve({ success: false, stdout: '', stderr: 'pack error', all: 'pack error', failed: true })
+      );
+
+      await expect(publishToRegistry(bumpInfo, { ...defaultOptions, packToPath })).rejects.toThrow('Error packing');
+
+      expect(logs.getMockLines('error')).toMatch('Something went wrong with packing packages!');
+
+      expect(
+        logs.getMockLines('all', { replacePaths: { [tempRoot]: '<root>', [packToPath]: '<packPath>' } })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/src/__tests__/publish/validatePackageVersions.test.ts
+++ b/src/__tests__/publish/validatePackageVersions.test.ts
@@ -27,10 +27,9 @@ describe('validatePackageVersions', () => {
     expect(npmMock.mock).toHaveBeenCalledTimes(1);
     // expect(npmMock.mockFetchJson).toHaveBeenCalledTimes(1);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
-      "[log]
-      Validating new package versions...
-      [log]
-      Package versions are OK to publish:
+      "[log] Validating new package versions...
+
+      [log] Package versions are OK to publish:
         • foo@1.0.0"
     `);
   });
@@ -46,10 +45,9 @@ describe('validatePackageVersions', () => {
     expect(npmMock.mock).toHaveBeenCalledTimes(2);
     // expect(npmMock.mockFetchJson).toHaveBeenCalledTimes(2);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
-      "[log]
-      Validating new package versions...
-      [log]
-      Package versions are OK to publish:
+      "[log] Validating new package versions...
+
+      [log] Package versions are OK to publish:
         • foo@1.0.1
         • bar@1.0.0"
     `);
@@ -67,13 +65,12 @@ describe('validatePackageVersions', () => {
     // expect(npmMock.mockFetchJson).toHaveBeenCalledTimes(3);
     // Multiple error packages are logged, along with the valid package
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
-      "[log]
-      Validating new package versions...
-      [log]
-      Package versions are OK to publish:
+      "[log] Validating new package versions...
+
+      [log] Package versions are OK to publish:
         • baz@1.0.0
-      [error]
-      ERROR: Attempting to publish package versions that already exist in the registry:
+
+      [error] ERROR: Attempting to publish package versions that already exist in the registry:
         • bar@1.0.0
         • foo@1.0.0"
     `);

--- a/src/packageManager/packPackage.ts
+++ b/src/packageManager/packPackage.ts
@@ -26,23 +26,23 @@ export async function packPackage(
 
   const packageRoot = path.dirname(packageInfo.packageJsonPath);
   const packageSpec = `${packageInfo.name}@${packageInfo.version}`;
-  console.log(`\nPacking - ${packageSpec}`);
-  console.log(`  (cwd: ${packageRoot})`);
+  console.log(`Packing - ${packageSpec}`);
+  console.log(`  (cwd: ${packageRoot})\n`);
 
   // Run npm pack in the package directory
   const result = await npm(packArgs, { cwd: packageRoot, all: true });
   // log afterwards instead of piping because we need to access the output to get the filename
-  console.log(result.all);
+  console.log((result.all || '') + '\n');
 
   if (!result.success) {
-    console.error(`\nPacking ${packageSpec} failed (see above for details)`);
+    console.error(`Packing ${packageSpec} failed (see above for details)\n`);
     return false;
   }
 
   const packFile = result.stdout.trim().split('\n').pop() || '';
   const packFilePath = path.join(packageRoot, packFile);
   if (!packFile.endsWith('.tgz') || !fs.existsSync(packFilePath)) {
-    console.error(`\nnpm pack output for ${packageSpec} (above) did not end with a filename that exists`);
+    console.error(`npm pack output for ${packageSpec} (above) did not end with a filename that exists\n`);
     return false;
   }
 
@@ -58,7 +58,7 @@ export async function packPackage(
     fs.mkdirSync(packToPath, { recursive: true });
     fs.renameSync(packFilePath, finalPackFilePath);
   } catch (err) {
-    console.error(`\nFailed to move ${packFilePath} to ${finalPackFilePath}: ${err}`);
+    console.error(`Failed to move ${packFilePath} to ${finalPackFilePath}: ${err}\n`);
     try {
       // attempt to clean up the pack file (ignore any failures)
       fs.rmSync(packFilePath);
@@ -68,6 +68,6 @@ export async function packPackage(
     return false;
   }
 
-  console.log(`\nPacked ${packageSpec} to ${finalPackFilePath}`);
+  console.log(`Packed ${packageSpec} to ${finalPackFilePath}`);
   return true;
 }

--- a/src/packageManager/packagePublish.ts
+++ b/src/packageManager/packagePublish.ts
@@ -18,10 +18,10 @@ export async function packagePublish(
   const packageRoot = path.dirname(packageInfo.packageJsonPath);
   const publishTag = publishArgs[publishArgs.indexOf('--tag') + 1];
   const packageSpec = `${packageInfo.name}@${packageInfo.version}`;
-  console.log(`\nPublishing - ${packageSpec} with tag ${publishTag}`);
+  console.log(`Publishing - ${packageSpec} with tag ${publishTag}`);
 
   console.log(`  publish command: ${publishArgs.join(' ')}`);
-  console.log(`  (cwd: ${packageRoot})`);
+  console.log(`  (cwd: ${packageRoot})\n`);
 
   let result: NpmResult;
 
@@ -40,11 +40,10 @@ export async function packagePublish(
     });
 
     if (result.success) {
-      console.log(`Published! - ${packageSpec}`);
+      console.log(`Published! - ${packageSpec}\n`);
       return result;
     }
 
-    console.log();
     const output = `Output:\n\n${result.all}\n`;
 
     // First check the output for specific cases where retries are unlikely to help.

--- a/src/publish/displayManualRecovery.ts
+++ b/src/publish/displayManualRecovery.ts
@@ -19,17 +19,18 @@ export function displayManualRecovery(
   }
 
   console.error(
-    'Something went wrong with publishing! Manually update these package and versions:\n' +
-      bulletedList(errorLines.sort())
+    'Something went wrong with publishing (see above for details). The following packages were NOT published:\n' +
+      bulletedList(errorLines.sort()) +
+      '\n'
   );
 
   if (succeededLines.length) {
+    // Previously this warned about invalid packages on the registry (referencing unpublished versions),
+    // but that should be impossible since packages are now published in topological order
     console.warn(
-      'These packages and versions were successfully published, but may be invalid if they depend on ' +
-        'package versions for which publishing failed:\n' +
+      'These packages and versions were successfully published, but will NOT be reflected in your local package.json files:\n' +
         bulletedList(succeededLines.sort()) +
-        '\n\nTo recover from this, run "beachball sync" to synchronize local package.json files with the registry. ' +
-        'If necessary, unpublish or deprecate any invalid packages from the above list after "beachball sync".'
+        '\n\nTo recover from this, run "beachball sync" to synchronize local package.json files with the registry.\n'
     );
   }
 }

--- a/src/publish/getPackagesToPublish.ts
+++ b/src/publish/getPackagesToPublish.ts
@@ -52,7 +52,7 @@ export function getPackagesToPublish(
 
   // this log is not helpful when called from `validate`
   if (skippedPackageReasons.length && params?.logSkipped) {
-    console.log(`\nSkipping publishing the following packages:\n${bulletedList(skippedPackageReasons.sort())}`);
+    console.log(`Skipping publishing the following packages:\n${bulletedList(skippedPackageReasons.sort())}\n`);
   }
 
   return packagesToPublish;

--- a/src/publish/tagPackages.ts
+++ b/src/publish/tagPackages.ts
@@ -22,7 +22,7 @@ export function tagPackages(
 
   // Reuse the getPackagesToPublish filtering logic to remove private or unchanged packages,
   // and also exclude packages with git tags disabled
-  const filteredPackages = getPackagesToPublish(bumpInfo, { toposort: false }).filter(pkg =>
+  const filteredPackages = getPackagesToPublish(bumpInfo).filter(pkg =>
     getPackageOption('gitTags', packageInfos[pkg], options)
   );
 

--- a/src/publish/toposortPackages.ts
+++ b/src/publish/toposortPackages.ts
@@ -6,11 +6,12 @@ import { getPackageDependencyGraph } from '../monorepo/getPackageDependencyGraph
  * Topologically sort the packages based on their dependency graph.
  * Dependency comes first before dependent.
  * @param packages Packages to be sorted.
- * @param packageInfos PackagesInfos for the sorted packages.
+ * @param packageInfos Packages in the repo
  */
 export function toposortPackages(packages: string[], packageInfos: PackageInfos): string[] {
+  const edges = getPackageDependencyGraph(packages, packageInfos);
   try {
-    return toposort(getPackageDependencyGraph(packages, packageInfos)).filter((pkg): pkg is string => !!pkg);
+    return toposort(edges).filter(Boolean) as string[];
   } catch (err) {
     throw new Error(`Failed to topologically sort packages: ${(err as Error)?.message}`);
   }

--- a/src/publish/validatePackageDependencies.ts
+++ b/src/publish/validatePackageDependencies.ts
@@ -29,8 +29,9 @@ export function validatePackageDependencies(packagesToValidate: string[], packag
   const errorDeps = Object.keys(prodDeps).filter(dep => packageInfos[dep]?.private);
   if (errorDeps.length) {
     console.error(
-      `ERROR: Found private packages among published package dependencies:\n` +
-        bulletedList(errorDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort())
+      `\nERROR: Found private packages among published package dependencies:\n` +
+        bulletedList(errorDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
+        '\n'
     );
     return false;
   }

--- a/src/publish/validatePackageVersions.ts
+++ b/src/publish/validatePackageVersions.ts
@@ -11,7 +11,7 @@ export async function validatePackageVersions(
   packageInfos: PackageInfos,
   options: NpmOptions
 ): Promise<boolean> {
-  console.log('\nValidating new package versions...');
+  console.log('Validating new package versions...\n');
 
   const publishedVersions = await listPackageVersions(packagesToValidate, options);
 
@@ -30,12 +30,13 @@ export async function validatePackageVersions(
 
   if (okVersions.length) {
     // keep the original order here to show what order they'll be published in
-    console.log(`\nPackage versions are OK to publish:\n${bulletedList(okVersions)}`);
+    console.log(`Package versions are OK to publish:\n${bulletedList(okVersions)}\n`);
   }
   if (errorVersions.length) {
     console.error(
-      `\nERROR: Attempting to publish package versions that already exist in the registry:\n` +
-        bulletedList(errorVersions.sort())
+      `ERROR: Attempting to publish package versions that already exist in the registry:\n` +
+        bulletedList(errorVersions.sort()) +
+        '\n'
     );
     return false;
   }


### PR DESCRIPTION
Add separate tests for `publishToRegistry()`, and remove slower E2E tests which are now adequately covered by the lower-level tests. The new tests include some snapshots of log output essentially as visual regression tests.

Also improve publish log messages and formatting (issues made obvious by snapshot tests).