### PR TITLE
(v2) Fetch with --no-tags

### DIFF
--- a/change/change-63587556-347d-45ce-a995-02eb05af0c6d.json
+++ b/change/change-63587556-347d-45ce-a995-02eb05af0c6d.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fetch with --no-tags",
+      "packageName": "beachball",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/beachball/src/__functional__/git/ensureSharedHistory.test.ts
+++ b/packages/beachball/src/__functional__/git/ensureSharedHistory.test.ts
@@ -77,7 +77,7 @@ describe('ensureSharedHistory', () => {
 
     ensureSharedHistory({ path: repo.rootPath, verbose: true, branch: defaultRemoteBranchName, fetch: true });
     // Ensure the expected git calls were made
-    expect(filteredGitCalls()).toEqual([`fetch origin ${defaultRefSpec}`]);
+    expect(filteredGitCalls()).toEqual([`fetch --no-tags origin ${defaultRefSpec}`]);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Fetching branch "master" from remote "origin" (${defaultRefSpec})...`);
@@ -91,7 +91,7 @@ describe('ensureSharedHistory', () => {
     gitSpy.mockClear();
 
     ensureSharedHistory({ path: repo.rootPath, verbose: true, branch: defaultBranchName, fetch: true });
-    expect(filteredGitCalls()).toContain('fetch');
+    expect(filteredGitCalls()).toContain('fetch --no-tags');
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch('Fetching all remotes...');
@@ -118,7 +118,7 @@ describe('ensureSharedHistory', () => {
     gitSpy.mockClear();
 
     ensureSharedHistory({ path: repo.rootPath, verbose: true, branch: defaultRemoteBranchName, fetch: true, depth: 1 });
-    expect(filteredGitCalls()).toEqual([`fetch origin ${defaultRefSpec}`]);
+    expect(filteredGitCalls()).toEqual([`fetch --no-tags origin ${defaultRefSpec}`]);
   });
 
   it('errors if fetching is disabled and target branch does not exist locally', () => {
@@ -168,7 +168,7 @@ describe('ensureSharedHistory', () => {
     expect(() =>
       ensureSharedHistory({ path: repo.rootPath, verbose: true, branch: defaultRemoteBranchName, fetch: true })
     ).toThrow('Fetching branch "master" from remote "origin" failed');
-    expect(filteredGitCalls()).toContain(`fetch origin ${defaultRefSpec}`);
+    expect(filteredGitCalls()).toContain(`fetch --no-tags origin ${defaultRefSpec}`);
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(`Fetching branch "master" from remote "origin" (${defaultRefSpec})...`);
@@ -183,7 +183,7 @@ describe('ensureSharedHistory', () => {
       ensureSharedHistory({ path: repo.rootPath, verbose: false, branch: 'origin/fake', fetch: true })
     ).toThrow('Fetching branch "fake" from remote "origin" failed');
     const gitOps = filteredGitCalls();
-    expect(gitOps).toContain('fetch origin +refs/heads/fake:refs/remotes/origin/fake');
+    expect(gitOps).toContain('fetch --no-tags origin +refs/heads/fake:refs/remotes/origin/fake');
 
     expect(logs.getMockLines('all')).toEqual('');
   });
@@ -197,7 +197,7 @@ describe('ensureSharedHistory', () => {
     ).toThrow('Fetching branch "fake" from remote "origin" failed');
 
     const gitOps = filteredGitCalls();
-    expect(gitOps).toContain('fetch origin +refs/heads/fake:refs/remotes/origin/fake');
+    expect(gitOps).toContain('fetch --no-tags origin +refs/heads/fake:refs/remotes/origin/fake');
 
     const allLogs = logs.getMockLines('all');
     expect(allLogs).toMatch(
@@ -252,8 +252,8 @@ describe('ensureSharedHistory', () => {
     expect(logs.mocks.error).not.toHaveBeenCalled();
 
     const testRefSpec = `+refs/heads/${testBranch}:refs/remotes/origin/${testBranch}`;
-    const deepen = `fetch --deepen=2 origin ${defaultRefSpec} ${testRefSpec}`;
-    expect(filteredGitCalls()).toEqual([`fetch --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
+    const deepen = `fetch --no-tags --deepen=2 origin ${defaultRefSpec} ${testRefSpec}`;
+    expect(filteredGitCalls()).toEqual([`fetch --no-tags --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
   });
 
   it('deepens history if needed when tracking ref already exists locally', () => {
@@ -285,8 +285,8 @@ describe('ensureSharedHistory', () => {
     expect(logs.mocks.error).not.toHaveBeenCalled();
 
     const testRefSpec = `+refs/heads/${testBranch}:refs/remotes/origin/${testBranch}`;
-    const deepen = `fetch --deepen=2 origin ${defaultRefSpec} ${testRefSpec}`;
-    expect(filteredGitCalls()).toEqual([`fetch --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
+    const deepen = `fetch --no-tags --deepen=2 origin ${defaultRefSpec} ${testRefSpec}`;
+    expect(filteredGitCalls()).toEqual([`fetch --no-tags --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
   });
 
   it('unshallows if deepening attempts fail', () => {
@@ -304,13 +304,13 @@ describe('ensureSharedHistory', () => {
 
     expect(logs.getMockLines('all')).toMatch("Still didn't find a common commit after deepening by 3. Unshallowing...");
     const testRefSpec = `+refs/heads/${testBranch}:refs/remotes/origin/${testBranch}`;
-    const deepen = `fetch --deepen=1 origin ${defaultRefSpec} ${testRefSpec}`;
+    const deepen = `fetch --no-tags --deepen=1 origin ${defaultRefSpec} ${testRefSpec}`;
     expect(filteredGitCalls()).toEqual([
-      `fetch --depth=1 origin ${defaultRefSpec}`,
+      `fetch --no-tags --depth=1 origin ${defaultRefSpec}`,
       deepen,
       deepen,
       deepen,
-      `fetch --unshallow origin ${defaultRefSpec} ${testRefSpec}`,
+      `fetch --no-tags --unshallow origin ${defaultRefSpec} ${testRefSpec}`,
     ]);
   });
 
@@ -336,7 +336,7 @@ describe('ensureSharedHistory', () => {
 
     expect(filteredGitCalls([])).toEqual([
       'rev-parse --verify origin/master',
-      `fetch origin ${defaultRefSpec}`,
+      `fetch --no-tags origin ${defaultRefSpec}`,
       'merge-base origin/master HEAD',
       'rev-parse --is-shallow-repository',
     ]);

--- a/packages/beachball/src/__functional__/git/fetch.test.ts
+++ b/packages/beachball/src/__functional__/git/fetch.test.ts
@@ -22,6 +22,7 @@ describe('gitFetch', () => {
   let realRemoteUrl = '';
   let modifiedRemote = false;
 
+  const baseArgs = ['fetch', '--no-tags'];
   const logs = initMockLogs();
 
   /** To speed things up, some tests only check the arguments and skip the git operation */
@@ -74,7 +75,7 @@ describe('gitFetch', () => {
 
   it('fetches and does not log by default', () => {
     const res = gitFetch({ cwd: repo.rootPath, remote: '', branch: defaultBranchName });
-    expect(gitSpy).toHaveBeenCalledWith(['fetch'], { cwd: repo.rootPath, stdio: 'pipe' });
+    expect(gitSpy).toHaveBeenCalledWith(baseArgs, { cwd: repo.rootPath, stdio: 'pipe' });
     expect(res).toMatchObject({ success: true });
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
@@ -115,7 +116,7 @@ describe('gitFetch', () => {
     const res = gitFetch({ cwd: repo.rootPath, verbose: true, remote: '', branch: defaultBranchName });
     // normally this would be called with stdio: inherit, but it's not done that way in tests
     // because process.stdout/stderr can't be mocked, so the test output would be too spammy
-    expect(gitSpy).toHaveBeenCalledWith(['fetch'], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith(baseArgs, expect.anything());
     expect(res).toMatchObject({ success: true });
     expect(res.errorMessage).toBeUndefined();
     expect(logs.mocks.log).toHaveBeenCalledWith('Fetching all remotes...');
@@ -128,7 +129,7 @@ describe('gitFetch', () => {
     gitOverride = () => ({ success: false, stdout: 'some logs', stderr: 'oh no', status: 1 } as GitProcessOutput);
 
     const res = gitFetch({ cwd: repo.rootPath, verbose: true, remote: '', branch: defaultBranchName });
-    expect(gitSpy).toHaveBeenCalledWith(['fetch'], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith(baseArgs, expect.anything());
     expect(res).toMatchObject({
       success: false,
       errorMessage: 'Fetching all remotes failed (code 1) - see above for details',
@@ -147,7 +148,7 @@ describe('gitFetch', () => {
     // refs/heads/ on the source side is unambiguous: bare branch names can be silently
     // misresolved, causing git to treat the ref as absent and delete the local tracking ref.
     const refspec = `+refs/heads/${defaultBranchName}:refs/remotes/${defaultRemoteName}/${defaultBranchName}`;
-    expect(gitSpy).toHaveBeenCalledWith(['fetch', defaultRemoteName, refspec], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith([...baseArgs, defaultRemoteName, refspec], expect.anything());
     expect(res).toMatchObject({ success: true });
     expect(logs.mocks.log).toHaveBeenCalledWith(
       `Fetching branch "${defaultBranchName}" from remote "${defaultRemoteName}" (${refspec})...`
@@ -170,7 +171,7 @@ describe('gitFetch', () => {
     const refspec1 = `+refs/heads/${defaultBranchName}:refs/remotes/${defaultRemoteName}/${defaultBranchName}`;
     const refspec2 = `+refs/heads/${otherBranch}:refs/remotes/${defaultRemoteName}/${otherBranch}`;
     expect(gitSpy).toHaveBeenCalledWith(
-      ['fetch', '--deepen=5', defaultRemoteName, refspec1, refspec2],
+      [...baseArgs, '--deepen=5', defaultRemoteName, refspec1, refspec2],
       expect.anything()
     );
     expect(res).toMatchObject({ success: true });
@@ -216,7 +217,7 @@ describe('gitFetch', () => {
 
     // The fetch command must target only origin with the correct refspec
     const expectedRefspec = `+refs/heads/${defaultBranchName}:refs/remotes/${defaultRemoteName}/${defaultBranchName}`;
-    expect(gitSpy).toHaveBeenCalledWith(['fetch', defaultRemoteName, expectedRefspec], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith([...baseArgs, defaultRemoteName, expectedRefspec], expect.anything());
 
     // origin/master must exist and be reachable
     gitFailFast(['rev-parse', '--verify', `refs/remotes/${defaultRemoteName}/${defaultBranchName}`], {
@@ -239,7 +240,7 @@ describe('gitFetch', () => {
     gitOverride = noOpSuccess;
     const res = gitFetch({ cwd: repo.rootPath, depth: 1, verbose: true, remote: '', branch: defaultBranchName });
 
-    expect(gitSpy).toHaveBeenCalledWith(['fetch', '--depth=1'], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith([...baseArgs, '--depth=1'], expect.anything());
     expect(res).toMatchObject({ success: true });
     expect(logs.mocks.log).toHaveBeenCalledWith(`Fetching all remotes (with --depth=1)...`);
   });
@@ -248,7 +249,7 @@ describe('gitFetch', () => {
     gitOverride = noOpSuccess;
     const res = gitFetch({ cwd: repo.rootPath, deepen: 1, verbose: true, remote: '', branch: defaultBranchName });
 
-    expect(gitSpy).toHaveBeenCalledWith(['fetch', '--deepen=1'], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith([...baseArgs, '--deepen=1'], expect.anything());
     expect(res).toMatchObject({ success: true });
     expect(logs.mocks.log).toHaveBeenCalledWith(`Fetching all remotes (with --deepen=1)...`);
   });
@@ -257,7 +258,7 @@ describe('gitFetch', () => {
     gitOverride = noOpSuccess;
     const res = gitFetch({ cwd: repo.rootPath, unshallow: true, verbose: true, remote: '', branch: defaultBranchName });
 
-    expect(gitSpy).toHaveBeenCalledWith(['fetch', '--unshallow'], expect.anything());
+    expect(gitSpy).toHaveBeenCalledWith([...baseArgs, '--unshallow'], expect.anything());
     expect(res).toMatchObject({ success: true });
     expect(logs.mocks.log).toHaveBeenCalledWith(`Fetching all remotes (with --unshallow)...`);
   });

--- a/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
+++ b/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
@@ -106,7 +106,9 @@ describe('bumpAndPush', () => {
     expect(mockPerformBump).toHaveBeenCalledTimes(1);
     expect(mockTagPackages).toHaveBeenCalledTimes(1);
     expect(wsToolsMocks.revertLocalChanges).toHaveBeenCalledTimes(1);
-    expect(getWsToolsGitCalls().join('\n')).toEqual('git fetch origin +refs/heads/master:refs/remotes/origin/master');
+    expect(getWsToolsGitCalls().join('\n')).toEqual(
+      'git fetch --no-tags origin +refs/heads/master:refs/remotes/origin/master'
+    );
     expect(getExecaCalls()).toEqual([
       'git merge -X theirs origin/master',
       'git add .',

--- a/packages/beachball/src/git/fetch.ts
+++ b/packages/beachball/src/git/fetch.ts
@@ -68,6 +68,7 @@ export function gitFetch(params: GitFetchParams): GitProcessOutput & { errorMess
   const result: ReturnType<typeof gitFetch> = git(
     [
       'fetch',
+      '--no-tags',
       ...extraArgs,
       // If the remote is unknown, don't specify the branch (fetching a branch without a remote is invalid)
       ...(resolvedRefspecs.length ? [remote, ...resolvedRefspecs] : []),


### PR DESCRIPTION
Use `git fetch --no-tags` since tags aren't needed for beachball's diff operations, and it should be faster.