### PR TITLE
Remove usage of quarantined dep versions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,10 +4,7 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 3d
 
-npmPreapprovedPackages:
-  - '@ms-cloudpack/esbuild-node-helpers'
-  - lage
-  - workspace-tools
+npmPreapprovedPackages: []
 
 # This plugin simplifies auth for the release pipeline by reusing .npmrc.
 # It's enabled (npmrcAuthEnabled) only for ADO publish by preparePublishRegistry.ts.
@@ -23,4 +20,4 @@ yarnPath: .yarn/releases/yarn-4.17.0.cjs
 
 catalogs:
   prod:
-    workspace-tools: ^0.41.10
+    workspace-tools: ^0.41.8

--- a/change/beachball-5caa022b-9249-4fea-b216-e88a82a478b3.json
+++ b/change/beachball-5caa022b-9249-4fea-b216-e88a82a478b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "temporary workaround",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.0.0",
     "jest": "^30.0.0",
-    "lage": "^2.15.16",
+    "lage": "^2.15.0",
     "lint-staged": "^16.0.0",
     "prettier": "~3.8.3",
     "syncpack": "^14.0.0",

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -9,11 +9,14 @@ import fs from 'fs';
 import { BeachballError } from '../../types/BeachballError';
 import path from 'path';
 
-jest.mock('workspace-tools', () => ({
-  ...jest.requireActual<typeof import('workspace-tools')>('workspace-tools'),
-  // not currently used (can add realistic mock if needed)
+jest.mock('../../git/tempGetDefaultRemoteBranch', () => ({
   resolveRemoteAndBranch: jest.fn(() => ({ remote: 'origin', remoteBranch: 'main' })),
 }));
+// jest.mock('workspace-tools', () => ({
+//   ...jest.requireActual<typeof import('workspace-tools')>('workspace-tools'),
+//   // not currently used (can add realistic mock if needed)
+//   resolveRemoteAndBranch: jest.fn(() => ({ remote: 'origin', remoteBranch: 'main' })),
+// }));
 
 describe('migrate command', () => {
   const logs = initMockLogs();

--- a/packages/beachball/src/__functional__/options/getCliOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getCliOptions.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { findProjectRoot } from 'workspace-tools';
+import { resolveRemoteAndBranch } from '../../git/tempGetDefaultRemoteBranch';
 import { getCliOptions } from '../../options/getCliOptions';
-import { findProjectRoot, resolveRemoteAndBranch } from 'workspace-tools';
 
-jest.mock('workspace-tools', () => {
+jest.mock('../../git/tempGetDefaultRemoteBranch', () => {
+  // jest.mock('workspace-tools', () => {
   return {
     resolveRemoteAndBranch: jest.fn((options: { branch?: string }) => {
       if (options.branch?.includes('/')) {
@@ -11,9 +13,11 @@ jest.mock('workspace-tools', () => {
       }
       return { remote: 'origin', remoteBranch: options.branch || 'main' };
     }),
-    findProjectRoot: jest.fn(() => 'fake-root'),
   };
 });
+jest.mock('workspace-tools', () => ({
+  findProjectRoot: jest.fn(() => 'fake-root'),
+}));
 
 //
 // These tests cover a mix of built-in parser behavior, provided options, and custom overrides.

--- a/packages/beachball/src/git/tempGetDefaultRemoteBranch.ts
+++ b/packages/beachball/src/git/tempGetDefaultRemoteBranch.ts
@@ -1,0 +1,111 @@
+// temporary copy of packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
+// to allow continued testing of ESRP before package quarantine time passes
+import { getDefaultRemote, type GetDefaultRemoteOptions } from 'workspace-tools/lib/git/getDefaultRemote';
+import { git } from 'workspace-tools/lib/git/git';
+import { getDefaultBranch } from 'workspace-tools/lib/git/gitUtilities';
+import { parseRemoteBranchPlusRemotes } from 'workspace-tools/lib/git/parseRemoteBranch';
+
+export type ParsedRemoteBranch = {
+  /**
+   * Remote name, e.g. `origin`.
+   * May be an empty string if the original branch reference didn't include a remote.
+   */
+  remote: string;
+  /** Branch name without remote, e.g. `main`. This is always set. */
+  remoteBranch: string;
+};
+
+export type RemoteBranch = Pick<ParsedRemoteBranch, 'remoteBranch'> & {
+  /** Remote name, e.g. `origin`. */
+  remote: string;
+};
+
+export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
+  /**
+   * Name of branch to use, **without** a remote prefix. If you want to resolve a branch
+   * that may already include a remote prefix, use {@link resolveRemoteAndBranch}.
+   *
+   * If undefined, uses the default branch name (falling back to `master`).
+   */
+  branch?: string;
+};
+
+/**
+ * Like {@link getDefaultRemoteBranch} but it returns an object.
+ *
+ * @returns A branch reference like `{ remote: "upstream", branch: "master" }` or `{ remote: "origin", branch: "main" }`.
+ */
+function getDefaultRemoteAndBranch(options: GetDefaultRemoteBranchOptions): RemoteBranch {
+  const { cwd, branch } = options;
+
+  const defaultRemote = getDefaultRemote(options);
+
+  if (branch) {
+    // For this specific function, `branch` has no remote prefix
+    return { remote: defaultRemote, remoteBranch: branch };
+  }
+
+  let remoteDefaultBranch: string | undefined;
+
+  // Get the default branch name from the default remote.
+  // ls-remote is a plumbing command with stable, locale-independent output.
+  // Output format: "ref: refs/heads/main\tHEAD\n<hash>\tHEAD"
+  const lsRemoteCmd = ['ls-remote', '--symref', defaultRemote, 'HEAD'];
+  const lsRemote = git(lsRemoteCmd, {
+    cwd,
+    throwOnError: options.strict,
+    description: `Fetching default branch info from remote "${defaultRemote}"`,
+  });
+  if (lsRemote.success) {
+    const refRegex = /^ref: refs\/heads\/(.*?)\t/;
+    const symRefLine = lsRemote.stdout.split('\n').find(line => refRegex.test(line));
+    remoteDefaultBranch = symRefLine && symRefLine.match(refRegex)?.[1];
+
+    if (!remoteDefaultBranch && options.strict) {
+      throw new Error(
+        `Could not parse default branch from \`git ${lsRemoteCmd.join(' ')}\` output:\n${lsRemote.stdout}`
+      );
+    }
+  }
+
+  // If no default branch found from the remote, fall back to the local git config or "master"
+  // (this can't use throwOnError in case the key isn't set)
+  remoteDefaultBranch ||= getDefaultBranch({ cwd });
+
+  return { remote: defaultRemote, remoteBranch: remoteDefaultBranch };
+}
+
+/**
+ * Resolve a user-provided branch (possibly with a remote) to a fully-qualified remote branch.
+ * First tries the less-expensive {@link parseRemoteBranchPlusRemotes} (compares with remote names
+ * read from `git config`) to see if there's an explicit remote in the branch name, then tries
+ * {@link getDefaultRemoteBranch}.
+ *
+ * If `options.strict` is true, throws in the same cases as {@link parseRemoteBranch},
+ * {@link getDefaultRemoteBranch}, {@link getDefaultRemote}, or {@link getRemotes}.
+ *
+ * @returns A fully-qualified target remote branch reference (e.g. `{ remote: "origin", branch: "main" }`)
+ */
+export function resolveRemoteAndBranch(
+  options: Omit<GetDefaultRemoteBranchOptions, 'branch' | 'remotes'> & {
+    /** Branch which might include a remote prefix */
+    branch: string | undefined;
+  }
+): RemoteBranch {
+  const { branch } = options;
+
+  let parsed: ReturnType<typeof parseRemoteBranchPlusRemotes> | undefined;
+  if (branch) {
+    // A branch is provided, so see if it includes a remote name.
+    // The result is saved so the fetched list of remotes can be reused.
+    parsed = parseRemoteBranchPlusRemotes({ ...options, branch });
+    if (parsed.remote) {
+      // have to extract these to avoid returning `remotes`
+      return { remote: parsed.remote, remoteBranch: parsed.remoteBranch };
+    }
+  }
+
+  // No branch provided, or the provided branch didn't include a remote.
+  // Get the default remote and possibly default branch.
+  return getDefaultRemoteAndBranch({ ...options, remotes: parsed?.remotes });
+}

--- a/packages/beachball/src/options/getCliOptions.ts
+++ b/packages/beachball/src/options/getCliOptions.ts
@@ -1,8 +1,9 @@
-import { findProjectRoot, resolveRemoteAndBranch } from 'workspace-tools';
+import { findProjectRoot } from 'workspace-tools';
 import parser from 'yargs-parser';
 import { env } from '../env';
 import type { CliOptions, ParsedOptions } from '../types/BeachballOptions';
 import { cacheRemoteBranch } from '../git/getRemoteBranch';
+import { resolveRemoteAndBranch } from '../git/tempGetDefaultRemoteBranch';
 
 export interface ProcessInfo {
   /** Complete argv (node and script path aren't used but elements must be present) */

--- a/packages/temp-esbuild-node-helpers/README.md
+++ b/packages/temp-esbuild-node-helpers/README.md
@@ -1,0 +1,1 @@
+Temporary copy of @ms-cloudpack/esbuild-node-helpers 0.1.7.

--- a/packages/temp-esbuild-node-helpers/bundleNode.d.ts
+++ b/packages/temp-esbuild-node-helpers/bundleNode.d.ts
@@ -1,0 +1,41 @@
+import * as esbuild from 'esbuild';
+import type { LicensePluginOptions } from './license/types.ts';
+import { type VerifyPackageJsonOptions } from './utils/verifyPackageJson.ts';
+export interface BundleNodeOptions
+  extends VerifyPackageJsonOptions, Pick<LicensePluginOptions, 'unacceptableLicenseTest' | 'excludeFromNotice'> {
+  /** Working directory, usually the package root (it will find the actual root from here) */
+  cwd: string;
+  /** Clean output before building (highly recommended due to hashed filenames) @default true */
+  clean?: boolean;
+  /** Extra options for esbuild */
+  esbuildOptions?: Omit<
+    esbuild.BuildOptions,
+    'absWorkingDir' | 'bundle' | 'entryPoints' | 'metafile' | 'outdir' | 'platform'
+  >;
+  /** Error if there are duplicate packages matching any of these regexps */
+  errorDupePackages?: RegExp[];
+  /** If true, write esbuild's metafile and analysis to disk under `<packageRoot>/temp` */
+  writeMetafile?: boolean;
+}
+/**
+ * Bundle a node package with esbuild. By default it creates an ESM bundle for Node 22+.
+ * `dependencies` will be externalized, but all other referenced deps will be bundled.
+ *
+ * It also writes a `NOTICE.txt` file at the package root with license information for dependencies
+ * from outside the current repo, and if `options.unacceptableLicenseTest` is provided, errors if
+ * any packages have disallowed licenses. It also errors if a package is missing license info.
+ *
+ * Before bundling, it checks for proper configuration of `package.json`:
+ * - `NOTICE.txt` and the output directory are included in `files`
+ * - If `verifyExportPaths` is set, `exports` are correctly mapped
+ * - If `verifyTypesInFiles` is true, `lib/** /*.d.ts` is included in `files`
+ *
+ * After bundling, it checks for duplicate dependencies:
+ * - Always error if there are multiple copies of the same version of a dependency
+ * - Optionally error if any dependencies match the regexps provided in `errorDupePackages`
+ *
+ * (Some of the current logic and messages assume the consuming repo is using yarn v4, likely
+ * with `nodeLinker: 'pnpm'`, but it can be updated as needed for other linkers and/or managers.)
+ */
+export declare function bundleNode(options: BundleNodeOptions): Promise<void>;
+//# sourceMappingURL=bundleNode.d.ts.map

--- a/packages/temp-esbuild-node-helpers/bundleNode.js
+++ b/packages/temp-esbuild-node-helpers/bundleNode.js
@@ -1,0 +1,142 @@
+import * as esbuild from 'esbuild';
+import fs from 'fs';
+import path from 'path';
+import { licensePlugin } from './license/licensePlugin.js';
+import { BundleError } from './utils/BundleError.js';
+import { checkForDuplicateDeps } from './utils/checkForDuplicateDeps.js';
+import { findRealPackageJson } from './utils/findRealPackageJson.js';
+import { colors, logError } from './utils/logHelpers.js';
+import { verifyPackageJson } from './utils/verifyPackageJson.js';
+/**
+ * This is added at the top of every file and makes CJS globals work in esbuild output.
+ * We need `require()` for bundled CJS that loads Node internals or native packages.
+ * The bundled CJS deps also use `__filename` and `__dirname` in a couple places.
+ * https://github.com/evanw/esbuild/issues/946#issuecomment-814703190
+ *
+ * `var` is used instead of `const` to avoid re-declaration issues if a bundled package applies the
+ * same workaround. The odd `createRequire` import name is for similar reasons.
+ */
+const cjsGlobalsHeader = `// @ts-nocheck
+/* eslint-disable */
+import { createRequire as esbuildNodeHelpersCreateRequire } from 'node:module';
+var require = esbuildNodeHelpersCreateRequire(import.meta.url);
+var __filename = import.meta.filename;
+var __dirname = import.meta.dirname;`;
+/**
+ * Bundle a node package with esbuild. By default it creates an ESM bundle for Node 22+.
+ * `dependencies` will be externalized, but all other referenced deps will be bundled.
+ *
+ * It also writes a `NOTICE.txt` file at the package root with license information for dependencies
+ * from outside the current repo, and if `options.unacceptableLicenseTest` is provided, errors if
+ * any packages have disallowed licenses. It also errors if a package is missing license info.
+ *
+ * Before bundling, it checks for proper configuration of `package.json`:
+ * - `NOTICE.txt` and the output directory are included in `files`
+ * - If `verifyExportPaths` is set, `exports` are correctly mapped
+ * - If `verifyTypesInFiles` is true, `lib/** /*.d.ts` is included in `files`
+ *
+ * After bundling, it checks for duplicate dependencies:
+ * - Always error if there are multiple copies of the same version of a dependency
+ * - Optionally error if any dependencies match the regexps provided in `errorDupePackages`
+ *
+ * (Some of the current logic and messages assume the consuming repo is using yarn v4, likely
+ * with `nodeLinker: 'pnpm'`, but it can be updated as needed for other linkers and/or managers.)
+ */
+export async function bundleNode(options) {
+  const { cwd, entryPoints, outDir, noticeDir, errorDupePackages, esbuildOptions, clean = true } = options;
+  console.log();
+  console.log('Bundling package with esbuild...\n');
+  const { packageJson, packageRoot } = findRealPackageJson(cwd);
+  verifyPackageJson(options, packageJson);
+  if (clean) {
+    // Remove old output. This is more important with esbuild due to hashed filenames.
+    fs.rmSync(path.join(packageRoot, outDir), { force: true, recursive: true });
+  }
+  // The header defining require() is needed with ESM output, but not if the user changed the format
+  const format = esbuildOptions?.format ?? 'esm';
+  const jsBanner = format === 'esm' ? cjsGlobalsHeader : undefined;
+  let result;
+  try {
+    result = await esbuild.build({
+      splitting: format === 'esm',
+      treeShaking: true,
+      target: ['node22'],
+      // some packages rely on specific names in instanceof checks
+      keepNames: true,
+      // log errors, warnings, and a summary (which includes the output file sizes)
+      logLevel: 'info',
+      // less important if not minifying, and bloats package size
+      // sourcemap: true,
+      ...esbuildOptions,
+      // Critical options
+      absWorkingDir: packageRoot,
+      entryPoints: entryPoints,
+      outdir: outDir,
+      platform: 'node',
+      bundle: true,
+      format,
+      // Exclude non-dev dependencies from the bundle. In a bundled package, generally the only
+      // dependencies should be other internal packages and anything with native binaries.
+      // (It appears node built-ins are automatically externalized with platform: 'node'.)
+      external: [
+        ...Object.keys({
+          ...packageJson.dependencies,
+          ...packageJson.peerDependencies,
+          ...packageJson.optionalDependencies,
+        }),
+        ...(esbuildOptions?.external || []),
+      ],
+      plugins: [
+        licensePlugin({
+          packageName: packageJson.name,
+          packageRoot,
+          absOutDir: noticeDir ? path.join(packageRoot, noticeDir) : packageRoot,
+          unacceptableLicenseTest: options.unacceptableLicenseTest,
+          excludeFromNotice: options.excludeFromNotice,
+        }),
+        ...(esbuildOptions?.plugins || []),
+      ],
+      banner: {
+        ...esbuildOptions?.banner,
+        js: [esbuildOptions?.banner?.js, jsBanner].filter(Boolean).join('\n'),
+      },
+      metafile: true,
+    });
+  } catch (err) {
+    const failure = err;
+    if (failure.errors.some(e => e.text.includes('Could not resolve') && e.location?.file.includes('.store'))) {
+      console.log(
+        `\n${colors.red(colors.bold('NOTE:'))} Packages that could not be found are usually missing peers, ` +
+          `which may not be specified properly for strict installation layouts. ` +
+          `You can work around this by updating ${colors.bold('yarnrc.yml packageExtensions')} to ` +
+          `include the missing package as a dependency or peerDependency of the importing package.`
+      );
+    }
+    const msg = `Bundling failed with ${failure.errors.length} error(s)!`;
+    logError(colors.red(colors.bold(msg + '\n')));
+    throw new BundleError(msg, { alreadyLogged: true, cause: err });
+  }
+  if (options.writeMetafile) {
+    // Write the metafile and analysis to disk for inspection.
+    const tmpDir = path.join(packageRoot, 'temp');
+    fs.mkdirSync(tmpDir, { recursive: true }); // do nothing if it exists
+    fs.writeFileSync(path.join(tmpDir, 'esbuild-metafile.json'), JSON.stringify(result.metafile, null, 2));
+    const analysis = await esbuild.analyzeMetafile(result.metafile, { verbose: true });
+    fs.writeFileSync(path.join(tmpDir, 'esbuild-metafile-analysis.txt'), analysis);
+  }
+  // Check for duplicate dependencies in the bundle.
+  const { errorDupeDeps, warnDupeDeps, sameVersionDupes } = checkForDuplicateDeps(
+    packageRoot,
+    Object.keys(result.metafile.inputs),
+    errorDupePackages
+  );
+  if (errorDupeDeps.length || sameVersionDupes.length) {
+    throw new BundleError('Duplicate dependencies detected (see above)', { alreadyLogged: true });
+  }
+  const hasDupeWarnings = !!warnDupeDeps.length;
+  const hasWarnings = hasDupeWarnings || !!result.warnings.length;
+  const color = hasWarnings ? 'yellow' : 'green';
+  // With logLevel set to 'info', esbuild will handle the basic logging.
+  console.log(colors[color](colors.bold(`Bundling completed${hasWarnings ? ' with warnings (see above)' : '!'}\n`)));
+}
+//# sourceMappingURL=bundleNode.js.map

--- a/packages/temp-esbuild-node-helpers/index.d.ts
+++ b/packages/temp-esbuild-node-helpers/index.d.ts
@@ -1,0 +1,7 @@
+export { bundleNode, type BundleNodeOptions } from './bundleNode.ts';
+export { licensePlugin } from './license/licensePlugin.ts';
+export { unacceptableLicenseTest } from './license/unacceptableLicenseTest.ts';
+export type { Dependency, LicensePluginOptions } from './license/types.ts';
+export { noticeFilename, writeNotice } from './license/writeNotice.ts';
+export { BundleError } from './utils/BundleError.ts';
+//# sourceMappingURL=index.d.ts.map

--- a/packages/temp-esbuild-node-helpers/index.js
+++ b/packages/temp-esbuild-node-helpers/index.js
@@ -1,0 +1,6 @@
+export { bundleNode } from './bundleNode.js';
+export { licensePlugin } from './license/licensePlugin.js';
+export { unacceptableLicenseTest } from './license/unacceptableLicenseTest.js';
+export { noticeFilename, writeNotice } from './license/writeNotice.js';
+export { BundleError } from './utils/BundleError.js';
+//# sourceMappingURL=index.js.map

--- a/packages/temp-esbuild-node-helpers/license/analyzeLicenses.d.ts
+++ b/packages/temp-esbuild-node-helpers/license/analyzeLicenses.d.ts
@@ -1,0 +1,12 @@
+import type { PackageJson } from '../types.ts';
+import type { Dependency, LicensePluginOptions } from './types.ts';
+/**
+ * Analyze licenses for all included packages.
+ * @param includedPackages Mapping from package root to package.json for all packages in the bundle
+ */
+export declare function analyzeLicenses(includedPackages: Record<string, PackageJson>, options: Pick<LicensePluginOptions, 'packageRoot' | 'unacceptableLicenseTest'>): {
+    dependencies: Dependency[];
+} | {
+    error: string;
+};
+//# sourceMappingURL=analyzeLicenses.d.ts.map

--- a/packages/temp-esbuild-node-helpers/license/analyzeLicenses.js
+++ b/packages/temp-esbuild-node-helpers/license/analyzeLicenses.js
@@ -1,0 +1,148 @@
+import fs from 'fs';
+import hostedGitInfo from 'hosted-git-info';
+import path from 'path';
+import validateLicense from 'validate-npm-package-license';
+import { BundleError } from "../utils/BundleError.js";
+import { bulletedList, colors, logError } from "../utils/logHelpers.js";
+/**
+ * Analyze licenses for all included packages.
+ * @param includedPackages Mapping from package root to package.json for all packages in the bundle
+ */
+export function analyzeLicenses(includedPackages, options) {
+    let dependencies;
+    let errorDependencies;
+    try {
+        ({ dependencies, errorDependencies } = readAndValidateLicenses(includedPackages, options));
+    }
+    catch (err) {
+        // this would be due to some issue reading a file (the function isn't intended to throw)
+        // but we need to catch it for clear error reporting in the esbuild onEnd context
+        logError(`Unexpected error during license analysis: ${err.stack || err}`);
+        throw new BundleError('Unexpected error during license analysis', { alreadyLogged: true, cause: err });
+    }
+    if (errorDependencies.length) {
+        // Return the formatted string from the function to verify the output formatting
+        // (it's hard to test this via the esbuild plugin)
+        const errors = errorDependencies.map((dep) => [`${dep.name}@${dep.version} (${dep.path})`, dep.issues]).flat(1);
+        return {
+            error: colors.red(`${colors.bold('ERROR:')} Found dependencies with license issues:\n${bulletedList(errors)}`),
+        };
+    }
+    return { dependencies };
+}
+/**
+ * Check the license specified in package.json, and if it's valid, read the license and notice text.
+ */
+function readAndValidateLicenses(includedPackages, options) {
+    const dependencies = [];
+    const errorDependencies = [];
+    const sortedEntries = Object.entries(includedPackages).sort((a, b) => a[1].name.localeCompare(b[1].name) || a[1].version.localeCompare(b[1].version));
+    for (const [depPkgRoot, depPkgJson] of sortedEntries) {
+        const pkgMeta = {
+            name: depPkgJson.name,
+            version: depPkgJson.version,
+            path: path.relative(options.packageRoot, depPkgRoot).replace(/\\/g, '/'),
+        };
+        const license = depPkgJson.license;
+        if (!license || typeof license !== 'string') {
+            errorDependencies.push({
+                ...pkgMeta,
+                issues: [license ? `Unexpected "license" format ${JSON.stringify(license)}` : 'Missing "license"'],
+            });
+            continue;
+        }
+        const licenseResult = validateLicense(license);
+        if (!licenseResult.validForNewPackages) {
+            errorDependencies.push({
+                ...pkgMeta,
+                issues: [`Invalid "license" value ${JSON.stringify(license)}`, ...(licenseResult.warnings || [])],
+            });
+            continue;
+        }
+        const licenseInFilePath = licenseResult.inFile && path.join(depPkgRoot, licenseResult.inFile);
+        if (licenseInFilePath && !fs.existsSync(licenseInFilePath)) {
+            errorDependencies.push({
+                ...pkgMeta,
+                issues: [`License file "${licenseResult.inFile}" (specified by "SEE LICENSE IN") not found`],
+            });
+            continue;
+        }
+        if (options.unacceptableLicenseTest?.(license)) {
+            errorDependencies.push({
+                ...pkgMeta,
+                issues: [
+                    `License ${JSON.stringify(license)} is not allowed (if incorrect, update the unacceptableLicenseTest setting)`,
+                ],
+            });
+            continue;
+        }
+        const files = fs.readdirSync(depPkgRoot);
+        // Read the license from either "SEE LICENSE IN ___" or a file named LICENSE*
+        let licenseText;
+        if (licenseInFilePath) {
+            licenseText = fs.readFileSync(licenseInFilePath, 'utf8');
+        }
+        else {
+            licenseText = findFile(/^license/i, files, depPkgRoot) || findFile(/^copying/i, files, depPkgRoot);
+        }
+        // Just look for a "notice" file at the root for notices
+        const noticeText = findFile(/^notice/i, files, depPkgRoot);
+        // Get author from package.json and/or "authors" file
+        let author = personToString(depPkgJson.author);
+        const authorsText = findFile(/^authors/i, files, depPkgRoot);
+        if (authorsText) {
+            author = (author ? author + '\n' : '') + authorsText;
+        }
+        // Same with contributors
+        let contributors = depPkgJson.contributors?.map(personToString).filter(Boolean).join('\n');
+        const contributorsText = findFile(/^contributors?/i, files, depPkgRoot);
+        if (contributorsText) {
+            contributors = (contributors ? contributors + '\n' : '') + contributorsText;
+        }
+        const maintainers = depPkgJson.maintainers?.map(personToString).join('\n');
+        // Following CG, use "homepage" by default, followed by "repository"
+        let url = depPkgJson.homepage;
+        const repository = depPkgJson.repository;
+        if (!url && repository) {
+            url = typeof repository === 'string' ? repository : repository.url;
+            const gitInfo = hostedGitInfo.fromUrl(url);
+            if (gitInfo) {
+                url = gitInfo.browse();
+            }
+        }
+        dependencies.push({
+            name: pkgMeta.name,
+            version: pkgMeta.version,
+            author,
+            contributors,
+            maintainers,
+            url,
+            license,
+            licenseText,
+            noticeText,
+        });
+    }
+    return { dependencies, errorDependencies };
+}
+/**
+ * Convert a person field to a string
+ */
+function personToString(person) {
+    if (!person || typeof person === 'string') {
+        return person;
+    }
+    const { name, email, url } = person;
+    return `${name}${email ? ` <${email}>` : ''}${url ? ` (${url})` : ''}`;
+}
+/**
+ * Find and read a file in a directory that matches a specific pattern.
+ * @param isMatch - The function or regexp to match the file name.
+ * @param files - The list of files to search.
+ * @param dir - The parent directory path.
+ * @returns The file contents if found (whitespace trimmed), otherwise undefined.
+ */
+function findFile(isMatch, files, dir) {
+    const match = files.find(typeof isMatch === 'function' ? isMatch : (file) => isMatch.test(file));
+    return match && fs.readFileSync(path.join(dir, match), 'utf8').trim();
+}
+//# sourceMappingURL=analyzeLicenses.js.map

--- a/packages/temp-esbuild-node-helpers/license/licensePlugin.d.ts
+++ b/packages/temp-esbuild-node-helpers/license/licensePlugin.d.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from 'esbuild';
+import type { LicensePluginOptions } from './types.ts';
+/**
+ * esbuild plugin to generate a NOTICE.txt file with license information for all dependencies
+ * that are included in the bundle (excluding any packages from the same repo).
+ *
+ * This relies on the info published with the package (in package.json or certain predefined files)
+ * and doesn't check github for other related files that aren't published.
+ *
+ * Other implementations:
+ * - There's a service [ClearlyDefined](https://clearlydefined.io) which is made by Microsoft
+ *   and used by CG to generate notices, and is more comprehensive with checking npm/github.
+ *   However, the public API is badly-documented, subject to unclear rate limits, and not reliable
+ *   (can't find some packages for the notice even though they exist in its database in the UI).
+ * - https://github.com/upupming/esbuild-plugin-license (only writes name, version, license type)
+ * - https://github.com/mhassan1/yarn-plugin-licenses (covers whole repo; similar formatting used here)
+ * - https://github.com/codepunkt/webpack-license-plugin (json output for webpack only)
+ */
+export declare function licensePlugin(options: LicensePluginOptions): Plugin;
+//# sourceMappingURL=licensePlugin.d.ts.map

--- a/packages/temp-esbuild-node-helpers/license/licensePlugin.js
+++ b/packages/temp-esbuild-node-helpers/license/licensePlugin.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { findRealPackageJson } from "../utils/findRealPackageJson.js";
+import { logError } from "../utils/logHelpers.js";
+import { writeNotice } from "./writeNotice.js";
+import { BundleError } from "../utils/BundleError.js";
+import { analyzeLicenses } from "./analyzeLicenses.js";
+/**
+ * esbuild plugin to generate a NOTICE.txt file with license information for all dependencies
+ * that are included in the bundle (excluding any packages from the same repo).
+ *
+ * This relies on the info published with the package (in package.json or certain predefined files)
+ * and doesn't check github for other related files that aren't published.
+ *
+ * Other implementations:
+ * - There's a service [ClearlyDefined](https://clearlydefined.io) which is made by Microsoft
+ *   and used by CG to generate notices, and is more comprehensive with checking npm/github.
+ *   However, the public API is badly-documented, subject to unclear rate limits, and not reliable
+ *   (can't find some packages for the notice even though they exist in its database in the UI).
+ * - https://github.com/upupming/esbuild-plugin-license (only writes name, version, license type)
+ * - https://github.com/mhassan1/yarn-plugin-licenses (covers whole repo; similar formatting used here)
+ * - https://github.com/codepunkt/webpack-license-plugin (json output for webpack only)
+ */
+export function licensePlugin(options) {
+    const includedPackages = {};
+    const packageCache = new Map();
+    return {
+        name: 'cloudpack-license-plugin',
+        setup(build) {
+            // On load, track all the packages that are included
+            // (any errors will be caught and logged by esbuild itself)
+            build.onLoad({ filter: /.*/ }, (args) => {
+                // esbuild docs make it sound like this can be a file URL or arbitrary URL
+                let filePath = args.path.startsWith('file://') ? fileURLToPath(args.path) : args.path;
+                // if this is something besides a filesystem path, ignore it
+                if (!fs.existsSync(filePath)) {
+                    return null;
+                }
+                // use the realpath for deduping store files
+                filePath = fs.realpathSync(filePath);
+                if (!filePath.includes('node_modules')) {
+                    return null;
+                }
+                const { packageRoot, packageJson } = findRealPackageJson(filePath, packageCache);
+                if (!includedPackages[packageRoot] && packageJson.name !== options.packageName) {
+                    includedPackages[packageRoot] = packageJson;
+                }
+                return null;
+            });
+            build.onEnd(() => {
+                // We have to catch any errors and explicitly log them since esbuild doesn't automatically
+                // log thrown errors at this point, and our wrapper that calls esbuild assumes errors have
+                // already been logged.
+                const licenseResult = analyzeLicenses(includedPackages, options);
+                if ('error' in licenseResult) {
+                    const errorStr = licenseResult.error;
+                    logError(errorStr + '\n');
+                    // Include the full text despite having logged it since this can make debugging easier
+                    throw new BundleError(errorStr, { alreadyLogged: true });
+                }
+                writeNotice(licenseResult.dependencies, options.absOutDir, options.excludeFromNotice);
+            });
+        },
+    };
+}
+//# sourceMappingURL=licensePlugin.js.map

--- a/packages/temp-esbuild-node-helpers/license/types.d.ts
+++ b/packages/temp-esbuild-node-helpers/license/types.d.ts
@@ -1,0 +1,35 @@
+export interface LicensePluginOptions {
+    /** Name of the package being bundled */
+    packageName: string;
+    /** Root directory of the package being bundled */
+    packageRoot: string;
+    /** Absolute output directory for the NOTICE.txt file */
+    absOutDir: string;
+    /** Function to determine if a dependency should be excluded from the NOTICE.txt file */
+    excludeFromNotice?: (dependency: Dependency) => boolean;
+    /**
+     * Return true if the license is unacceptable.
+     * You can use `unacceptableLicenseTest` exported from this package as a default.
+     *
+     * @param licenseName A valid SPDX license expression (without "LicenseRef"), "UNLICENSED",
+     * "SEE LICENSE IN <filename>", or null if no valid license info was found in package.json.
+     */
+    unacceptableLicenseTest?: (licenseName: string | null) => boolean;
+}
+/** Dependency format used internally by `licensePlugin` */
+export interface Dependency {
+    name: string;
+    version: string;
+    author: string | undefined;
+    maintainers: string | undefined;
+    contributors: string | undefined;
+    url: string | undefined;
+    license: string | null;
+    licenseText: string | undefined;
+    noticeText: string | undefined;
+}
+export interface ErrorDependency extends Pick<Dependency, 'name' | 'version'> {
+    path: string;
+    issues: string[];
+}
+//# sourceMappingURL=types.d.ts.map

--- a/packages/temp-esbuild-node-helpers/license/types.js
+++ b/packages/temp-esbuild-node-helpers/license/types.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=types.js.map

--- a/packages/temp-esbuild-node-helpers/license/unacceptableLicenseTest.d.ts
+++ b/packages/temp-esbuild-node-helpers/license/unacceptableLicenseTest.d.ts
@@ -1,0 +1,8 @@
+/**
+ * A default license plugin check for unacceptable licenses.
+ * It requires a license to be defined and only allows a predefined expected list
+ * (which could be expanded if new acceptable licenses are encountered).
+ * @returns true if the license is **un**acceptable
+ */
+export declare function unacceptableLicenseTest(license: string | null): boolean;
+//# sourceMappingURL=unacceptableLicenseTest.d.ts.map

--- a/packages/temp-esbuild-node-helpers/license/unacceptableLicenseTest.js
+++ b/packages/temp-esbuild-node-helpers/license/unacceptableLicenseTest.js
@@ -1,0 +1,12 @@
+/**
+ * A default license plugin check for unacceptable licenses.
+ * It requires a license to be defined and only allows a predefined expected list
+ * (which could be expanded if new acceptable licenses are encountered).
+ * @returns true if the license is **un**acceptable
+ */
+export function unacceptableLicenseTest(license) {
+    // Conservatively list only the licenses we expect today.
+    // Additional licenses could be added if encountered and acceptable.
+    return !license || !['0BSD', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause', 'ISC', 'MIT'].includes(license);
+}
+//# sourceMappingURL=unacceptableLicenseTest.js.map

--- a/packages/temp-esbuild-node-helpers/license/writeNotice.d.ts
+++ b/packages/temp-esbuild-node-helpers/license/writeNotice.d.ts
@@ -1,0 +1,7 @@
+import type { Dependency } from './types.ts';
+export declare const noticeFilename = "NOTICE.txt";
+/**
+ * Write NOTICE.txt with license and author info for the given dependencies.
+ */
+export declare function writeNotice(dependencies: Dependency[], absOutDir: string, excludeFromNotice?: (dependency: Dependency) => boolean): void;
+//# sourceMappingURL=writeNotice.d.ts.map

--- a/packages/temp-esbuild-node-helpers/license/writeNotice.js
+++ b/packages/temp-esbuild-node-helpers/license/writeNotice.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+export const noticeFilename = 'NOTICE.txt';
+/**
+ * Write NOTICE.txt with license and author info for the given dependencies.
+ */
+export function writeNotice(dependencies, absOutDir, excludeFromNotice) {
+    if (!dependencies.length)
+        return;
+    const filteredDependencies = excludeFromNotice ? dependencies.filter((dep) => !excludeFromNotice(dep)) : dependencies;
+    if (!filteredDependencies.length)
+        return;
+    const noticeText = [
+        `NOTICES\n\nThis package incorporates material as listed below or described in the code.`,
+        ...filteredDependencies
+            .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version))
+            .map((dep) => {
+            const shortLicense = dep.license ? (/^see license/i.test(dep.license) ? '' : dep.license) : 'unknown license';
+            return [
+                `${dep.name} ${dep.version}${shortLicense ? ` - ${shortLicense}` : ''}${dep.url ? `\n${dep.url}` : ''}`,
+                // Unclear which author/maintainer/contributor info is required, so include all of them
+                dep.author && `Author: ${dep.author}`,
+                dep.maintainers && `Maintainers:\n${dep.maintainers}`,
+                dep.contributors && `Contributors:\n${dep.contributors}`,
+                // The license text typically includes the official copyright notice
+                dep.licenseText,
+                // As of writing we don't use any packages that publish NOTICES
+                dep.noticeText && `NOTICES:\n\n${dep.noticeText}`,
+            ]
+                .filter(Boolean)
+                .join('\n\n');
+        }),
+    ].join('\n\n----\n\n');
+    const outFile = path.join(absOutDir, noticeFilename);
+    fs.mkdirSync(absOutDir, { recursive: true });
+    fs.writeFileSync(outFile, noticeText, 'utf8');
+    console.log(`Wrote license notices to ${outFile}\n`);
+}
+//# sourceMappingURL=writeNotice.js.map

--- a/packages/temp-esbuild-node-helpers/package.json
+++ b/packages/temp-esbuild-node-helpers/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "temp-esbuild-node-helpers",
+  "version": "0.1.7",
+  "description": "Helpers for creating a bundle for Node with esbuild",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  },
+  "publishConfig": {},
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "dependencies": {
+    "@ms-cloudpack/environment": "^0.1.7",
+    "esbuild": "^0.28.1",
+    "hosted-git-info": "^9.0.0",
+    "picocolors": "^1.1.1",
+    "validate-npm-package-license": "^3.0.4"
+  }
+}

--- a/packages/temp-esbuild-node-helpers/types.d.ts
+++ b/packages/temp-esbuild-node-helpers/types.d.ts
@@ -1,0 +1,31 @@
+export type PackageJsonPerson =
+  | string
+  | {
+      name: string;
+      email?: string;
+      url?: string;
+    };
+export interface PackageJson {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  exports?: unknown;
+  files?: string[];
+  bin?: string | Record<string, string>;
+  types?: string;
+  author?: PackageJsonPerson;
+  contributors?: PackageJsonPerson[];
+  maintainers?: PackageJsonPerson[];
+  homepage?: string;
+  license?: string;
+  repository?:
+    | string
+    | {
+        type: string;
+        url: string;
+      };
+}
+//# sourceMappingURL=types.d.ts.map

--- a/packages/temp-esbuild-node-helpers/types.js
+++ b/packages/temp-esbuild-node-helpers/types.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=types.js.map

--- a/packages/temp-esbuild-node-helpers/utils/BundleError.d.ts
+++ b/packages/temp-esbuild-node-helpers/utils/BundleError.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown by `bundleNode`. Check the `alreadyLogged` property to see if the message
+ * has already been logged to the console.
+ */
+export declare class BundleError extends Error {
+  readonly alreadyLogged: boolean;
+  constructor(
+    message: string,
+    options?: ErrorOptions & {
+      alreadyLogged?: boolean;
+    }
+  );
+}
+//# sourceMappingURL=BundleError.d.ts.map

--- a/packages/temp-esbuild-node-helpers/utils/BundleError.js
+++ b/packages/temp-esbuild-node-helpers/utils/BundleError.js
@@ -1,0 +1,12 @@
+/**
+ * Thrown by `bundleNode`. Check the `alreadyLogged` property to see if the message
+ * has already been logged to the console.
+ */
+export class BundleError extends Error {
+  alreadyLogged;
+  constructor(message, options) {
+    super(message, { cause: options?.cause });
+    this.alreadyLogged = !!options?.alreadyLogged;
+  }
+}
+//# sourceMappingURL=BundleError.js.map

--- a/packages/temp-esbuild-node-helpers/utils/checkForDuplicateDeps.d.ts
+++ b/packages/temp-esbuild-node-helpers/utils/checkForDuplicateDeps.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Check the metafile to determine if there are any duplicate dependencies in the bundle
+ * @param packageRoot The root directory of the package being bundled
+ * @param inputPaths List of input paths detected by esbuild (keys of `metafile.inputs`)
+ * @param errorDupePackages List of regex patterns for packages that should trigger an error if
+ * duplicates are found
+ */
+export declare function checkForDuplicateDeps(
+  packageRoot: string,
+  inputPaths: string[],
+  errorDupePackages: RegExp[] | undefined
+): {
+  errorDupeDeps: [string, string[][]][];
+  warnDupeDeps: [string, string[][]][];
+  sameVersionDupes: [string, string[][]][];
+};
+//# sourceMappingURL=checkForDuplicateDeps.d.ts.map

--- a/packages/temp-esbuild-node-helpers/utils/checkForDuplicateDeps.js
+++ b/packages/temp-esbuild-node-helpers/utils/checkForDuplicateDeps.js
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+import { bulletedList, colors, logError } from './logHelpers.js';
+/**
+ * Check the metafile to determine if there are any duplicate dependencies in the bundle
+ * @param packageRoot The root directory of the package being bundled
+ * @param inputPaths List of input paths detected by esbuild (keys of `metafile.inputs`)
+ * @param errorDupePackages List of regex patterns for packages that should trigger an error if
+ * duplicates are found
+ */
+export function checkForDuplicateDeps(packageRoot, inputPaths, errorDupePackages) {
+  // Find all the paths to external dependencies.
+  // There may be multiple files from the same dep, so the set dedupes them.
+  const depPackages = new Set();
+  for (const input of inputPaths) {
+    const pathParts = input.split('/');
+    const storeIndex = pathParts.indexOf('.store');
+    const nodeModulesIndex = pathParts.indexOf('node_modules');
+    if (storeIndex !== -1) {
+      depPackages.add(pathParts.slice(0, storeIndex + 2).join('/') + '/package');
+    } else if (nodeModulesIndex !== -1) {
+      const pkgSegment = pathParts[nodeModulesIndex + 1];
+      const depPath = pathParts.slice(0, nodeModulesIndex + (pkgSegment.startsWith('@') ? 3 : 2)).join('/');
+      depPackages.add(depPath);
+    }
+  }
+  if (depPackages.size) {
+    console.log(`Included external dependencies:\n${bulletedList([...depPackages].sort())}\n`);
+  }
+  // Make a mapping from dependency name to versions in case there are multiple versions.
+  const depPaths = {};
+  for (const depPath of depPackages) {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(packageRoot, depPath, 'package.json'), 'utf8'));
+    depPaths[pkg.name] ??= [];
+    depPaths[pkg.name].push({ version: pkg.version, path: depPath });
+  }
+  // If there are multiple versions of a package, this isn't ideal but can sometimes be necessary
+  // (different things depending on incompatible versions).
+  const allDupeDeps = Object.entries(depPaths)
+    .filter(([_, paths]) => paths.length > 1)
+    .map(([name, versions]) => [name, [versions.map(pkg => `${pkg.version} ${pkg.path}`)]]);
+  const errorDupeDeps = errorDupePackages
+    ? allDupeDeps.filter(([name]) => errorDupePackages?.some(re => re.test(name)))
+    : [];
+  const warnDupeDeps = allDupeDeps.filter(d => !errorDupeDeps.includes(d));
+  if (warnDupeDeps.length) {
+    console.warn(
+      colors.yellow(
+        `${colors.bold('Warning:')} Found multiple versions of the following dependencies in the bundle ` +
+          '(this is not ideal but may be unavoidable if deps in the tree use incompatible semver specs):'
+      )
+    );
+    console.warn(colors.yellow(bulletedList(warnDupeDeps.flat(1)) + '\n'));
+  }
+  if (errorDupeDeps.length) {
+    logError(colors.red(`${colors.bold('ERROR:')} Found multiple versions of the following critical dependencies:`));
+    console.error(colors.red(bulletedList(errorDupeDeps.flat(1))));
+    console.error(
+      colors.red(
+        // Exceptions can be added if it's not possible to avoid the duplicates.
+        '\nPlease attempt to remove these dupes using "yarn set resolution", strategic dep upgrades, ' +
+          'or possibly package.json resolutions.\n'
+      )
+    );
+  }
+  // Check for multiple physical copies of the same dependency version (usually caused by different
+  // peer dependency permutations--see error message below for more details)
+  const sameVersionDupes = Object.entries(depPaths)
+    .map(([name, versions]) => {
+      // most common case: there's only one of a given dep
+      if (versions.length === 1) {
+        return undefined;
+      }
+      // Get the version of each copy of the package and group by version.
+      const versionsToPaths = {};
+      for (const pkg of versions) {
+        versionsToPaths[pkg.version] ??= [];
+        versionsToPaths[pkg.version].push(pkg.path);
+      }
+      // Return versions with more than one physical copy.
+      return Object.values(versionsToPaths).some(vpaths => vpaths.length > 1)
+        ? [name, Object.entries(versionsToPaths)]
+        : undefined;
+    })
+    .filter(Boolean);
+  if (sameVersionDupes.length) {
+    logError(colors.red(`${colors.bold('ERROR:')} Found multiple copies of the same dependency version:`));
+    console.error(colors.red(bulletedList(sameVersionDupes.flat(1))));
+    console.error(
+      colors.red(
+        // Past duplicated packages had peer deps on @opentelemetry/api, and the difference was that
+        // for some reason the node_modules of one copy was missing @opentelemetry/api.
+        // Using packageExtensions to add @opentelemetry/api as a *dependency* got rid of the dupes.
+        '\nThis may be caused by the yarn pnpm linker making multiple "virtual" folders for the same package ' +
+          'version when different permutations of peer deps and/or resolutions are present.' +
+          '\n\nPossible fix: look in yarn.lock to see if the duplicated package has any peer deps, ' +
+          'and use yarnrc.yml packageExtensions to add the peer as a dependency.\n'
+      )
+    );
+  }
+  return { errorDupeDeps, warnDupeDeps, sameVersionDupes };
+}
+//# sourceMappingURL=checkForDuplicateDeps.js.map

--- a/packages/temp-esbuild-node-helpers/utils/findRealPackageJson.d.ts
+++ b/packages/temp-esbuild-node-helpers/utils/findRealPackageJson.d.ts
@@ -1,0 +1,15 @@
+import type { PackageJson } from '../types.ts';
+export interface PackageJsonResult {
+  packageRoot: string;
+  packageJson: PackageJson;
+}
+/**
+ * Find the actual package.json (the one with a name) for the current file.
+ * This implementation accounts for intermediate package.json files with just a "type", no name.
+ * @param cache Optional cache if iterating over multiple files which may be from the same package
+ */
+export declare function findRealPackageJson(
+  fileRealpath: string,
+  cache?: Map<string, PackageJsonResult | null>
+): PackageJsonResult;
+//# sourceMappingURL=findRealPackageJson.d.ts.map

--- a/packages/temp-esbuild-node-helpers/utils/findRealPackageJson.js
+++ b/packages/temp-esbuild-node-helpers/utils/findRealPackageJson.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+/**
+ * Find the actual package.json (the one with a name) for the current file.
+ * This implementation accounts for intermediate package.json files with just a "type", no name.
+ * @param cache Optional cache if iterating over multiple files which may be from the same package
+ */
+export function findRealPackageJson(fileRealpath, cache = new Map()) {
+  const root = path.parse(fileRealpath).root;
+  // Start with the path itself in case it's already a directory
+  let dir = fileRealpath;
+  const dirs = [];
+  while (dir !== root) {
+    dirs.push(dir);
+    if (cache.has(dir)) {
+      break;
+    }
+    if (fs.existsSync(path.join(dir, 'package.json'))) {
+      const packageJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      if (packageJson.name) {
+        cache.set(dir, { packageRoot: dir, packageJson });
+        break;
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  const result = cache.get(dir) || null;
+  for (const d of dirs) {
+    cache.set(d, result);
+  }
+  if (result) {
+    return result;
+  }
+  throw new Error('Unable to find package.json for ' + fileRealpath);
+}
+//# sourceMappingURL=findRealPackageJson.js.map

--- a/packages/temp-esbuild-node-helpers/utils/logHelpers.d.ts
+++ b/packages/temp-esbuild-node-helpers/utils/logHelpers.d.ts
@@ -1,0 +1,14 @@
+/** picocolors instance that's disabled in jest */
+export declare const colors: import('picocolors/types.js').Colors;
+/**
+ * Log an error, with a special error prefix if running in github or ADO.
+ *
+ * If `message` is an Error object, it will log the stack.
+ */
+export declare function logError(message: unknown): void;
+/**
+ * Format a nested bulleted list.
+ */
+export type BulletList = (string | undefined | BulletList)[];
+export declare function bulletedList(lines: BulletList, indent?: number): string;
+//# sourceMappingURL=logHelpers.d.ts.map

--- a/packages/temp-esbuild-node-helpers/utils/logHelpers.js
+++ b/packages/temp-esbuild-node-helpers/utils/logHelpers.js
@@ -1,0 +1,26 @@
+import { environmentInfo } from '@ms-cloudpack/environment';
+import defaultColors, { createColors } from 'picocolors';
+// This package uses some custom helpers instead of task-reporter since it may be used elsewhere
+/** picocolors instance that's disabled in jest */
+export const colors = environmentInfo.isJest ? createColors(false) : defaultColors;
+const errorPrefix = environmentInfo.ado ? '##vso[task.logissue type=error]' : environmentInfo.isCI ? '::error::' : '';
+/**
+ * Log an error, with a special error prefix if running in github or ADO.
+ *
+ * If `message` is an Error object, it will log the stack.
+ */
+export function logError(message) {
+  console.error(`${errorPrefix}${String((message instanceof Error && message.stack) || message)}`);
+}
+export function bulletedList(lines, indent = 1) {
+  const indentString = ' '.repeat(indent * 2);
+  return lines
+    .reduce((result, curr) => {
+      if (curr) {
+        result.push(Array.isArray(curr) ? bulletedList(curr, indent + 1) : `${indentString}- ${curr}`);
+      }
+      return result;
+    }, [])
+    .join('\n');
+}
+//# sourceMappingURL=logHelpers.js.map

--- a/packages/temp-esbuild-node-helpers/utils/verifyPackageJson.d.ts
+++ b/packages/temp-esbuild-node-helpers/utils/verifyPackageJson.d.ts
@@ -1,0 +1,35 @@
+import type { PackageJson } from '../types.ts';
+export interface VerifyPackageJsonOptions {
+  /**
+   * Mapping from path under `outDir` to original file path. Original paths are usually relative to
+   * the package root (with forward slashes) but could also be files in other packages.
+   */
+  entryPoints: Record<string, string>;
+  /** Relative directory for output files with forward slashes */
+  outDir: string;
+  /** Relative directory to write the NOTICE.txt file (default package root) */
+  noticeDir?: string;
+  /**
+   * If set, verify that the output file is correctly referenced in package.json `exports`.
+   * Top-level keys match `entry`. Next level keys match package.json `exports` keys.
+   * Value is the condition for that export key (use `'default'` to allow paths with no condition).
+   */
+  verifyExportPaths?: {
+    [entryKey: string]: {
+      key: string;
+      condition: string;
+    };
+  };
+  /**
+   * Verify contents of package.json `files` field
+   * @default true
+   */
+  verifyFiles?: boolean;
+  /**
+   * If true, verify `lib/** /*.d.ts` (without the space) is included in package.json `files`.
+   * If a string, verify it's included in `files`.
+   */
+  verifyTypesInFiles?: true | string;
+}
+export declare function verifyPackageJson(options: VerifyPackageJsonOptions, packageJson: PackageJson): void;
+//# sourceMappingURL=verifyPackageJson.d.ts.map

--- a/packages/temp-esbuild-node-helpers/utils/verifyPackageJson.js
+++ b/packages/temp-esbuild-node-helpers/utils/verifyPackageJson.js
@@ -1,0 +1,59 @@
+import { BundleError } from './BundleError.js';
+import { noticeFilename } from '../license/writeNotice.js';
+export function verifyPackageJson(options, packageJson) {
+  const { entryPoints, outDir, verifyExportPaths, verifyTypesInFiles, verifyFiles = true, noticeDir = '' } = options;
+  if (verifyFiles && !packageJson.files) {
+    throw new BundleError('package.json is missing "files" field');
+  }
+  if (verifyTypesInFiles) {
+    const typesGlob = typeof verifyTypesInFiles === 'string' ? verifyTypesInFiles : 'lib/**/*.d.ts';
+    if (!packageJson.files?.includes(typesGlob)) {
+      throw new BundleError(`package.json "files" must include "${typesGlob}"`);
+    }
+  }
+  const noticePath = `${noticeDir ? `${noticeDir}/` : ''}${noticeFilename}`;
+  if (verifyFiles && !packageJson.files?.includes(noticePath)) {
+    throw new BundleError(`package.json "files" must include "${noticePath}"`);
+  }
+  if (
+    verifyFiles &&
+    !packageJson.files?.includes(outDir) &&
+    !packageJson.files?.some(f => f.startsWith(`${outDir}/`))
+  ) {
+    throw new BundleError(`package.json "files" must include "${outDir}"`);
+  }
+  if (verifyExportPaths) {
+    // Verify the package.json exports map and published files are set up properly
+    const exports = packageJson.exports;
+    if (!exports || typeof exports === 'string') {
+      throw new BundleError(
+        `package.json "exports" must be an object when verifyExportPaths option is enabled (current: ${exports && JSON.stringify(exports)})`
+      );
+    }
+    const entryKeys = new Set(Object.keys(entryPoints));
+    for (const [entryKey, { key, condition }] of Object.entries(verifyExportPaths)) {
+      if (!entryKeys.delete(entryKey)) {
+        throw new BundleError(`verifyExportPaths includes a key "${entryKey}" that is missing from entryPoints`);
+      }
+      const outFile = `${outDir}/${entryKey}.js`;
+      const exportsValue = exports[key];
+      const exportsFile =
+        typeof exportsValue === 'string'
+          ? condition === 'default'
+            ? exportsValue
+            : undefined
+          : exportsValue?.[condition];
+      if (exportsFile !== `./${outFile}`) {
+        throw new BundleError(
+          `package.json exports["${key}"] must include { "${condition}": "./${outFile}" } (current: ${exportsValue && JSON.stringify(exportsValue)})`
+        );
+      }
+    }
+    if (entryKeys.size) {
+      throw new BundleError(
+        `verifyExportPaths did not reference the following entry points: ${[...entryKeys].join(', ')}`
+      );
+    }
+  }
+}
+//# sourceMappingURL=verifyPackageJson.js.map

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,7 @@
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' yarn run -T jest"
   },
   "devDependencies": {
-    "@ms-cloudpack/esbuild-node-helpers": "0.1.7",
+    "@ms-cloudpack/esbuild-node-helpers": "workspace:packages/temp-esbuild-node-helpers",
     "@ms-cloudpack/eslint-plugin-deprecated": "^0.1.5",
     "cross-env": "^10.1.0",
     "esbuild": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,7 +1536,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     husky: "npm:^9.0.0"
     jest: "npm:^30.0.0"
-    lage: "npm:^2.15.16"
+    lage: "npm:^2.15.0"
     lint-staged: "npm:^16.0.0"
     prettier: "npm:~3.8.3"
     syncpack: "npm:^14.0.0"
@@ -1549,7 +1549,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@microsoft/beachball-scripts@workspace:scripts"
   dependencies:
-    "@ms-cloudpack/esbuild-node-helpers": "npm:0.1.7"
+    "@ms-cloudpack/esbuild-node-helpers": "workspace:packages/temp-esbuild-node-helpers"
     "@ms-cloudpack/eslint-plugin-deprecated": "npm:^0.1.5"
     cross-env: "npm:^10.1.0"
     esbuild: "npm:^0.28.1"
@@ -1586,19 +1586,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ms-cloudpack/esbuild-node-helpers@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@ms-cloudpack/esbuild-node-helpers@npm:0.1.7"
+"@ms-cloudpack/esbuild-node-helpers@workspace:packages/temp-esbuild-node-helpers, temp-esbuild-node-helpers@workspace:packages/temp-esbuild-node-helpers":
+  version: 0.0.0-use.local
+  resolution: "temp-esbuild-node-helpers@workspace:packages/temp-esbuild-node-helpers"
   dependencies:
     "@ms-cloudpack/environment": "npm:^0.1.7"
+    esbuild: "npm:^0.28.1"
     hosted-git-info: "npm:^9.0.0"
     picocolors: "npm:^1.1.1"
     validate-npm-package-license: "npm:^3.0.4"
-  peerDependencies:
-    esbuild: ">=0.28.0"
-  checksum: 10c0/599acd0474b43b72c91a39f10444216d48aa82abab242f6c3023693de10297e711781f287cbff13defd760052b6fd1fdb27ecea878f155144f9606d9ac68ceaa
-  languageName: node
-  linkType: hard
+  languageName: unknown
+  linkType: soft
 
 "@ms-cloudpack/eslint-plugin-deprecated@npm:^0.1.5":
   version: 0.1.5
@@ -6162,9 +6160,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lage@npm:^2.15.16":
-  version: 2.15.16
-  resolution: "lage@npm:2.15.16"
+"lage@npm:^2.15.0":
+  version: 2.15.13
+  resolution: "lage@npm:2.15.13"
   dependencies:
     fsevents: "npm:~2.3.2"
     glob-hasher: "npm:^1.4.2"
@@ -6174,7 +6172,7 @@ __metadata:
   bin:
     lage: dist/lage.js
     lage-server: dist/lage-server.js
-  checksum: 10c0/6ca8a090e18885a045a6a2b66ffe88ce124c4b412e19a106f3c1dcea898b33fd614338f7873ea0e712be25b9cf3256e6745f9a17a6489b8b3409d1d5aad55074
+  checksum: 10c0/8cb89b90e2202171dd0990bf94df4479c7760d2b7ea5a453e039bccc66a51c73b42b94602884c2000fc2974879fa93013445847056877acafce062ae7937b882
   languageName: node
   linkType: hard
 
@@ -8885,9 +8883,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workspace-tools@npm:^0.41.10":
-  version: 0.41.10
-  resolution: "workspace-tools@npm:0.41.10"
+"workspace-tools@npm:^0.41.8":
+  version: 0.41.8
+  resolution: "workspace-tools@npm:0.41.8"
   dependencies:
     "@yarnpkg/lockfile": "npm:^1.1.0"
     fast-glob: "npm:^3.3.3"
@@ -8895,7 +8893,7 @@ __metadata:
     jju: "npm:^1.4.0"
     js-yaml: "npm:^4.2.0"
     micromatch: "npm:^4.0.8"
-  checksum: 10c0/2a6e7bad84e1855afb63854d76eb9129e2ca06abb2936251988924a852c071fd7f276b557587a052665cca1800bee0c1dec82804e47e89ceebebd45a6305cb2c
+  checksum: 10c0/20e3c4860c9d68ae7bf7a02ecfc5940199f5c1eca600229cb191e4c446dc22c26fe1d27d5bfb329c7bce3df595ae39a7b7705e1d41c1b46e36d345add4a50688
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove quarantine exceptions to continue testing with ESRP. This required temporarily copying one file from `workspace-tools`, and all of `@ms-cloudpack/esbuild-node-helpers`. 

Will be reverted once new version quarantine time has passed.