### PR TITLE
Remove shouldPublish option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "js/ts.preferences.quoteStyle": "single",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "jest.runMode": "on-demand",
-  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "eslint.workingDirectories": [{ "pattern": "./packages/*" }],
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true,

--- a/change/change-11debe3b-5bd9-4f4c-9d11-0b99026b3373.json
+++ b/change/change-11debe3b-5bd9-4f4c-9d11-0b99026b3373.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Remove `shouldPublish` option. In most cases, you should use `private: true` instead. If this doesn't work, please open an issue with details of your scenario and desired behavior.",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -100,7 +100,6 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 | `registry` | `string` | | repo | Publish to this npm registry |
 | `retries` | `number` | `3` | repo | Number of retries for a package publish before failing |
 | `scope` | `string[]` | | repo | Only consider package paths matching these patterns ([see details](#scoping)) |
-| `shouldPublish` | `false \| undefined` | | package | Manually disable publishing of a package by beachball (does not work to force publishing) |
 | `tag` | `string` | `'latest'` | repo, package | `dist-tag` for npm when published |
 | `transform` | [`TransformOptions`][4] | | repo | Transformations for change files |
 

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { RepositoryFactory } from '../../__fixtures__/repositoryFactory';
 import { migrate } from '../../commands/migrate';
+import { BeachballError } from '../../types/BeachballError';
 
 describe('migrate command', () => {
   const logs = initMockLogs();
@@ -9,7 +10,7 @@ describe('migrate command', () => {
   let repositoryFactory: RepositoryFactory;
 
   beforeAll(() => {
-    repositoryFactory = new RepositoryFactory('single');
+    repositoryFactory = new RepositoryFactory('monorepo');
   });
 
   afterAll(() => {
@@ -20,5 +21,21 @@ describe('migrate command', () => {
     const repo = repositoryFactory.cloneRepository();
     migrate({ path: repo.rootPath });
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"No config updates are needed for v3."`);
+  });
+
+  it('reports packages using the removed shouldPublish option', () => {
+    const repo = repositoryFactory.cloneRepository();
+    repo.updateJsonFile('packages/foo/package.json', { beachball: { shouldPublish: false } });
+    repo.updateJsonFile('packages/baz/package.json', { beachball: { shouldPublish: false } });
+
+    expect(() => migrate({ path: repo.rootPath })).toThrow(BeachballError);
+
+    const output = logs.getMockLines('log', { root: repo.rootPath });
+    expect(output).toMatchInlineSnapshot(`
+      "The following updates are needed for v3:
+        • The following packages use \`"shouldPublish": false\`, which is no longer supported. Typically you should use \`"private": true\` instead (if this doesn't work, please open an issue with details of your scenario).
+          ▪ <root>/packages/baz/package.json
+          ▪ <root>/packages/foo/package.json"
+    `);
   });
 });

--- a/packages/beachball/src/__functional__/publish/publishToRegistry.test.ts
+++ b/packages/beachball/src/__functional__/publish/publishToRegistry.test.ts
@@ -154,7 +154,7 @@ describe('publishToRegistry', () => {
   });
 
   it('returns early when no packages need publishing', async () => {
-    const bumpInfo = makeBumpInfo({ foo: { private: true } }, { calculatedChangeTypes: { foo: 'none' } });
+    const bumpInfo = makeBumpInfo({ foo: {} }, { calculatedChangeTypes: { foo: 'none' } });
 
     await publishToRegistry(bumpInfo, defaultOptions);
 
@@ -163,7 +163,7 @@ describe('publishToRegistry', () => {
 
     expect(logs.getMockLines('all', { root: tempRoot })).toMatchInlineSnapshot(`
       "[log] Skipping publishing the following packages:
-        • foo has change type none
+        • foo has change type "none"
 
       [log] Nothing to publish"
     `);

--- a/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
@@ -183,11 +183,12 @@ describe('getAllChangedPackages', () => {
     const packageInfos = monorepoPackageInfos();
     // Update packages so they'll be ignored
     packageInfos.foo.private = true;
-    packageInfos.bar.packageOptions = { shouldPublish: false }; // package.json beachball field
+    packageInfos.bar.private = true;
 
     const result = getAllChangedPackagesWrapper({
       packageInfos,
       repoOptions: { scope: ['!packages/grouped/*'] },
+      extraArgv: ['--verbose'],
       allChangedFiles: [
         'packages/foo/foo.js',
         'packages/bar/bar.js',
@@ -199,6 +200,14 @@ describe('getAllChangedPackages', () => {
 
     expect(result).toEqual(['baz']);
     const logLines = logs.getMockLines('all');
-    expect(logLines).toMatchInlineSnapshot(`""`);
+    expect(logLines).toMatchInlineSnapshot(`
+      "[log] Found 5 changed files in current branch (before filtering)
+      [log]   - ~~packages/foo/foo.js~~ (foo is private)
+      [log]   - ~~packages/bar/bar.js~~ (bar is private)
+      [log]   - packages/baz/baz.js
+      [log]   - ~~packages/grouped/a/grouped.js~~ (grouped/a is out of scope)
+      [log]   - ~~packages/grouped/b/grouped.js~~ (grouped/b is out of scope)
+      [log] Found 1 file in 1 package that should be published"
+    `);
   });
 });

--- a/packages/beachball/src/__tests__/changefile/isPackageIncluded.test.ts
+++ b/packages/beachball/src/__tests__/changefile/isPackageIncluded.test.ts
@@ -18,14 +18,6 @@ describe('isPackageIncluded', () => {
     });
   });
 
-  it('excludes packages with beachball.shouldPublish=false', () => {
-    const { foo } = makePackageInfos({ foo: { beachball: { shouldPublish: false } } });
-    expect(isPackageIncluded(foo, new Set(['foo']))).toEqual({
-      isIncluded: false,
-      reason: 'foo has beachball.shouldPublish=false',
-    });
-  });
-
   it('excludes packages out of scope', () => {
     const { foo } = makePackageInfos({ foo: {} });
     expect(isPackageIncluded(foo, new Set(['bar']))).toEqual({
@@ -42,21 +34,11 @@ describe('isPackageIncluded', () => {
     });
   });
 
-  it('reports private before shouldPublish=false', () => {
-    const { foo } = makePackageInfos({
-      foo: { private: true, beachball: { shouldPublish: false } },
-    });
-    expect(isPackageIncluded(foo, new Set(['foo']))).toEqual({
-      isIncluded: false,
-      reason: 'foo is private',
-    });
-  });
-
-  it('reports shouldPublish=false before out-of-scope', () => {
-    const { foo } = makePackageInfos({ foo: { beachball: { shouldPublish: false } } });
+  it('reports private before out-of-scope', () => {
+    const { foo } = makePackageInfos({ foo: { private: true } });
     expect(isPackageIncluded(foo, new Set(['bar']))).toEqual({
       isIncluded: false,
-      reason: 'foo has beachball.shouldPublish=false',
+      reason: 'foo is private',
     });
   });
 });

--- a/packages/beachball/src/__tests__/options/getPackageInfosWithOptions.test.ts
+++ b/packages/beachball/src/__tests__/options/getPackageInfosWithOptions.test.ts
@@ -104,7 +104,6 @@ describe('getPackageInfosWithOptions', () => {
         gitTags: false,
         disallowedChangeTypes: null,
         defaultNpmTag: '',
-        shouldPublish: false,
       };
 
       const result = getPackageInfosWithOptions([{ ...baseWsPackage, beachball }], null);
@@ -116,6 +115,12 @@ describe('getPackageInfosWithOptions', () => {
       const result = getPackageInfosWithOptions([{ ...baseWsPackage, beachball: {} }], null);
 
       expect(result['test-package']).not.toHaveProperty('packageOptions' satisfies keyof PackageInfo);
+    });
+
+    it('throws if beachball.shouldPublish is used (removed option)', () => {
+      expect(() =>
+        getPackageInfosWithOptions([{ ...baseWsPackage, beachball: { shouldPublish: false } as PackageOptions }], null)
+      ).toThrow(/shouldPublish/);
     });
   });
 
@@ -166,7 +171,6 @@ describe('getPackageInfosWithOptions', () => {
           version: '0.1.0',
           packageJsonPath: '/monorepo/packages/internal/package.json',
           private: true,
-          beachball: { shouldPublish: false },
         },
       ];
 
@@ -183,9 +187,7 @@ describe('getPackageInfosWithOptions', () => {
       });
 
       expect(result['@company/internal'].private).toBe(true);
-      expect(result['@company/internal'].packageOptions).toEqual({
-        shouldPublish: false,
-      });
+      expect(result['@company/internal'].packageOptions).toBeUndefined();
     });
   });
 });

--- a/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
+++ b/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
@@ -68,7 +68,7 @@ describe('getPackagesToPublish', () => {
     expect(result).toEqual(['pkg-c']);
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
       "Skipping publishing the following packages:
-        • pkg-a has change type none"
+        • pkg-a has change type "none""
     `);
   });
 
@@ -80,7 +80,7 @@ describe('getPackagesToPublish', () => {
     expect(result).toEqual(['pkg-a']);
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
       "Skipping publishing the following packages:
-        • pkg-b is out-of-scope"
+        • pkg-b is out of scope"
     `);
   });
 
@@ -105,7 +105,7 @@ describe('getPackagesToPublish', () => {
     expect(result).toEqual([]);
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
       "Skipping publishing the following packages:
-        • pkg-b is out-of-scope"
+        • pkg-b is out of scope"
     `);
   });
 

--- a/packages/beachball/src/changefile/isPackageIncluded.ts
+++ b/packages/beachball/src/changefile/isPackageIncluded.ts
@@ -15,12 +15,9 @@ export function isPackageIncluded(
     ? 'no corresponding package found'
     : packageInfo.private
       ? `${packageInfo.name} is private`
-      : // This is a package-only option (can't be set at repo level or via CLI)
-        packageInfo.packageOptions?.shouldPublish === false
-        ? `${packageInfo.name} has beachball.shouldPublish=false`
-        : !scopedPackages.has(packageInfo.name)
-          ? `${packageInfo.name} is out of scope`
-          : ''; // not ignored
+      : !scopedPackages.has(packageInfo.name)
+        ? `${packageInfo.name} is out of scope`
+        : ''; // not ignored
 
   return { isIncluded: !reason, reason };
 }

--- a/packages/beachball/src/commands/configGet.ts
+++ b/packages/beachball/src/commands/configGet.ts
@@ -11,7 +11,6 @@ const packageOptionKeys: Record<string, true> = {
   defaultNpmTag: true,
   disallowedChangeTypes: true,
   gitTags: true,
-  shouldPublish: true,
 } satisfies Record<keyof PackageOptions, true>;
 
 /** Keys from RepoOptions (the full set of valid config file settings, exhaustive via Record) */

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -1,4 +1,8 @@
+import type { PackageInfo as WSPackageInfo } from 'workspace-tools';
 import type { BeachballOptions } from '../types/BeachballOptions';
+import { getRawPackageInfos } from '../monorepo/getPackageInfos';
+import { bulletedList, type BulletList } from '../logging/bulletedList';
+import { BeachballError } from '../types/BeachballError';
 
 /**
  * Handles the `beachball migrate` command.
@@ -6,17 +10,37 @@ import type { BeachballOptions } from '../types/BeachballOptions';
  * Checks the config for any settings that need to be updated for v3 and logs them to the console.
  * If no updates are needed, a success message is printed.
  */
-export function migrate(_options: Pick<BeachballOptions, 'path'>): void {
-  const updates: string[] = [];
+export function migrate(options: Pick<BeachballOptions, 'path'>): void {
+  const updates: BulletList = [];
 
-  // (Future migration checks will be added here)
+  const rawPackageInfos = getRawPackageInfos({
+    projectRoot: options.path,
+    packageRoot: options.path,
+    options,
+  });
+
+  if (rawPackageInfos) {
+    checkShouldPublish(rawPackageInfos, updates);
+  }
 
   if (updates.length === 0) {
     console.log('No config updates are needed for v3.');
   } else {
     console.log('The following updates are needed for v3:');
-    for (const update of updates) {
-      console.log(`  - ${update}`);
-    }
+    console.log(bulletedList(updates));
+    throw new BeachballError('Config updates needed', { alreadyLogged: true });
+  }
+}
+
+function checkShouldPublish(rawPackageInfos: WSPackageInfo[], updates: BulletList): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const packagesWithShouldPublish = rawPackageInfos.filter(pkg => pkg.beachball?.shouldPublish === false);
+  if (packagesWithShouldPublish.length) {
+    updates.push(
+      `The following packages use \`"shouldPublish": false\`, which is no longer supported. ` +
+        'Typically you should use `"private": true` instead ' +
+        `(if this doesn't work, please open an issue with details of your scenario).`,
+      packagesWithShouldPublish.map(pkg => pkg.packageJsonPath)
+    );
   }
 }

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -38,11 +38,30 @@ export function getPackageInfos(optionsOrCwd: string | PackageInfosOptions): Pac
   const projectRoot = typeof optionsOrCwd === 'string' ? findProjectRoot(cwd) : cwd;
   const packageRoot = findPackageRoot(cwd);
 
+  const wsPackageInfos = getRawPackageInfos({ projectRoot, packageRoot, options: parsedOptions?.options });
+  if (wsPackageInfos) {
+    return parsedOptions
+      ? getPackageInfosWithOptions(wsPackageInfos, parsedOptions.cliOptions)
+      : // eslint-disable-next-line @ms-cloudpack/no-deprecated
+        getPackageInfosWithOptions(wsPackageInfos);
+  }
+  return {};
+}
+
+/**
+ * Internal helper to get raw package infos.
+ */
+export function getRawPackageInfos(params: {
+  projectRoot: string;
+  packageRoot: string | undefined;
+  options: PackageInfosOptions['options'] | undefined;
+}): WSPackageInfo[] | undefined {
+  const { projectRoot, packageRoot, options } = params;
+
   let wsPackageInfos: WSPackageInfo[] | undefined;
   if (projectRoot) {
     wsPackageInfos =
-      getPackageInfosFromMonorepoManager(projectRoot) ||
-      getPackageInfosFromOtherMonorepo(projectRoot, parsedOptions?.options);
+      getPackageInfosFromMonorepoManager(projectRoot) || getPackageInfosFromOtherMonorepo(projectRoot, options);
   }
 
   if (!wsPackageInfos?.length && packageRoot) {
@@ -52,13 +71,7 @@ export function getPackageInfos(optionsOrCwd: string | PackageInfosOptions): Pac
     }
   }
 
-  if (wsPackageInfos) {
-    return parsedOptions
-      ? getPackageInfosWithOptions(wsPackageInfos, parsedOptions.cliOptions)
-      : // eslint-disable-next-line @ms-cloudpack/no-deprecated
-        getPackageInfosWithOptions(wsPackageInfos);
-  }
-  return {};
+  return wsPackageInfos;
 }
 
 /** Try to find packages from a monorepo manager */

--- a/packages/beachball/src/options/getPackageInfosWithOptions.ts
+++ b/packages/beachball/src/options/getPackageInfosWithOptions.ts
@@ -3,6 +3,7 @@ import type { PackageOptions, CliOptions } from '../types/BeachballOptions';
 import { getCliOptions } from './getCliOptions';
 import { env } from '../env';
 import { consideredDependencies, type PackageInfo, type PackageInfos } from '../types/PackageInfo';
+import { BeachballError } from '../types/BeachballError';
 
 /**
  * Fill in options to convert `workspace-tools` `PackageInfos` to the format used in this repo,
@@ -58,7 +59,14 @@ export function getPackageInfosWithOptions(
     // Check for package-specific options in the "beachball" key of package.json and
     // merge any overrides from CLI options
     // TODO: merge group options too (group disallowedChangeTypes currently override package)
-    const packageOptions = mergePackageOptions(packageJson.beachball as PackageOptions | undefined, cliOptions);
+    const beachballOptions = packageJson.beachball as (PackageOptions & { shouldPublish?: unknown }) | undefined;
+    if (beachballOptions && 'shouldPublish' in beachballOptions) {
+      throw new BeachballError(
+        `Package "${packageJson.name}" uses the removed "beachball.shouldPublish" option in its package.json. ` +
+          'This option has been removed. To prevent a package from being published, set "private": true in its package.json.'
+      );
+    }
+    const packageOptions = mergePackageOptions(beachballOptions, cliOptions);
     packageOptions && (newPackageInfo.packageOptions = packageOptions);
 
     packageInfos[packageJson.name] = newPackageInfo;
@@ -72,7 +80,6 @@ const packageKeys = Object.keys({
   defaultNpmTag: true,
   disallowedChangeTypes: true,
   gitTags: true,
-  shouldPublish: true,
 } satisfies Record<keyof PackageOptions, true>) as (keyof PackageOptions)[];
 
 /**

--- a/packages/beachball/src/publish/getPackagesToPublish.ts
+++ b/packages/beachball/src/publish/getPackagesToPublish.ts
@@ -1,3 +1,4 @@
+import { isPackageIncluded } from '../changefile/isPackageIncluded';
 import { bulletedList } from '../logging/bulletedList';
 import type { PublishBumpInfo } from '../types/BumpInfo';
 
@@ -26,19 +27,15 @@ export function getPackagesToPublish(
     const packageInfo = packageInfos[pkg];
     const changeType = calculatedChangeTypes[pkg];
 
-    let skipReason = '';
-    if (changeType === 'none') {
-      skipReason = 'has change type none';
-    } else if (packageInfo.private) {
-      skipReason = 'is private';
-    } else if (!scopedPackages.has(pkg)) {
-      skipReason = 'is out-of-scope';
+    // It might not be possible for isPackageIncluded to return false at this point,
+    // but include those checks anyway to be safe
+    const { isIncluded, reason } = isPackageIncluded(packageInfo, scopedPackages);
+    if (!isIncluded) {
+      skippedPackageReasons.push(reason);
+    } else if (changeType === 'none') {
+      skippedPackageReasons.push(`${pkg} has change type "none"`);
     } else if (!changeType && !newPackages?.includes(pkg)) {
-      skipReason = 'is not bumped (no calculated change type)';
-    }
-
-    if (skipReason) {
-      skippedPackageReasons.push(`${pkg} ${skipReason}`);
+      skippedPackageReasons.push(`${pkg} is not bumped (no calculated change type)`);
     } else {
       packagesToPublish.push(pkg);
     }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -288,11 +288,6 @@ export interface PackageOptions extends Partial<
   Pick<RepoOptions, 'gitTags' | 'disallowedChangeTypes' | 'defaultNpmTag'>
 > {
   tag?: string | null;
-  /**
-   * Disable publishing a particular package.
-   * (Does NOT work to enable publishing a package that wouldn't otherwise be published.)
-   */
-  shouldPublish?: false;
 }
 
 /**


### PR DESCRIPTION
The package-level `beachball.shouldPublish: false` option was added in #30 without much detail about the intended scenario, and it has some major behavior coherency issues: obviously it should prevent npm publishing, but what about change files, version bumps, changelogs, and git tags? And what if a public package depends on a `shouldPublish: false` package? (In v2 it also doesn't prevent publishing due to dependent bumps, which was probably an accident.) The option is also very rarely used, and nearly all existing usage pairs it with `private: true` where it's not needed. 

Rather than adding a bunch of complexity for theoretical guesses at the intended scenario, this PR removes the option and flags it as a migration error. In most cases it's trivially replaced by `private: true`, but if this doesn't work, I'd rather someone open an issue with details of their scenario and desired behavior so we can design for that.