### PR TITLE
Consistently use initMockLogs

### DIFF
--- a/src/__functional__/changelog/prepareChangelogPaths.test.ts
+++ b/src/__functional__/changelog/prepareChangelogPaths.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import { removeTempDir } from '../../__fixtures__/tmpdir';
 import { prepareChangelogPaths } from '../../changelog/prepareChangelogPaths';
 import { createTestFileStructure } from '../../__fixtures__/createTestFileStructure';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 describe('prepareChangelogPaths', () => {
-  let consoleLogMock: jest.SpiedFunction<typeof console.log>;
+  // there will be a bunch of ignorable warnings because /faketmpdir doesn't exist
+  const logs = initMockLogs({ alsoLog: ['error'] });
   let tempDir: string | undefined;
 
   const fakeDir = path.resolve('/faketmpdir');
@@ -14,14 +16,7 @@ describe('prepareChangelogPaths', () => {
   /** This is the beginning of the md5 hash digest of "test" */
   const testHash = '098f6bcd';
 
-  beforeAll(() => {
-    consoleLogMock = jest.spyOn(console, 'log').mockImplementation(() => {});
-    // there will be a bunch of ignorable warnings because /faketmpdir doesn't exist
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-  });
-
   afterEach(() => {
-    consoleLogMock.mockClear();
     tempDir && removeTempDir(tempDir);
     tempDir = undefined;
   });
@@ -138,8 +133,8 @@ describe('prepareChangelogPaths', () => {
     expect(fs.existsSync(path.join(tempDir, 'CHANGELOG.json'))).toBe(false);
     expect(fs.readFileSync(paths.json!, 'utf8')).toBe('{}');
 
-    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
-    expect(consoleLogMock).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
+    expect(logs.mocks.log).toHaveBeenCalledTimes(2);
   });
 
   it('migrates existing path with hash to non-hash path (uniqueFilenames true to false)', () => {
@@ -166,8 +161,8 @@ describe('prepareChangelogPaths', () => {
     expect(fs.existsSync(path.join(tempDir, `${oldName}.json`))).toBe(false);
     expect(fs.readFileSync(paths.json!, 'utf8')).toBe('{}');
 
-    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
-    expect(consoleLogMock).toHaveBeenCalledTimes(2);
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
+    expect(logs.mocks.log).toHaveBeenCalledTimes(2);
   });
 
   it('renames newest file if uniqueFilenames is true and there are multiple files with hashes', async () => {
@@ -198,8 +193,8 @@ describe('prepareChangelogPaths', () => {
     expect(fs.existsSync(path.join(tempDir, `CHANGELOG-${lastHash}.md`))).toBe(false);
     expect(fs.readFileSync(paths.md!, 'utf8')).toBe('last md');
 
-    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
-    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringContaining('Renamed existing changelog file'));
+    expect(logs.mocks.log).toHaveBeenCalledTimes(1);
 
     // The other files are untouched
     expect(fs.readFileSync(path.join(tempDir, file1), 'utf8')).toBe('md 1');

--- a/src/__functional__/options/getOptions.test.ts
+++ b/src/__functional__/options/getOptions.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it, beforeAll, afterAll, jest } from '@jest/globals';
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { getOptions, getParsedOptions } from '../../options/getOptions';
 import type { RepoOptions } from '../../types/BeachballOptions';
 import { writeJson } from '../../object/writeJson';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 describe('getOptions (deprecated)', () => {
+  initMockLogs({ alsoLog: ['error', 'warn'] });
+
   let repositoryFactory: RepositoryFactory;
   // Don't reuse a repo in these tests! If multiple tests load beachball.config.js from the same path,
   // it will use the version from the require cache, which will have outdated contents.
@@ -25,7 +28,6 @@ describe('getOptions (deprecated)', () => {
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory('single');
-    jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterAll(() => {
@@ -109,7 +111,6 @@ describe('getParsedOptions', () => {
 
   beforeAll(() => {
     repositoryFactory = new RepositoryFactory('single');
-    jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterAll(() => {

--- a/src/__tests__/bump/setDependentVersions.test.ts
+++ b/src/__tests__/bump/setDependentVersions.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, afterEach, jest, beforeAll } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import { setDependentVersions } from '../../bump/setDependentVersions';
 import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
 import { consideredDependencies } from '../../types/PackageInfo';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 type PartialBumpInfo = Parameters<typeof setDependentVersions>[0];
 
 describe('setDependentVersions', () => {
-  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  const logs = initMockLogs({ alsoLog: ['warn', 'error'] });
 
   /**
    * Make the bump info. Package versions should reflect any bumps applied.
@@ -25,15 +26,6 @@ describe('setDependentVersions', () => {
       ...rest,
     };
   }
-
-  beforeAll(() => {
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
-    jest.spyOn(console, 'info').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   it('returns empty object when no packages are in scope', () => {
     const bumpInfo = makeBumpInfo({
@@ -107,7 +99,7 @@ describe('setDependentVersions', () => {
     expect(result).toEqual({ 'pkg-b': new Set(['pkg-a']) });
 
     // doesn't log by default
-    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
   it('handles (ignores) external dependencies', () => {
@@ -149,7 +141,7 @@ describe('setDependentVersions', () => {
 
     setDependentVersions(bumpInfo, { verbose: true });
 
-    expect(consoleLogSpy).toHaveBeenCalledWith('pkg-b needs to be bumped because pkg-a ^1.0.0 -> ^2.0.0');
+    expect(logs.mocks.log).toHaveBeenCalledWith('pkg-b needs to be bumped because pkg-a ^1.0.0 -> ^2.0.0');
   });
 
   // Documenting this issue

--- a/src/__tests__/bump/updateLockFile.test.ts
+++ b/src/__tests__/bump/updateLockFile.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, jest, afterEach, beforeAll, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, afterEach, beforeEach } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import { updateLockFile } from '../../bump/updateLockFile';
 import { packageManager, type PackageManagerResult } from '../../packageManager/packageManager';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 jest.mock('fs');
 jest.mock('../../packageManager/packageManager');
@@ -15,16 +16,10 @@ jest.mock('../../env', () => ({
 }));
 
 describe('updateLockFile', () => {
+  const logs = initMockLogs({ alsoLog: ['error'] });
   const mockRoot = path.resolve('/mock/root');
   const mockFs = fs as jest.Mocked<typeof fs>;
   const mockPackageManager = packageManager as jest.MockedFunction<typeof packageManager>;
-  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-  let consoleWarnSpy: jest.SpiedFunction<typeof console.warn>;
-
-  beforeAll(() => {
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-  });
 
   beforeEach(() => {
     mockPackageManager.mockResolvedValue({ success: true } as PackageManagerResult);
@@ -40,7 +35,7 @@ describe('updateLockFile', () => {
 
     await updateLockFile({ path: mockRoot });
 
-    expect(consoleLogSpy).toHaveBeenCalledWith('Updating package-lock.json after bumping packages');
+    expect(logs.mocks.log).toHaveBeenCalledWith('Updating package-lock.json after bumping packages');
     expect(mockPackageManager).toHaveBeenCalledWith('npm', ['install', '--package-lock-only', '--ignore-scripts'], {
       stdio: 'inherit',
       cwd: mockRoot,
@@ -52,7 +47,7 @@ describe('updateLockFile', () => {
 
     await updateLockFile({ path: mockRoot });
 
-    expect(consoleLogSpy).toHaveBeenCalledWith('Updating pnpm-lock.yaml after bumping packages');
+    expect(logs.mocks.log).toHaveBeenCalledWith('Updating pnpm-lock.yaml after bumping packages');
     expect(mockPackageManager).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], {
       stdio: 'inherit',
       cwd: mockRoot,
@@ -72,7 +67,7 @@ describe('updateLockFile', () => {
       stdio: 'inherit',
       cwd: mockRoot,
     });
-    expect(consoleLogSpy).toHaveBeenCalledWith('Updating yarn.lock after bumping packages');
+    expect(logs.mocks.log).toHaveBeenCalledWith('Updating yarn.lock after bumping packages');
   });
 
   it('skips yarn.lock update for yarn v1', async () => {
@@ -83,8 +78,8 @@ describe('updateLockFile', () => {
 
     expect(mockPackageManager).toHaveBeenCalledWith('yarn', ['--version'], { cwd: mockRoot });
     expect(mockPackageManager).toHaveBeenCalledTimes(1);
-    expect(consoleLogSpy).not.toHaveBeenCalled();
-    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+    expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
   it('warns when yarn version check fails', async () => {
@@ -93,7 +88,7 @@ describe('updateLockFile', () => {
 
     await updateLockFile({ path: mockRoot });
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Failed to get yarn version. Continuing...');
+    expect(logs.mocks.warn).toHaveBeenCalledWith('Failed to get yarn version. Continuing...');
   });
 
   it('warns when lock file update fails', async () => {
@@ -102,7 +97,7 @@ describe('updateLockFile', () => {
 
     await updateLockFile({ path: mockRoot });
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Updating package-lock.json failed. Continuing...');
+    expect(logs.mocks.warn).toHaveBeenCalledWith('Updating package-lock.json failed. Continuing...');
   });
 
   it('does nothing when no lock file exists', async () => {
@@ -111,6 +106,6 @@ describe('updateLockFile', () => {
     await updateLockFile({ path: mockRoot });
 
     expect(mockPackageManager).not.toHaveBeenCalled();
-    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/bump/updatePackageJsons.test.ts
+++ b/src/__tests__/bump/updatePackageJsons.test.ts
@@ -1,10 +1,11 @@
-import { jest, describe, it, expect, beforeEach, afterEach, beforeAll } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import fs from 'fs';
 import { updatePackageJsons } from '../../bump/updatePackageJsons';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import { consideredDependencies, type PackageInfo } from '../../types/PackageInfo';
 import * as readJsonModule from '../../object/readJson';
 import * as writeJsonModule from '../../object/writeJson';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 jest.mock('fs');
 jest.mock('../../object/readJson');
@@ -14,7 +15,7 @@ describe('updatePackageJsons', () => {
   const mockFs = fs as jest.Mocked<typeof fs>;
   const mockReadJson = readJsonModule as jest.Mocked<typeof readJsonModule>;
   const mockWriteJson = writeJsonModule as jest.Mocked<typeof writeJsonModule>;
-  let consoleWarnSpy: jest.SpiedFunction<typeof console.warn>;
+  const logs = initMockLogs({ alsoLog: ['error'] });
 
   /**
    * Get `writeJson` args for a package, with beachball-specific keys removed.
@@ -23,10 +24,6 @@ describe('updatePackageJsons', () => {
     const { packageJsonPath, ...json } = packageInfo;
     return [packageJsonPath, json];
   }
-
-  beforeAll(() => {
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -80,7 +77,7 @@ describe('updatePackageJsons', () => {
 
     updatePackageJsons(modifiedPackages, packageInfos);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Skipping pkg-a since package.json does not exist');
+    expect(logs.mocks.warn).toHaveBeenCalledWith('Skipping pkg-a since package.json does not exist');
     expect(mockReadJson.readJson).not.toHaveBeenCalled();
     expect(mockWriteJson.writeJson).not.toHaveBeenCalled();
   });

--- a/src/__tests__/validate/isValidChangelogOptions.test.ts
+++ b/src/__tests__/validate/isValidChangelogOptions.test.ts
@@ -1,22 +1,15 @@
-import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { isValidChangelogOptions } from '../../validation/isValidChangelogOptions';
 import type { ChangelogGroupOptions, ChangelogOptions } from '../../types/ChangelogOptions';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 describe('isValidChangelogOptions', () => {
-  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
-
-  beforeAll(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  const logs = initMockLogs();
 
   it('returns true when options have no groups', () => {
     const options: ChangelogOptions = {};
     expect(isValidChangelogOptions(options)).toBe(true);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('returns true when groups are valid with masterPackageName', () => {
@@ -30,7 +23,7 @@ describe('isValidChangelogOptions', () => {
       ],
     } as ChangelogOptions;
     expect(isValidChangelogOptions(options)).toBe(true);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('returns true when groups are valid with mainPackageName', () => {
@@ -44,7 +37,7 @@ describe('isValidChangelogOptions', () => {
       ],
     };
     expect(isValidChangelogOptions(options)).toBe(true);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('returns false when group is missing changelogPath', () => {
@@ -57,7 +50,7 @@ describe('isValidChangelogOptions', () => {
       ],
     } as ChangelogOptions;
     expect(isValidChangelogOptions(options)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logs.mocks.error).toHaveBeenCalled();
   });
 
   it('returns false when group is missing mainPackageName and masterPackageName', () => {
@@ -70,7 +63,7 @@ describe('isValidChangelogOptions', () => {
       ],
     } as ChangelogOptions;
     expect(isValidChangelogOptions(options)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logs.mocks.error).toHaveBeenCalled();
   });
 
   it('returns false when group is missing include', () => {
@@ -83,7 +76,7 @@ describe('isValidChangelogOptions', () => {
       ],
     } as ChangelogOptions;
     expect(isValidChangelogOptions(options)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logs.mocks.error).toHaveBeenCalled();
   });
 
   it('returns false when multiple groups are invalid', () => {
@@ -98,7 +91,7 @@ describe('isValidChangelogOptions', () => {
       ],
     };
     expect(isValidChangelogOptions(options)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logs.mocks.error).toHaveBeenCalled();
   });
 
   it('returns false for a mix of valid and invalid groups', () => {
@@ -115,6 +108,6 @@ describe('isValidChangelogOptions', () => {
       ],
     };
     expect(isValidChangelogOptions(options)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logs.mocks.error).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/validate/isValidGroupOptions.test.ts
+++ b/src/__tests__/validate/isValidGroupOptions.test.ts
@@ -1,19 +1,12 @@
-import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { isValidGroupOptions, isValidGroupedPackageOptions } from '../../validation/isValidGroupOptions';
 import type { VersionGroupOptions } from '../../types/BeachballOptions';
 import type { PackageGroups } from '../../types/PackageInfo';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 
 describe('isValidGroupOptions', () => {
-  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
-
-  beforeAll(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  const logs = initMockLogs();
 
   it('returns true for valid groups', () => {
     const groups: VersionGroupOptions[] = [
@@ -21,15 +14,15 @@ describe('isValidGroupOptions', () => {
       { name: 'group2', include: ['pkg3'], disallowedChangeTypes: null },
     ];
     expect(isValidGroupOptions(groups)).toBe(true);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('returns false when groups is not an array', () => {
     const groups = { name: 'group1', include: ['pkg1'] };
     // eslint-disable-next-line
     expect(isValidGroupOptions(groups as any)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: Expected "groups" configuration setting to be an array. Received:
       { "name": "group1", "include": ["pkg1"] }"
     `);
@@ -38,8 +31,8 @@ describe('isValidGroupOptions', () => {
   it('returns false when a group is missing name', () => {
     const groups = [{ include: ['pkg1'] }] as VersionGroupOptions[];
     expect(isValidGroupOptions(groups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: "groups" configuration entries must define "include" and "name". Found invalid groups:
         • { "include": ["pkg1"] }"
     `);
@@ -48,7 +41,7 @@ describe('isValidGroupOptions', () => {
   it('returns false when a group is missing include', () => {
     const groups = [{ name: 'group1' }] as VersionGroupOptions[];
     expect(isValidGroupOptions(groups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('must define "include" and "name"'));
+    expect(logs.mocks.error).toHaveBeenCalledWith(expect.stringContaining('must define "include" and "name"'));
   });
 
   it('returns false when multiple groups are invalid', () => {
@@ -59,8 +52,8 @@ describe('isValidGroupOptions', () => {
       { name: 'ok2', include: ['pkg3'], disallowedChangeTypes: null },
     ];
     expect(isValidGroupOptions(groups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: "groups" configuration entries must define "include" and "name". Found invalid groups:
         • { "name": "group1" }
         • { "include": ["pkg1"] }"
@@ -69,15 +62,7 @@ describe('isValidGroupOptions', () => {
 });
 
 describe('isValidGroupedPackageOptions', () => {
-  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
-
-  beforeAll(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  const logs = initMockLogs();
 
   it('returns true when no packages have disallowedChangeTypes', () => {
     const packageInfos = makePackageInfos({ pkg1: {}, pkg2: {} });
@@ -85,7 +70,7 @@ describe('isValidGroupedPackageOptions', () => {
       group1: { packageNames: ['pkg1', 'pkg2'], disallowedChangeTypes: null },
     };
     expect(isValidGroupedPackageOptions(packageInfos, packageGroups)).toBe(true);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
   it('returns false when a grouped package has disallowedChangeTypes', () => {
@@ -97,8 +82,8 @@ describe('isValidGroupedPackageOptions', () => {
       group1: { packageNames: ['pkg1', 'pkg2'], disallowedChangeTypes: null },
     };
     expect(isValidGroupedPackageOptions(packageInfos, packageGroups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: Found package configs that define disallowedChangeTypes and are also part of a group. Define disallowedChangeTypes in the group instead.
         • pkg1 in group "group1""
     `);
@@ -114,8 +99,8 @@ describe('isValidGroupedPackageOptions', () => {
       group1: { packageNames: ['pkg1', 'pkg2', 'pkg3'], disallowedChangeTypes: null },
     };
     expect(isValidGroupedPackageOptions(packageInfos, packageGroups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: Found package configs that define disallowedChangeTypes and are also part of a group. Define disallowedChangeTypes in the group instead.
         • pkg1 in group "group1"
         • pkg2 in group "group1""
@@ -135,8 +120,8 @@ describe('isValidGroupedPackageOptions', () => {
       group3: { packageNames: ['pkg4'], disallowedChangeTypes: null },
     };
     expect(isValidGroupedPackageOptions(packageInfos, packageGroups)).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
+    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
+    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
       "ERROR: Found package configs that define disallowedChangeTypes and are also part of a group. Define disallowedChangeTypes in the group instead.
         • pkg1 in group "group1""
     `);


### PR DESCRIPTION
Instead of direct console spies, use the `initMockLogs` helper everywhere.