### PR TITLE
Update the layer logic to only consider the set of published packages

### DIFF
--- a/change/beachball-67477388-db1e-4196-a46b-f080400a8ca8.json
+++ b/change/beachball-67477388-db1e-4196-a46b-f080400a8ca8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update the layer logic to only consider the set of published packages when building its graph",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/beachball/src/__tests__/monorepo/getPackageGraph.test.ts
+++ b/packages/beachball/src/__tests__/monorepo/getPackageGraph.test.ts
@@ -3,7 +3,6 @@ import type { PackageInfos } from '../../types/PackageInfo';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import { _getPackageDependencyGraph, getPackageGraph } from '../../monorepo/getPackageGraph';
 import { getPackageGraphLayers } from '../../publish/getPackageGraphLayers';
-import { generateChangeSet } from '../../__fixtures__/changeFiles';
 
 // These tests cover the helper to get the edges.
 describe('_getPackageDependencyGraph', () => {
@@ -153,11 +152,7 @@ describe('getPackageGraph', () => {
     packageInfos: PackageInfos,
     possibleSolutions: string[][]
   ): Promise<void> {
-    const getPackageGraphLayersOutput = getPackageGraphLayers({
-      packagesToPublish: inputPackages,
-      bumpInfo: { packageInfos, changeFileChangeInfos: generateChangeSet(inputPackages) },
-      options: { bumpDeps: true, scope: null },
-    }).flat();
+    const getPackageGraphLayersOutput = getPackageGraphLayers(inputPackages, packageInfos).flat();
     const getPackageGraphPackageNamesOutput = await getPackageGraphPackageNames(inputPackages, packageInfos);
 
     expect(possibleSolutions).toContainEqual(getPackageGraphLayersOutput);

--- a/packages/beachball/src/__tests__/publish/getPackageGraphLayers.test.ts
+++ b/packages/beachball/src/__tests__/publish/getPackageGraphLayers.test.ts
@@ -1,198 +1,98 @@
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import { generateChangeSet } from '../../__fixtures__/changeFiles';
+import { describe, expect, it } from '@jest/globals';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { makePackageInfos, type PartialPackageInfos } from '../../__fixtures__/packageInfos';
 import { getPackageGraphLayers } from '../../publish/getPackageGraphLayers';
-import type { BeachballOptions } from '../../types/BeachballOptions';
-import { getPackageDependencies } from 'workspace-tools';
-import { initMockLogs } from '../../__fixtures__/mockLogs';
-
-jest.mock('workspace-tools', () => {
-  const wstools = jest.requireActual<typeof import('workspace-tools')>('workspace-tools');
-  return { ...wstools, getPackageDependencies: jest.fn(wstools.getPackageDependencies) };
-});
 
 describe('getPackageGraphLayers', () => {
   const logs = initMockLogs();
-  const getPackageDependenciesSpy = getPackageDependencies as jest.MockedFunction<typeof getPackageDependencies>;
-  const anything = expect.anything();
-
-  afterEach(() => {
-    getPackageDependenciesSpy.mockClear();
-  });
 
   /**
    * Call `getPackageGraphLayers` and sort each layer for easier testing (order within layer doesn't matter).
-   *
-   * `changeSet` defaults to including all of `packagesToPublish`.
-   * Option defaults are the same as from `getDefaultOptions`.
    */
-  function getPackageGraphLayersWrapper(params: {
-    packageInfos: PartialPackageInfos;
-    changeSet?: Parameters<typeof generateChangeSet>[0];
-    packagesToPublish: string[];
-    options?: Partial<Pick<BeachballOptions, 'bumpDeps' | 'scope'>>;
-  }): string[][] {
-    const { packageInfos, changeSet, packagesToPublish, options = {} } = params;
-
-    return getPackageGraphLayers({
-      packagesToPublish,
-      options: { bumpDeps: true, scope: null, ...options },
-      bumpInfo: {
-        packageInfos: makePackageInfos(packageInfos),
-        changeFileChangeInfos: generateChangeSet(changeSet || packagesToPublish),
-      },
-    }).map(layer => layer.sort());
+  function getPackageGraphLayersWrapper(packagesToPublish: string[], packageInfos: PartialPackageInfos): string[][] {
+    return getPackageGraphLayers(packagesToPublish, makePackageInfos(packageInfos)).map(layer => layer.sort());
   }
 
   it('returns empty for no packages to publish', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: { foo: {}, bar: {} },
-      packagesToPublish: [],
-    });
+    const result = getPackageGraphLayersWrapper([], { foo: {}, bar: {} });
     expect(result).toEqual([]);
   });
 
   it('returns single layer for one package with no deps', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: { foo: {} },
-      packagesToPublish: ['foo'],
-    });
+    const result = getPackageGraphLayersWrapper(['foo'], { foo: {} });
     expect(result).toEqual([['foo']]);
   });
 
   it('puts independent packages in the same layer', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: { foo: {}, bar: {}, baz: {} },
-      packagesToPublish: ['foo', 'bar', 'baz'],
-    });
+    const result = getPackageGraphLayersWrapper(['foo', 'bar', 'baz'], { foo: {}, bar: {}, baz: {} });
     expect(result).toEqual([['bar', 'baz', 'foo']]);
   });
 
   it('puts packages in layers based on linear dependency chain', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { b: '1.0.0' } },
-        b: { dependencies: { c: '1.0.0' } },
-        c: {},
-      },
-      packagesToPublish: ['a', 'b', 'c'],
+    const result = getPackageGraphLayersWrapper(['a', 'b', 'c'], {
+      a: { dependencies: { b: '1.0.0' } },
+      b: { dependencies: { c: '1.0.0' } },
+      c: {},
     });
     expect(result).toEqual([['c'], ['b'], ['a']]);
-
-    // Verify this works for later tests
-    expect(getPackageDependencies).toHaveBeenLastCalledWith(anything, new Set(['a', 'b', 'c']), anything);
   });
 
   it('handles diamond dependency', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { b: '1.0.0', c: '1.0.0' } },
-        b: { dependencies: { d: '1.0.0' } },
-        c: { dependencies: { d: '1.0.0' } },
-        d: {},
-      },
-      packagesToPublish: ['a', 'b', 'c', 'd'],
+    const result = getPackageGraphLayersWrapper(['a', 'b', 'c', 'd'], {
+      a: { dependencies: { b: '1.0.0', c: '1.0.0' } },
+      b: { dependencies: { d: '1.0.0' } },
+      c: { dependencies: { d: '1.0.0' } },
+      d: {},
     });
     expect(result).toEqual([['d'], ['b', 'c'], ['a']]);
   });
 
   it('considers dependencies, optionalDependencies, and peerDependencies', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { peerDependencies: { d: '1.0.0' } },
-        b: { optionalDependencies: { d: '1.0.0' } },
-        c: { dependencies: { d: '1.0.0' } },
-        d: {},
-      },
-      packagesToPublish: ['a', 'b', 'c', 'd'],
+    const result = getPackageGraphLayersWrapper(['a', 'b', 'c', 'd'], {
+      a: { peerDependencies: { d: '1.0.0' } },
+      b: { optionalDependencies: { d: '1.0.0' } },
+      c: { dependencies: { d: '1.0.0' } },
+      d: {},
     });
     expect(result).toEqual([['d'], ['a', 'b', 'c']]);
   });
 
   it('ignores devDependencies', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { devDependencies: { b: '1.0.0' } },
-        b: {},
-      },
-      packagesToPublish: ['a', 'b'],
+    const result = getPackageGraphLayersWrapper(['a', 'b'], {
+      a: { devDependencies: { b: '1.0.0' } },
+      b: {},
     });
     // a's devDep on b should be ignored, so both are in the same layer
     expect(result).toEqual([['a', 'b']]);
   });
 
-  it.each<[string, Partial<Parameters<typeof getPackageGraphLayersWrapper>[0]>]>([
-    ['bumpDeps: false', { options: { bumpDeps: false } }],
-    // Doesn't matter if the scope includes everything; we conservatively fall back with any scope
-    ['scope', { options: { scope: ['**/*'] } }],
-    ['dependentChangeType "none"', { changeSet: [{ packageName: 'a', dependentChangeType: 'none' }, 'c'] }],
-  ])('with %s, separates layers through unpublished intermediate packages', (_, params) => {
-    // Graph: app -> utils -> core -> base, with lib -> core as well
-    // Only app, core, and lib are published (utils and base are not)
-    // base is layer 0, core is layer 2 (through base), utils is layer 3, app is layer 4, lib is layer 3
-    const packageInfos = {
-      app: { dependencies: { utils: '1.0.0' } },
-      utils: { dependencies: { core: '1.0.0' } },
-      core: { dependencies: { base: '1.0.0' } },
-      base: {},
-      lib: { dependencies: { core: '1.0.0' } },
-    };
-    const result = getPackageGraphLayersWrapper({
-      packageInfos,
-      packagesToPublish: ['app', 'core', 'lib'],
-      options: { bumpDeps: false },
-      ...params,
-    });
-
-    // All the packages in the repo are considered in the calculation
-    expect(getPackageDependencies).toHaveBeenLastCalledWith(anything, new Set(Object.keys(packageInfos)), anything);
-
-    // core depends on base (layer 0 -> layer 1 for core)
-    // lib depends on core directly (layer 2)
-    // app depends on utils (layer 2) which depends on core (layer 1), so app is layer 3
-    // After filtering: [[core], [lib], [app]] — lib and app end up in separate layers
-    // because utils (unpublished) sits between app and core
-    expect(result).toEqual([['core'], ['lib'], ['app']]);
-  });
-
   // This is a probably-impossible case, but documenting the behavior (it should never happen
   // because for "b" to be missing, bumpDeps would need to be false, which would trigger the
   // logic to fall back to all packages)
-  it('with default options, ignores deps outside packagesToPublish', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { b: '1.0.0' } },
-        b: { dependencies: { c: '1.0.0' } },
-        c: {},
-      },
-      packagesToPublish: ['a', 'c'],
+  it('ignores deps outside packagesToPublish', () => {
+    const result = getPackageGraphLayersWrapper(['a', 'c'], {
+      a: { dependencies: { b: '1.0.0' } },
+      b: { dependencies: { c: '1.0.0' } },
+      c: {},
     });
-
-    expect(getPackageDependencies).toHaveBeenLastCalledWith(anything, new Set(['a', 'c']), anything);
 
     // These end up in the same layer because "b" is not considered
     expect(result).toEqual([['a', 'c']]);
   });
 
   it('ignores dependencies on packages outside packageInfos', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { 'external-pkg': '1.0.0' } },
-        b: {},
-      },
-      packagesToPublish: ['a', 'b'],
+    const result = getPackageGraphLayersWrapper(['a', 'b'], {
+      a: { dependencies: { 'external-pkg': '1.0.0' } },
+      b: {},
     });
     expect(result).toEqual([['a', 'b']]);
   });
 
   it('handles cycles by grouping cyclic packages in a final layer', () => {
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { b: '1.0.0' } },
-        b: { dependencies: { a: '1.0.0' } },
-        c: {},
-      },
-      packagesToPublish: ['a', 'b', 'c'],
+    const result = getPackageGraphLayersWrapper(['a', 'b', 'c'], {
+      a: { dependencies: { b: '1.0.0' } },
+      b: { dependencies: { a: '1.0.0' } },
+      c: {},
     });
     expect(result).toEqual([['c'], ['a', 'b']]);
 
@@ -206,14 +106,11 @@ describe('getPackageGraphLayers', () => {
 
   it('handles cycle with non-cyclic dependents', () => {
     // d depends on a, and a<->b form a cycle; c is independent
-    const result = getPackageGraphLayersWrapper({
-      packageInfos: {
-        a: { dependencies: { b: '1.0.0' } },
-        b: { dependencies: { a: '1.0.0' } },
-        c: {},
-        d: { dependencies: { a: '1.0.0', c: '1.0.0' } },
-      },
-      packagesToPublish: ['a', 'b', 'c', 'd'],
+    const result = getPackageGraphLayersWrapper(['a', 'b', 'c', 'd'], {
+      a: { dependencies: { b: '1.0.0' } },
+      b: { dependencies: { a: '1.0.0' } },
+      c: {},
+      d: { dependencies: { a: '1.0.0', c: '1.0.0' } },
     });
     // c is layer 0; a, b, and d are all stuck (d can't be placed until a is, but a is cyclic)
     // so they all end up in the final cycle-remainder layer

--- a/packages/beachball/src/bump/performBump.ts
+++ b/packages/beachball/src/bump/performBump.ts
@@ -7,10 +7,16 @@ import { updatePackageJsons } from './updatePackageJsons';
 import { updateLockFile } from './updateLockFile';
 
 /**
- * Write the bump results to the filesystem:
- * update package.json files, update lock file, write changelogs, and delete change files.
+ * Write the bump results to the filesystem (but don't commit yet):
+ * - call prebump hook
+ * - update package.json files
+ * - update lock file
+ * - write changelogs
+ * - delete change files
+ * - call postbump hook
  *
  * This should NOT mutate `bumpInfo`.
+ *
  * @param bumpInfo Bump info produced by `bumpInMemory` which already reflects in-memory bumps
  */
 export async function performBump(bumpInfo: Readonly<BumpInfo>, options: BeachballOptions): Promise<void> {

--- a/packages/beachball/src/monorepo/getPackageGraph.ts
+++ b/packages/beachball/src/monorepo/getPackageGraph.ts
@@ -59,7 +59,7 @@ export function _getPackageDependencyGraph(packages: string[], packageInfos: Pac
  * Call {@link getPackageDependencies} with consistent options: ignore dev deps,
  * include deps of all other types if included in `packageSet`.
  */
-export function getPackageDependenciesWrapper(packageInfo: PackageInfos[string], packageSet: Set<string>): string[] {
+export function getPackageDependenciesWrapper(packageInfo: PackageInfo, packageSet: Set<string>): string[] {
   return getPackageDependencies(packageInfo, packageSet, {
     withDevDependencies: false,
     withPeerDependencies: true,

--- a/packages/beachball/src/publish/getPackageGraphLayers.ts
+++ b/packages/beachball/src/publish/getPackageGraphLayers.ts
@@ -1,58 +1,42 @@
-import type { BeachballOptions } from '../types/BeachballOptions';
-import type { BumpInfo } from '../types/BumpInfo';
 import { getPackageDependenciesWrapper } from '../monorepo/getPackageGraph';
 import { bulletedList } from '../logging/bulletedList';
+import type { PackageInfos } from '../types/PackageInfo';
 
 /**
  * Given the packages to publish and the full map of packages in the repo, organize the packages into
  * graph layers that can be published in parallel. The first layer will be packages with no deps
  * on other published packages, and the last layer will be root packages that depend on all others.
  *
- * If possible, layers are computed based on only the set of published packages. This should be safe
- * with beachball's default behaviors, but layers will be computed over the full graph under any of
- * the following conditions which might cause missing edges. (Not 100% sure this is necessary, but
- * not sure how to disprove it either...)
- * - `bumpDeps` is false
- * - `scope` is set
- * - Any change has `dependentChangeType` set to "none" when its type is not "none"
- *
  * Currently, there's only VERY basic cycle handling: all cycles are grouped together on a final
  * layer, regardless of any interdependencies. The `toposort` package previously used by beachball
  * doesn't handle cycles at all, so this should be fine for now. (Tarjan's strongly connected
  * components algorithm could be used to break cycles into more layers if needed in the future.)
  *
+ * (Note: layers are computed based on **only** the set of published packages. This *should* be safe
+ * from an ordering standpoint, at least with beachball's default behaviors. When layer support was
+ * initially added, this function would consider all graph edges if `bumpDeps: false`, `scope` set,
+ * or any change had `dependentChangeType: "none", type: "(not none)"`. But logic that predated
+ * layers didn't consider this, so it's probably fine in practice, especially since the layer logic
+ * is mainly to guard against relatively rare mid-publish failures or race conditions.)
+ *
  * @returns An array of layers, where each layer is an array of package names that can be
  * published in parallel.
  */
-export function getPackageGraphLayers(params: {
-  packagesToPublish: string[];
-  bumpInfo: Pick<BumpInfo, 'changeFileChangeInfos' | 'packageInfos'>;
-  options: Pick<BeachballOptions, 'bumpDeps' | 'scope'>;
-}): string[][] {
-  const { packagesToPublish, bumpInfo, options } = params;
-  const { packageInfos, changeFileChangeInfos } = bumpInfo;
-  if (packagesToPublish.length === 0) {
+export function getPackageGraphLayers(packagesToPublish: string[], packageInfos: PackageInfos): string[][] {
+  if (!packagesToPublish.length) {
     return [];
   }
 
-  // See function comment for explanation
-  const canConsiderPublishedOnly =
-    options.bumpDeps &&
-    !options.scope &&
-    !changeFileChangeInfos.some(
-      change => change.change.type !== 'none' && change.change.dependentChangeType === 'none'
-    );
-  const packagesToConsider = canConsiderPublishedOnly ? packagesToPublish : Object.keys(packageInfos);
-  const packagesToConsiderSet = new Set(packagesToConsider);
+  const publishSet = new Set(packagesToPublish);
 
-  // Build internal dependency graph for packagesToConsider
+  // Build internal dependency graph
   const dependentsOf = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
 
-  for (const pkgName of packagesToConsider) {
-    // Get dependencies of this package, filtered to packagesToConsiderSet.
+  for (const pkgName of packagesToPublish) {
+    // Get dependencies of this package, filtered to publishSet.
     // Ignore dev deps since they're not installed by consumers and can't cause ordering issues.
-    const deps = getPackageDependenciesWrapper(packageInfos[pkgName], packagesToConsiderSet);
+    const deps = getPackageDependenciesWrapper(packageInfos[pkgName], publishSet);
     inDegree.set(pkgName, deps.length);
 
     for (const dep of deps) {
@@ -70,16 +54,10 @@ export function getPackageGraphLayers(params: {
   const layers: string[][] = [];
 
   // Seed with all packages that have no in-repo dependencies
-  let currentLayer = packagesToConsider.filter(pkg => (inDegree.get(pkg) ?? 0) === 0);
+  let currentLayer = packagesToPublish.filter(pkg => (inDegree.get(pkg) ?? 0) === 0);
 
-  while (currentLayer.length > 0) {
-    // Filter this layer to only packages being published
-    const publishLayer = canConsiderPublishedOnly
-      ? currentLayer
-      : currentLayer.filter(pkg => packagesToPublish.includes(pkg));
-    if (publishLayer.length > 0) {
-      layers.push(publishLayer);
-    }
+  while (currentLayer.length) {
+    layers.push(currentLayer);
 
     // Mark placed and compute next layer
     const nextLayer: string[] = [];
@@ -98,7 +76,7 @@ export function getPackageGraphLayers(params: {
 
   // Handle cycles: any remaining packages not yet placed
   const cyclic = packagesToPublish.filter(pkg => !placed.has(pkg));
-  if (cyclic.length > 0) {
+  if (cyclic.length) {
     console.warn(
       [
         'Circular dependencies detected among the following packages:',

--- a/packages/beachball/src/publish/publishToRegistry.ts
+++ b/packages/beachball/src/publish/publishToRegistry.ts
@@ -62,12 +62,12 @@ export async function publishToRegistry(bumpInfo: BumpInfo, options: BeachballOp
   let layers: string[][] | undefined;
   if (packToPath) {
     // If packing, get the layers instead of toposorting
-    layers = getPackageGraphLayers({ packagesToPublish, bumpInfo, options });
+    layers = getPackageGraphLayers(packagesToPublish, bumpInfo.packageInfos);
   } else if (options.concurrency === 1) {
     // Otherwise, unless publishing concurrently, toposort the packages in case publishing fails
     // partway through. We can reuse the layer logic for this. (Skip for concurrent publishing
     // since p-graph handles ordering.)
-    packagesToPublish = getPackageGraphLayers({ packagesToPublish, bumpInfo, options }).flat();
+    packagesToPublish = getPackageGraphLayers(packagesToPublish, bumpInfo.packageInfos).flat();
   }
 
   // performing publishConfig and workspace version overrides requires this procedure to

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -134,7 +134,7 @@ export interface RepoOptions {
   changelog?: ChangelogOptions;
   /**
    * If true, commit change files automatically after `beachball change`.
-   * If false, only stage them.
+   * If false, only stage them. (Only applies to the `change` command.)
    * @default true
    */
   commit?: boolean;
@@ -356,15 +356,15 @@ export interface VersionGroupOptions {
 
 export interface HooksOptions {
   /**
-   * Runs for each package after version bumps have been processed and committed to git, but before the actual
-   * publish command.
+   * Runs for each package after version bumps have been processed, but before npm publish
+   * (only for packages that will be published).
    *
-   * This allows for file modifications which will be reflected in the published package but not be reflected in the
-   * repository.
+   * This allows for file modifications which will be reflected in the published package but not be
+   * reflected in the repository. For changes which should also be committed, use `postbump`.
    *
    * @param packagePath The path to the package directory
    * @param name The name of the package as defined in package.json
-   * @param version The post-bump version of the package to be published
+   * @param version The **post-bump** version of the package to be published
    * @param packageInfos Metadata about other packages processed by Beachball after bumping. Readonly.
    */
   prepublish?: (
@@ -375,8 +375,8 @@ export interface HooksOptions {
   ) => void | Promise<void>;
 
   /**
-   * Runs for each package after the publish command.
-   * Any file changes made in this step will **not** be committed automatically.
+   * Runs for each package after the npm publish command (only for packages that were published).
+   * Any file changes made in this step will **not** be committed or published.
    *
    * @param packagePath The path to the package directory
    * @param name The name of the package as defined in package.json
@@ -391,23 +391,32 @@ export interface HooksOptions {
   ) => void | Promise<void>;
 
   /**
-   * Runs for each package, before writing changelog and package.json updates
-   * to the filesystem. May be called multiple times during publish.
+   * Runs for each bumped package, before writing changelog and package.json updates to the
+   * filesystem. Skipped if `bump: false`.
+   *
+   * In the `bump` flow, this is called once for each package.
+   * In the `publish` flow, it's called:
+   * 1. when generating version bumps and changelogs to commit/push
+   * 2. before publishing to npm
    *
    * @param packagePath The path to the package directory
    * @param name The name of the package as defined in package.json
-   * @param version The pre-bump version of the package to be published
+   * @param version The **pre-bump** version of the package to be published
    */
   prebump?: (packagePath: string, name: string, version: string) => void | Promise<void>;
 
   /**
-   * Runs for each package, after writing changelog and package.json updates
-   * to the filesystem. May be called multiple times during publish.
-   * In the `publish` flow, files written in this hook will be committed automatically.
+   * Runs for each bumped package, after writing changelog and package.json updates to the
+   * filesystem. Skipped if `bump: false`.
+   *
+   * In the `bump` flow, this is called once for each package.
+   * In the `publish` flow, it's called:
+   * 1. when generating version bumps and changelogs to commit/push (file changes will be committed)
+   * 2. before publishing to npm, only for packages that will be published (file changes will be published)
    *
    * @param packagePath The path to the package directory
    * @param name The name of the package as defined in package.json
-   * @param version The post-bump version of the package to be published
+   * @param version The **post-bump** version of the package to be published
    * @param packageInfos Metadata about other packages processed by Beachball after bumping. Readonly.
    */
   postbump?: (
@@ -418,7 +427,8 @@ export interface HooksOptions {
   ) => void | Promise<void>;
 
   /**
-   * Runs once after all bumps to all packages before committing changes
+   * Runs once after all bumps to all packages before committing changes.
+   * Files modified in this step will be automatically committed (but not published).
    * @param cwd The monorepo root path
    */
   precommit?: (cwd: string) => void | Promise<void>;


### PR DESCRIPTION
This change mirrors the logic prior to the introduction of layers (#1158 `getPackageDependencyGraph`) and is more efficient. However, keep the `withDevDependencies: false` setting for both package graphs and layers (diverging from the original logic) since those definitely don't impact the published graph, and I'm not aware of any reason it's critical to consider them when determining ordering for hook runs.

The conditions that triggered including all layers (`bumpDeps: false`, `scope` set, or any change had `dependentChangeType: "none", type: "(not none)"`) *might* theoretically matter, but the logic could be added back later if there's an example of it causing an issue.

Also update some docs on config types.