### PR TITLE
Fix skill name in change prompt

### DIFF
--- a/change/beachball-13a1b781-2b1a-4eff-ad1a-03696ad51619.json
+++ b/change/beachball-13a1b781-2b1a-4eff-ad1a-03696ad51619.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Fix skill name in change prompt",
+  "type": "none",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -56,7 +56,7 @@ export async function promptForChange(params: {
     if ((await determineAgent()).isAgent) {
       lines.push(
         '',
-        'For AI agents, you can ask the user to add the "beachball-change-files" skill ' +
+        'For AI agents, you can ask the user to add the "beachball-change-file" skill ' +
           '(see https://microsoft.github.io/beachball/concepts/ai-integration) ' +
           'for better manual instructions about creating change files.'
       );


### PR DESCRIPTION
Fix typo. Change type is `none` because this will already be in v2.