### PR TITLE
Fix ESRP token scope

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,7 @@ npmMinimalAgeGate: 3d
 
 npmPreapprovedPackages:
   - '@ms-cloudpack/esbuild-node-helpers'
+  - lage
   - workspace-tools
 
 # This plugin simplifies auth for the release pipeline by reusing .npmrc.

--- a/actions/should-release/dist/index.js
+++ b/actions/should-release/dist/index.js
@@ -1,11 +1,9 @@
 // @ts-nocheck
 /* eslint-disable */
-import { createRequire as topLevelCreateRequire } from 'node:module';
-import topLevelPath from 'node:path';
-import topLevelUrl from 'node:url';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = topLevelUrl.fileURLToPath(import.meta.url);
-const __dirname = topLevelPath.dirname(__filename);
+import { createRequire as esbuildNodeHelpersCreateRequire } from 'node:module';
+var require = esbuildNodeHelpersCreateRequire(import.meta.url);
+var __filename = import.meta.filename;
+var __dirname = import.meta.dirname;
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/change/@microsoft-beachball-action-should-release-aeb6b385-fef8-4a39-89a3-2a928bd64df0.json
+++ b/change/@microsoft-beachball-action-should-release-aeb6b385-fef8-4a39-89a3-2a928bd64df0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update build output",
+  "packageName": "@microsoft/beachball-action-should-release",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -9,6 +9,8 @@
  */
 const config = {
   npmClient: 'yarn',
+  // use fancy reporter locally and platform-specific ones for CI
+  reporter: process.env.CI || process.env.TF_BUILD ? undefined : 'fancy',
   pipeline: {
     build: {
       dependsOn: ['^build'],

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.0.0",
     "jest": "^30.0.0",
-    "lage": "^2.15.0",
+    "lage": "^2.15.16",
     "lint-staged": "^16.0.0",
     "prettier": "~3.8.3",
     "syncpack": "^14.0.0",

--- a/packages/esrp-npm-release/src/ESRPReleaseService.ts
+++ b/packages/esrp-npm-release/src/ESRPReleaseService.ts
@@ -14,7 +14,7 @@ import {
   redactReleaseRequest,
   type CreateNpmReleaseRequestMessageParams,
 } from './esrpApi/npmRelease.ts';
-import { esrpApiEndpoint, getReleaseDetails, getReleaseStatus, submitRelease } from './esrpApi/releaseHttp.ts';
+import { esrpApiScope, getReleaseDetails, getReleaseStatus, submitRelease } from './esrpApi/releaseHttp.ts';
 import type { ReleaseResultMessage } from './types/api.ts';
 import type { Logger } from './utils/Logger.ts';
 import { ReleaseError } from './utils/ReleaseError.ts';
@@ -190,9 +190,9 @@ export class ESRPReleaseService {
   }
 
   async #getEsrpAccessToken(): Promise<AccessToken> {
-    this.#logger.log(`Acquiring AAD access token for ESRP API at ${esrpApiEndpoint}`);
+    this.#logger.log(`Acquiring AAD access token for ESRP API under scope ${esrpApiScope}`);
     return await getAadToken({
-      scopes: [`${esrpApiEndpoint}.default`],
+      scopes: [`${esrpApiScope}.default`],
       clientId: this.#clientId,
       tenantId: this.#tenantId,
       auth: { certPfxContent: this.#authCertificatePfx },

--- a/packages/esrp-npm-release/src/ESRPReleaseService.ts
+++ b/packages/esrp-npm-release/src/ESRPReleaseService.ts
@@ -190,9 +190,10 @@ export class ESRPReleaseService {
   }
 
   async #getEsrpAccessToken(): Promise<AccessToken> {
-    this.#logger.log(`Acquiring AAD access token for ESRP API under scope ${esrpApiScope}`);
+    const scope = `${esrpApiScope}.default`;
+    this.#logger.log(`Acquiring AAD access token for ESRP API (scope: ${scope})`);
     return await getAadToken({
-      scopes: [`${esrpApiScope}.default`],
+      scopes: [scope],
       clientId: this.#clientId,
       tenantId: this.#tenantId,
       auth: { certPfxContent: this.#authCertificatePfx },

--- a/packages/esrp-npm-release/src/__fixtures__/mockEsrpHttp.ts
+++ b/packages/esrp-npm-release/src/__fixtures__/mockEsrpHttp.ts
@@ -22,7 +22,7 @@ export type MockEsrpHttp = jest.Mocked<typeof releaseHttp> & {
 export function createMockEsrpHttp(): MockEsrpHttp {
   const getReleaseStatus = jest.fn(() => Promise.resolve({ status: 'pass' } as ReleaseResultMessage));
   return {
-    esrpApiEndpoint: 'https://api.esrp.microsoft.com/',
+    esrpApiScope: 'https://msazurecloud.onmicrosoft.com/api.esrp.microsoft.com/',
     submitRelease: jest.fn(() => Promise.resolve({ operationId: 'mock-op-id' })),
     getReleaseStatus,
     getReleaseDetails: jest.fn(() => Promise.resolve({})),

--- a/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
@@ -159,7 +159,7 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
         "[log] Found 2 certificate(s) in PFX; leaf is at index 0 (using as-is)",
         "[log] ##[group]Releasing layer 01",
         "[log] [layer-01] Acquiring fresh credentials for release",
-        "[log] [layer-01] Acquiring AAD access token for ESRP API at https://api.esrp.microsoft.com/",
+        "[log] [layer-01] Acquiring AAD access token for ESRP API (scope: https://msazurecloud.onmicrosoft.com/api.esrp.microsoft.com/.default)",
         "[log] [layer-01] Requesting user delegation key for staging storage account "mockaccount"",
         "[log] [layer-01] Uploading <temp>/layer-01-123456789.zip to https://stagingaccount.blob.core.windows.net/staging/r/op-1",
         "[log] [layer-01] Generating SAS token for staging blob "repo1/<uuid>"",

--- a/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
@@ -17,7 +17,7 @@ import { createMockEsrpHttp } from '../__fixtures__/mockEsrpHttp.ts';
 import { setupTempDir } from '../__fixtures__/tempDir.ts';
 import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtures__/testCert.ts';
 import type * as getAadTokenModule from '../auth/getAadToken.ts';
-import { esrpApiEndpoint } from '../esrpApi/releaseHttp.ts';
+import { esrpApiScope } from '../esrpApi/releaseHttp.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
 
 const mockGetAadToken = jest.fn<typeof getAadTokenModule.getAadToken>();
@@ -131,7 +131,7 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     await runCreateRelease();
 
     expect(mockGetAadToken).toHaveBeenCalledWith({
-      scopes: [`${esrpApiEndpoint}.default`],
+      scopes: [`${esrpApiScope}.default`],
       clientId: 'cid',
       tenantId: 'tid',
       auth: { certPfxContent: 'auth-pfx-not-parsed' },

--- a/packages/esrp-npm-release/src/auth/getAadToken.ts
+++ b/packages/esrp-npm-release/src/auth/getAadToken.ts
@@ -7,7 +7,6 @@ import { ReleaseError } from '../utils/ReleaseError.ts';
 
 export interface GetAadTokenParams extends Pick<ReleaseHttpParams, 'clientId'> {
   tenantId: string;
-  /** Typically this should be `['<domain>.default']` */
   scopes: string[];
   auth: { certPfxContent: string } | { idToken: string };
   logger: Logger;

--- a/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
+++ b/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
@@ -15,9 +15,10 @@ export interface ReleaseHttpParams {
   releaseId: string;
 }
 
-export const esrpApiEndpoint = 'https://api.esrp.microsoft.com/';
+const esrpApiDomain = 'api.esrp.microsoft.com';
+export const esrpApiScope = `https://msazurecloud.onmicrosoft.com/${esrpApiDomain}/`;
 
-const esrpBaseUrl = `${esrpApiEndpoint}api/v3/releaseservices/clients/`;
+const esrpBaseUrl = `https://${esrpApiDomain}/api/v3/releaseservices/clients/`;
 // const esrpBaseUrl = 'https://ppe.api.esrp.microsoft.com/api/v3/releaseservices/clients/';
 
 /**

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,7 @@
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' yarn run -T jest"
   },
   "devDependencies": {
-    "@ms-cloudpack/esbuild-node-helpers": "0.1.6",
+    "@ms-cloudpack/esbuild-node-helpers": "0.1.7",
     "@ms-cloudpack/eslint-plugin-deprecated": "^0.1.5",
     "cross-env": "^10.1.0",
     "esbuild": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,7 +1536,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     husky: "npm:^9.0.0"
     jest: "npm:^30.0.0"
-    lage: "npm:^2.15.0"
+    lage: "npm:^2.15.16"
     lint-staged: "npm:^16.0.0"
     prettier: "npm:~3.8.3"
     syncpack: "npm:^14.0.0"
@@ -6162,9 +6162,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lage@npm:^2.15.0":
-  version: 2.15.12
-  resolution: "lage@npm:2.15.12"
+"lage@npm:^2.15.16":
+  version: 2.15.16
+  resolution: "lage@npm:2.15.16"
   dependencies:
     fsevents: "npm:~2.3.2"
     glob-hasher: "npm:^1.4.2"
@@ -6174,7 +6174,7 @@ __metadata:
   bin:
     lage: dist/lage.js
     lage-server: dist/lage-server.js
-  checksum: 10c0/1bf1cc296a326647a69ea97c3c71004b4e02ee94b92e01b69c4e8e87ae74455b700f0dd65f5ad08598e6e178f4ab4aa25b7d2252b2963528847a283e4ccdf0f5
+  checksum: 10c0/6ca8a090e18885a045a6a2b66ffe88ce124c4b412e19a106f3c1dcea898b33fd614338f7873ea0e712be25b9cf3256e6745f9a17a6489b8b3409d1d5aad55074
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,7 +1549,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@microsoft/beachball-scripts@workspace:scripts"
   dependencies:
-    "@ms-cloudpack/esbuild-node-helpers": "npm:0.1.6"
+    "@ms-cloudpack/esbuild-node-helpers": "npm:0.1.7"
     "@ms-cloudpack/eslint-plugin-deprecated": "npm:^0.1.5"
     cross-env: "npm:^10.1.0"
     esbuild: "npm:^0.28.1"
@@ -1586,9 +1586,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ms-cloudpack/esbuild-node-helpers@npm:0.1.6":
-  version: 0.1.6
-  resolution: "@ms-cloudpack/esbuild-node-helpers@npm:0.1.6"
+"@ms-cloudpack/esbuild-node-helpers@npm:0.1.7":
+  version: 0.1.7
+  resolution: "@ms-cloudpack/esbuild-node-helpers@npm:0.1.7"
   dependencies:
     "@ms-cloudpack/environment": "npm:^0.1.7"
     hosted-git-info: "npm:^9.0.0"
@@ -1596,7 +1596,7 @@ __metadata:
     validate-npm-package-license: "npm:^3.0.4"
   peerDependencies:
     esbuild: ">=0.28.0"
-  checksum: 10c0/a927afb7eede8d30b732442e0c2ba78d2961bcdc5113854563ea5a2b9aead73653d3c3953bc2119d97e20e06d207c6b207e284fd9a2c675622a39b9a487e4b4a
+  checksum: 10c0/599acd0474b43b72c91a39f10444216d48aa82abab242f6c3023693de10297e711781f287cbff13defd760052b6fd1fdb27ecea878f155144f9606d9ac68ceaa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update token scope per instructions.

Update esbuild-node-helpers to fix "duplicate identifier __filename" error.