### PR TITLE
Configure trusted publishing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,16 +22,29 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        npm: [8]
         include:
           - os: ubuntu-latest
             # npm 6 and 8 have slightly different behavior with verdaccio in publishing tests.
             # It's unclear if this translates to meaningful differences in behavior in actual scenarios,
             # but test against both versions to be safe. (Only do this on the ubuntu build for speed.)
             npm: 6
+            node: 14
+          # node 14/npm 8 on ubuntu and windows
+          - os: ubuntu-latest
+            npm: 8
+            node: 14
+          - os: windows-latest
+            npm: 8
+            node: 14
+          # node 22/npm 11 on ubuntu and windows
+          - os: ubuntu-latest
+            npm: 11
+            node: 22
+          - os: windows-latest
+            npm: 11
+            node: 22
 
-    name: build (${{ matrix.os }}, npm ${{ matrix.npm }})
+    name: build (${{ matrix.os }}, node ${{ matrix.node }}, npm ${{ matrix.npm }})
 
     runs-on: ${{ matrix.os }}
 
@@ -39,11 +52,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Node.js from .nvmrc
+      - name: Install Node.js ${{ matrix.node }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: yarn
-          node-version-file: .nvmrc
+          node-version: ${{ matrix.node }}
+
+      # Temporary extra command to work around weird node issue (swich to just npm i -g npm once fixed)
+      # https://github.com/nodejs/node/issues/62425#issuecomment-4200715930
+      - name: node 22 npm workaround
+        if: matrix.node == 22
+        run: npm i -g npm@10.9.8
 
       # Guarantee a predictable version of npm for the first round of tests
       - name: Install npm@${{ matrix.npm }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,13 +36,13 @@ jobs:
           - os: windows-latest
             npm: 8
             node: 14
-          # node 22/npm 11 on ubuntu and windows
+          # node 20/npm 11 on ubuntu and windows (can't use 22 for reasons described in release.yml)
           - os: ubuntu-latest
             npm: 11
-            node: 22
+            node: 20
           - os: windows-latest
             npm: 11
-            node: 22
+            node: 20
 
     name: build (${{ matrix.os }}, node ${{ matrix.node }}, npm ${{ matrix.npm }})
 
@@ -58,12 +58,6 @@ jobs:
           cache: yarn
           node-version: ${{ matrix.node }}
 
-      # Temporary extra command to work around weird node issue (swich to just npm i -g npm once fixed)
-      # https://github.com/nodejs/node/issues/62425#issuecomment-4200715930
-      - name: node 22 npm workaround
-        if: matrix.node == 22
-        run: npm i -g npm@10.9.8
-
       # Guarantee a predictable version of npm for the first round of tests
       - name: Install npm@${{ matrix.npm }}
         run: npm install --global npm@${{ matrix.npm }}
@@ -75,7 +69,7 @@ jobs:
       - run: yarn checkchange --verbose
 
       - run: yarn format:check
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.npm == 8
 
       - run: yarn lint
 
@@ -95,11 +89,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Node.js 22
+      - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: yarn
-          node-version: 24
+          node-version-file: ./docs/.nvmrc
 
       - run: yarn --immutable
         working-directory: ./docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,12 @@ name: Release
 on:
   workflow_dispatch:
 
-# Use newer node and npm for trusted publishing support
+# Use newer node and npm for trusted publishing support. Can't use node 22 yet because of test issues.
+# (`npm login` hangs with the current verdaccio version; this is fixed in latest verdaccio, but it's
+# not compatible with old node)
 env:
+  nodeVersion: 20
   npmVersion: 11
-  nodeVersion: 22
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +22,10 @@ jobs:
 
     # This environment contains secrets needed for publishing
     environment: release
+
+    permissions:
+      # for trusted publishing
+      id-token: write
 
     steps:
       - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,10 @@ name: Release
 on:
   workflow_dispatch:
 
+# Use newer node and npm for trusted publishing support
 env:
-  npmVersion: 8
+  npmVersion: 11
+  nodeVersion: 22
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,14 +28,13 @@ jobs:
           # Don't save creds in the git config (so it's easier to override later)
           persist-credentials: false
 
-      - name: Install Node.js from .nvmrc
+      - name: Install Node.js ${{ env.nodeVersion }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version-file: .nvmrc
+          node-version: ${{ env.nodeVersion }}
 
-      # Guarantee a predictable version of npm (the PR build tests against both 6 and 8)
-      - name: Install package managers
-        run: npm install --global npm@${{ env.npmVersion }} yarn@1
+      - name: Install npm@${{ env.npmVersion }}
+        run: npm install --global npm@${{ env.npmVersion }}
 
       - run: yarn --frozen-lockfile
 
@@ -58,7 +59,6 @@ jobs:
           # Add a token to the remote URL for auth during release
           git remote set-url origin "https://$REPO_PAT@github.com/$GITHUB_REPOSITORY"
 
-          yarn release -y -n "$NPM_AUTHTOKEN"
+          yarn release -y
         env:
-          NPM_AUTHTOKEN: ${{ secrets.NPM_AUTHTOKEN }}
           REPO_PAT: ${{ secrets.REPO_PAT }}

--- a/src/__fixtures__/registry.ts
+++ b/src/__fixtures__/registry.ts
@@ -17,7 +17,7 @@ const portRange = 1000;
  * Lists of tests known to use `Registry`. This is used to make each test try a different
  * port range to avoid collisions caused by race conditions with grabbing free ports.
  */
-const knownTests = ['packagePublish', 'publishE2E', 'publishNpm', 'syncE2E'];
+const knownTests = ['packagePublish'];
 
 // NOTE: If you are getting timeouts and port collisions, set jest.setTimeout to a higher value.
 //       The default value of 5 seconds may not be enough in situations with port collisions.
@@ -71,7 +71,13 @@ export class Registry {
     try {
       const registry = this.getUrl();
       console.log(`logging in to ${registry}`);
-      const npm = execa('npm', ['adduser', '--registry', registry]);
+      const npm = execa('npm', ['login', '--registry', registry, '--verbose']);
+      // If this is failing or hanging and you need to debug:
+      //   npm.stdout?.pipe(process.stdout);
+      //   npm.stderr?.pipe(process.stderr);
+      // With Node 22+ and verdaccio 5, the npm login HTTP request fails for some reason.
+      // This is fixed with latest verdaccio, which we can bump when bumping Node.
+
       // for some reason there's no way to supply the username, password, and email besides stdin
       npm.stdout?.on('data', chunk => {
         const chunkStr = String(chunk);
@@ -79,7 +85,7 @@ export class Registry {
           npm.stdin?.write(verdaccioUser.username + '\r\n');
         } else if (chunkStr.includes('Password:')) {
           npm.stdin?.write(verdaccioUser.password + '\r\n');
-        } else if (chunkStr.includes('Email:')) {
+        } else if (chunkStr.includes('Email:') || chunkStr.includes('Email (')) {
           npm.stdin?.write('fake@example.com\r\n');
         }
       });


### PR DESCRIPTION
Run release build on newer Node/npm and configure trusted publishing.

Run PR builds on newer Node/npm in addition to old. For now I had to use Node 20 (not 22) because with verdaccio 5, the `npm login` request to the mock registry fails for unknown reasons. This works fine in latest verdaccio, but it's not possible to upgrade yet due to incompatibilities with old Node/npm.