### PR TITLE
Security: NPM auth token is passed on command line (process list exposure)

### DIFF
--- a/packages/beachball/src/packageManager/npmArgs.ts
+++ b/packages/beachball/src/packageManager/npmArgs.ts
@@ -11,6 +11,10 @@ export function getNpmLogLevelArgs(verbose: boolean | undefined): string[] {
 export function getNpmPublishArgs(packageInfo: PackageInfo, options: Omit<NpmOptions, 'path'>): string[] {
   const { registry, access } = options;
   const authArgs = getNpmAuthArgs(options);
+  if (authArgs) {
+    process.env.NODE_AUTH_TOKEN = authArgs.value;
+  }
+
   const args = [
     'publish',
     '--registry',
@@ -22,7 +26,6 @@ export function getNpmPublishArgs(packageInfo: PackageInfo, options: Omit<NpmOpt
       getPackageOption('defaultNpmTag', packageInfo, options) ||
       'latest',
     ...getNpmLogLevelArgs(options.verbose),
-    ...(authArgs ? [`--${authArgs.key}=${authArgs.value}`] : []),
   ];
 
   if (access && packageInfo.name[0] === '@') {


### PR DESCRIPTION
## Summary

Security: NPM auth token is passed on command line (process list exposure)

## Problem

**Severity**: `High` | **File**: `packages/beachball/src/packageManager/npmArgs.ts:L20`

Publish arguments include auth credentials directly as CLI flags (for example `--//registry/:_authToken=<token>`). Command-line arguments can be exposed via process listings, CI diagnostics, crash reports, or audit tooling, leading to credential leakage.

## Solution

Do not pass tokens in CLI args. Prefer environment variables supported by npm (`NODE_AUTH_TOKEN`) or write a temporary `.npmrc` with restrictive permissions and delete it after use. Ensure logs never print full auth material.

## Changes

- `packages/beachball/src/packageManager/npmArgs.ts` (modified)