### PR TITLE
Fix cherry-pick change types

### DIFF
--- a/change/change-4095d8fa-faa9-49db-8687-4a11e49f08fd.json
+++ b/change/change-4095d8fa-faa9-49db-8687-4a11e49f08fd.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "type": "patch",
-      "comment": "Fix npm auth environment variables with yarn 4",
+      "type": "none",
+      "comment": "(cherry-pick) Fix npm auth environment variables with yarn 4",
       "packageName": "beachball",
       "email": "elcraig@microsoft.com",
-      "dependentChangeType": "patch"
+      "dependentChangeType": "none"
     }
   ]
 }

--- a/change/change-e0ebd254-f3c4-4b0b-aa4f-533fe9300419.json
+++ b/change/change-e0ebd254-f3c4-4b0b-aa4f-533fe9300419.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "type": "patch",
-      "comment": "Fully fix iterative deepening for latest git",
+      "type": "none",
+      "comment": "(cherry-pick) Fully fix iterative deepening for latest git",
       "packageName": "beachball",
       "email": "elcraig@microsoft.com",
-      "dependentChangeType": "patch"
+      "dependentChangeType": "none"
     }
   ]
 }


### PR DESCRIPTION
Cherry-picks to v3 (`main`) that are already in v2 should have change type `none` since they're not really part of the new release.