### PR TITLE
Disable CHANGELOG.json generation by default

### DIFF
--- a/change/change-db9fc43e-95c6-4f7f-be83-d12fdab2cc32.json
+++ b/change/change-db9fc43e-95c6-4f7f-be83-d12fdab2cc32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Disable CHANGELOG.json generation by default (`generateChangelog` defaults to `'md'`), since most repos don't use JSON changelogs and so it's just unnecessary bloat in git history. If you want to keep generating CHANGELOG.json files, set `generateChangelog: true` in your beachball config.",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/docs/concepts/large-repos.md
+++ b/docs/concepts/large-repos.md
@@ -54,14 +54,7 @@ Beachball's changelogs and change files can have a [shockingly large impact](htt
 
 ### Disable `CHANGELOG.json` if not using
 
-If you don't have a workflow that uses `CHANGELOG.json` (most common), set **`generateChangelog: 'md'`** to only generate `CHANGELOG.md`.
-After enabling, you must **manually** delete existing `CHANGELOG.json` files.
-
-```js
-const config = {
-  generateChangelog: 'md',
-};
-```
+As of Beachball v3, `CHANGELOG.json` is disabled by default since most repos don't use it. If you'd previously set `generateChangelog: true` in your repo but don't need `CHANGELOG.json`, change it to `generateChangelog: 'md'` and delete the existing files.
 
 It's also possible to disable changelog generation entirely with `generateChangelog: false`, though this defeats one of the main points of the tool.
 

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -85,7 +85,7 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 | `defaultNpmTag` | `string` | `'latest'` | repo, package | The default `dist-tag` used for NPM publish |
 | `disallowedChangeTypes` | `string[]` | | repo, package | What change types are disallowed |
 | `fetch` | `boolean` | `true` | repo | Fetch from remote before doing diff comparisons |
-| `generateChangelog` | `boolean \| 'md' \| 'json'` | `true` | repo | Whether to generate `CHANGELOG.md/json` (`'md'` or `'json'` to generate only that type) |
+| `generateChangelog` | `boolean \| 'md' \| 'json'` | `'md'` | repo | Whether to generate `CHANGELOG.md/json` (`'md'` or `'json'` to generate only that type) |
 | `getGitTag` | `(pkg, defaultTag) => string \| string[] \| null` | | repo | Get package-specific git tag(s); return `null` to skip tagging a package |
 | `gitTags` | `boolean` | `true` | repo, package | Whether to create git tags for published packages (eg: `foo_v1.0.1`). Note that `getGitTag` is still respected, overriding this option on a per-package basis. |
 | `groups` | [`VersionGroupOptions[]`][3] | | repo | Bump these packages together ([see details][3]) |

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -79,6 +79,7 @@ describe('bump command', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: false,
+      generateChangelog: true,
     });
     const comment = 'test comment for pkg-1';
     generateChangeFiles([{ packageName: 'pkg-1', comment, type: 'minor' }], options);
@@ -260,6 +261,7 @@ describe('bump command', () => {
     const { options, parsedOptions } = getOptions({
       groups: [{ include: 'packages/grp/*', name: 'grp', disallowedChangeTypes: [] }],
       bumpDeps: true,
+      generateChangelog: true,
     });
     // Bump commonlib, which is not in the group, but triggers a dependent bump of pkg-3,
     // which triggers bump of the whole group and then the app.
@@ -304,6 +306,7 @@ describe('bump command', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
+      generateChangelog: true,
       scope: ['!packages/bar'],
     });
     // bar depends on baz, so that gives bar an extra chance to get a dependent bump
@@ -340,6 +343,7 @@ describe('bump command', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
+      generateChangelog: true,
       scope: ['!packages/foo'],
     });
     generateChangeFiles([{ packageName: 'bar', type: 'patch' }], options);
@@ -460,6 +464,7 @@ describe('bump command', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
+      generateChangelog: true,
     });
     generateChangeFiles([{ packageName: 'pkg-1', type: 'minor' }], options);
     repo.push();
@@ -510,6 +515,7 @@ describe('bump command', () => {
 
     const { options, parsedOptions } = getOptions({
       bumpDeps: true,
+      generateChangelog: true,
     });
     generateChangeFiles([{ packageName: 'pkg-1', type: 'minor' }], options);
     repo.push();

--- a/packages/beachball/src/__functional__/changelog/writeChangelog.test.ts
+++ b/packages/beachball/src/__functional__/changelog/writeChangelog.test.ts
@@ -35,12 +35,15 @@ describe('writeChangelog', () => {
 
   initMockLogs();
 
+  /**
+   * Note: `generateChangelog` defaults to `true` here
+   */
   function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>, cwd?: string) {
     const parsedOptions = getParsedOptions({
       cwd: cwd || repo?.rootPath || '',
       argv: [],
       env: {},
-      testRepoOptions: { branch: defaultRemoteBranchName, ...repoOptions },
+      testRepoOptions: { branch: defaultRemoteBranchName, generateChangelog: true, ...repoOptions },
     });
     const packageInfos = getPackageInfos(parsedOptions);
     return { packageInfos, options: parsedOptions.options, parsedOptions };

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -5,6 +5,7 @@ import { getParsedOptions } from '../../options/getOptions';
 import type { RepoOptions } from '../../types/BeachballOptions';
 import { removeTempDir } from '../../__fixtures__/tmpdir';
 import { createTestFileStructureType, updateJsonFile } from '../../__fixtures__/createTestFileStructure';
+import fs from 'fs';
 import { BeachballError } from '../../types/BeachballError';
 import path from 'path';
 
@@ -55,6 +56,33 @@ describe('migrate command', () => {
           ▪ <root>/packages/baz/package.json
           ▪ <root>/packages/foo/package.json"
     `);
+  });
+
+  it('errors when CHANGELOG.json files exist and generateChangelog is unset', () => {
+    tempRoot = createTestFileStructureType('monorepo');
+    fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.json'), '{}');
+    fs.writeFileSync(path.join(tempRoot, 'packages/baz/CHANGELOG.json'), '{}');
+
+    expect(() => migrate(getOptions())).toThrow(BeachballError);
+
+    const output = logs.getMockLines('all', { root: tempRoot });
+    expect(output).toMatchInlineSnapshot(`
+      "[error] The following updates are needed for v3:
+      [error]   • Found packages with existing CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, since most repos don't use them (CHANGELOG.md is still generated).
+          ▪ If you DO want CHANGELOG.json files, set \`generateChangelog: true\` in your beachball config
+          ▪ If you are NOT using CHANGELOG.json, delete these files:
+            ◦ <root>/packages/baz/CHANGELOG.json
+            ◦ <root>/packages/foo/CHANGELOG.json"
+    `);
+  });
+
+  it('does not error on CHANGELOG.json files when generateChangelog is explicitly set', () => {
+    tempRoot = createTestFileStructureType('monorepo');
+    fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.json'), '{}');
+
+    migrate(getOptions({ generateChangelog: true }));
+
+    expect(logs.getMockLines('all')).toEqual('[log] No config updates are needed for v3.');
   });
 
   it('errors on private packages using shouldPublish option', () => {

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -29,6 +29,9 @@ describe('migrate command', () => {
 
   it('logs a success message when no config updates are needed', () => {
     tempRoot = createTestFileStructureType('monorepo');
+    // a changelog md file is okay
+    fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.md'), '');
+
     migrate(getOptions());
     expect(logs.getMockLines('log')).toEqual('No config updates are needed for v3.');
   });
@@ -68,11 +71,31 @@ describe('migrate command', () => {
     const output = logs.getMockLines('all', { root: tempRoot });
     expect(output).toMatchInlineSnapshot(`
       "[error] The following updates are needed for v3:
-      [error]   • Found packages with existing CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, since most repos don't use them (CHANGELOG.md is still generated).
+      [error]   • Found CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, since most repos don't use them (CHANGELOG.md is still generated).
           ▪ If you DO want CHANGELOG.json files, set \`generateChangelog: true\` in your beachball config
           ▪ If you are NOT using CHANGELOG.json, delete these files:
             ◦ <root>/packages/baz/CHANGELOG.json
             ◦ <root>/packages/foo/CHANGELOG.json"
+    `);
+  });
+
+  it('errors when groups have CHANGELOG.json files and generateChangelog is unset', () => {
+    tempRoot = createTestFileStructureType('monorepo');
+    fs.mkdirSync(path.join(tempRoot, 'changelogs'));
+    fs.writeFileSync(path.join(tempRoot, 'changelogs/CHANGELOG.json'), '{}');
+    const options = getOptions({
+      changelog: { groups: [{ changelogPath: 'changelogs', include: true, mainPackageName: 'foo' }] },
+    });
+
+    expect(() => migrate(options)).toThrow(BeachballError);
+
+    const output = logs.getMockLines('all', { root: tempRoot });
+    expect(output).toMatchInlineSnapshot(`
+      "[error] The following updates are needed for v3:
+      [error]   • Found CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, since most repos don't use them (CHANGELOG.md is still generated).
+          ▪ If you DO want CHANGELOG.json files, set \`generateChangelog: true\` in your beachball config
+          ▪ If you are NOT using CHANGELOG.json, delete these files:
+            ◦ <root>/changelogs/CHANGELOG.json"
     `);
   });
 

--- a/packages/beachball/src/__functional__/options/getOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getOptions.test.ts
@@ -121,7 +121,7 @@ describe('getParsedOptions', () => {
 
   it('uses the branch name defined in beachball.config.js', () => {
     const repo = repositoryFactory.cloneRepository();
-    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo' };
+    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo', access: 'public' };
     fs.writeFileSync(
       path.join(repo.rootPath, 'beachball.config.js'),
       `module.exports = ${JSON.stringify(repoOptions)};`
@@ -130,6 +130,7 @@ describe('getParsedOptions', () => {
     const parsedOptions = getParsedOptions({ argv: baseArgv(), env: {}, cwd: repo.rootPath });
     expect(parsedOptions).toEqual({
       options: expect.objectContaining({ branch: 'origin/foo' }),
+      repoOptions: { branch: 'origin/foo', access: 'public' },
       cliOptions: { path: repo.rootPath, command: 'stuff' },
     });
   });
@@ -141,6 +142,7 @@ describe('getParsedOptions', () => {
     const parsedOptions = getParsedOptions({ argv: baseArgv(), env: {}, cwd: repo.rootPath });
     expect(parsedOptions).toEqual({
       options: expect.objectContaining({ branch: 'origin/foo' }),
+      repoOptions: { branch: 'origin/foo' },
       cliOptions: { path: repo.rootPath, command: 'stuff' },
     });
   });
@@ -168,20 +170,21 @@ describe('getParsedOptions', () => {
 
   it('overrides repo options with CLI options', () => {
     const repo = repositoryFactory.cloneRepository();
-    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo' };
+    const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo', bump: false };
     fs.writeFileSync(
       path.join(repo.rootPath, 'beachball.config.js'),
       `module.exports = ${JSON.stringify(repoOptions)};`
     );
 
     const parsedOptions = getParsedOptions({
-      argv: [...baseArgv(), '--branch', 'origin/bar'],
+      argv: [...baseArgv(), '--branch', 'origin/bar', '--bump'],
       cwd: repo.rootPath,
       env: {},
     });
     expect(parsedOptions).toEqual({
       options: expect.objectContaining({ branch: 'origin/bar' }),
-      cliOptions: { path: repo.rootPath, command: 'stuff', branch: 'origin/bar' },
+      repoOptions: { branch: 'origin/foo', bump: false },
+      cliOptions: { path: repo.rootPath, command: 'stuff', branch: 'origin/bar', bump: true },
     });
   });
 

--- a/packages/beachball/src/__tests__/commands/configList.test.ts
+++ b/packages/beachball/src/__tests__/commands/configList.test.ts
@@ -67,7 +67,7 @@ describe('configList', () => {
         depth: undefined
         disallowedChangeTypes: null
         fetch: true
-        generateChangelog: true
+        generateChangelog: "md"
         gitTags: true
         gitTimeout: undefined
         ignorePatterns: ["*.test.ts"]

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -1,8 +1,10 @@
-import type { ParsedOptions } from '../types/BeachballOptions';
+import fs from 'fs';
+import path from 'path';
 import { findPackageRoot, type PackageInfo as WSPackageInfo } from 'workspace-tools';
-import { getRawPackageInfos } from '../monorepo/getPackageInfos';
 import { bulletedList, type BulletList } from '../logging/bulletedList';
+import { getRawPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballError } from '../types/BeachballError';
+import type { ParsedOptions } from '../types/BeachballOptions';
 
 /**
  * Handles the `beachball migrate` command.
@@ -11,7 +13,7 @@ import { BeachballError } from '../types/BeachballError';
  * If no updates are needed, a success message is printed.
  */
 export function migrate(parsedOptions: ParsedOptions): void {
-  const { options } = parsedOptions;
+  const { options, repoOptions } = parsedOptions;
   const updates: BulletList = [];
   const warnings: BulletList = [];
 
@@ -21,12 +23,13 @@ export function migrate(parsedOptions: ParsedOptions): void {
     options,
   });
 
-  if ((options as { new?: boolean }).new !== undefined) {
+  if ((repoOptions as { new?: boolean }).new !== undefined) {
     updates.push('The `new` option has been removed. Please remove it from your config.');
   }
 
   if (rawPackageInfos) {
     checkShouldPublish({ rawPackageInfos, warnings, updates });
+    checkChangelogJson({ rawPackageInfos, repoOptions, updates });
   }
 
   if (!updates.length && !warnings.length) {
@@ -68,6 +71,34 @@ function checkShouldPublish(params: {
       'Found non-private packages using `"shouldPublish": false`. The behavior of this setting has changed--' +
         'please see the v3 migration guide for details and verify it still works for your scenario.',
       publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
+    );
+  }
+}
+
+function checkChangelogJson(params: {
+  rawPackageInfos: WSPackageInfo[];
+  repoOptions: Pick<ParsedOptions['repoOptions'], 'generateChangelog'>;
+  updates: BulletList;
+}): void {
+  const { rawPackageInfos, repoOptions, updates } = params;
+  if (repoOptions.generateChangelog !== undefined) {
+    // skip the check if they have any explicit setting
+    return;
+  }
+
+  const changelogJsons = rawPackageInfos
+    .map(pkg => path.join(path.dirname(pkg.packageJsonPath), 'CHANGELOG.json'))
+    .filter(file => fs.existsSync(file));
+
+  if (changelogJsons.length) {
+    updates.push(
+      'Found packages with existing CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, ' +
+        "since most repos don't use them (CHANGELOG.md is still generated).",
+      [
+        'If you DO want CHANGELOG.json files, set `generateChangelog: true` in your beachball config',
+        'If you are NOT using CHANGELOG.json, delete these files:',
+        changelogJsons.sort(),
+      ]
     );
   }
 }

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -4,7 +4,7 @@ import { findPackageRoot, type PackageInfo as WSPackageInfo } from 'workspace-to
 import { bulletedList, type BulletList } from '../logging/bulletedList';
 import { getRawPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballError } from '../types/BeachballError';
-import type { ParsedOptions } from '../types/BeachballOptions';
+import type { BeachballOptions, ParsedOptions } from '../types/BeachballOptions';
 
 /**
  * Handles the `beachball migrate` command.
@@ -29,7 +29,7 @@ export function migrate(parsedOptions: ParsedOptions): void {
 
   if (rawPackageInfos) {
     checkShouldPublish({ rawPackageInfos, warnings, updates });
-    checkChangelogJson({ rawPackageInfos, repoOptions, updates });
+    checkChangelogJson({ rawPackageInfos, options, repoOptions, updates });
   }
 
   if (!updates.length && !warnings.length) {
@@ -77,22 +77,27 @@ function checkShouldPublish(params: {
 
 function checkChangelogJson(params: {
   rawPackageInfos: WSPackageInfo[];
-  repoOptions: Pick<ParsedOptions['repoOptions'], 'generateChangelog'>;
+  options: Pick<BeachballOptions, 'path'>;
+  repoOptions: Pick<ParsedOptions['repoOptions'], 'generateChangelog' | 'changelog'>;
   updates: BulletList;
 }): void {
-  const { rawPackageInfos, repoOptions, updates } = params;
+  const { rawPackageInfos, options, repoOptions, updates } = params;
   if (repoOptions.generateChangelog !== undefined) {
     // skip the check if they have any explicit setting
     return;
   }
 
-  const changelogJsons = rawPackageInfos
-    .map(pkg => path.join(path.dirname(pkg.packageJsonPath), 'CHANGELOG.json'))
-    .filter(file => fs.existsSync(file));
+  const allChangelogJsons = [
+    ...rawPackageInfos.map(pkg => path.join(path.dirname(pkg.packageJsonPath), 'CHANGELOG.json')),
+    ...(repoOptions.changelog?.groups?.map(group =>
+      path.resolve(options.path, group.changelogPath, 'CHANGELOG.json')
+    ) ?? []),
+  ];
+  const changelogJsons = allChangelogJsons.filter(file => fs.existsSync(file));
 
   if (changelogJsons.length) {
     updates.push(
-      'Found packages with existing CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, ' +
+      'Found CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, ' +
         "since most repos don't use them (CHANGELOG.md is still generated).",
       [
         'If you DO want CHANGELOG.json files, set `generateChangelog: true` in your beachball config',

--- a/packages/beachball/src/options/getDefaultOptions.ts
+++ b/packages/beachball/src/options/getDefaultOptions.ts
@@ -22,7 +22,7 @@ export function getDefaultOptions(): BeachballOptions {
     depth: undefined,
     disallowedChangeTypes: null,
     fetch: true,
-    generateChangelog: true,
+    generateChangelog: 'md',
     gitTags: true,
     gitTimeout: undefined,
     message: '',

--- a/packages/beachball/src/options/getOptions.ts
+++ b/packages/beachball/src/options/getOptions.ts
@@ -27,6 +27,7 @@ export function getParsedOptions(params: ProcessInfo & { testRepoOptions?: Parti
   const repoOptions = testRepoOptions || getRepoOptions(cliOptions);
   return {
     cliOptions,
+    repoOptions,
     options: mergeRepoOptions({ repoOptions, cliOptions }),
   };
 }

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -11,7 +11,11 @@ export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 export interface ParsedOptions {
   /** Only the specified CLI options */
   cliOptions: Partial<CliOptions>;
-  /** Only the repo options (will also include the `branch` filled in) */
+  /**
+   * Only the repo options (will also include the `branch` filled in).
+   * NOTE: This may include values that have been overridden by CLI options.
+   * This object should only be used when you need to specifically check the config file values.
+   */
   repoOptions: Partial<RepoOptions>;
   /** Merged repo-level options (includes repo, CLI, and defaults) */
   options: BeachballOptions;

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -11,6 +11,8 @@ export type BeachballOptions = CliOptions & RepoOptions & PackageOptions;
 export interface ParsedOptions {
   /** Only the specified CLI options */
   cliOptions: Partial<CliOptions>;
+  /** Only the repo options (will also include the `branch` filled in) */
+  repoOptions: Partial<RepoOptions>;
   /** Merged repo-level options (includes repo, CLI, and defaults) */
   options: BeachballOptions;
 }
@@ -171,10 +173,11 @@ export interface RepoOptions {
   fromRef?: string;
   /**
    * Whether to generate changelog files.
-   * - `true` (default) to generate both CHANGELOG.md and CHANGELOG.json
-   * - `false` to skip changelog generation
-   * - `'md'` to generate only CHANGELOG.md
+   * - `'md'` (default) to generate only CHANGELOG.md
    * - `'json'` to generate only CHANGELOG.json
+   * - `true` to generate both CHANGELOG.md and CHANGELOG.json
+   * - `false` to skip changelog generation
+   * @default 'md'
    */
   generateChangelog: boolean | 'md' | 'json';
   /**


### PR DESCRIPTION
Disable CHANGELOG.json generation by default (`generateChangelog` defaults to `'md'`), since most repos don't use JSON changelogs and so it's just unnecessary bloat in git history. If you want to keep generating CHANGELOG.json files, set `generateChangelog: true` in your beachball config.

If no `generateChangelog` setting is present in the repo, the `beachball migrate` command will detect existing changelogs and direct to either delete them or set `generateChangelog: true`.

Fixes #979