### PR TITLE
Fix handling of group disallowedChangeTypes with dependent bumps

### DIFF
--- a/change/change-e5e83f54-1a36-4545-9dcc-ee8af7201e1e.json
+++ b/change/change-e5e83f54-1a36-4545-9dcc-ee8af7201e1e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Fix handling of group `disallowedChangeTypes` in dependent bumps (`updateRelatedChangeType`). This should be non-breaking but has a chance of unexpected side effects.",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -13,26 +13,24 @@ describe('updateRelatedChangeType', () => {
    * Call `updateRelatedChangeType` once for each of `changes`.
    * Returns the updated bump info.
    */
-  function callUpdateRelatedChangeType(
-    options: Partial<Pick<BeachballOptions, 'bumpDeps'>> & {
-      changes: Array<Pick<ChangeInfo, 'packageName' | 'type' | 'dependentChangeType'>>;
-      /**
-       * All the packages used in this fixture, including any per-package beachball options.
-       * Must include any dependencies (all versions are 1.0.0).
-       */
-      packages: PartialPackageInfos;
-      /** Repo disallowed change types */
-      options?: Pick<BeachballOptions, 'disallowedChangeTypes'>;
-      /**
-       * Initial calculated change types before updates. This is **required** if `packageGroups`
-       * is specified (since the initial calculation is complex) but otherwise a default can be
-       * calculated from `changes`.
-       */
-      calculatedChangeTypes?: { [packageName: string]: ChangeType };
-      packageGroups?: PackageGroups;
-    }
-  ) {
-    const { packages, packageGroups, bumpDeps = true } = options;
+  function callUpdateRelatedChangeType(options: {
+    changes: Array<Pick<ChangeInfo, 'packageName' | 'type' | 'dependentChangeType'>>;
+    /**
+     * All the packages used in this fixture, including any per-package beachball options.
+     * Must include any dependencies (all versions are 1.0.0).
+     */
+    packages: PartialPackageInfos;
+    /** Repo disallowed change types */
+    options?: Pick<BeachballOptions, 'disallowedChangeTypes'>;
+    /**
+     * Initial calculated change types before updates. This is **required** if `packageGroups`
+     * is specified (since the initial calculation is complex) but otherwise a default can be
+     * calculated from `changes`.
+     */
+    calculatedChangeTypes?: { [packageName: string]: ChangeType };
+    packageGroups?: PackageGroups;
+  }) {
+    const { packages, packageGroups } = options;
 
     if (packageGroups && !options.calculatedChangeTypes) {
       throw new Error('calculatedChangeTypes must be specified if packageGroups is used');
@@ -46,6 +44,14 @@ describe('updateRelatedChangeType', () => {
     }));
 
     const packageInfos = makePackageInfos(packages);
+    const packageToGroup: Record<string, string> = {};
+    if (packageGroups) {
+      for (const [groupName, group] of Object.entries(packageGroups)) {
+        for (const packageName of group.packageNames) {
+          packageToGroup[packageName] = groupName;
+        }
+      }
+    }
 
     const params: RelatedChangeTypeParams = {
       bumpInfo: {
@@ -57,9 +63,8 @@ describe('updateRelatedChangeType', () => {
       options: { disallowedChangeTypes: null, ...options.options },
       // Dependents are confusing to reason about directly (or specify in fixtures) since they're
       // backwards from dependencies, so just reuse the actual helper that calculates them
-      dependents: bumpDeps
-        ? getDependentsForPackages({ packageInfos, scopedPackages: new Set(Object.keys(packageInfos)) })
-        : undefined,
+      dependents: getDependentsForPackages({ packageInfos, scopedPackages: new Set(Object.keys(packageInfos)) }),
+      packageToGroup,
     };
 
     for (const change of changes) {
@@ -82,19 +87,6 @@ describe('updateRelatedChangeType', () => {
       foo: 'patch',
       bar: 'minor',
     });
-  });
-
-  it('does not bump dependents with bumpDeps: false', () => {
-    const bumpInfo = callUpdateRelatedChangeType({
-      bumpDeps: false,
-      changes: [{ packageName: 'foo', type: 'patch', dependentChangeType: 'minor' }],
-      packages: {
-        bar: { dependencies: { foo: '1.0.0' } },
-        foo: {},
-      },
-    });
-
-    expect(bumpInfo.calculatedChangeTypes).toEqual({ foo: 'patch' });
   });
 
   it("respects bumped dependent package's own change type if higher than dependentChangeType", () => {
@@ -165,10 +157,29 @@ describe('updateRelatedChangeType', () => {
     });
   });
 
+  it('bumps all grouped packages, if a dependency was bumped and group was not previously bumped', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
+      calculatedChangeTypes: { dep: 'major' },
+      packages: {
+        foo: { dependencies: { dep: '1.0.0' } },
+        bar: {},
+        dep: {},
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: null } },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'major',
+      foo: 'minor',
+      bar: 'minor',
+    });
+  });
+
   // bumpInPlace sets calculatedChangeTypes for all packages in a group to the same type.
   // So the meaningful thing to test is that a bump of a dependency *outside* the group
   // propagates in to bump the group.
-  it('bumps all grouped packages, if a dependency was bumped', () => {
+  it('bumps all grouped packages, if a dependency was bumped and group had lower bump type', () => {
     const bumpInfo = callUpdateRelatedChangeType({
       packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: null } },
       // Suppose there was some additional change file that already patch bumped the group packages
@@ -282,25 +293,24 @@ describe('updateRelatedChangeType', () => {
     });
   });
 
-  // currently fails
-  // it('respects disallowed change type from group', () => {
-  //   const bumpInfo = callUpdateRelatedChangeType({
-  //     changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
-  //     calculatedChangeTypes: { dep: 'major' },
-  //     packages: {
-  //       foo: { dependencies: { dep: '1.0.0' } },
-  //       bar: {},
-  //       dep: {},
-  //     },
-  //     packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: ['major', 'minor'] } },
-  //   });
-  //
-  //   expect(bumpInfo.calculatedChangeTypes).toEqual({
-  //     dep: 'major',
-  //     foo: 'preminor',
-  //     bar: 'preminor',
-  //   });
-  // });
+  it('respects disallowed change type from group', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'major', dependentChangeType: 'minor' }],
+      calculatedChangeTypes: { dep: 'major' },
+      packages: {
+        foo: { dependencies: { dep: '1.0.0' } },
+        bar: {},
+        dep: {},
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: ['major', 'minor'] } },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'major',
+      foo: 'preminor',
+      bar: 'preminor',
+    });
+  });
 
   it('does not bump any dependents when dependentChangeType is none', () => {
     const bumpInfo = callUpdateRelatedChangeType({
@@ -336,33 +346,20 @@ describe('updateRelatedChangeType', () => {
     });
   });
 
-  it('bumps package with devDependency on the changed package', () => {
+  it('bumps package with devDependency or peerDependency on the changed package', () => {
     const bumpInfo = callUpdateRelatedChangeType({
-      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
+      changes: [{ packageName: 'dep', type: 'minor', dependentChangeType: 'patch' }],
       packages: {
         dep: {},
         consumer: { devDependencies: { dep: '1.0.0' } },
+        peerConsumer: { peerDependencies: { dep: '1.0.0' } },
       },
     });
 
     expect(bumpInfo.calculatedChangeTypes).toEqual({
-      dep: 'patch',
-      consumer: 'minor',
-    });
-  });
-
-  it('bumps package with peerDependency on the changed package', () => {
-    const bumpInfo = callUpdateRelatedChangeType({
-      changes: [{ packageName: 'dep', type: 'patch', dependentChangeType: 'minor' }],
-      packages: {
-        dep: {},
-        consumer: { peerDependencies: { dep: '1.0.0' } },
-      },
-    });
-
-    expect(bumpInfo.calculatedChangeTypes).toEqual({
-      dep: 'patch',
-      consumer: 'minor',
+      dep: 'minor',
+      consumer: 'patch',
+      peerConsumer: 'patch',
     });
   });
 
@@ -475,6 +472,27 @@ describe('updateRelatedChangeType', () => {
       g1b: 'minor',
       g2a: 'minor',
       g2b: 'minor',
+    });
+  });
+
+  it('does not re-bump group members of the changed package via dependentChangeType', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'foo', type: 'patch', dependentChangeType: 'minor' }],
+      calculatedChangeTypes: { foo: 'patch', bar: 'patch' },
+      packages: {
+        foo: {},
+        bar: {},
+        external: { dependencies: { foo: '1.0.0' } },
+      },
+      packageGroups: { grp: { packageNames: ['foo', 'bar'], disallowedChangeTypes: null } },
+    });
+
+    // 'bar' stays at 'patch' — the startKey check skips group expansion for the initial package.
+    // 'external' gets 'minor' because it depends on 'foo'.
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      foo: 'patch',
+      bar: 'patch',
+      external: 'minor',
     });
   });
 });

--- a/packages/beachball/src/bump/bumpInMemory.ts
+++ b/packages/beachball/src/bump/bumpInMemory.ts
@@ -17,8 +17,8 @@ import { setDependentVersions } from './setDependentVersions';
 export function bumpInMemory(options: BeachballOptions, context: Omit<CommandContext, 'bumpInfo'>): BumpInfo {
   const { bumpDeps } = options;
 
-  // Pass 1: calculatedChangeTypes includes ONLY changes direct from the change files
-  // (no dependents, groups, or disallowedChangeTypes)
+  // Pass 1: calculatedChangeTypes includes ONLY changes direct from the change files (no dependents,
+  // groups, or disallowedChangeTypes). "none" changes are removed.
   const calculatedChangeTypes = initializePackageChangeTypes(context.changeSet);
 
   // (Splitting out a couple properties that aren't modified as initial step of reducing mutation approach)
@@ -37,11 +37,15 @@ export function bumpInMemory(options: BeachballOptions, context: Omit<CommandCon
   //       - set the version for all packages in the group in (bumpPackageInfoVersion())
   //       - the main concern is how to capture the bump reason in grouped changelog
 
-  // pass 2: initialize grouped calculatedChangeTypes together
-  for (const group of Object.values(bumpInfo.packageGroups)) {
+  // pass 2: initialize grouped calculatedChangeTypes together (and cache the package to group mapping)
+  const packageToGroup: Record<string, string> = {};
+  for (const [groupName, group] of Object.entries(bumpInfo.packageGroups)) {
     // If any of the group's packages have a change, find the max change type out of any package in the group.
+    // ("none" types were removed by initializePackageChangeTypes).
     const seenTypes = new Set<ChangeType>();
     for (const packageNameInGroup of group.packageNames) {
+      packageToGroup[packageNameInGroup] = groupName;
+
       const changeType = calculatedChangeTypes[packageNameInGroup];
       if (changeType) {
         seenTypes.add(changeType);
@@ -49,7 +53,8 @@ export function bumpInMemory(options: BeachballOptions, context: Omit<CommandCon
     }
 
     if (seenTypes.size) {
-      // Set all packages in the group to the max change type.
+      // Set all packages in the group to the max valid type found, overwriting any previous type
+      // (validate() should have prevented an invalid group type at this step, but check to be safe)
       const maxChangeInGroup = getMaxChangeType([...seenTypes], group.disallowedChangeTypes);
       for (const packageNameInGroup of group.packageNames) {
         calculatedChangeTypes[packageNameInGroup] = maxChangeInGroup;
@@ -57,11 +62,13 @@ export function bumpInMemory(options: BeachballOptions, context: Omit<CommandCon
     }
   }
 
-  // Pass 3: Calculate change types for dependents and groups.
+  // Pass 3: Calculate change types for dependents (propagating dependent bumps through groups).
   // TODO: fix weird behavior - https://github.com/microsoft/beachball/issues/620
-  const dependents = bumpDeps ? getDependentsForPackages(bumpInfo) : undefined;
-  for (const { change } of context.changeSet) {
-    updateRelatedChangeType({ change, bumpInfo, dependents, options });
+  if (bumpDeps) {
+    const dependents = getDependentsForPackages(bumpInfo);
+    for (const { change } of context.changeSet) {
+      updateRelatedChangeType({ change, bumpInfo, dependents, options, packageToGroup });
+    }
   }
 
   // pass 4: actually bump the packages in the bumpInfo in memory (no disk writes at this point)

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -2,24 +2,24 @@ import { getMaxChangeType } from '../changefile/changeTypes';
 import { getPackageOption } from '../options/getPackageOption';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import type { BumpInfo, PackageDependents } from '../types/BumpInfo';
-import type { ChangeFileInfo } from '../types/ChangeInfo';
+import type { ChangeFileInfo, ChangeType } from '../types/ChangeInfo';
 
 /**
- * This is the core of the `bumpInfo` dependency bumping logic - done once per change info.
+ * Apply `dependentChangeType` bumps (propagating through groups) and respecting `disallowedChangeTypes`
+ * from repo, group, and package settings. This is only called if `bumpDeps` is true.
  *
- * The algorithm is an iterative graph traversal algorithm (breadth first):
- * - One root entry: `change.packageName`
+ * The algorithm is an iterative graph traversal:
+ * - One root entry: `change.packageName` with `change.dependentChangeType`
  * - For each parent in `dependents`:
  *   - Update its `calculatedChangeTypes` entry to `max(current value, change.dependentChangeType)`
- *   - Enqueue all of its dependents to be seen
- * - If the package is part of a group, enqueue all packages in the group
+ *   - Enqueue all of its dependents (if not already seen)
+ * - If the package is part of a group, enqueue all packages in the group (if not already seen)
  *
  * Preconditions:
  * - `bumpInfo.calculatedChangeTypes` includes:
  *   - For non-grouped packages that have changed, the highest change type from any change file
  *   - For each grouped package where anything in the group has changed, the highest change type
  *     from any change file in the group
- * - `dependents` is undefined if `BeachballOptions.bumpDeps` was false
  *
  * What it mutates:
  * - `bumpInfo.calculatedChangeTypes`: update change type for package and dependents
@@ -31,74 +31,83 @@ import type { ChangeFileInfo } from '../types/ChangeInfo';
 export function updateRelatedChangeType(params: {
   change: ChangeFileInfo;
   bumpInfo: Pick<BumpInfo, 'calculatedChangeTypes' | 'packageGroups' | 'packageInfos'>;
-  dependents: PackageDependents | undefined;
+  dependents: PackageDependents;
   options: Pick<BeachballOptions, 'disallowedChangeTypes'>;
+  /** Cached package name to group name mapping for quick lookup */
+  packageToGroup: Record<string, string>;
 }): void {
-  const { change, bumpInfo, dependents } = params;
+  const { change, bumpInfo, dependents, packageToGroup } = params;
   const { calculatedChangeTypes, packageGroups, packageInfos } = bumpInfo;
 
   // If dependentChangeType is none (or somehow unset), there's nothing to do.
-  const dependentChangeType = getMaxChangeType([change.dependentChangeType]);
-  if (dependentChangeType === 'none') {
+  if (getMaxChangeType([change.dependentChangeType]) === 'none') {
     return;
   }
 
-  // Enqueue the first package.
-  // This part of the bump algorithm is a performance bottleneck, so it's important to bail early
+  // Enqueue the first package. (dependentChangeType in the queue is usually the same as from the
+  // change file, but for packages in a group with disallowedChangeTypes, it might have been downgraded.)
+  //
+  // WARNING: This part of the bump algorithm is a performance bottleneck, so it's important to bail early
   // whenever possible, and to use `seen` to reduce queue insertion.
   // https://github.com/microsoft/beachball/pull/1042
-  const queue = [change.packageName];
-  const seen = new Set<string>();
+  type SeenKey = `${string}#${ChangeType}`;
+  const seen = new Set<SeenKey>();
+  const seenGroups = new Set<SeenKey>();
+  const queue: Array<{ subjectPackage: string; dependentChangeType: ChangeType }> = [
+    { subjectPackage: change.packageName, dependentChangeType: change.dependentChangeType },
+  ];
+  const startKey: SeenKey = `${change.packageName}#${change.dependentChangeType}`;
 
   while (queue.length > 0) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const subjectPackage = queue.shift()!;
+    const { subjectPackage, dependentChangeType } = queue.shift()!;
+    const queueKey: SeenKey = `${subjectPackage}#${dependentChangeType}`;
 
     // Step 1. Update change type of the subjectPackage according to dependentChangeType if needed.
-    // (Skip for the initial package.)
-    if (subjectPackage !== change.packageName) {
-      const oldType = calculatedChangeTypes[subjectPackage];
-      calculatedChangeTypes[subjectPackage] = getMaxChangeType(
-        [oldType, dependentChangeType],
-        getPackageOption('disallowedChangeTypes', packageInfos[subjectPackage], params.options)
-      );
+    // Also update members of its group if applicable.
+    // (Skip the initial package since dependentChangeType doesn't apply there.)
+    if (queueKey !== startKey) {
+      const groupName = packageToGroup[subjectPackage];
+      const group = groupName ? packageGroups[groupName] : undefined;
 
-      // TODO: what's the interaction with groups here?
-      if (calculatedChangeTypes[subjectPackage] === oldType) {
+      const oldType = calculatedChangeTypes[subjectPackage];
+      const newType = (calculatedChangeTypes[subjectPackage] = getMaxChangeType(
+        [oldType, dependentChangeType],
+        // Group disallowedChangeTypes take precedence (actually validation verifies both can't be set)
+        // TODO: it's probably better to just save the disallowedChangeTypes with each grouped package during setup?
+        group?.disallowedChangeTypes === null
+          ? null
+          : group?.disallowedChangeTypes ||
+              getPackageOption('disallowedChangeTypes', packageInfos[subjectPackage], params.options)
+      ));
+
+      if (newType === oldType) {
         // We didn't change this type, so keep going.
         continue;
       }
-    }
 
-    // Step 2. For all dependent packages of the current subjectPackage, place in queue to be updated at least to the "updatedChangeType"
-    // (dependents will be undefined if bumpDeps was false)
-    const dependentPackages = dependents?.[subjectPackage];
-
-    if (dependentPackages?.length) {
-      for (const dependentPackage of dependentPackages) {
-        if (seen.has(dependentPackage)) {
-          continue;
+      // If this package is in a group, enqueue other packages in the group.
+      // (Use an extra set tracking groups to avoid iterating over all member packages.)
+      const groupKey = groupName ? (`${groupName}#${dependentChangeType}` as const) : undefined;
+      if (group && groupKey && !seenGroups.has(groupKey)) {
+        seenGroups.add(groupKey);
+        for (const packageNameInGroup of group.packageNames) {
+          const key: SeenKey = `${packageNameInGroup}#${dependentChangeType}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            queue.push({ subjectPackage: packageNameInGroup, dependentChangeType: newType });
+          }
         }
-
-        seen.add(dependentPackage);
-        queue.push(dependentPackage);
       }
     }
 
-    // TODO: when we do "locked", or "lock step" versioning, we could simply skip this grouped traversal,
-    //       - set the version for all packages in the group in bumpPackageInfoVersion()
-    //       - the main concern is how to capture the bump reason in grouped changelog
-
-    // Step 3. For group-linked packages, update the change type to the max(change file info's change type, propagated update change type)
-    // TODO: ensure this is consistent with other group handling, and whether it's necessary at all if bumpDeps is false
-    const group = Object.values(packageGroups).find(g => g.packageNames.includes(subjectPackage));
-
-    if (group && !group.disallowedChangeTypes?.includes(dependentChangeType)) {
-      for (const packageNameInGroup of group.packageNames) {
-        if (!seen.has(packageNameInGroup)) {
-          seen.add(packageNameInGroup);
-          queue.push(packageNameInGroup);
-        }
+    // Step 2. For all dependent packages of the current subjectPackage, place in queue to be
+    // updated at least to the dependentChangeType
+    for (const dependentPackage of dependents[subjectPackage] || []) {
+      const key: SeenKey = `${dependentPackage}#${dependentChangeType}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        queue.push({ subjectPackage: dependentPackage, dependentChangeType });
       }
     }
   }


### PR DESCRIPTION
Fix handling of group `disallowedChangeTypes` in dependent bumps (`bumpInMemory` and `updateRelatedChangeType`). 

This should be non-breaking, but this bumping code is the most complex part of beachball and has a higher risk of unexpected side effects, so it's only going in v3. Though from tests, this change didn't cause any failures, and it makes a couple disabled tests pass that didn't before.

Changes:
- Only call `updateRelatedChangeType` if `bumpDeps` is enabled. (Bumping of groups without `bumpDeps` is handled in `bumpInMemory` pass 2.)
- TODO...

Fixes #1092