### PR TITLE
Consistent behavior with shouldPublish: false

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "js/ts.preferences.quoteStyle": "single",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "jest.runMode": "on-demand",
-  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "eslint.workingDirectories": [{ "pattern": "./packages/*" }],
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ DO NOT run `jest` or `tsc` directly from the top level!
 | Build                               | `yarn build`            |
 | Run all tests (NOT a specific test) | `yarn test`             |
 | Lint (code + deps)                  | `yarn lint`             |
-| Lint code only                      | `yarn lint:code`        |
+| Lint code only (only works at root) | `yarn lint:code`        |
 | Format                              | `yarn format`           |
 | Update snapshots                    | `yarn update-snapshots` |
 

--- a/change/change-59249eb8-7e57-4db3-9450-f365f8b54114.json
+++ b/change/change-59249eb8-7e57-4db3-9450-f365f8b54114.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Apply consistent behavior with package `shouldPublish: false` setting: skip `npm publish` but *do* require change files and produce version bumps, changelogs, and git tags",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -100,7 +100,7 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 | `registry` | `string` | | repo | Publish to this npm registry |
 | `retries` | `number` | `3` | repo | Number of retries for a package publish before failing |
 | `scope` | `string[]` | | repo | Only consider package paths matching these patterns ([see details](#scoping)) |
-| `shouldPublish` | `false \| undefined` | | package | Manually disable publishing of a package by beachball (does not work to force publishing) |
+| `shouldPublish` | `false \| undefined` | | package | In most cases you should use `private: true` in `package.json` instead. This option skips the `npm publish` (or `pack`) step for this package, but it's still bumped, tagged, and gets changelog entries. Does not work to force publishing. |
 | `tag` | `string` | `'latest'` | repo, package | `dist-tag` for npm when published |
 | `transform` | [`TransformOptions`][4] | | repo | Transformations for change files |
 

--- a/docs/overview/v3-migration.md
+++ b/docs/overview/v3-migration.md
@@ -8,10 +8,6 @@ category: doc
 
 This page describes how to migrate from beachball v2 to v3.
 
-## Changelog
-
-For the full list of changes between v2 and v3, see the [beachball CHANGELOG.md](https://github.com/microsoft/beachball/blob/main/packages/beachball/CHANGELOG.md).
-
 ## Running the migrate command
 
 beachball v3 includes a `migrate` command that checks your config and logs any updates needed for v3:
@@ -27,3 +23,21 @@ No config updates are needed for v3.
 ```
 
 Otherwise, the command will list specific config updates that are needed. The command doesn't attempt to make updates directly due to the variety of locations and file types where the config can be specified.
+
+## Breaking changes
+
+For the full list of changes between v2 and v3, see the [beachball CHANGELOG.md](https://github.com/microsoft/beachball/blob/main/packages/beachball/CHANGELOG.md).
+
+### `shouldPublish` behavior change
+
+> Note: **you should almost never need this option** - in most scenarios, just set `private: true` in `package.json` instead.
+
+In v2, the `beachball.shouldPublish: false` package option was handled inconsistently: packages didn't get change files or direct version bumps, but if a `shouldPublish: false` package was a dependent of a bumped package, it was silently bumped _and published_ anyway.
+
+In v3, `shouldPublish: false` packages are full participants in all steps of the workflow _except_ `npm publish`:
+
+- Change files **are** generated and required
+- Version bumps, git tags, and changelogs **are** produced (same as published packages)
+- The final `npm publish` (or `pack`) step is **skipped**
+- If a published package has a `shouldPublish: false` package in its production dependencies, Beachball will exit with an error (same as with `private: true` deps)
+- Since `shouldPublish: false` is redundant with `private: true`, `beachball migrate` reports this as an error

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -321,14 +321,14 @@ describe('publish command (e2e)', () => {
     expect(newPackageInfos.bar.version).toBe('1.4.0');
   });
 
-  // shouldPublish:false packages should also accept their own change files. The package is
-  // bumped/tagged/changelogged but still not published.
-  it('accepts a direct change file for a shouldPublish:false package without publishing it', async () => {
+  // A package with shouldPublish: false gets all steps of the publish process except npm publish
+  it('handles packages with shouldPublish:false', async () => {
     repositoryFactory = new RepositoryFactory({
       folders: {
         packages: {
           foo: { version: '1.0.0', beachball: { shouldPublish: false } },
           bar: { version: '1.0.0' },
+          baz: { version: '1.0.0', dependencies: { bar: '^1.0.0' } },
         },
       },
     });
@@ -336,20 +336,25 @@ describe('publish command (e2e)', () => {
 
     const { options, parsedOptions } = getOptions({ fetch: false });
 
-    generateChangeFiles(['foo'], options);
+    generateChangeFiles(['foo', 'bar'], options);
     repo.push();
 
     await publishWrapper(parsedOptions);
 
+    // foo is not published, but the other two are
     expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
-    expect(npmMock.getPublishedVersions('bar')).toBeUndefined();
+    expect(npmMock.getPublishedVersions('bar')).toEqual({ versions: ['1.1.0'], 'dist-tags': { latest: '1.1.0' } });
+    expect(npmMock.getPublishedVersions('baz')).toEqual({ versions: ['1.0.1'], 'dist-tags': { latest: '1.0.1' } });
 
     repo.checkout(defaultBranchName);
     repo.pull();
-    expect(repo.getCurrentTags()).toEqual(['foo_v1.1.0']);
+    // foo is git tagged
+    expect(repo.getCurrentTags()).toEqual(['bar_v1.1.0', 'baz_v1.0.1', 'foo_v1.1.0']);
 
     const newPackageInfos = getPackageInfos(parsedOptions);
+    // foo is bumped and committed with a changelog
     expect(newPackageInfos.foo.version).toBe('1.1.0');
+    expect(fs.existsSync(repo.pathTo('packages/foo/CHANGELOG.md'))).toBe(true);
   });
 
   it('does not publish an out-of-scope package', async () => {

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -283,6 +283,75 @@ describe('publish command (e2e)', () => {
     expect(newPackageInfos.baz.version).toBe('1.4.0');
   });
 
+  // Verify the coherent shouldPublish:false semantics: the package is bumped, tagged, and
+  // included in the dependent graph, but it is NOT published to the registry.
+  it('bumps and tags a shouldPublish:false dependent but does not publish it', async () => {
+    repositoryFactory = new RepositoryFactory({
+      folders: {
+        packages: {
+          foo: { version: '1.0.0', dependencies: { bar: '^1.3.4' }, beachball: { shouldPublish: false } },
+          bar: { version: '1.3.4' },
+        },
+      },
+    });
+    repo = repositoryFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions({ fetch: false });
+
+    generateChangeFiles(['bar'], options);
+    repo.push();
+
+    await publishWrapper(parsedOptions);
+
+    // bar is bumped and published normally
+    expect(npmMock.getPublishedVersions('bar')).toEqual({
+      versions: ['1.4.0'],
+      'dist-tags': { latest: '1.4.0' },
+    });
+    // foo (shouldPublish: false) is not published, but is still bumped and tagged
+    expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
+
+    repo.checkout(defaultBranchName);
+    repo.pull();
+    expect(repo.getCurrentTags()).toEqual(['bar_v1.4.0', 'foo_v1.0.1']);
+
+    const newPackageInfos = getPackageInfos(parsedOptions);
+    expect(newPackageInfos.foo.version).toBe('1.0.1');
+    expect(newPackageInfos.foo.dependencies?.bar).toBe('^1.4.0');
+    expect(newPackageInfos.bar.version).toBe('1.4.0');
+  });
+
+  // shouldPublish:false packages should also accept their own change files. The package is
+  // bumped/tagged/changelogged but still not published.
+  it('accepts a direct change file for a shouldPublish:false package without publishing it', async () => {
+    repositoryFactory = new RepositoryFactory({
+      folders: {
+        packages: {
+          foo: { version: '1.0.0', beachball: { shouldPublish: false } },
+          bar: { version: '1.0.0' },
+        },
+      },
+    });
+    repo = repositoryFactory.cloneRepository();
+
+    const { options, parsedOptions } = getOptions({ fetch: false });
+
+    generateChangeFiles(['foo'], options);
+    repo.push();
+
+    await publishWrapper(parsedOptions);
+
+    expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
+    expect(npmMock.getPublishedVersions('bar')).toBeUndefined();
+
+    repo.checkout(defaultBranchName);
+    repo.pull();
+    expect(repo.getCurrentTags()).toEqual(['foo_v1.1.0']);
+
+    const newPackageInfos = getPackageInfos(parsedOptions);
+    expect(newPackageInfos.foo.version).toBe('1.1.0');
+  });
+
   it('does not publish an out-of-scope package', async () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -283,44 +283,6 @@ describe('publish command (e2e)', () => {
     expect(newPackageInfos.baz.version).toBe('1.4.0');
   });
 
-  // Verify the coherent shouldPublish:false semantics: the package is bumped, tagged, and
-  // included in the dependent graph, but it is NOT published to the registry.
-  it('bumps and tags a shouldPublish:false dependent but does not publish it', async () => {
-    repositoryFactory = new RepositoryFactory({
-      folders: {
-        packages: {
-          foo: { version: '1.0.0', dependencies: { bar: '^1.3.4' }, beachball: { shouldPublish: false } },
-          bar: { version: '1.3.4' },
-        },
-      },
-    });
-    repo = repositoryFactory.cloneRepository();
-
-    const { options, parsedOptions } = getOptions({ fetch: false });
-
-    generateChangeFiles(['bar'], options);
-    repo.push();
-
-    await publishWrapper(parsedOptions);
-
-    // bar is bumped and published normally
-    expect(npmMock.getPublishedVersions('bar')).toEqual({
-      versions: ['1.4.0'],
-      'dist-tags': { latest: '1.4.0' },
-    });
-    // foo (shouldPublish: false) is not published, but is still bumped and tagged
-    expect(npmMock.getPublishedVersions('foo')).toBeUndefined();
-
-    repo.checkout(defaultBranchName);
-    repo.pull();
-    expect(repo.getCurrentTags()).toEqual(['bar_v1.4.0', 'foo_v1.0.1']);
-
-    const newPackageInfos = getPackageInfos(parsedOptions);
-    expect(newPackageInfos.foo.version).toBe('1.0.1');
-    expect(newPackageInfos.foo.dependencies?.bar).toBe('^1.4.0');
-    expect(newPackageInfos.bar.version).toBe('1.4.0');
-  });
-
   // A package with shouldPublish: false gets all steps of the publish process except npm publish
   it('handles packages with shouldPublish:false', async () => {
     repositoryFactory = new RepositoryFactory({

--- a/packages/beachball/src/__e2e__/validate.test.ts
+++ b/packages/beachball/src/__e2e__/validate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, afterAll, beforeAll, afterEach } from '@jest/globals';
+import { generateChangeFiles } from '../__fixtures__/changeFiles';
 import { defaultRemoteBranchName } from '../__fixtures__/gitDefaults';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { initMockLogs } from '../__fixtures__/mockLogs';
@@ -64,6 +65,29 @@ describe('validate', () => {
 
     const result = validateWrapper({ checkChangeNeeded: true, allowMissingChangeFiles: true });
     expect(result.isChangeNeeded).toBe(true);
+    expect(logs.mocks.error).not.toHaveBeenCalled();
+  });
+
+  // A shouldPublish: false package depending on a private (or shouldPublish: false) package must
+  // not be treated as a "published package" during dependency validation. Otherwise `check`
+  // produces a false-positive error, since the dependent itself won't be published.
+  it('does not report dependency errors for shouldPublish:false package depending on private package', () => {
+    repo = repositoryFactory.cloneRepository();
+    repo.updateJsonFile('packages/foo/package.json', { beachball: { shouldPublish: false } });
+    repo.updateJsonFile('packages/bar/package.json', { private: true });
+
+    const parsedOptions = getParsedOptions({
+      cwd: repo.rootPath,
+      argv: [],
+      env: {},
+      testRepoOptions: { branch: defaultRemoteBranchName },
+    });
+
+    generateChangeFiles(['foo'], parsedOptions.options);
+
+    const result = validate(parsedOptions, { checkChangeNeeded: true, checkDependencies: true });
+
+    expect(result.isChangeNeeded).toBe(false);
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/beachball/src/__fixtures__/createTestFileStructure.ts
+++ b/packages/beachball/src/__fixtures__/createTestFileStructure.ts
@@ -2,9 +2,11 @@ import fs from 'fs';
 import { tmpdir } from './tmpdir';
 import path from 'path';
 import type { RepoOptions } from '../types/BeachballOptions';
+import { readJson } from '../object/readJson';
+import { writeJson } from '../object/writeJson';
 
 /**
- * For each key in `files`, create a test folder and write a file of that filename, where the
+ * For each key in `files`, create a test folder and write a file of that filePath, where the
  * content is the value (and create any intermediate folders).
  * @returns path to the test folder
  */
@@ -56,4 +58,19 @@ export function createTestFileStructureType(type: 'single' | 'monorepo'): string
         'yarn.lock': '',
       });
   }
+}
+
+/**
+ * Shallow-merge the given updates with an existing JSON file.
+ */
+export function updateJsonFile(filePath: string, updates: object): void {
+  if (!filePath.endsWith('.json')) {
+    throw new Error('This method only works with json files');
+  }
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`JSON file does not exist: ${filePath}`);
+  }
+  const oldContent = readJson<object>(filePath);
+  writeJson(filePath, { ...oldContent, ...updates });
 }

--- a/packages/beachball/src/__fixtures__/repository.ts
+++ b/packages/beachball/src/__fixtures__/repository.ts
@@ -10,8 +10,7 @@ import {
   optsWithLang,
   setDefaultBranchName,
 } from './gitDefaults';
-import { readJson } from '../object/readJson';
-import { writeJson } from '../object/writeJson';
+import { updateJsonFile } from './createTestFileStructure';
 
 /**
  * Clone options. See the docs for details on behavior and interaction of these options.
@@ -173,17 +172,7 @@ ${gitResult.stderr.toString()}`);
    * such as making it private.
    */
   updateJsonFile(filename: string, updates: object, options?: { commit?: boolean }): void {
-    if (!filename.endsWith('.json')) {
-      throw new Error('This method only works with json files');
-    }
-
-    const fullPath = this.pathTo(filename);
-    if (!fs.existsSync(fullPath)) {
-      throw new Error(`JSON file does not exist: ${filename}`);
-    }
-    const oldContent = readJson<object>(fullPath);
-    writeJson(fullPath, { ...oldContent, ...updates });
-
+    updateJsonFile(this.pathTo(filename), updates);
     if (options?.commit) {
       this.git(['add', filename]);
       this.git(['commit', '-m', `"${filename}"`]);

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -4,8 +4,9 @@ import { migrate } from '../../commands/migrate';
 import { getParsedOptions } from '../../options/getOptions';
 import type { RepoOptions } from '../../types/BeachballOptions';
 import { removeTempDir } from '../../__fixtures__/tmpdir';
-import { createTestFileStructureType } from '../../__fixtures__/createTestFileStructure';
+import { createTestFileStructureType, updateJsonFile } from '../../__fixtures__/createTestFileStructure';
 import { BeachballError } from '../../types/BeachballError';
+import path from 'path';
 
 jest.mock('workspace-tools', () => ({
   ...jest.requireActual<typeof import('workspace-tools')>('workspace-tools'),
@@ -37,6 +38,44 @@ describe('migrate command', () => {
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[error] The following updates are needed for v3:
       [error]   • The \`new\` option has been removed. Please remove it from your config."
+    `);
+  });
+
+  it('warns on public packages using shouldPublish option', () => {
+    tempRoot = createTestFileStructureType('monorepo');
+    updateJsonFile(path.join(tempRoot, 'packages/foo/package.json'), { beachball: { shouldPublish: false } });
+    updateJsonFile(path.join(tempRoot, 'packages/baz/package.json'), { beachball: { shouldPublish: false } });
+
+    migrate(getOptions());
+
+    const output = logs.getMockLines('all', { root: tempRoot });
+    expect(output).toMatchInlineSnapshot(`
+      "[warn] The following warnings were found for your config:
+      [warn]   • Found non-private packages using \`"shouldPublish": false\`. The behavior of this setting has changed--please see the v3 migration guide for details and verify it still works for your scenario.
+          ▪ <root>/packages/baz/package.json
+          ▪ <root>/packages/foo/package.json"
+    `);
+  });
+
+  it('errors on private packages using shouldPublish option', () => {
+    tempRoot = createTestFileStructureType('monorepo');
+    updateJsonFile(path.join(tempRoot, 'packages/foo/package.json'), {
+      private: true,
+      beachball: { shouldPublish: false },
+    });
+    updateJsonFile(path.join(tempRoot, 'packages/baz/package.json'), {
+      private: true,
+      beachball: { shouldPublish: false },
+    });
+
+    expect(() => migrate(getOptions())).toThrow(BeachballError);
+
+    const output = logs.getMockLines('all', { root: tempRoot });
+    expect(output).toMatchInlineSnapshot(`
+      "[error] The following updates are needed for v3:
+      [error]   • Found private packages using \`"shouldPublish": false\`. This setting does nothing with private packages and should be removed.
+          ▪ <root>/packages/baz/package.json
+          ▪ <root>/packages/foo/package.json"
     `);
   });
 });

--- a/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
@@ -188,6 +188,7 @@ describe('getAllChangedPackages', () => {
     const result = getAllChangedPackagesWrapper({
       packageInfos,
       repoOptions: { scope: ['!packages/grouped/*'] },
+      extraArgv: ['--verbose'],
       allChangedFiles: [
         'packages/foo/foo.js',
         'packages/bar/bar.js',
@@ -197,8 +198,16 @@ describe('getAllChangedPackages', () => {
       ],
     });
 
-    expect(result).toEqual(['baz']);
+    expect(result).toEqual(['bar', 'baz']);
     const logLines = logs.getMockLines('all');
-    expect(logLines).toMatchInlineSnapshot(`""`);
+    expect(logLines).toMatchInlineSnapshot(`
+      "[log] Found 5 changed files in current branch (before filtering)
+      [log]   - ~~packages/foo/foo.js~~ (foo is private)
+      [log]   - packages/bar/bar.js
+      [log]   - packages/baz/baz.js
+      [log]   - ~~packages/grouped/a/grouped.js~~ (grouped/a is out of scope)
+      [log]   - ~~packages/grouped/b/grouped.js~~ (grouped/b is out of scope)
+      [log] Found 2 files in 2 packages that should be published"
+    `);
   });
 });

--- a/packages/beachball/src/__tests__/changefile/isPackageIncluded.test.ts
+++ b/packages/beachball/src/__tests__/changefile/isPackageIncluded.test.ts
@@ -18,14 +18,6 @@ describe('isPackageIncluded', () => {
     });
   });
 
-  it('excludes packages with beachball.shouldPublish=false', () => {
-    const { foo } = makePackageInfos({ foo: { beachball: { shouldPublish: false } } });
-    expect(isPackageIncluded(foo, new Set(['foo']))).toEqual({
-      isIncluded: false,
-      reason: 'foo has beachball.shouldPublish=false',
-    });
-  });
-
   it('excludes packages out of scope', () => {
     const { foo } = makePackageInfos({ foo: {} });
     expect(isPackageIncluded(foo, new Set(['bar']))).toEqual({
@@ -42,21 +34,16 @@ describe('isPackageIncluded', () => {
     });
   });
 
-  it('reports private before shouldPublish=false', () => {
-    const { foo } = makePackageInfos({
-      foo: { private: true, beachball: { shouldPublish: false } },
-    });
-    expect(isPackageIncluded(foo, new Set(['foo']))).toEqual({
-      isIncluded: false,
-      reason: 'foo is private',
-    });
+  it('includes packages with beachball.shouldPublish=false', () => {
+    const { foo } = makePackageInfos({ foo: { beachball: { shouldPublish: false } } });
+    expect(isPackageIncluded(foo, new Set(['foo']))).toEqual({ isIncluded: true, reason: '' });
   });
 
-  it('reports shouldPublish=false before out-of-scope', () => {
-    const { foo } = makePackageInfos({ foo: { beachball: { shouldPublish: false } } });
+  it('reports private before out-of-scope', () => {
+    const { foo } = makePackageInfos({ foo: { private: true } });
     expect(isPackageIncluded(foo, new Set(['bar']))).toEqual({
       isIncluded: false,
-      reason: 'foo has beachball.shouldPublish=false',
+      reason: 'foo is private',
     });
   });
 });

--- a/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
+++ b/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
@@ -98,18 +98,21 @@ describe('getPackagesToPublish', () => {
     `);
   });
 
-  it('includes packages with beachball.shouldPublish=false by default', () => {
+  it('excludes packages with beachball.shouldPublish=false by default', () => {
     const result = getPackagesToPublishWrapper({
       packageInfos: {
         'pkg-a': { beachball: { shouldPublish: false } },
         'pkg-b': {},
       },
     });
-    expect(result).toEqual(['pkg-a', 'pkg-b']);
-    expect(logs.mocks.log).not.toHaveBeenCalled();
+    expect(result).toEqual(['pkg-b']);
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+      "Skipping publishing the following packages:
+        • pkg-a has beachball.shouldPublish=false"
+    `);
   });
 
-  it('excludes packages with beachball.shouldPublish=false when respectShouldPublish=true', () => {
+  it('includes packages with beachball.shouldPublish=false when ignoreShouldPublish=true', () => {
     const result = getPackagesToPublishWrapper(
       {
         packageInfos: {
@@ -117,12 +120,9 @@ describe('getPackagesToPublish', () => {
           'pkg-b': {},
         },
       },
-      { respectShouldPublish: true }
+      { ignoreShouldPublish: true }
     );
-    expect(result).toEqual(['pkg-b']);
-    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
-      "Skipping publishing the following packages:
-        • pkg-a has beachball.shouldPublish=false"
-    `);
+    expect(result).toEqual(['pkg-a', 'pkg-b']);
+    expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 });

--- a/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
+++ b/packages/beachball/src/__tests__/publish/getPackagesToPublish.test.ts
@@ -97,4 +97,32 @@ describe('getPackagesToPublish', () => {
         • pkg-b is not bumped (no calculated change type)"
     `);
   });
+
+  it('includes packages with beachball.shouldPublish=false by default', () => {
+    const result = getPackagesToPublishWrapper({
+      packageInfos: {
+        'pkg-a': { beachball: { shouldPublish: false } },
+        'pkg-b': {},
+      },
+    });
+    expect(result).toEqual(['pkg-a', 'pkg-b']);
+    expect(logs.mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('excludes packages with beachball.shouldPublish=false when respectShouldPublish=true', () => {
+    const result = getPackagesToPublishWrapper(
+      {
+        packageInfos: {
+          'pkg-a': { beachball: { shouldPublish: false } },
+          'pkg-b': {},
+        },
+      },
+      { respectShouldPublish: true }
+    );
+    expect(result).toEqual(['pkg-b']);
+    expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
+      "Skipping publishing the following packages:
+        • pkg-a has beachball.shouldPublish=false"
+    `);
+  });
 });

--- a/packages/beachball/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/packages/beachball/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -31,7 +31,7 @@ describe('validatePackageDependencies', () => {
       expect(validatePackageDependencies(['foo', 'bar'], packageInfos)).toBeFalsy();
 
       expect(logs.getMockLines('error')).toEqual(
-        'ERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:\n  • foo: used by bar'
+        'ERROR: Found unpublished (beachball.shouldPublish: false) packages among published package dependencies:\n  • foo: used by bar'
       );
     }
   );
@@ -48,8 +48,7 @@ describe('validatePackageDependencies', () => {
       "ERROR: Found private packages among published package dependencies:
         • foo: used by bar
 
-
-      ERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:
+      ERROR: Found unpublished (beachball.shouldPublish: false) packages among published package dependencies:
         • qux: used by bar"
     `);
   });

--- a/packages/beachball/src/__tests__/publish/validatePackageDependencies.test.ts
+++ b/packages/beachball/src/__tests__/publish/validatePackageDependencies.test.ts
@@ -21,6 +21,39 @@ describe('validatePackageDependencies', () => {
     }
   );
 
+  it.each(['dependencies', 'peerDependencies', 'optionalDependencies'] as const)(
+    'invalid when %s contains shouldPublish:false package',
+    depType => {
+      const packageInfos = makePackageInfos({
+        foo: { beachball: { shouldPublish: false } },
+        bar: { [depType]: { foo: '1.0.0' } },
+      });
+      expect(validatePackageDependencies(['foo', 'bar'], packageInfos)).toBeFalsy();
+
+      expect(logs.getMockLines('error')).toEqual(
+        'ERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:\n  • foo: used by bar'
+      );
+    }
+  );
+
+  it('reports both private and shouldPublish:false deps in adjacent blocks', () => {
+    const packageInfos = makePackageInfos({
+      foo: { private: true },
+      qux: { beachball: { shouldPublish: false } },
+      bar: { dependencies: { foo: '1.0.0', qux: '1.0.0' } },
+    });
+    expect(validatePackageDependencies(['foo', 'qux', 'bar'], packageInfos)).toBeFalsy();
+
+    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
+      "ERROR: Found private packages among published package dependencies:
+        • foo: used by bar
+
+
+      ERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:
+        • qux: used by bar"
+    `);
+  });
+
   it('valid when non-listed package depends on private package', () => {
     const packageInfos = makePackageInfos({
       foo: { private: true },
@@ -33,6 +66,14 @@ describe('validatePackageDependencies', () => {
   it('valid when devDependencies contains private package', () => {
     const packageInfos = makePackageInfos({
       foo: { private: true },
+      bar: { devDependencies: { foo: '1.0.0' } },
+    });
+    expect(validatePackageDependencies(['foo', 'bar'], packageInfos)).toBeTruthy();
+  });
+
+  it('valid when devDependencies contains shouldPublish:false package', () => {
+    const packageInfos = makePackageInfos({
+      foo: { beachball: { shouldPublish: false } },
       bar: { devDependencies: { foo: '1.0.0' } },
     });
     expect(validatePackageDependencies(['foo', 'bar'], packageInfos)).toBeTruthy();

--- a/packages/beachball/src/changefile/isPackageIncluded.ts
+++ b/packages/beachball/src/changefile/isPackageIncluded.ts
@@ -15,12 +15,9 @@ export function isPackageIncluded(
     ? 'no corresponding package found'
     : packageInfo.private
       ? `${packageInfo.name} is private`
-      : // This is a package-only option (can't be set at repo level or via CLI)
-        packageInfo.packageOptions?.shouldPublish === false
-        ? `${packageInfo.name} has beachball.shouldPublish=false`
-        : !scopedPackages.has(packageInfo.name)
-          ? `${packageInfo.name} is out of scope`
-          : ''; // not ignored
+      : !scopedPackages.has(packageInfo.name)
+        ? `${packageInfo.name} is out of scope`
+        : ''; // not ignored
 
   return { isIncluded: !reason, reason };
 }

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -1,6 +1,8 @@
-import { bulletedList } from '../logging/bulletedList';
-import { BeachballError } from '../types/BeachballError';
 import type { ParsedOptions } from '../types/BeachballOptions';
+import type { PackageInfo as WSPackageInfo } from 'workspace-tools';
+import { getRawPackageInfos } from '../monorepo/getPackageInfos';
+import { bulletedList, type BulletList } from '../logging/bulletedList';
+import { BeachballError } from '../types/BeachballError';
 
 /**
  * Handles the `beachball migrate` command.
@@ -10,17 +12,62 @@ import type { ParsedOptions } from '../types/BeachballOptions';
  */
 export function migrate(parsedOptions: ParsedOptions): void {
   const { options } = parsedOptions;
-  const updates: string[] = [];
+  const updates: BulletList = [];
+  const warnings: BulletList = [];
+
+  const rawPackageInfos = getRawPackageInfos({
+    projectRoot: options.path,
+    packageRoot: options.path,
+    options,
+  });
 
   if ((options as { new?: boolean }).new !== undefined) {
     updates.push('The `new` option has been removed. Please remove it from your config.');
   }
 
-  if (updates.length === 0) {
+  if (rawPackageInfos) {
+    checkShouldPublish({ rawPackageInfos, warnings, updates });
+  }
+
+  if (!updates.length && !warnings.length) {
     console.log('No config updates are needed for v3.');
-  } else {
+  }
+  if (warnings.length) {
+    console.warn(`The following warnings were found for your config:`);
+    console.warn(bulletedList(warnings) + '\n');
+  }
+  if (updates.length) {
     console.error('The following updates are needed for v3:');
     console.error(bulletedList(updates) + '\n');
     throw new BeachballError('Config updates needed', { alreadyLogged: true });
+  }
+}
+
+function checkShouldPublish(params: {
+  rawPackageInfos: WSPackageInfo[];
+  warnings: BulletList;
+  updates: BulletList;
+}): void {
+  const { rawPackageInfos, warnings, updates } = params;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const packagesWithShouldPublish = rawPackageInfos.filter(pkg => pkg.beachball?.shouldPublish === false);
+  const privatePackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => pkg.private);
+  const publicPackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => !pkg.private);
+
+  if (privatePackagesWithShouldPublish.length) {
+    updates.push(
+      'Found private packages using `"shouldPublish": false`. ' +
+        'This setting does nothing with private packages and should be removed.',
+      privatePackagesWithShouldPublish.map(pkg => pkg.packageJsonPath)
+    );
+  }
+
+  if (publicPackagesWithShouldPublish.length) {
+    warnings.push(
+      'Found non-private packages using `"shouldPublish": false`. The behavior of this setting has changed--' +
+        'please see the v3 migration guide for details and verify it still works for your scenario.',
+      publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath)
+    );
   }
 }

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -1,5 +1,5 @@
 import type { ParsedOptions } from '../types/BeachballOptions';
-import type { PackageInfo as WSPackageInfo } from 'workspace-tools';
+import { findPackageRoot, type PackageInfo as WSPackageInfo } from 'workspace-tools';
 import { getRawPackageInfos } from '../monorepo/getPackageInfos';
 import { bulletedList, type BulletList } from '../logging/bulletedList';
 import { BeachballError } from '../types/BeachballError';
@@ -17,7 +17,7 @@ export function migrate(parsedOptions: ParsedOptions): void {
 
   const rawPackageInfos = getRawPackageInfos({
     projectRoot: options.path,
-    packageRoot: options.path,
+    packageRoot: findPackageRoot(options.path),
     options,
   });
 
@@ -59,7 +59,7 @@ function checkShouldPublish(params: {
     updates.push(
       'Found private packages using `"shouldPublish": false`. ' +
         'This setting does nothing with private packages and should be removed.',
-      privatePackagesWithShouldPublish.map(pkg => pkg.packageJsonPath)
+      privatePackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
     );
   }
 
@@ -67,7 +67,7 @@ function checkShouldPublish(params: {
     warnings.push(
       'Found non-private packages using `"shouldPublish": false`. The behavior of this setting has changed--' +
         'please see the v3 migration guide for details and verify it still works for your scenario.',
-      publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath)
+      publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
     );
   }
 }

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -38,11 +38,30 @@ export function getPackageInfos(optionsOrCwd: string | PackageInfosOptions): Pac
   const projectRoot = typeof optionsOrCwd === 'string' ? findProjectRoot(cwd) : cwd;
   const packageRoot = findPackageRoot(cwd);
 
+  const wsPackageInfos = getRawPackageInfos({ projectRoot, packageRoot, options: parsedOptions?.options });
+  if (wsPackageInfos) {
+    return parsedOptions
+      ? getPackageInfosWithOptions(wsPackageInfos, parsedOptions.cliOptions)
+      : // eslint-disable-next-line @ms-cloudpack/no-deprecated
+        getPackageInfosWithOptions(wsPackageInfos);
+  }
+  return {};
+}
+
+/**
+ * Internal helper to get raw package infos.
+ */
+export function getRawPackageInfos(params: {
+  projectRoot: string;
+  packageRoot: string | undefined;
+  options: PackageInfosOptions['options'] | undefined;
+}): WSPackageInfo[] | undefined {
+  const { projectRoot, packageRoot, options } = params;
+
   let wsPackageInfos: WSPackageInfo[] | undefined;
   if (projectRoot) {
     wsPackageInfos =
-      getPackageInfosFromMonorepoManager(projectRoot) ||
-      getPackageInfosFromOtherMonorepo(projectRoot, parsedOptions?.options);
+      getPackageInfosFromMonorepoManager(projectRoot) || getPackageInfosFromOtherMonorepo(projectRoot, options);
   }
 
   if (!wsPackageInfos?.length && packageRoot) {
@@ -52,13 +71,7 @@ export function getPackageInfos(optionsOrCwd: string | PackageInfosOptions): Pac
     }
   }
 
-  if (wsPackageInfos) {
-    return parsedOptions
-      ? getPackageInfosWithOptions(wsPackageInfos, parsedOptions.cliOptions)
-      : // eslint-disable-next-line @ms-cloudpack/no-deprecated
-        getPackageInfosWithOptions(wsPackageInfos);
-  }
-  return {};
+  return wsPackageInfos;
 }
 
 /** Try to find packages from a monorepo manager */

--- a/packages/beachball/src/publish/getPackagesToPublish.ts
+++ b/packages/beachball/src/publish/getPackagesToPublish.ts
@@ -11,8 +11,8 @@ export function getPackagesToPublish(
   params?: {
     /** If true, log skipped packages and reasons */
     logSkipped?: boolean;
-    /** If true, filter out packages with beachball.shouldPublish=false */
-    respectShouldPublish?: boolean;
+    /** If true, include packages with beachball.shouldPublish=false */
+    ignoreShouldPublish?: boolean;
   }
 ): string[] {
   const { modifiedPackages, packageInfos, calculatedChangeTypes, scopedPackages } = bumpInfo;
@@ -33,7 +33,7 @@ export function getPackagesToPublish(
       skipReason = 'is out-of-scope';
     } else if (!changeType) {
       skipReason = 'is not bumped (no calculated change type)';
-    } else if (params?.respectShouldPublish && packageInfo.packageOptions?.shouldPublish === false) {
+    } else if (!params?.ignoreShouldPublish && packageInfo.packageOptions?.shouldPublish === false) {
       skipReason = 'has beachball.shouldPublish=false';
     }
 

--- a/packages/beachball/src/publish/getPackagesToPublish.ts
+++ b/packages/beachball/src/publish/getPackagesToPublish.ts
@@ -11,6 +11,8 @@ export function getPackagesToPublish(
   params?: {
     /** If true, log skipped packages and reasons */
     logSkipped?: boolean;
+    /** If true, filter out packages with beachball.shouldPublish=false */
+    respectShouldPublish?: boolean;
   }
 ): string[] {
   const { modifiedPackages, packageInfos, calculatedChangeTypes, scopedPackages } = bumpInfo;
@@ -31,6 +33,8 @@ export function getPackagesToPublish(
       skipReason = 'is out-of-scope';
     } else if (!changeType) {
       skipReason = 'is not bumped (no calculated change type)';
+    } else if (params?.respectShouldPublish && packageInfo.packageOptions?.shouldPublish === false) {
+      skipReason = 'has beachball.shouldPublish=false';
     }
 
     if (skipReason) {

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -35,8 +35,9 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
     await performBump(bumpInfo, options);
   }
 
-  // get the packages to publish, reducing the set by packages that don't need publishing
-  let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true });
+  // Get the packages to publish, reducing the set by packages that don't need publishing.
+  // This is where packages with shouldPublish: false should be filtered out.
+  let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true, respectShouldPublish: true });
   if (!packagesToPublish.length) {
     console.log('Nothing to publish\n');
     return;

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -37,7 +37,7 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
 
   // Get the packages to publish, reducing the set by packages that don't need publishing.
   // This is where packages with shouldPublish: false should be filtered out.
-  let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true, respectShouldPublish: true });
+  let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true });
   if (!packagesToPublish.length) {
     console.log('Nothing to publish\n');
     return;

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -36,7 +36,7 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
   }
 
   // Get the packages to publish, reducing the set by packages that don't need publishing.
-  // This is where packages with shouldPublish: false should be filtered out.
+  // This is where packages with shouldPublish: false are filtered out.
   let packagesToPublish = getPackagesToPublish(bumpInfo, { logSkipped: true });
   if (!packagesToPublish.length) {
     console.log('Nothing to publish\n');

--- a/packages/beachball/src/publish/tagPackages.ts
+++ b/packages/beachball/src/publish/tagPackages.ts
@@ -21,8 +21,8 @@ export function tagPackages(
   const { packageInfos } = bumpInfo;
 
   // Reuse the getPackagesToPublish filtering logic to remove private or unchanged packages,
-  // and also exclude packages with git tags disabled
-  const filteredPackages = getPackagesToPublish(bumpInfo).filter(pkg =>
+  // and also exclude packages with git tags disabled. For this step, ignore shouldPublish=false.
+  const filteredPackages = getPackagesToPublish(bumpInfo, { ignoreShouldPublish: true }).filter(pkg =>
     getPackageOption('gitTags', packageInfos[pkg], options)
   );
 

--- a/packages/beachball/src/publish/validatePackageDependencies.ts
+++ b/packages/beachball/src/publish/validatePackageDependencies.ts
@@ -35,14 +35,14 @@ export function validatePackageDependencies(packagesToValidate: string[], packag
 
   if (privateDeps.length) {
     console.error(
-      `\nERROR: Found private packages among published package dependencies:\n` +
+      `ERROR: Found private packages among published package dependencies:\n` +
         bulletedList(privateDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
         '\n'
     );
   }
   if (unpublishedDeps.length) {
     console.error(
-      `\nERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:\n` +
+      `ERROR: Found unpublished (beachball.shouldPublish: false) packages among published package dependencies:\n` +
         bulletedList(unpublishedDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
         '\n'
     );

--- a/packages/beachball/src/publish/validatePackageDependencies.ts
+++ b/packages/beachball/src/publish/validatePackageDependencies.ts
@@ -4,7 +4,9 @@ import { bulletedList } from '../logging/bulletedList';
 const prodDepTypes = consideredDependencies.filter(t => t !== 'devDependencies');
 
 /**
- * Validate no private package is listed as package dependency for packages which will be published.
+ * Validate that no private or `shouldPublish: false` package is listed as a production dependency
+ * of any package that will be published. Either would result in an unresolvable dependency at
+ * install time.
  */
 export function validatePackageDependencies(packagesToValidate: string[], packageInfos: PackageInfos): boolean {
   /** Mapping from in-repo dep to all validated packages that depend on it */
@@ -26,15 +28,29 @@ export function validatePackageDependencies(packagesToValidate: string[], packag
   // in-repo version. If there's an issue because that's not the case, extra logic could be added
   // to verify that the versions are `workspace:` or semver-satisfied (which would also require
   // logic for catalog versions).
-  const errorDeps = Object.keys(prodDeps).filter(dep => packageInfos[dep]?.private);
-  if (errorDeps.length) {
+  const privateDeps = Object.keys(prodDeps).filter(dep => packageInfos[dep]?.private);
+  const unpublishedDeps = Object.keys(prodDeps).filter(
+    dep => !packageInfos[dep]?.private && packageInfos[dep]?.packageOptions?.shouldPublish === false
+  );
+
+  if (privateDeps.length) {
     console.error(
       `\nERROR: Found private packages among published package dependencies:\n` +
-        bulletedList(errorDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
+        bulletedList(privateDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
         '\n'
     );
+  }
+  if (unpublishedDeps.length) {
+    console.error(
+      `\nERROR: Found unpublished (shouldPublish: false) packages among published package dependencies:\n` +
+        bulletedList(unpublishedDeps.map(dep => `${dep}: used by ${prodDeps[dep].join(', ')}`).sort()) +
+        '\n'
+    );
+  }
+  if (privateDeps.length || unpublishedDeps.length) {
     return false;
   }
+
   console.log('  OK!\n');
   return true;
 }

--- a/packages/beachball/src/publish/validatePackageDependencies.ts
+++ b/packages/beachball/src/publish/validatePackageDependencies.ts
@@ -30,7 +30,7 @@ export function validatePackageDependencies(packagesToValidate: string[], packag
   // logic for catalog versions).
   const privateDeps = Object.keys(prodDeps).filter(dep => packageInfos[dep]?.private);
   const unpublishedDeps = Object.keys(prodDeps).filter(
-    dep => !packageInfos[dep]?.private && packageInfos[dep]?.packageOptions?.shouldPublish === false
+    dep => packageInfos[dep]?.packageOptions?.shouldPublish === false
   );
 
   if (privateDeps.length) {


### PR DESCRIPTION
## Background

The package-level `beachball.shouldPublish: false` option was added in #30 without much detail about the intended scenario, and it has some major behavior coherency issues: obviously it should prevent npm publishing, but what about change files, version bumps, changelogs, and git tags? And what if a public package depends on a `shouldPublish: false` package? (In v2 it also doesn't prevent publishing due to dependent bumps, which was probably an accident.)

The option is very rarely used today, and nearly all existing usage pairs it with `private: true` where it's not needed. ([This](https://github.com/Azure/communication-ui-library/blob/main/packages/communication-react/package.json) is the only usage I could find that's not obviously incorrect.)

## Changes

These changes are motivated by the scenario of merging https://github.com/microsoft/beachball-actions  into this repo: actions are not published to npm, but it's helpful if they can be versioned with beachball and produce git tags and changelogs.

This PR updates `shouldPublish: false` packages to be full participants in all steps of the workflow _except_ `npm publish`:

- Change files **are** generated and required
- Version bumps, git tags, and changelogs **are** produced (same as published packages)
- The final `npm publish` (or `pack`) step is **skipped**
- If a published package has a `shouldPublish: false` package in its production dependencies, Beachball will exit with an error (same as with `private: true` deps)
- Since `shouldPublish: false` is redundant with `private: true`, `beachball migrate` reports this as an error

Fixes #499