### PR TITLE
(v2) Add link to change type help

### DIFF
--- a/change/change-776c5b47-5792-4158-9c83-570498dc921e.json
+++ b/change/change-776c5b47-5792-4158-9c83-570498dc921e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add link to change type help",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -4,7 +4,8 @@
   "description": "The Sunniest Semantic Version Bumper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/beachball"
+    "url": "https://github.com/microsoft/beachball",
+    "directory": "packages/beachball"
   },
   "homepage": "https://microsoft.github.io/beachball/",
   "license": "MIT",
@@ -22,7 +23,6 @@
     "lib/!(__*)/**/*"
   ],
   "scripts": {
-    "beachball": "node ./lib/cli.js",
     "build": "tsc",
     "depcheck": "depcheck .",
     "lint": "eslint --color --max-warnings=0 src",

--- a/packages/beachball/src/__tests__/changefile/getQuestionsForPackage.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getQuestionsForPackage.test.ts
@@ -48,6 +48,7 @@ describe('getQuestionsForPackage', () => {
           { title: expect.stringContaining('Major'), value: 'major' },
         ],
         message: 'Change type',
+        hint: expect.any(String),
         name: 'type',
         type: 'select',
       },

--- a/packages/beachball/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
+++ b/packages/beachball/src/__tests__/changefile/promptForChange_promptForPackageChange.test.ts
@@ -88,16 +88,16 @@ describe('promptForChange _promptForPackageChange', () => {
 
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`"Please describe the changes for: foo"`);
     expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  Patch      - bug fixes; no API changes.
-        ? Describe changes (type or choose one) »
-        >   message
-        √ Describe changes (type or choose one) » message"
-      `);
+      "? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
+      >    Patch      - bug fixes; no API changes.
+           Minor      - small feature; backwards compatible API changes.
+           None       - this change does not affect the published package in any way.
+           Major      - major feature; breaking changes.
+      √ Change type »  Patch      - bug fixes; no API changes.
+      ? Describe changes (type or choose one) »
+      >   message
+      √ Describe changes (type or choose one) » message"
+    `);
     expect(answers).toEqual({ type: 'patch', comment: 'message' });
   });
 
@@ -200,32 +200,32 @@ describe('promptForChange _promptForPackageChange', () => {
     await stdin.sendByChar('\n');
 
     expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        ? Change type » - Use arrow-keys. Return to submit.
-             Patch      - bug fixes; no API changes.
-        >    Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        ? Change type » - Use arrow-keys. Return to submit.
-             Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-        >    None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  None       - this change does not affect the published package in any way.
-        ? Describe changes (type or choose one) »
-        >   first
-            second
-            third
-        ? Describe changes (type or choose one) »
-            first
-        >   second
-            third
-        √ Describe changes (type or choose one) » second"
-      `);
+      "? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
+      >    Patch      - bug fixes; no API changes.
+           Minor      - small feature; backwards compatible API changes.
+           None       - this change does not affect the published package in any way.
+           Major      - major feature; breaking changes.
+      ? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
+           Patch      - bug fixes; no API changes.
+      >    Minor      - small feature; backwards compatible API changes.
+           None       - this change does not affect the published package in any way.
+           Major      - major feature; breaking changes.
+      ? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
+           Patch      - bug fixes; no API changes.
+           Minor      - small feature; backwards compatible API changes.
+      >    None       - this change does not affect the published package in any way.
+           Major      - major feature; breaking changes.
+      √ Change type »  None       - this change does not affect the published package in any way.
+      ? Describe changes (type or choose one) »
+      >   first
+          second
+          third
+      ? Describe changes (type or choose one) »
+          first
+      >   second
+          third
+      √ Describe changes (type or choose one) » second"
+    `);
 
     const answers = await answerPromise;
     expect(answers).toEqual({ type: 'none', comment: 'second' });
@@ -314,17 +314,17 @@ describe('promptForChange _promptForPackageChange', () => {
       `);
 
     expect(stdout.getOutput()).toMatchInlineSnapshot(`
-        "? Change type » - Use arrow-keys. Return to submit.
-        >    Patch      - bug fixes; no API changes.
-             Minor      - small feature; backwards compatible API changes.
-             None       - this change does not affect the published package in any way.
-             Major      - major feature; breaking changes.
-        √ Change type »  Patch      - bug fixes; no API changes.
-        ? Describe changes (type or choose one) »
-        >   message
-        ? Describe changes (type or choose one) » a
-        × Describe changes (type or choose one) » a"
-      `);
+      "? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
+      >    Patch      - bug fixes; no API changes.
+           Minor      - small feature; backwards compatible API changes.
+           None       - this change does not affect the published package in any way.
+           Major      - major feature; breaking changes.
+      √ Change type »  Patch      - bug fixes; no API changes.
+      ? Describe changes (type or choose one) »
+      >   message
+      ? Describe changes (type or choose one) » a
+      × Describe changes (type or choose one) » a"
+    `);
 
     expect(answers).toBeUndefined();
   });

--- a/packages/beachball/src/changefile/getQuestionsForPackage.ts
+++ b/packages/beachball/src/changefile/getQuestionsForPackage.ts
@@ -71,6 +71,7 @@ function getChangeTypePrompt(params: {
     type: 'select',
     name: 'type',
     message: 'Change type',
+    hint: 'See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.',
     choices: changeTypeChoices,
   };
 }


### PR DESCRIPTION
Update the change prompt to link to the docs about change types:
```
? Change type » See https://aka.ms/beachball-change for help. Use arrow keys; return to submit.
>    Patch      - bug fixes; no API changes.
      Minor      - small feature; backwards compatible API changes.
      None       - this change does not affect the published package in any way.
      Major      - major feature; breaking changes.
```
Fixes #1268