### PR TITLE
Add more tests and improve publish logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "runtimeExecutable": "npm",
       "cwd": "${workspaceFolder}",
       "runtimeArgs": ["run-script", "test"],
-      "args": ["--", "--runInBand", "--watch", "--testTimeout=1000000", "${fileBasenameNoExtension}"],
+      "args": ["--", "--runInBand", "--watch", "--testTimeout=1000000", "${file}"],
       "sourceMaps": true,
       "outputCapture": "std",
       "console": "integratedTerminal",

--- a/change/beachball-a829dbf8-bbe0-44f3-8b0a-dc845bba6f17.json
+++ b/change/beachball-a829dbf8-bbe0-44f3-8b0a-dc845bba6f17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refine publish logging",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -88,9 +88,9 @@ describe('publish command (e2e)', () => {
     generateChangeFiles(['foo'], options);
     repo.push();
 
-    let fetchCount = 0;
     addGitObserver(args => {
-      args[0] === 'fetch' && fetchCount++;
+      // no fetch when flag set to false
+      expect(args[0]).not.toBe('fetch');
     });
 
     await publishWrapper(parsedOptions);
@@ -100,9 +100,6 @@ describe('publish command (e2e)', () => {
       versions: ['1.1.0'],
       'dist-tags': { latest: '1.1.0' },
     });
-
-    // no fetch when flag set to false
-    expect(fetchCount).toBe(0);
 
     repo.checkout(defaultBranchName);
     repo.pull();

--- a/src/__e2e__/publishE2E.test.ts
+++ b/src/__e2e__/publishE2E.test.ts
@@ -20,7 +20,7 @@ import { validate } from '../validation/validate';
 // These tests are slow, so they should only cover E2E publishing scenarios that can't be fully
 // covered by lower-level tests (such as publishToRegistry or bumping functional tests), and a
 // few all-up scenarios as sanity checks. Tests specific to git or npm scenarios should
-// potentially go in publishGit.test.ts or publishRegistry.test.ts instead.
+// potentially go in publishGit.test.ts or publishNpm.test.ts instead.
 //
 // Spawning actual npm to run commands against a fake registry is extremely slow, so mock it for
 // this test (packagePublish covers the more complete npm registry scenario).

--- a/src/__e2e__/publishGit.test.ts
+++ b/src/__e2e__/publishGit.test.ts
@@ -16,7 +16,6 @@ import { getParsedOptions } from '../options/getOptions';
 import { readJson } from '../object/readJson';
 import { createCommandContext } from '../monorepo/createCommandContext';
 import type { RepoOptions } from '../types/BeachballOptions';
-import { addGitObserver, clearGitObservers } from 'workspace-tools';
 
 describe('publish command (git)', () => {
   let repositoryFactory: RepositoryFactory | undefined;
@@ -44,7 +43,6 @@ describe('publish command (git)', () => {
   }
 
   afterEach(() => {
-    clearGitObservers();
     repositoryFactory?.cleanUp();
     repositoryFactory = undefined;
     repo = undefined;
@@ -128,27 +126,5 @@ describe('publish command (git)', () => {
 
     // changes from publish process were committed
     expect(fs.existsSync(txtPath)).toBe(true);
-  });
-
-  it('specifies fetch depth when depth param is defined', async () => {
-    repositoryFactory = new RepositoryFactory('single');
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({
-      depth: 10,
-    });
-
-    generateChangeFiles(['foo'], options);
-    repo.push();
-
-    const gitObserver = jest.fn((args: string[]) => {
-      if (args[0] === 'fetch') {
-        expect(args).toContain('--depth=10');
-      }
-    });
-    addGitObserver(gitObserver);
-
-    await publish(options, createCommandContext(parsedOptions));
-    expect(gitObserver).toHaveBeenCalled();
   });
 });

--- a/src/__e2e__/publishNpm.test.ts
+++ b/src/__e2e__/publishNpm.test.ts
@@ -110,7 +110,7 @@ describe('publish command (npm)', () => {
 
     // If there's only the private package with a change file, nothing happens
     await publishWrapper(parsedOptions);
-    expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringContaining('Nothing to bump - skipping publish!'));
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package foopkg'));
     expect(logs.mocks.error).not.toHaveBeenCalled();
     expect(npmMock.getPublishedVersions('foopkg')).toBeUndefined();
@@ -132,10 +132,9 @@ describe('publish command (npm)', () => {
       [log]   OK!
 
       [log]
-      [log]
-      Preparing to publish
-      [log]
-      Publishing with the following configuration:
+      [log] Preparing to publish
+
+      [log] Publishing with the following configuration:
 
         registry: fake
 
@@ -150,8 +149,8 @@ describe('publish command (npm)', () => {
 
 
       [log] Creating temporary publish branch publish_<timestamp>
-      [log]
-      Bumping versions and publishing packages to npm registry
+
+      [log] Bumping versions and publishing packages to npm registry
 
       [log] Removing change files:
       [log] - publicpkg-<guid>.json
@@ -171,8 +170,9 @@ describe('publish command (npm)', () => {
 
       [log]
       [log] Skipping git push and tagging
-      [log]
-      Cleaning up
+
+      [log] Cleaning up
+
       [log] git checkout master
       [log] deleting temporary publish branch publish_<timestamp>"
     `);
@@ -210,7 +210,7 @@ describe('publish command (npm)', () => {
     // initial validate() isn't relevant here
     await publish(options, createCommandContext(parsedOptions));
 
-    expect(logs.mocks.log).toHaveBeenCalledWith('Nothing to bump, skipping publish!');
+    expect(logs.mocks.log).toHaveBeenCalledWith(expect.stringContaining('Nothing to bump - skipping publish!'));
     expect(logs.mocks.warn).toHaveBeenCalledWith(expect.stringContaining('Change detected for private package bar'));
     expect(logs.mocks.warn).toHaveBeenCalledWith(
       expect.stringContaining('Change detected for nonexistent package fake')

--- a/src/__e2e__/publishNpm.test.ts
+++ b/src/__e2e__/publishNpm.test.ts
@@ -25,7 +25,7 @@ import { validate } from '../validation/validate';
 jest.mock('../packageManager/npm');
 // jest.mock('npm-registry-fetch');
 
-describe('publish command (registry)', () => {
+describe('publish command (npm)', () => {
   const npmMock = initNpmMock();
 
   let repositoryFactory: RepositoryFactory | undefined;

--- a/src/__fixtures__/mockLogs.ts
+++ b/src/__fixtures__/mockLogs.ts
@@ -1,4 +1,4 @@
-import { jest, afterEach, beforeAll, afterAll } from '@jest/globals';
+import { jest, afterEach, beforeAll, afterAll, beforeEach } from '@jest/globals';
 
 /** Methods that will be mocked. More could be added later if needed. */
 type MockLogMethod = 'log' | 'warn' | 'error';
@@ -10,6 +10,12 @@ type MockLogsOptions = {
    * All logging can be enabled by setting the VERBOSE env var.
    */
   alsoLog?: boolean | MockLogMethod[];
+
+  /**
+   * Instead of setting up mocks in `beforeAll`, do it in `beforeEach`.
+   * This allows calling `jest.resetAllMocks()` in tests without breaking the logging mocks.
+   */
+  mockBeforeEach?: boolean;
 };
 
 export type MockLogs = {
@@ -49,7 +55,7 @@ export type MockLogs = {
  * of any lifecycle hooks or tests because it calls lifecycle hooks internally for setup and teardown.
  */
 export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
-  const { alsoLog } = options;
+  const { alsoLog, mockBeforeEach } = options;
   let allLines: unknown[][] = [];
   let overrideOptions: MockLogsOptions | undefined;
   const jestConsole = { ...console };
@@ -102,7 +108,7 @@ export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
     },
   };
 
-  beforeAll(() => {
+  (mockBeforeEach ? beforeEach : beforeAll)(() => {
     for (const method of mockedMethods) {
       const mainShouldLog = shouldLog(method, alsoLog);
 
@@ -121,7 +127,7 @@ export function initMockLogs(options: MockLogsOptions = {}): MockLogs {
     logs.clear();
   });
 
-  afterAll(() => {
+  (mockBeforeEach ? afterEach : afterAll)(() => {
     Object.values(logs.mocks).forEach(mock => mock.mockRestore());
   });
 

--- a/src/__fixtures__/registry.ts
+++ b/src/__fixtures__/registry.ts
@@ -17,7 +17,7 @@ const portRange = 1000;
  * Lists of tests known to use `Registry`. This is used to make each test try a different
  * port range to avoid collisions caused by race conditions with grabbing free ports.
  */
-const knownTests = ['packagePublish', 'publishE2E', 'publishRegistry', 'syncE2E'];
+const knownTests = ['packagePublish', 'publishE2E', 'publishNpm', 'syncE2E'];
 
 // NOTE: If you are getting timeouts and port collisions, set jest.setTimeout to a higher value.
 //       The default value of 5 seconds may not be enough in situations with port collisions.

--- a/src/__functional__/commands/__snapshots__/publish.test.ts.snap
+++ b/src/__functional__/commands/__snapshots__/publish.test.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`publish command logs expected output for a standard publish flow 1`] = `
+"[log]
+Validating options and change files...
+[log]
+Validating package dependencies...
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log]
+[log] Preparing to publish
+
+[log] Publishing with the following configuration:
+
+  registry: fake
+
+  current branch: master
+  current hash: <commit>
+  target branch: origin/master
+  npm dist-tag: latest
+
+  bumps versions before publishing: yes
+  publishes to npm registry: yes
+  pushes bumps and changelogs to remote git repo: no
+
+
+[log] Creating temporary publish branch publish_<timestamp>
+
+[log] Bumping versions and publishing packages to npm registry
+
+[log]
+[log] Skipping git push and tagging
+
+[log] Cleaning up
+
+[log] git checkout master
+[log] deleting temporary publish branch publish_<timestamp>"
+`;

--- a/src/__functional__/commands/publish.test.ts
+++ b/src/__functional__/commands/publish.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { getBranchName, getCurrentHash } from 'workspace-tools';
+import { generateChangeFiles } from '../../__fixtures__/changeFiles';
+import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { deepFreezeProperties } from '../../__fixtures__/object';
+import type { Repository } from '../../__fixtures__/repository';
+import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
+import { bumpInMemory } from '../../bump/bumpInMemory';
+import { publish } from '../../commands/publish';
+import { createCommandContext } from '../../monorepo/createCommandContext';
+import { getParsedOptions } from '../../options/getOptions';
+import { bumpAndPush } from '../../publish/bumpAndPush';
+import { publishToRegistry } from '../../publish/publishToRegistry';
+import type { ParsedOptions, RepoOptions } from '../../types/BeachballOptions';
+import { validate } from '../../validation/validate';
+import { getNewPackages } from '../../publish/getNewPackages';
+
+//
+// These tests focus on functionality of the publish() function itself, not its major helpers
+// such as publishToRegistry or bumpAndPush, which have their own dedicated tests.
+// Also, basics like logging and verifying which child functions are called per options should be
+// covered in the unit test publish.mock.test.ts, since tests using git are more expensive.
+//
+jest.mock('../../publish/publishToRegistry');
+jest.mock('../../publish/bumpAndPush');
+jest.mock('../../publish/getNewPackages');
+
+describe('publish command', () => {
+  // this test uses resetAllMocks, so mock the log methods in beforeEach
+  const logs = initMockLogs({ mockBeforeEach: true });
+
+  const mockPublishToRegistry = publishToRegistry as jest.MockedFunction<typeof publishToRegistry>;
+  const mockBumpAndPush = bumpAndPush as jest.MockedFunction<typeof bumpAndPush>;
+  const mockGetNewPackages = getNewPackages as jest.MockedFunction<typeof getNewPackages>;
+
+  // These tests reuse factories, so they must NOT actually push changes
+  // (even if push is true, bumpAndPush is mocked)
+  let singleRepoFactory: RepositoryFactory;
+  let monorepoFactory: RepositoryFactory;
+  let repo: Repository | undefined;
+
+  function getOptions(repoOptions?: Partial<RepoOptions>) {
+    const parsedOptions = getParsedOptions({
+      cwd: repo!.rootPath,
+      argv: ['node', 'beachball', 'publish', '--yes'],
+      testRepoOptions: {
+        branch: defaultRemoteBranchName,
+        registry: 'fake',
+        message: 'apply package updates',
+        fetch: false,
+        push: false,
+        gitTags: false,
+        tag: 'latest',
+        access: 'public',
+        ...repoOptions,
+      },
+    });
+    return { options: parsedOptions.options, parsedOptions };
+  }
+
+  /**
+   * For more realistic testing, call `validate()` like the CLI command does, then call `publish()`.
+   * This helps catch any new issues with double bumps or context mutation.
+   */
+  async function publishWrapper(parsedOptions: ParsedOptions) {
+    // This does an initial bump
+    const { context } = validate(parsedOptions, { checkDependencies: true });
+    // Ensure the later bump process does not modify the context
+    deepFreezeProperties(context.bumpInfo);
+    deepFreezeProperties(context.originalPackageInfos);
+    await publish(parsedOptions.options, context);
+    return context;
+  }
+
+  beforeAll(() => {
+    singleRepoFactory = new RepositoryFactory('single');
+    monorepoFactory = new RepositoryFactory('monorepo');
+  });
+
+  beforeEach(() => {
+    mockPublishToRegistry.mockImplementation(() => Promise.resolve());
+    mockBumpAndPush.mockImplementation(() => Promise.resolve());
+    mockGetNewPackages.mockImplementation(() => Promise.resolve([]));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    repo = undefined;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('bumps and pushes when enabled', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions({ bump: true, push: true });
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    await publishWrapper(parsedOptions);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    expect(mockBumpAndPush).toHaveBeenCalledTimes(1);
+
+    // Verify bumpAndPush received a publish branch name and the options
+    expect(mockBumpAndPush).toHaveBeenCalledWith(
+      expect.objectContaining({ modifiedPackages: expect.any(Set) }),
+      expect.stringMatching(/^publish_\d+$/),
+      expect.objectContaining({ bump: true, push: true })
+    );
+  });
+
+  it('calls publishToRegistry when packToPath is set even if publish is false', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions({ publish: false, packToPath: '/tmp/fake-pack' });
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    await publishWrapper(parsedOptions);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns to original branch and deletes publish branch after completion', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    const branchBefore = getBranchName({ cwd: repo.rootPath });
+
+    await publishWrapper(parsedOptions);
+
+    expect(getBranchName({ cwd: repo.rootPath })).toBe(branchBefore);
+    expect(repo.git(['branch']).stdout).not.toMatch(/publish_/);
+  });
+
+  it('returns to correct hash from detached HEAD', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    repo.checkout('--detach');
+    const hashBefore = getCurrentHash({ cwd: repo.rootPath });
+
+    await publishWrapper(parsedOptions);
+
+    expect(getCurrentHash({ cwd: repo.rootPath })).toBe(hashBefore);
+    expect(repo.git(['branch']).stdout).not.toMatch(/publish_/);
+  });
+
+  it('populates bumpInfo with correct change types', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    const context = createCommandContext(parsedOptions);
+    expect(context.bumpInfo).toBeUndefined();
+
+    await publish(options, context);
+
+    expect(context.bumpInfo).toBeDefined();
+    expect(context.bumpInfo!.calculatedChangeTypes).toHaveProperty('foo', 'minor');
+    expect(context.bumpInfo!.modifiedPackages).toContain('foo');
+    expect(context.bumpInfo!.packageInfos.foo.version).toBe('1.1.0');
+  });
+
+  it('passes correct bumpInfo to publishToRegistry in a monorepo', async () => {
+    repo = monorepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions({ bumpDeps: true });
+    // baz has a minor change; bar depends on baz, foo depends on bar
+    generateChangeFiles(['baz'], options);
+    logs.clear();
+
+    await publishWrapper(parsedOptions);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    const bumpInfo = mockPublishToRegistry.mock.calls[0][0];
+
+    expect(bumpInfo.calculatedChangeTypes.baz).toBe('minor');
+    expect(bumpInfo.packageInfos.baz.version).toBe('1.4.0');
+
+    expect(bumpInfo.calculatedChangeTypes.bar).toBe('patch');
+    expect(bumpInfo.packageInfos.bar.version).toBe('1.3.5');
+
+    expect(bumpInfo.calculatedChangeTypes.foo).toBe('patch');
+    expect(bumpInfo.packageInfos.foo.version).toBe('1.0.1');
+
+    expect(bumpInfo.modifiedPackages).toEqual(new Set(['foo', 'bar', 'baz']));
+  });
+
+  it('reuses pre-calculated bumpInfo from context', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    const context = createCommandContext(parsedOptions);
+    context.bumpInfo = bumpInMemory(options, context);
+    const originalBumpInfo = context.bumpInfo;
+
+    await publish(options, context);
+
+    // Should be the same object reference (not recalculated)
+    expect(context.bumpInfo).toBe(originalBumpInfo);
+    expect(mockPublishToRegistry.mock.calls[0][0]).toBe(originalBumpInfo);
+  });
+
+  it('logs expected output for a standard publish flow', async () => {
+    repo = singleRepoFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions();
+    generateChangeFiles(['foo'], options);
+    logs.clear();
+
+    await publishWrapper(parsedOptions);
+
+    expect(logs.getMockLines('all', { root: repo.rootPath, sanitize: true })).toMatchSnapshot();
+  });
+});

--- a/src/__functional__/publish/__snapshots__/publishToRegistry.test.ts.snap
+++ b/src/__functional__/publish/__snapshots__/publishToRegistry.test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`publishToRegistry includes new packages not modified 1`] = `
+"[log] Validating new package versions...
+
+[log] Package versions are OK to publish:
+  • foo@1.0.0
+  • baz@1.0.0
+
+[log] Validating no private package among package dependencies
+[log]   OK!
+
+[log] Publishing - foo@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/foo)
+
+[log] Published! - foo@1.0.0
+
+[log] Publishing - baz@1.0.0 with tag latest
+[log]   publish command: publish --registry http://localhost:99999 --tag latest --loglevel warn
+[log]   (cwd: <root>/packages/baz)
+
+[log] Published! - baz@1.0.0"
+`;
+
 exports[`publishToRegistry publishes multiple packages in dependency order 1`] = `
 "[log] Validating new package versions...
 

--- a/src/__functional__/publish/publishToRegistry.test.ts
+++ b/src/__functional__/publish/publishToRegistry.test.ts
@@ -11,9 +11,16 @@ import { publishToRegistry } from '../../publish/publishToRegistry';
 import type { BeachballOptions, HooksOptions } from '../../types/BeachballOptions';
 import type { PublishBumpInfo } from '../../types/BumpInfo';
 import type { PackageJson } from '../../types/PackageInfo';
+import { writeChangelog } from '../../changelog/writeChangelog';
 
 // Mock npm calls (publish, pack, show)
 jest.mock('../../packageManager/npm');
+
+// Also mock most of the helpers from performBump (these cover parts of bumping that
+// aren't fully set up in this test)
+jest.mock('../../changefile/unlinkChangeFiles');
+jest.mock('../../changelog/writeChangelog');
+jest.mock('../../bump/updateLockFile');
 
 describe('publishToRegistry', () => {
   const npmMock = initNpmMock();
@@ -34,12 +41,15 @@ describe('publishToRegistry', () => {
 
   afterEach(() => {
     removeTempDir(tempRoot);
+    jest.clearAllMocks();
   });
 
   /** Create a minimal PublishBumpInfo where all packages are modified and in scope */
   function makeBumpInfo(
     partialPackageInfos: Parameters<typeof makePackageInfos>[0],
-    extra?: Partial<Pick<PublishBumpInfo, 'modifiedPackages' | 'calculatedChangeTypes' | 'scopedPackages'>>
+    extra?: Partial<
+      Pick<PublishBumpInfo, 'modifiedPackages' | 'calculatedChangeTypes' | 'scopedPackages' | 'newPackages'>
+    >
   ): PublishBumpInfo {
     const packageInfos = makePackageInfos(partialPackageInfos, { path: tempRoot });
 
@@ -66,10 +76,14 @@ describe('publishToRegistry', () => {
   it('publishes a single package', async () => {
     const bumpInfo = makeBumpInfo({ foo: {} });
 
-    await publishToRegistry(bumpInfo, defaultOptions);
+    // In addition to testing the basic functionality, use a prebump hook to verify
+    // performBump isn't called due to bump: false
+    const prebump = jest.fn<Required<HooksOptions>['prebump']>();
+    await publishToRegistry(bumpInfo, { ...defaultOptions, hooks: { prebump } });
 
     const published = npmMock.getPublishedVersions('foo');
     expect(published?.versions).toEqual(['1.0.0']);
+    expect(prebump).not.toHaveBeenCalled();
 
     // This is like a visual regression test for the log UX
     expect(logs.getMockLines('all', { root: tempRoot })).toMatchInlineSnapshot(`
@@ -105,6 +119,22 @@ describe('publishToRegistry', () => {
     const publishCalls = npmMock.mock.mock.calls.filter(([args]) => args[0] === 'publish');
     const publishOrder = publishCalls.map(([, opts]) => path.basename(opts.cwd!));
     expect(publishOrder).toEqual(['lib', 'app']);
+
+    expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
+  });
+
+  it('includes new packages not modified', async () => {
+    const bumpInfo = makeBumpInfo(
+      { foo: {}, bar: {}, baz: {} },
+      { newPackages: ['baz'], modifiedPackages: new Set(['foo']), calculatedChangeTypes: { foo: 'patch' } }
+    );
+
+    await publishToRegistry(bumpInfo, defaultOptions);
+
+    expect(npmMock.getPublishedVersions('foo')?.versions).toEqual(['1.0.0']);
+    expect(npmMock.getPublishedVersions('baz')?.versions).toEqual(['1.0.0']);
+    // bar should not be published since it doesn't have a change type and isn't new
+    expect(npmMock.getPublishedVersions('bar')).toBeUndefined();
 
     expect(logs.getMockLines('all', { root: tempRoot })).toMatchSnapshot();
   });
@@ -201,6 +231,46 @@ describe('publishToRegistry', () => {
     };
     expectHookCalls(prepublish);
     expectHookCalls(postpublish);
+  });
+
+  // More details of performBump are covered by its test
+  it('bumps versions on disk before publishing with bump: true', async () => {
+    const bumpInfo = makeBumpInfo({ foo: {} });
+    // Simulate what bumpInMemory would have already done: update the in-memory version
+    // (functions that use the other parts of bumpInfo are mocked)
+    bumpInfo.packageInfos.foo.version = '1.0.1';
+
+    const prebump = jest.fn<Required<HooksOptions>['prebump']>();
+    const postbump = jest.fn<Required<HooksOptions>['postbump']>();
+    // Use the prepublish hook to verify the bump hooks are called correctly
+    const prepublish = jest.fn<Required<HooksOptions>['prepublish']>(() => {
+      expect(prebump).toHaveBeenCalledTimes(1);
+      expect(postbump).toHaveBeenCalledTimes(1);
+      const fooPath = expect.stringMatching(/packages[\\/]foo$/);
+      // BUG: this should use the old version 1.0.0, not the new one
+      // https://github.com/microsoft/beachball/issues/1116
+      expect(prebump).toHaveBeenCalledWith(fooPath, 'foo', '1.0.1', expect.anything());
+      // this is correct
+      expect(postbump).toHaveBeenCalledWith(fooPath, 'foo', '1.0.1', expect.anything());
+    });
+
+    await publishToRegistry(bumpInfo, {
+      ...defaultOptions,
+      bump: true,
+      hooks: { prebump, postbump, prepublish },
+      generateChangelog: true,
+    });
+
+    // performBump should have written the bumped version to disk, then publish used it
+    const published = npmMock.getPublishedVersions('foo');
+    expect(published?.versions).toEqual(['1.0.1']);
+    expect(prepublish).toHaveBeenCalledTimes(1);
+
+    // Verify the on-disk package.json was updated
+    const packageJson = JSON.parse(fs.readFileSync(bumpInfo.packageInfos.foo.packageJsonPath, 'utf-8')) as PackageJson;
+    expect(packageJson.version).toBe('1.0.1');
+    // And the mocked writeChangelog was called
+    expect(writeChangelog).toHaveBeenCalled();
   });
 
   describe('with concurrency > 1', () => {

--- a/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -281,4 +281,200 @@ describe('updateRelatedChangeType', () => {
       foo: 'preminor',
     });
   });
+
+  // currently fails
+  // it('respects disallowed change type from group', () => {
+  //   const bumpInfo = callUpdateRelatedChangeType({
+  //     changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
+  //     calculatedChangeTypes: { dep: 'major' },
+  //     packages: {
+  //       foo: { dependencies: { dep: '1.0.0' } },
+  //       bar: {},
+  //       dep: {},
+  //     },
+  //     packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: ['major', 'minor'] } },
+  //   });
+  //
+  //   expect(bumpInfo.calculatedChangeTypes).toEqual({
+  //     dep: 'major',
+  //     foo: 'preminor',
+  //     bar: 'preminor',
+  //   });
+  // });
+
+  it('does not bump any dependents when dependentChangeType is none', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'none' }],
+      packages: {
+        dep: {},
+        a: { dependencies: { dep: '1.0.0' } },
+        b: { dependencies: { a: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'major',
+    });
+  });
+
+  it('does not propagate when dependent already has a higher calculated change type', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      calculatedChangeTypes: { dep: 'patch', foo: 'major' },
+      packages: {
+        dep: {},
+        foo: { dependencies: { dep: '1.0.0' } },
+        app: { dependencies: { foo: '1.0.0' } },
+      },
+    });
+
+    // foo already has 'major' which is higher than 'minor', so propagation stops.
+    // app should NOT be bumped since foo's type didn't increase.
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      foo: 'major',
+    });
+  });
+
+  it('bumps package with devDependency on the changed package', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        consumer: { devDependencies: { dep: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      consumer: 'minor',
+    });
+  });
+
+  it('bumps package with peerDependency on the changed package', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        consumer: { peerDependencies: { dep: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      consumer: 'minor',
+    });
+  });
+
+  it('bumps converging dependent through diamond dependency graph', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        a: { dependencies: { dep: '1.0.0' } },
+        b: { dependencies: { dep: '1.0.0' } },
+        app: { dependencies: { a: '1.0.0', b: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      a: 'minor',
+      b: 'minor',
+      app: 'minor',
+    });
+  });
+
+  it('propagates dependentChangeType through a deep chain', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        c1: { dependencies: { dep: '1.0.0' } },
+        c2: { dependencies: { c1: '1.0.0' } },
+        c3: { dependencies: { c2: '1.0.0' } },
+        leaf: { dependencies: { c3: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      c1: 'minor',
+      c2: 'minor',
+      c3: 'minor',
+      leaf: 'minor',
+    });
+  });
+
+  it('propagates original dependentChangeType past a package with disallowedChangeTypes', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        a: {
+          dependencies: { dep: '1.0.0' },
+          beachball: { disallowedChangeTypes: ['minor'] },
+        },
+        b: { dependencies: { a: '1.0.0' } },
+      },
+    });
+
+    // 'a' gets preminor because minor is disallowed for it.
+    // 'b' gets minor (not preminor) because the original dependentChangeType propagates,
+    // not the downgraded type.
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'major',
+      a: 'preminor',
+      b: 'minor',
+    });
+  });
+
+  it('package disallowedChangeTypes null overrides repo disallowedChangeTypes', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
+      packages: {
+        dep: {},
+        foo: {
+          dependencies: { dep: '1.0.0' },
+          beachball: { disallowedChangeTypes: null },
+        },
+        bar: { dependencies: { dep: '1.0.0' } },
+      },
+      options: { disallowedChangeTypes: ['minor'] },
+    });
+
+    // foo explicitly sets disallowedChangeTypes to null, overriding the repo setting
+    // bar inherits the repo's disallowedChangeTypes
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'major',
+      foo: 'minor',
+      bar: 'preminor',
+    });
+  });
+
+  it('bumps second group when first group member depends on second group member', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      calculatedChangeTypes: { dep: 'patch' },
+      packages: {
+        dep: {},
+        g1a: { dependencies: { dep: '1.0.0' } },
+        g1b: {},
+        g2a: { dependencies: { g1a: '1.0.0' } },
+        g2b: {},
+      },
+      packageGroups: {
+        grp1: { packageNames: ['g1a', 'g1b'], disallowedChangeTypes: null },
+        grp2: { packageNames: ['g2a', 'g2b'], disallowedChangeTypes: null },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'patch',
+      g1a: 'minor',
+      g1b: 'minor',
+      g2a: 'minor',
+      g2b: 'minor',
+    });
+  });
 });

--- a/src/__tests__/commands/publish.mock.test.ts
+++ b/src/__tests__/commands/publish.mock.test.ts
@@ -1,0 +1,259 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as wsTools from 'workspace-tools';
+import { generateChangeSet } from '../../__fixtures__/changeFiles';
+import { defaultBranchName, defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
+import { publish } from '../../commands/publish';
+import { getParsedOptions } from '../../options/getOptions';
+import { bumpAndPush } from '../../publish/bumpAndPush';
+import { getNewPackages } from '../../publish/getNewPackages';
+import { publishToRegistry } from '../../publish/publishToRegistry';
+import type { RepoOptions } from '../../types/BeachballOptions';
+import type { BumpInfo } from '../../types/BumpInfo';
+import type { CommandContext } from '../../types/CommandContext';
+
+jest.mock('workspace-tools');
+jest.mock('../../bump/bumpInMemory');
+jest.mock('../../publish/bumpAndPush');
+jest.mock('../../publish/getNewPackages');
+jest.mock('../../publish/publishToRegistry');
+
+describe('publish command (all helpers mocked)', () => {
+  // this test uses resetAllMocks, so mock the log methods in beforeEach
+  const logs = initMockLogs({ mockBeforeEach: true });
+
+  const mockPublishToRegistry = publishToRegistry as jest.MockedFunction<typeof publishToRegistry>;
+  const mockBumpAndPush = bumpAndPush as jest.MockedFunction<typeof bumpAndPush>;
+  const mockGetNewPackages = getNewPackages as jest.MockedFunction<typeof getNewPackages>;
+  const wsToolsMocks = wsTools as jest.Mocked<typeof wsTools>;
+  const matchAny = expect.anything();
+  const matchPublishBranch = expect.stringMatching(/^publish_\d+$/);
+  const currentHash = 'abc123';
+
+  /**
+   * Get options and context. The context has a completely empty `bumpInfo`, but the `changeSet`
+   * contains a change for each package (since it's looked at directly by logic within `publish()`).
+   */
+  function getOptionsAndContext(params: {
+    /** bump, push, and publish are true by default */
+    repoOptions?: Partial<RepoOptions>;
+    packageInfos: PartialPackageInfos;
+    context?: Partial<CommandContext>;
+  }) {
+    const { repoOptions, packageInfos, context: partialContext } = params;
+
+    const parsedOptions = getParsedOptions({
+      cwd: '',
+      argv: ['node', 'beachball', 'publish', '--yes'],
+      testRepoOptions: {
+        branch: defaultRemoteBranchName,
+        registry: 'fake',
+        message: 'apply package updates',
+        push: true,
+        bump: true,
+        publish: true,
+        tag: 'latest',
+        new: false,
+        ...repoOptions,
+      },
+    });
+
+    const context: CommandContext = {
+      originalPackageInfos: makePackageInfos(packageInfos, parsedOptions.cliOptions),
+      packageGroups: {},
+      scopedPackages: new Set(Object.keys(packageInfos)),
+      changeSet: generateChangeSet(Object.keys(packageInfos)),
+      bumpInfo: {} as BumpInfo,
+      ...partialContext,
+    };
+
+    return { options: parsedOptions.options, context };
+  }
+
+  beforeEach(() => {
+    /* eslint-disable -- require-await, incorrect no-deprecated */
+    mockPublishToRegistry.mockImplementation(async () => console.log('fake publishing\n'));
+    mockBumpAndPush.mockImplementation(async () => console.log('fake bump and push\n'));
+    mockGetNewPackages.mockImplementation(() => Promise.resolve([]));
+    wsToolsMocks.getBranchName.mockReturnValue(defaultBranchName);
+    wsToolsMocks.getCurrentHash.mockReturnValue(currentHash);
+    wsToolsMocks.git.mockReturnValue({ stdout: '', stderr: '', success: true } as wsTools.GitProcessOutput);
+    /* eslint-enable */
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns early when there are no change files', async () => {
+    const { options, context } = getOptionsAndContext({
+      packageInfos: { foo: {} },
+      context: { changeSet: [] },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).not.toHaveBeenCalled();
+    expect(mockBumpAndPush).not.toHaveBeenCalled();
+
+    expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
+      "[log] Preparing to publish
+
+      [log] Nothing to bump - skipping publish!"
+    `);
+  });
+
+  it('bumps, pushes, publishes, and checks for new packages when options are all true', async () => {
+    const { options, context } = getOptionsAndContext({
+      packageInfos: { foo: {} },
+      repoOptions: { new: true, branch: 'origin/publish-branch' },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    expect(mockBumpAndPush).toHaveBeenCalledTimes(1);
+    expect(mockGetNewPackages).toHaveBeenCalledTimes(1);
+    const logContent = logs.getMockLines('all', { sanitize: true });
+    expect(logContent).toContain('bumps versions before publishing: yes');
+    expect(logContent).toContain('pushes bumps and changelogs to remote git repo: yes');
+    expect(logContent).not.toContain('Skipping git push and tagging');
+
+    // Snapshot all the logs for this test
+    expect(logContent).toMatchInlineSnapshot(`
+      "[log] Preparing to publish
+
+      [log] Publishing with the following configuration:
+
+        registry: fake
+
+        current branch: master
+        current hash: abc123
+        target branch: origin/publish-branch
+        npm dist-tag: latest
+
+        bumps versions before publishing: yes
+        publishes to npm registry: yes
+        pushes bumps and changelogs to remote git repo: yes
+
+
+      [log] Creating temporary publish branch publish_<timestamp>
+
+      [log] Fetching all unmodified packages from the registry to check if there are any newly-added packages that didn't have a change file...
+      (NOTE: If your PR build runs \`beachball check\`, this step is unnecessarily slowing down your publish process. In that case, it's recommended to remove \`new: true\` from your config or remove \`--new\` from your publish command.)
+
+      [log] Bumping versions and publishing packages to npm registry
+
+      [log] fake publishing
+
+      [log]
+      [log] fake bump and push
+
+      [log] Cleaning up
+
+      [log] git checkout master
+      [log] deleting temporary publish branch publish_<timestamp>"
+    `);
+  });
+
+  it('skips bumpAndPush when push is false', async () => {
+    const { options, context } = getOptionsAndContext({
+      repoOptions: { push: false },
+      packageInfos: { foo: {} },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    expect(mockBumpAndPush).not.toHaveBeenCalled();
+    expect(mockGetNewPackages).not.toHaveBeenCalled();
+    const logContent = logs.getMockLines('all');
+    expect(logContent).toContain('bumps versions before publishing: yes');
+    expect(logContent).toContain('pushes bumps and changelogs to remote git repo: no');
+    expect(logContent).toContain('publishes to npm registry: yes');
+    expect(logContent).toContain('Skipping git push and tagging');
+  });
+
+  it('skips bumpAndPush when bump is false', async () => {
+    const { options, context } = getOptionsAndContext({
+      repoOptions: { bump: false },
+      packageInfos: { foo: {} },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    expect(mockBumpAndPush).not.toHaveBeenCalled();
+    const logContent = logs.getMockLines('all');
+    expect(logContent).toContain('bumps versions before publishing: no');
+    expect(logContent).toContain('pushes bumps and changelogs to remote git repo: no');
+    expect(logContent).toContain('Skipping git push and tagging');
+  });
+
+  it('skips publishToRegistry when publish is false', async () => {
+    const { options, context } = getOptionsAndContext({
+      repoOptions: { publish: false },
+      packageInfos: { foo: {} },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).not.toHaveBeenCalled();
+    expect(mockBumpAndPush).toHaveBeenCalledTimes(1);
+    const logContent = logs.getMockLines('all');
+    expect(logContent).toContain('publishes to npm registry: no');
+    expect(logContent).toContain('bumps versions before publishing: yes');
+    expect(logContent).toContain('Skipping publish');
+  });
+
+  it('calls publishToRegistry when packToPath is set even if publish is false', async () => {
+    const { options, context } = getOptionsAndContext({
+      repoOptions: { publish: false, packToPath: '/tmp/fake-pack' },
+      packageInfos: { foo: {} },
+    });
+
+    await publish(options, context);
+
+    expect(mockPublishToRegistry).toHaveBeenCalledTimes(1);
+    expect(mockBumpAndPush).toHaveBeenCalledTimes(1);
+    const logContent = logs.getMockLines('all');
+    expect(logContent).toContain('packs to path instead of publishing to npm registry: /tmp/fake-pack');
+    expect(logContent).toContain('bumps versions before packing: yes');
+    expect(logContent).not.toContain('Skipping publish');
+  });
+
+  // This also needs to be covered by a test with real git
+  it('returns to original branch and deletes publish branch after completion', async () => {
+    const currentBranch = 'fake-branch';
+    // eslint-disable-next-line etc/no-deprecated
+    wsToolsMocks.getBranchName.mockReturnValue(currentBranch);
+    const { options, context } = getOptionsAndContext({
+      packageInfos: { foo: {} },
+    });
+
+    await publish(options, context);
+
+    expect(wsToolsMocks.gitFailFast).toHaveBeenNthCalledWith(1, ['checkout', '-b', matchPublishBranch], matchAny);
+    expect(wsToolsMocks.gitFailFast).toHaveBeenLastCalledWith(['checkout', currentBranch], matchAny);
+    expect(wsToolsMocks.git).toHaveBeenLastCalledWith(['branch', '-D', matchPublishBranch], matchAny);
+  });
+
+  it('returns to correct hash from detached HEAD', async () => {
+    // eslint-disable-next-line etc/no-deprecated
+    wsToolsMocks.getBranchName.mockReturnValue('HEAD');
+
+    const { options, context } = getOptionsAndContext({ packageInfos: { foo: {} } });
+
+    await publish(options, context);
+
+    expect(wsToolsMocks.gitFailFast).toHaveBeenNthCalledWith(1, ['checkout', '-b', matchPublishBranch], matchAny);
+    expect(wsToolsMocks.gitFailFast).toHaveBeenLastCalledWith(['checkout', currentHash], matchAny);
+    expect(wsToolsMocks.git).toHaveBeenLastCalledWith(['branch', '-D', matchPublishBranch], matchAny);
+    expect(logs.mocks.log).toHaveBeenCalledWith('Looks like the repo was detached from a branch');
+  });
+});

--- a/src/__tests__/publish/__snapshots__/bumpAndPush.test.ts.snap
+++ b/src/__tests__/publish/__snapshots__/bumpAndPush.test.ts.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bumpAndPush retries on fetch failure then succeeds 2`] = `
+"[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 1/5)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[warn] fetch error
+[warn] Fetching branch "master" from remote "origin" failed (code 1)
+[warn] [WARN 1/5]: Fetching from origin/master has failed! (see above for details)
+[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 2/5)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[log] Fetching branch "master" from remote "origin" completed successfully
+[log]
+Merging with origin/master...
+[log] Running: git merge -X theirs origin/master
+[log]
+[log] git merge -X theirs origin/master completed successfully
+[log]
+Bumping versions locally (and writing changelogs if requested)
+[log]
+Merging publish_12345 into origin/master...
+[log] Running: git add .
+[log]
+[log] git add . completed successfully
+[log] Running: git commit -m apply package updates
+[log]
+[log] git commit -m apply package updates completed successfully
+[log] Running: git checkout origin/master
+[log]
+[log] git checkout origin/master completed successfully
+[log] Running: git merge -X ours publish_12345
+[log]
+[log] git merge -X ours publish_12345 completed successfully
+[log]
+Creating git tags for new versions...
+[log]
+Pushing to origin/master...
+[log] Running: git push --no-verify --follow-tags --verbose origin HEAD:master
+[log]
+[log] git push --no-verify --follow-tags --verbose origin HEAD:master completed successfully"
+`;
+
+exports[`bumpAndPush succeeds on first attempt 1`] = `
+"[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 1/5)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[log] Fetching branch "master" from remote "origin" completed successfully
+[log]
+Merging with origin/master...
+[log] Running: git merge -X theirs origin/master
+[log]
+[log] git merge -X theirs origin/master completed successfully
+[log]
+Bumping versions locally (and writing changelogs if requested)
+[log]
+Merging publish_12345 into origin/master...
+[log] Running: git add .
+[log]
+[log] git add . completed successfully
+[log] Running: git commit -m apply package updates
+[log]
+[log] git commit -m apply package updates completed successfully
+[log] Running: git checkout origin/master
+[log]
+[log] git checkout origin/master completed successfully
+[log] Running: git merge -X ours publish_12345
+[log]
+[log] git merge -X ours publish_12345 completed successfully
+[log]
+Creating git tags for new versions...
+[log]
+Pushing to origin/master...
+[log] Running: git push --no-verify --follow-tags --verbose origin HEAD:master
+[log]
+[log] git push --no-verify --follow-tags --verbose origin HEAD:master completed successfully"
+`;
+
+exports[`bumpAndPush throws and calls displayManualRecovery after all retries exhausted 1`] = `
+"[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 1/3)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[warn] network error
+[warn] Fetching branch "master" from remote "origin" failed (code 1)
+[warn] [WARN 1/3]: Fetching from origin/master has failed! (see above for details)
+[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 2/3)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[warn] network error
+[warn] Fetching branch "master" from remote "origin" failed (code 1)
+[warn] [WARN 2/3]: Fetching from origin/master has failed! (see above for details)
+[log] --------------------------------------------------------------------------------
+[log] Bumping versions and pushing to git (attempt 3/3)
+[log] Reverting
+[log]
+[log] Fetching branch "master" from remote "origin"...
+[warn] network error
+[warn] Fetching branch "master" from remote "origin" failed (code 1)
+[warn] [WARN 3/3]: Fetching from origin/master has failed! (see above for details)
+[log]
+[error] Something went wrong with publishing (see above for details). The following packages were NOT published:
+  • bar@2.0.0
+  • foo@1.1.0"
+`;

--- a/src/__tests__/publish/bumpAndPush.test.ts
+++ b/src/__tests__/publish/bumpAndPush.test.ts
@@ -1,0 +1,249 @@
+/* eslint-disable etc/no-deprecated -- lots of incorrect warnings about variadic signatures */
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import path from 'path';
+import * as wsTools from 'workspace-tools';
+import type { GitProcessOutput } from 'workspace-tools';
+import _execa from 'execa';
+import { bumpAndPush } from '../../publish/bumpAndPush';
+import { performBump as _performBump } from '../../bump/performBump';
+import { tagPackages as _tagPackages } from '../../publish/tagPackages';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import type { BumpInfo } from '../../types/BumpInfo';
+import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { getParsedOptions } from '../../options/getOptions';
+import { BeachballError } from '../../types/BeachballError';
+import type { BeachballOptions } from '../../types/BeachballOptions';
+
+jest.mock('execa');
+jest.mock('workspace-tools');
+jest.mock('../../bump/performBump'); // this has a bunch of logic which is tested separately
+jest.mock('../../publish/tagPackages');
+
+// execa's overloaded types are too complex for jest.Mock, so we cast it to the signature that's used
+const mockExeca = _execa as unknown as jest.MockedFunction<
+  (file: string, args?: readonly string[], options?: _execa.Options) => _execa.ExecaChildProcess
+>;
+const mockPerformBump = _performBump as jest.MockedFunction<typeof _performBump>;
+const mockTagPackages = _tagPackages as jest.MockedFunction<typeof _tagPackages>;
+const wsToolsMocks = wsTools as jest.Mocked<typeof wsTools>;
+
+describe('bumpAndPush', () => {
+  const logs = initMockLogs();
+
+  const fakeRoot = path.resolve('/fake/root');
+  const publishBranch = 'publish_12345';
+
+  /** Create a mock execa result that resolves like a real ExecaChildProcess */
+  function makeExecaResult(opts: { success: boolean; output?: string; timedOut?: boolean }) {
+    const result = {
+      failed: !opts.success,
+      all: opts.output ?? '',
+      exitCode: opts.success ? 0 : 1,
+      stdout: opts.output ?? '',
+      stderr: '',
+      timedOut: opts.timedOut ?? false,
+    } as _execa.ExecaReturnValue;
+    return Object.assign(Promise.resolve(result), { stdout: null, stderr: null }) as _execa.ExecaChildProcess;
+  }
+
+  function getExecaCalls() {
+    return mockExeca.mock.calls.map(([file, args]) => `${file} ${args?.join(' ')}`);
+  }
+
+  function getWsToolsGitCalls() {
+    return wsToolsMocks.git.mock.calls.map(([args]) => `git ${args.join(' ')}`);
+  }
+
+  /** Create a mock workspace-tools git() result */
+  function makeGitResult(opts: { success: boolean; output?: string }): GitProcessOutput {
+    return {
+      stderr: opts.success ? '' : opts.output ?? '',
+      stdout: opts.success ? opts.output ?? '' : '',
+      success: opts.success,
+      status: opts.success ? 0 : 1,
+    } as GitProcessOutput;
+  }
+
+  function callBumpAndPush(optionOverrides?: Partial<BeachballOptions>, maxRetries?: number) {
+    const { options } = getParsedOptions({
+      cwd: fakeRoot,
+      argv: [],
+      testRepoOptions: {
+        branch: defaultRemoteBranchName,
+        message: 'apply package updates',
+        ...optionOverrides,
+      },
+    });
+    const bumpInfo: BumpInfo = {
+      packageInfos: makePackageInfos({ foo: { version: '1.1.0' }, bar: { version: '2.0.0' } }),
+      modifiedPackages: new Set(['foo', 'bar']),
+      changeFileChangeInfos: [],
+      calculatedChangeTypes: { foo: 'minor', bar: 'major' },
+      dependentChangedBy: {},
+      packageGroups: {},
+      scopedPackages: new Set(['foo', 'bar']),
+    };
+    return bumpAndPush(bumpInfo, publishBranch, options, maxRetries);
+  }
+
+  beforeEach(() => {
+    wsToolsMocks.parseRemoteBranch.mockReturnValue({ remote: 'origin', remoteBranch: 'master' });
+    wsToolsMocks.revertLocalChanges.mockReturnValue(true);
+    wsToolsMocks.git.mockReturnValue(makeGitResult({ success: true }));
+    mockExeca.mockImplementation(() => makeExecaResult({ success: true }));
+    mockPerformBump.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('succeeds on first attempt', async () => {
+    await callBumpAndPush();
+
+    expect(mockPerformBump).toHaveBeenCalledTimes(1);
+    expect(mockTagPackages).toHaveBeenCalledTimes(1);
+    expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(1);
+    expect(getWsToolsGitCalls().join('\n')).toEqual('git fetch origin master');
+    expect(getExecaCalls()).toEqual([
+      'git merge -X theirs origin/master',
+      'git add .',
+      'git commit -m apply package updates',
+      'git checkout origin/master',
+      'git merge -X ours publish_12345',
+      'git push --no-verify --follow-tags --verbose origin HEAD:master',
+    ]);
+
+    // Beachball's logs are its UI, so snapshots are essentially "visual regression" tests
+    expect(logs.getMockLines('all')).toMatchSnapshot();
+  });
+
+  it('skips fetch when options.fetch is false', async () => {
+    await callBumpAndPush({ fetch: false });
+
+    expect(wsToolsMocks.git).not.toHaveBeenCalled();
+    expect(getExecaCalls().join('\n')).not.toContain('fetch');
+  });
+
+  it('retries on fetch failure then succeeds', async () => {
+    wsToolsMocks.git
+      .mockReturnValueOnce(makeGitResult({ success: false, output: 'fetch error' }))
+      .mockReturnValueOnce(makeGitResult({ success: true }));
+
+    await callBumpAndPush();
+
+    expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(2);
+    expect(mockPerformBump).toHaveBeenCalledTimes(1);
+
+    expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
+      "fetch error
+      Fetching branch "master" from remote "origin" failed (code 1)
+      [WARN 1/5]: Fetching from origin/master has failed! (see above for details)"
+    `);
+    expect(logs.getMockLines('all')).toMatchSnapshot();
+  });
+
+  it('retries on mergePublishBranch failure then succeeds', async () => {
+    // First attempt: merge with branch succeeds, but commit in mergePublishBranch fails
+    // (merge is call 1, add is call 2, commit is call 3)
+    let callCount = 0;
+    mockExeca.mockImplementation(() => {
+      callCount++;
+      // Fail on 3rd call (commit) in first attempt
+      if (callCount === 3) {
+        return makeExecaResult({ success: false, output: 'commit failed' });
+      }
+      return makeExecaResult({ success: true });
+    });
+
+    await callBumpAndPush();
+
+    expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(2);
+    expect(mockPerformBump).toHaveBeenCalledTimes(2);
+
+    expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
+      "commit failed
+      git commit -m apply package updates failed (code 1)
+      [WARN 1/5]: Merging to target has failed! (see above for details)"
+    `);
+  });
+
+  it('retries on push failure then succeeds', async () => {
+    let pushCount = 0;
+    mockExeca.mockImplementation((_cmd, args) => {
+      if (args?.[0] === 'push') {
+        pushCount++;
+        if (pushCount === 1) return makeExecaResult({ success: false, output: 'push rejected' });
+      }
+      return makeExecaResult({ success: true });
+    });
+
+    await callBumpAndPush();
+
+    expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(2);
+    expect(mockPerformBump).toHaveBeenCalledTimes(2);
+    expect(mockTagPackages).toHaveBeenCalledTimes(2);
+
+    expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
+      "push rejected
+      git push --no-verify --follow-tags --verbose origin HEAD:master failed (code 1)
+      [WARN 1/5]: Pushing to origin/master has failed! (see above for details)"
+    `);
+  });
+
+  it('shows timeout message on push timeout', async () => {
+    let pushCount = 0;
+    mockExeca.mockImplementation((_cmd, args) => {
+      if (args?.[0] === 'push') {
+        pushCount++;
+        if (pushCount === 1) return makeExecaResult({ success: false, timedOut: true });
+      }
+      return makeExecaResult({ success: true });
+    });
+
+    await callBumpAndPush();
+
+    expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
+      "git push --no-verify --follow-tags --verbose origin HEAD:master failed (code 1)
+      [WARN 1/5]: Pushing to origin/master has timed out! (see above for details)"
+    `);
+  });
+
+  it('calls precommit hook before merge steps', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    const precommit = jest.fn<(cwd: string) => Promise<void>>(async () => console.log('hello from hook'));
+    await callBumpAndPush({ hooks: { precommit } });
+
+    expect(precommit).toHaveBeenCalledTimes(1);
+    expect(precommit).toHaveBeenCalledWith(fakeRoot);
+
+    // Should be called right before series of merge steps
+    expect(logs.getMockLines('log')).toContain('hello from hook\n\nMerging publish_');
+  });
+
+  it('calls precommit hook on each retry', async () => {
+    const precommit = jest.fn<(cwd: string) => Promise<void>>();
+    mockExeca.mockImplementation((_cmd, args) =>
+      args?.[0] === 'push' ? makeExecaResult({ success: false, output: 'oh no' }) : makeExecaResult({ success: true })
+    );
+
+    await expect(() => callBumpAndPush({ hooks: { precommit } }, 3)).rejects.toThrow(BeachballError);
+
+    expect(precommit).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws and calls displayManualRecovery after all retries exhausted', async () => {
+    // Fail every fetch (happens to give the shortest snapshot output)
+    wsToolsMocks.git.mockReturnValue(makeGitResult({ success: false, output: 'network error' }));
+
+    await expect(() => callBumpAndPush({}, 3)).rejects.toThrow('Failed to bump and push after 3 attempts');
+
+    expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(3);
+    expect(mockPerformBump).not.toHaveBeenCalled();
+
+    const logOutput = logs.getMockLines('all');
+    expect(logOutput).toContain('Something went wrong with publishing'); // from displayManualRecovery
+    expect(logOutput).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/publish/bumpAndPush.test.ts
+++ b/src/__tests__/publish/bumpAndPush.test.ts
@@ -126,6 +126,18 @@ describe('bumpAndPush', () => {
     expect(getExecaCalls().join('\n')).not.toContain('fetch');
   });
 
+  it('specifies fetch depth when depth param is defined', async () => {
+    wsToolsMocks.git.mockImplementation((args: string[]) => {
+      if (args[0] === 'fetch') {
+        expect(args).toContain('--depth=10');
+      }
+      return { stdout: '', stderr: '', success: true } as wsTools.GitProcessOutput;
+    });
+
+    expect.assertions(1);
+    await callBumpAndPush({ fetch: true, depth: 10 });
+  });
+
   it('retries on fetch failure then succeeds', async () => {
     wsToolsMocks.git
       .mockReturnValueOnce(makeGitResult({ success: false, output: 'fetch error' }))

--- a/src/__tests__/publish/getNewPackages.test.ts
+++ b/src/__tests__/publish/getNewPackages.test.ts
@@ -55,9 +55,11 @@ describe('getNewPackages', () => {
     expect(newPackages).toEqual(['foo', 'bar']);
     expect(npmMock.mock).toHaveBeenCalledTimes(2);
     // expect(npmMock.mockFetchJson).toHaveBeenCalledTimes(2);
-    expect(logs.mocks.log).toHaveBeenCalledTimes(2);
-    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: foo');
-    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: bar');
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+      "New package(s) detected:
+        • foo
+        • bar"
+    `);
   });
 
   it('returns only new package with mix of new, old, and modified', async () => {
@@ -69,7 +71,9 @@ describe('getNewPackages', () => {
     expect(newPackages).toEqual(['baz']);
     expect(npmMock.mock).toHaveBeenCalledTimes(2);
     // expect(npmMock.mockFetchJson).toHaveBeenCalledTimes(2);
-    expect(logs.mocks.log).toHaveBeenCalledTimes(1);
-    expect(logs.mocks.log).toHaveBeenCalledWith('New package detected: baz');
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+      "New package(s) detected:
+        • baz"
+    `);
   });
 });

--- a/src/__tests__/publish/tagPackages.test.ts
+++ b/src/__tests__/publish/tagPackages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-import { gitFailFast } from 'workspace-tools';
+import { gitFailFast as _gitFailFast } from 'workspace-tools';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { tagPackages } from '../../publish/tagPackages';
 import { generateTag } from '../../git/generateTag';
@@ -8,6 +8,7 @@ import { makePackageInfos } from '../../__fixtures__/packageInfos';
 jest.mock('workspace-tools', () => ({
   gitFailFast: jest.fn(),
 }));
+const gitFailFast = _gitFailFast as jest.MockedFunction<typeof _gitFailFast>;
 
 const createTagParameters = (tag: string) => {
   return [['tag', '-a', '-f', tag, '-m', tag], { cwd: '' }];
@@ -60,7 +61,7 @@ describe('tagPackages', () => {
   initMockLogs();
 
   beforeEach(() => {
-    (gitFailFast as jest.Mock).mockReset();
+    gitFailFast.mockReset();
   });
 
   it('does not create package tag for packages with gitTags=false', () => {
@@ -88,6 +89,24 @@ describe('tagPackages', () => {
     // verify git is being called to create new auto tag for foo
     const newFooTag = generateTag('foo', oneTagBumpInfo.packageInfos['foo'].version);
     expect(gitFailFast).toHaveBeenCalledWith(...createTagParameters(newFooTag));
+  });
+
+  it('tags multiple packages with gitTags=true', () => {
+    const modifiedPackages = new Set(['foo', 'bar']);
+    tagPackages(
+      { ...oneTagBumpInfo, modifiedPackages, packageInfos: makePackageInfos({ foo: {}, bar: {} }) },
+      { path: '', gitTags: true, tag: 'beta' }
+    );
+    expect(gitFailFast).toHaveBeenCalledTimes(3);
+
+    // verify git is being called to create new auto tags for foo and bar,
+    // and an overall tag since it's not "latest"
+    const gitCalls = gitFailFast.mock.calls.map(([args]) => args.join(' '));
+    expect(gitCalls).toEqual([
+      'tag -a -f foo_v1.0.0 -m foo_v1.0.0',
+      'tag -a -f bar_v1.0.0 -m bar_v1.0.0',
+      'tag -a -f beta -m beta',
+    ]);
   });
 
   it('does not create package tag for packages with changeType none', () => {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,13 +1,13 @@
-import { bumpInMemory } from '../bump/bumpInMemory';
-import type { BeachballOptions } from '../types/BeachballOptions';
-import { gitFailFast, getBranchName, getCurrentHash, git } from 'workspace-tools';
 import prompts from 'prompts';
-import { bumpAndPush } from '../publish/bumpAndPush';
-import { publishToRegistry } from '../publish/publishToRegistry';
-import { getNewPackages } from '../publish/getNewPackages';
-import type { CommandContext } from '../types/CommandContext';
+import { getBranchName, getCurrentHash, git, gitFailFast } from 'workspace-tools';
+import { bumpInMemory } from '../bump/bumpInMemory';
 import { createCommandContext } from '../monorepo/createCommandContext';
+import { bumpAndPush } from '../publish/bumpAndPush';
+import { getNewPackages } from '../publish/getNewPackages';
+import { publishToRegistry } from '../publish/publishToRegistry';
+import type { BeachballOptions } from '../types/BeachballOptions';
 import type { PublishBumpInfo } from '../types/BumpInfo';
+import type { CommandContext } from '../types/CommandContext';
 
 /**
  * Potentially bump, publish, and push package changes depending on options.
@@ -17,7 +17,7 @@ export async function publish(options: BeachballOptions, context: CommandContext
 /** @deprecated Use other signature */
 export async function publish(options: BeachballOptions): Promise<void>;
 export async function publish(options: BeachballOptions, context?: CommandContext): Promise<void> {
-  console.log('\nPreparing to publish');
+  console.log('Preparing to publish\n');
 
   const { path: cwd, branch, registry, tag, packToPath } = options;
   // eslint-disable-next-line etc/no-deprecated -- compat code
@@ -27,7 +27,7 @@ export async function publish(options: BeachballOptions, context?: CommandContex
   const { changeSet: changes } = context;
 
   if (!changes.length) {
-    console.log('Nothing to bump, skipping publish!');
+    console.log('Nothing to bump - skipping publish!\n');
     return;
   }
 
@@ -35,7 +35,7 @@ export async function publish(options: BeachballOptions, context?: CommandContex
   const currentHash = getCurrentHash({ cwd });
   const shouldBumpAndPush = !!(options.bump && options.push && branch);
 
-  console.log(`\nPublishing with the following configuration:
+  console.log(`Publishing with the following configuration:
 
   registry: ${registry}
 
@@ -65,16 +65,18 @@ export async function publish(options: BeachballOptions, context?: CommandContex
     if (!response.yes) {
       return;
     }
+    console.log();
   }
 
   // checkout publish branch
-  const publishBranch = 'publish_' + String(new Date().getTime());
+  const publishBranch = `publish_${Date.now()}`;
 
-  console.log(`Creating temporary publish branch ${publishBranch}`);
+  console.log(`Creating temporary publish branch ${publishBranch}\n`);
   gitFailFast(['checkout', '-b', publishBranch], { cwd });
 
   if (!context.bumpInfo) {
-    console.log(`\nGathering info ${options.bump ? 'to bump versions' : 'about versions and changes'}`);
+    // This only applies for legacy usage (not by beachball directly)
+    console.log(`Gathering info ${options.bump ? 'to bump versions' : 'about versions and changes'}\n`);
     context.bumpInfo = bumpInMemory(options, context);
   }
   const bumpInfo: PublishBumpInfo = context.bumpInfo;
@@ -84,11 +86,11 @@ export async function publish(options: BeachballOptions, context?: CommandContex
     // Publish newly created packages even if they don't have change files
     // (this is unlikely unless the packages were pushed without a PR that runs "beachball check")
     console.log(
-      '\nFetching all unmodified packages from the registry to check if there are any ' +
+      'Fetching all unmodified packages from the registry to check if there are any ' +
         "newly-added packages that didn't have a change file...\n" +
         '(NOTE: If your PR build runs `beachball check`, this step is unnecessarily slowing down ' +
         "your publish process. In that case, it's recommended to remove `new: true` from your " +
-        'config or remove `--new` from your publish command.)'
+        'config or remove `--new` from your publish command.)\n'
     );
     bumpInfo.newPackages = await getNewPackages(bumpInfo, options);
   }
@@ -100,11 +102,12 @@ export async function publish(options: BeachballOptions, context?: CommandContex
     const message = options.bump
       ? `Bumping versions and ${publishMessage}`
       : publishMessage[0].toUpperCase() + publishMessage.slice(1);
-    console.log(`\n${message}\n`);
+    console.log(`${message}\n`);
+
     await publishToRegistry(bumpInfo, options);
     console.log();
   } else {
-    console.log('Skipping publish');
+    console.log('Skipping publish\n');
   }
 
   // Step 2.
@@ -114,14 +117,13 @@ export async function publish(options: BeachballOptions, context?: CommandContex
     // this does its own section logging
     await bumpAndPush(bumpInfo, publishBranch, options);
   } else {
-    console.log('Skipping git push and tagging');
+    console.log('Skipping git push and tagging\n');
   }
 
   // Step 3.
   // Clean up: switch back to current branch, delete publish branch
-  console.log('\nCleaning up');
+  console.log('Cleaning up\n');
 
-  const revParseSuccessful = currentBranch || currentHash;
   if (currentBranch && currentBranch !== 'HEAD') {
     console.log(`git checkout ${currentBranch}`);
     gitFailFast(['checkout', currentBranch], { cwd });
@@ -131,7 +133,7 @@ export async function publish(options: BeachballOptions, context?: CommandContex
     gitFailFast(['checkout', currentHash], { cwd });
   }
 
-  if (revParseSuccessful) {
+  if (currentBranch || currentHash) {
     console.log(`deleting temporary publish branch ${publishBranch}`);
     const deletionResult = git(['branch', '-D', publishBranch], { cwd });
     if (!deletionResult.success) {

--- a/src/publish/bumpAndPush.ts
+++ b/src/publish/bumpAndPush.ts
@@ -8,7 +8,7 @@ import { gitFetch } from '../git/fetch';
 import { gitAsync } from '../git/gitAsync';
 import { BeachballError } from '../types/BeachballError';
 
-const bumpPushRetries = 5;
+const defaultBumpPushRetries = 5;
 /** Use verbose logging for these steps to make it easier to debug if something goes wrong */
 const verbose = true;
 
@@ -16,11 +16,14 @@ const verbose = true;
  * Bump versions locally, commit, optionally tag, and push to git.
  *
  * This should NOT mutate `bumpInfo`.
+ *
+ * @param bumpPushRetries Retry count, overrideable for testing only
  */
 export async function bumpAndPush(
   bumpInfo: Readonly<BumpInfo>,
   publishBranch: string,
-  options: BeachballOptions
+  options: BeachballOptions,
+  bumpPushRetries = defaultBumpPushRetries
 ): Promise<void> {
   const { path: cwd, branch, depth, gitTimeout } = options;
   const { remote, remoteBranch } = parseRemoteBranch({ branch, cwd });
@@ -87,6 +90,7 @@ export async function bumpAndPush(
   }
 
   if (!completed) {
+    console.log();
     displayManualRecovery(bumpInfo);
     throw new BeachballError(`Failed to bump and push after ${bumpPushRetries} attempts`, {
       alreadyLogged: true,

--- a/src/publish/getNewPackages.ts
+++ b/src/publish/getNewPackages.ts
@@ -1,6 +1,7 @@
 import type { BumpInfo } from '../types/BumpInfo';
 import { listPackageVersions } from '../packageManager/listPackageVersions';
 import type { NpmOptions } from '../types/NpmOptions';
+import { bulletedList } from '../logging/bulletedList';
 
 /**
  * Get package versions from the registry to determine if there are any new packages that didn't
@@ -19,11 +20,9 @@ export async function getNewPackages(
 
   const publishedVersions = await listPackageVersions(maybeNewPackages, options);
 
-  return maybeNewPackages.filter(pkg => {
-    if (!publishedVersions[pkg]?.length) {
-      console.log(`New package detected: ${pkg}`);
-      return true;
-    }
-    return false;
-  });
+  const result = maybeNewPackages.filter(pkg => !publishedVersions[pkg]?.length);
+  if (result.length) {
+    console.log(`New package(s) detected:\n${bulletedList(result)}\n`);
+  }
+  return result;
 }

--- a/src/publish/publishToRegistry.ts
+++ b/src/publish/publishToRegistry.ts
@@ -33,7 +33,7 @@ export async function publishToRegistry(bumpInfo: PublishBumpInfo, options: Beac
   // get the packages to publish, reducing the set by packages that don't need publishing
   let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true });
   if (!packagesToPublish.length) {
-    console.log('Nothing to publish');
+    console.log('Nothing to publish\n');
     return;
   }
 
@@ -121,7 +121,7 @@ export async function publishToRegistry(bumpInfo: PublishBumpInfo, options: Beac
     if (packToPath) {
       // The regular recovery message is mostly irrelevant for packing, since nothing was published
       console.error(
-        'Something went wrong with packing packages! No packages were published, so you can address the issue and try again.'
+        'Something went wrong with packing packages! No packages were published, so you can address the issue and try again.\n'
       );
     } else {
       displayManualRecovery(bumpInfo, succeededPackages);


### PR DESCRIPTION
Add more tests, including snapshot tests for publishing. 

Log snapshots in beachball are essentially "visual regression" tests since the logs are the UI, and adding the snapshots showed some opportunities to improve the spacing/formatting of various publish logs.