### PR TITLE
Update internal logic for parsing remote branch

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -22,4 +22,4 @@ yarnPath: .yarn/releases/yarn-4.17.0.cjs
 
 catalogs:
   prod:
-    workspace-tools: ^0.41.9
+    workspace-tools: ^0.41.10

--- a/change/beachball-4cfba6ef-9575-41b5-abdb-9f77195e3f3c.json
+++ b/change/beachball-4cfba6ef-9575-41b5-abdb-9f77195e3f3c.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Update internal logic for parsing remote branch",
+  "type": "patch",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -12,7 +12,7 @@ import path from 'path';
 jest.mock('workspace-tools', () => ({
   ...jest.requireActual<typeof import('workspace-tools')>('workspace-tools'),
   // not currently used (can add realistic mock if needed)
-  resolveRemoteAndBranch: jest.fn(() => ({ remote: 'origin', branch: 'main' })),
+  resolveRemoteAndBranch: jest.fn(() => ({ remote: 'origin', remoteBranch: 'main' })),
 }));
 
 describe('migrate command', () => {

--- a/packages/beachball/src/__functional__/options/getCliOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getCliOptions.test.ts
@@ -6,10 +6,10 @@ jest.mock('workspace-tools', () => {
   return {
     resolveRemoteAndBranch: jest.fn((options: { branch?: string }) => {
       if (options.branch?.includes('/')) {
-        const [remote, branch] = options.branch.split('/');
-        return { remote, branch };
+        const [remote, remoteBranch] = options.branch.split('/');
+        return { remote, remoteBranch };
       }
-      return { remote: 'origin', branch: options.branch || 'main' };
+      return { remote: 'origin', remoteBranch: options.branch || 'main' };
     }),
     findProjectRoot: jest.fn(() => 'fake-root'),
   };
@@ -164,7 +164,7 @@ describe('getCliOptions', () => {
   });
 
   it('uses provided branch with remote', () => {
-    // resolveRemoteAndBranch is mocked to use branch.split('/') as remote and branch
+    // resolveRemoteAndBranch is mocked to use branch.split('/') as remote and remoteBranch
     const options = getCliOptionsTest(['--branch', 'someremote/foo']);
     expect(options).toEqual({ ...defaults, branch: 'someremote/foo' });
     expect(resolveRemoteAndBranch).toHaveBeenCalled();

--- a/packages/beachball/src/git/ensureSharedHistory.ts
+++ b/packages/beachball/src/git/ensureSharedHistory.ts
@@ -1,6 +1,7 @@
-import { git, parseRemoteBranch } from 'workspace-tools';
+import { git } from 'workspace-tools';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { gitFetch } from './fetch';
+import { getRemoteBranch, type RemoteBranch } from './getRemoteBranch';
 import { bulletedList, type BulletList } from '../logging/bulletedList';
 import { BeachballError } from '../types/BeachballError';
 
@@ -21,8 +22,7 @@ export function ensureSharedHistory(
   options: Pick<BeachballOptions, 'fetch' | 'path' | 'branch' | 'depth' | 'verbose'>
 ): void {
   const { fetch, path: cwd, branch, depth, verbose } = options;
-  // The config-reading logic ensures that `branch` always includes a remote
-  const { remote, remoteBranch } = parseRemoteBranch({ branch, cwd });
+  const { remote, remoteBranch } = getRemoteBranch(options);
 
   // Ensure the comparison branch ref exists
   if (!hasBranchRef(branch, cwd)) {
@@ -86,14 +86,14 @@ export function ensureSharedHistory(
  * Returns true if a common commit can be found after fetching more history.
  * Throws if there's any issue
  */
-function deepenHistory(params: {
-  remote: string;
-  remoteBranch: string;
-  branch: string;
-  depth: number | undefined;
-  cwd: string;
-  verbose?: boolean;
-}): boolean {
+function deepenHistory(
+  params: RemoteBranch & {
+    branch: string;
+    depth: number | undefined;
+    cwd: string;
+    verbose?: boolean;
+  }
+): boolean {
   const { remote, remoteBranch, branch, cwd, verbose } = params;
   const depth = params.depth || 100;
 

--- a/packages/beachball/src/git/getRemoteBranch.ts
+++ b/packages/beachball/src/git/getRemoteBranch.ts
@@ -1,0 +1,49 @@
+import { parseRemoteBranch } from 'workspace-tools';
+import { BeachballError } from '../types/BeachballError';
+import type { BeachballOptions } from '../types/BeachballOptions';
+
+export type RemoteBranch = {
+  /** Remote name (always set) */
+  remote: string;
+  /** Branch name without the remote prefix */
+  remoteBranch: string;
+};
+
+const cache: Record<`${string}#${string}`, RemoteBranch> = {};
+
+/**
+ * Get the remote name and branch name (no prefix) from `branch`, with caching.
+ *
+ * Throws if the remote could not be determined (should never happen after initial option processing,
+ * which ensures the branch includes a remote name).
+ */
+export function getRemoteBranch(options: Pick<BeachballOptions, 'branch' | 'path'>): RemoteBranch {
+  const { branch, path: cwd } = options;
+
+  const cacheKey = getCacheKey({ cwd, branch });
+  if (cache[cacheKey]) {
+    return cache[cacheKey];
+  }
+
+  // If `branch` starts with "origin" or "upstream", that's assumed to be the remote, but otherwise
+  // it will get the actual list of remotes from git config.
+  const parsed = parseRemoteBranch({ branch, cwd });
+  if (!parsed.remote) {
+    throw new BeachballError(`Could not determine the remote for "${branch}"`);
+  }
+  const result = { remote: parsed.remote, remoteBranch: parsed.remoteBranch };
+  cache[cacheKey] = result;
+  return result;
+}
+
+/**
+ * Add remote branch info to the cache for both `${remote}/${remoteBranch}` and `${remoteBranch}` keys.
+ */
+export function cacheRemoteBranch(info: RemoteBranch, cwd: string): void {
+  cache[getCacheKey({ cwd, branch: `${info.remote}/${info.remoteBranch}` })] = info;
+  cache[getCacheKey({ cwd, branch: info.remoteBranch })] = info;
+}
+
+function getCacheKey(params: { cwd: string; branch: string }): `${string}#${string}` {
+  return `${params.cwd}#${params.branch}` as const;
+}

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -2,6 +2,7 @@ import { findProjectRoot, resolveRemoteAndBranch } from 'workspace-tools';
 import parser from 'yargs-parser';
 import { env } from '../env';
 import type { CliOptions, ParsedOptions } from '../types/BeachballOptions';
+import { cacheRemoteBranch } from '../git/getRemoteBranch';
 
 export interface ProcessInfo {
   /** Complete argv (node and script path aren't used but elements must be present) */
@@ -220,5 +221,7 @@ export function resolveBranchOption(rawOptions: Partial<Pick<CliOptions, 'branch
     verbose: rawOptions.verbose,
     strict: true,
   });
-  return `${branchResult.remote}/${branchResult.branch}`;
+  cacheRemoteBranch(branchResult, cwd);
+
+  return `${branchResult.remote}/${branchResult.remoteBranch}`;
 }

--- a/packages/beachball/src/publish/bumpAndPush.ts
+++ b/packages/beachball/src/publish/bumpAndPush.ts
@@ -1,10 +1,11 @@
 import { performBump } from '../bump/performBump';
 import type { BumpInfo } from '../types/BumpInfo';
 import type { BeachballOptions } from '../types/BeachballOptions';
-import { revertLocalChanges, parseRemoteBranch } from 'workspace-tools';
+import { revertLocalChanges } from 'workspace-tools';
 import { tagPackages } from './tagPackages';
 import { displayManualRecovery } from './displayManualRecovery';
 import { gitFetch } from '../git/fetch';
+import { getRemoteBranch } from '../git/getRemoteBranch';
 import { gitAsync } from '../git/gitAsync';
 import { BeachballError } from '../types/BeachballError';
 
@@ -26,7 +27,7 @@ export async function bumpAndPush(
   bumpPushRetries = defaultBumpPushRetries
 ): Promise<void> {
   const { path: cwd, branch, depth, gitTimeout } = options;
-  const { remote, remoteBranch } = parseRemoteBranch({ branch, cwd });
+  const { remote, remoteBranch } = getRemoteBranch(options);
 
   let completed = false;
   let tryNumber = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8885,9 +8885,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workspace-tools@npm:^0.41.9":
-  version: 0.41.9
-  resolution: "workspace-tools@npm:0.41.9"
+"workspace-tools@npm:^0.41.10":
+  version: 0.41.10
+  resolution: "workspace-tools@npm:0.41.10"
   dependencies:
     "@yarnpkg/lockfile": "npm:^1.1.0"
     fast-glob: "npm:^3.3.3"
@@ -8895,7 +8895,7 @@ __metadata:
     jju: "npm:^1.4.0"
     js-yaml: "npm:^4.2.0"
     micromatch: "npm:^4.0.8"
-  checksum: 10c0/803acc4530afba938413d658795a0fc943fb663b802765b43a8a301877b3738827d79b5239caac67f19255f40dadaf96d374aa9784bc58bc16ce4b96f56b067b
+  checksum: 10c0/2a6e7bad84e1855afb63854d76eb9129e2ca06abb2936251988924a852c071fd7f276b557587a052665cca1800bee0c1dec82804e47e89ceebebd45a6305cb2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Wrap `parseRemoteBranch` with caching, in preparation for other changes that are likely to require using the remote for more operations.