### PR TITLE
Prefer --token over NPM_TOKEN

### DIFF
--- a/change/change-e8985df7-93ea-470b-b4f4-bb4edeeb7e9b.json
+++ b/change/change-e8985df7-93ea-470b-b4f4-bb4edeeb7e9b.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Prefer `--token`/`-n` over `process.env.NPM_TOKEN`",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/beachball/src/__functional__/options/getCliOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getCliOptions.test.ts
@@ -214,6 +214,16 @@ describe('getCliOptions', () => {
     expect(options).toEqual({ ...defaults, token: 'fake-token' });
   });
 
+  it('prefers CLI token over NPM_TOKEN environment variable', () => {
+    const options = getCliOptionsTest(['--token', 'cli-token'], undefined, { NPM_TOKEN: 'env-token' });
+    expect(options).toEqual({ ...defaults, token: 'cli-token' });
+  });
+
+  it('prefers empty string CLI token over NPM_TOKEN environment variable', () => {
+    const options = getCliOptionsTest(['--token', ''], undefined, { NPM_TOKEN: 'env-token' });
+    expect(options).toEqual({ ...defaults, token: '' });
+  });
+
   describe('config command', () => {
     it('parses config get with setting name', () => {
       const options = getCliOptionsTest(['config', 'get', 'branch']);

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -208,7 +208,9 @@ export function getCliOptions(processOrArgv: ProcessInfo | string[]): ParsedOpti
     cliOptions._extraPositionalArgs = extraPositionalArgs;
   }
 
-  if (processInfo.env.NPM_TOKEN) {
+  // If both --token and NPM_TOKEN are provided, prefer the CLI token (could go either way, but
+  // this is safer for compatibility in case anyone was already using that env name another way)
+  if (processInfo.env.NPM_TOKEN && cliOptions.token === undefined) {
     cliOptions.token = processInfo.env.NPM_TOKEN;
   }
 


### PR DESCRIPTION
If both `--token`/`-n` and `NPM_TOKEN` are provided, prefer the CLI token. This is safer for compatibility in case anyone was already using that env name another way.