### PR TITLE
Post-renovate move cleanup

### DIFF
--- a/change/@microsoft-m365-renovate-config-218faab8-d6ac-4c44-8569-df6949d4dbb0.json
+++ b/change/@microsoft-m365-renovate-config-218faab8-d6ac-4c44-8569-df6949d4dbb0.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "Move to beachball repo, with some fixes and removals of unused or no longer recommended presets.",
-  "packageName": "@microsoft/m365-renovate-config",
-  "email": "elcraig@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-m365-renovate-config-c66e8c1c-dadf-42ec-9972-16f6c745da61.json
+++ b/change/@microsoft-m365-renovate-config-c66e8c1c-dadf-42ec-9972-16f6c745da61.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix preset tests",
+  "packageName": "@microsoft/m365-renovate-config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,19 +7,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // TODO replace these
-    "github>microsoft/m365-renovate-config//default",
-    "github>microsoft/m365-renovate-config//disableEsmVersions",
-    "github>microsoft/m365-renovate-config//groupMore",
-    "github>microsoft/m365-renovate-config//groupTypes",
-    "github>microsoft/m365-renovate-config//keepFresh",
-    "github>microsoft/m365-renovate-config//restrictNode(22)"
-    // "github>microsoft/beachball//renovate/presets/default",
-    // "github>microsoft/beachball//renovate/presets/disableEsmVersions",
-    // "github>microsoft/beachball//renovate/presets/groupMore",
-    // "github>microsoft/beachball//renovate/presets/groupTypes",
-    // "github>microsoft/beachball//renovate/presets/keepFresh",
-    // "github>microsoft/beachball//renovate/presets/restrictNode(22)"
+    "github>microsoft/beachball//renovate/presets/default",
+    "github>microsoft/beachball//renovate/presets/disableEsmVersions",
+    "github>microsoft/beachball//renovate/presets/groupMore",
+    "github>microsoft/beachball//renovate/presets/groupTypes",
+    "github>microsoft/beachball//renovate/presets/keepFresh",
+    "github>microsoft/beachball//renovate/presets/restrictNode(22)"
   ],
 
   "ignorePaths": ["**/node_modules/**", "**/__*/**", "**/.yarn/**"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -51,6 +51,9 @@
     }
   },
 
+  // Only check these managers for efficiency
+  "enabledManagers": ["custom.regex", "azure-pipelines", "bicep", "github-actions", "npm", "nvm"],
+
   "customManagers": [
     {
       // Look for "using: 'nodeX'" in action.yaml files

--- a/renovate/CHANGELOG.md
+++ b/renovate/CHANGELOG.md
@@ -36,9 +36,9 @@ The following presets have been removed:
 
 ### Updated behavior
 
-- [`default`](#default) includes `docker:pinDigests`, `helpers:pinGitHubActionDigests`, and `configMigration`
-- [`beachball`](#beachball) includes the old `beachballPostUpgrade` behavior directly (use `default` if you don't want that)
-- [`groupFluent`](#groupfluent): outdated Fluent-family packages were removed
+- [`default`](./README.md#default) includes `docker:pinDigests`, `helpers:pinGitHubActionDigests`, and `configMigration`
+- [`beachball`](./README.md#beachball) includes the old `beachballPostUpgrade` behavior directly (use `default` if you don't want that)
+- [`groupFluent`](./README.md#groupfluent): outdated Fluent-family packages were removed
 
 ## 2.8.4
 

--- a/renovate/CHANGELOG.md
+++ b/renovate/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 <!-- Start content -->
 
+## 3.0.0
+
+July 21, 2026
+
+Version 3 is the migration from `microsoft/m365-renovate-config` into this repo. There are a few breaking changes.
+
+### Preset reference format
+
+The `extends` reference format has changed due to nested subfolders:
+
+```jsonc
+// before
+"github>microsoft/m365-renovate-config",
+"github>microsoft/m365-renovate-config:foo",
+// after
+"github>microsoft/beachball//renovate/presets/default",
+"github>microsoft/beachball//renovate/presets/foo",
+```
+
+Note that **pinning to a ref/tag won't work** if the preset `extends` any other local presets, since those would be pulled from `main` by default. That was done in the `m365-renovate-config` repo and could be brought back if necessary, but it requires an extra branch and [several extra steps](https://github.com/microsoft/m365-renovate-config/blob/main/scripts/release/bumpAndRelease.ts#L125) to update all references and create a corresponding commit (please open an issue if interested).
+
+### Removed presets
+
+The following presets have been removed:
+
+- `automergeDevLock`, `automergeTypes` - manually set auto-merge instead
+- `beachballPostUpgrade` - merged with `beachball`
+- `groupFixtureUpdates` - minimally useful
+- `minorDependencyUpdates` - didn't work as desired (it's better to go understand Renovate's [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) for yourself and pick what you want)
+- `newConfigWarningIssue` - included in `default`
+- `pinActions` - included in `default` via `helpers:pinGitHubActionDigests`
+
+### Updated behavior
+
+- [`default`](#default) includes `docker:pinDigests`, `helpers:pinGitHubActionDigests`, and `configMigration`
+- [`beachball`](#beachball) includes the old `beachballPostUpgrade` behavior directly (use `default` if you don't want that)
+- [`groupFluent`](#groupfluent): outdated Fluent-family packages were removed
+
 ## 2.8.4
 
 [Compare source](https://github.com/microsoft/m365-renovate-config/compare/v2.8.3...v2.8.4) - July 20, 2026 at 4:52 PM PDT

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -24,35 +24,7 @@ To reference a preset from this repo in your Renovate config ([syntax reference]
 
 Note that **pinning to a ref/tag won't work** if the preset `extends` any other local presets, since those would be pulled from `main` by default. That was done in the `m365-renovate-config` repo and could be brought back if necessary, but it requires an extra branch and [several extra steps](https://github.com/microsoft/m365-renovate-config/blob/main/scripts/release/bumpAndRelease.ts#L125) to update all references and create a corresponding commit (please open an issue if interested).
 
-## Version 3 updates
-
-<!-- TODO move most of this into the changelog -->
-
-Version 3 is the migration from `microsoft/m365-renovate-config` into this repo. There are a few breaking changes.
-
-### Preset reference format
-
-The `extends` reference format has changed due to nested subfolders. Find/replace:
-
-- `microsoft/m365-renovate-config:` to `microsoft/beachball//renovate/presets/`
-- Implicit default preset: `microsoft/m365-renovate-config` to `microsoft/beachball//renovate/presets/default`
-
-### Removed presets
-
-The following presets have been removed:
-
-- `automergeDevLock`, `automergeTypes` - manually set auto-merge instead
-- `beachballPostUpgrade` - merged with `beachball`
-- `groupFixtureUpdates` - minimally useful
-- `minorDependencyUpdates` - didn't work as desired (it's better to go understand Renovate's [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) for yourself and pick what you want)
-- `newConfigWarningIssue` - included in `default`
-- `pinActions` - included in `default` via `helpers:pinGitHubActionDigests`
-
-### Updated behavior
-
-- [`default`](#default) includes `docker:pinDigests`, `helpers:pinGitHubActionDigests`, and `configMigration`
-- [`beachball`](#beachball) includes the old `beachballPostUpgrade` behavior directly (use `default` if you don't want that)
-- [`groupFluent`](#groupfluent): outdated Fluent-family packages were removed
+See the [changelog](./CHANGELOG.md#300) for more details of what changed in the repo move.
 
 ## Development notes
 

--- a/renovate/package.json
+++ b/renovate/package.json
@@ -15,6 +15,7 @@
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' yarn run -T jest",
     "presets:basic": "node ./scripts/testPresetsBasic.ts",
     "presets:full": "node ./scripts/testPresetsFull.ts",
+    "process-log": "node ./scripts/processLog.ts",
     "update-readme": "node ./scripts/updateReadme.ts"
   },
   "devDependencies": {

--- a/renovate/package.json
+++ b/renovate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/m365-renovate-config",
-  "version": "2.8.4",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Shared Renovate presets for use in M365 projects",
   "beachball": {

--- a/renovate/scripts/processLog.ts
+++ b/renovate/scripts/processLog.ts
@@ -1,0 +1,23 @@
+import execa from 'execa';
+import { parseRenovateLogs } from './utils/renovateLogs.ts';
+import type { RenovateLog } from './utils/types.ts';
+import { updateAndFormat } from './utils/runBin.ts';
+
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Missing path to Renovate log file');
+  process.exit(1);
+}
+const open = process.argv[3] === '--open';
+
+const logs = parseRenovateLogs(filePath).logs as Partial<RenovateLog>[];
+for (const log of logs) {
+  for (const prop of ['name', 'hostname', 'pid', 'logContext', 'v', 'time', 'repository']) {
+    delete log[prop];
+  }
+}
+const outPath = filePath.replace(/\\.log$/, '') + '.json';
+await updateAndFormat(outPath, JSON.stringify(logs));
+
+console.log(`Wrote logs to "${outPath}"`);
+open && execa.sync('code', [outPath]);

--- a/renovate/scripts/processLog.ts
+++ b/renovate/scripts/processLog.ts
@@ -16,7 +16,7 @@ for (const log of logs) {
     delete log[prop];
   }
 }
-const outPath = filePath.replace(/\\.log$/, '') + '.json';
+const outPath = filePath.replace(/\.log$/, '') + '.json';
 await updateAndFormat(outPath, JSON.stringify(logs));
 
 console.log(`Wrote logs to "${outPath}"`);

--- a/renovate/scripts/serverConfig.ts
+++ b/renovate/scripts/serverConfig.ts
@@ -5,9 +5,6 @@ import { readPresets } from './utils/readPresets.ts';
 
 const presets = readPresets();
 
-// TODO: REVERT THIS (see comment where it's used about why it's temporarily done)
-const tempFilteredPresets = githubBranchName === 'renovate-configs' ? presets.filter(p => !p.json?.extends) : presets;
-
 /**
  * Renovate self-hosted (server) config for testPresetsFull.ts
  * https://docs.renovatebot.com/self-hosted-configuration/
@@ -29,9 +26,7 @@ const config = {
     // (Note this will NOT fix the names of extended presets within another preset,
     // so extended presets will be fetched from main, not the branch. This is usually
     // fine but will cause an error if a preset extends a newly-added preset in a PR.)
-    extends: tempFilteredPresets.map(p =>
-      getExtendsForLocalPreset(p, githubBranchName === defaultBranch ? '' : githubBranchName)
-    ),
+    extends: presets.map(p => getExtendsForLocalPreset(p, githubBranchName === defaultBranch ? '' : githubBranchName)),
     // Disable alerts since the PR token doesn't have perms to read them
     vulnerabilityAlerts: { enabled: false },
     // Use the config from the current branch. Unfortunately this is also merged with the

--- a/renovate/scripts/testPresetsBasic.ts
+++ b/renovate/scripts/testPresetsBasic.ts
@@ -97,6 +97,7 @@ async function checkFile(preset: ConfigData, isServerConfig: boolean): Promise<R
       ...(isServerConfig ? [] : ['--no-global']),
       absolutePath,
     ],
+    logLevel: 'warn',
     logFile: paths.logFileBasic,
   });
 

--- a/renovate/scripts/utils/readPresets.ts
+++ b/renovate/scripts/utils/readPresets.ts
@@ -15,7 +15,10 @@ export const specialConfigNames = {
  */
 export function readPresets(params: { exclude?: string[] } = {}): LocalPresetData[] {
   const excludePresets = params?.exclude ?? [];
-  const presetFiles = fs.readdirSync(paths.presetsRoot).filter(file => /^[^.].*\.json$/.test(file));
+  const presetFiles = fs
+    .readdirSync(paths.presetsRoot)
+    .filter(file => /^[^.].*\.json$/.test(file))
+    .sort();
 
   if (!presetFiles.length) {
     logError('No presets found under ' + paths.presetsRoot);

--- a/renovate/scripts/utils/renovateLogs.ts
+++ b/renovate/scripts/utils/renovateLogs.ts
@@ -29,7 +29,7 @@ export type ParsedRenovateLogs = {
  * @returns Environment variables to set for Renovate
  */
 export function getRenovateEnv(params: RenovateEnvParams): Record<string, string> {
-  const { logLevel = 'warn', logFile, configFile } = params;
+  const { logLevel = 'info', logFile, configFile } = params;
   return {
     LOG_LEVEL: logLevel,
     // write a JSON log file

--- a/renovate/scripts/utils/renovateLogs.ts
+++ b/renovate/scripts/utils/renovateLogs.ts
@@ -3,7 +3,7 @@ import { logEndGroup, logGroup } from './github.ts';
 import type { RenovateLog, RenovateLogLevelName } from './types.ts';
 
 export type RenovateEnvParams = {
-  /** Log level for pretty console output (default warn) */
+  /** Log level for pretty console output (default info) */
   logLevel?: RenovateLogLevelName;
   /** Path to a log file */
   logFile: string;
@@ -12,6 +12,7 @@ export type RenovateEnvParams = {
 };
 
 export type ParsedRenovateLogs = {
+  logs: RenovateLog[];
   /** migrated config (possibly validation only) */
   migratedConfig?: unknown;
   /** new config/alt migration message? (possibly validation only) */
@@ -86,6 +87,7 @@ export function parseRenovateLogs(logFile: string, startMarker?: string): Parsed
   }
 
   return {
+    logs,
     migratedConfig,
     newConfig,
     resultLog: logs.findLast(l => l.msg === 'Repository finished' && l.result) as ParsedRenovateLogs['resultLog'],

--- a/renovate/scripts/utils/runBin.ts
+++ b/renovate/scripts/utils/runBin.ts
@@ -33,8 +33,7 @@ let hasMatchingRenovate: true | undefined;
 
 /**
  * Run Renovate from the configured working directory. Must call `verifyRenovate` first.
- * Does not reject on error, and the log level defaults to `warn` (avoiding a giant log
- * of the entire merged config in the main build logs).
+ * Does not reject on error.
  */
 export function runRenovate(
   bin: 'renovate' | 'renovate-config-validator',


### PR DESCRIPTION
Update todos in tests, update repo renovate config to reference the new presets, and update changelog.