### PR TITLE
More renovate updates

### DIFF
--- a/change/@microsoft-m365-renovate-config-dddec310-1795-4750-93bd-5cc0e40e07a7.json
+++ b/change/@microsoft-m365-renovate-config-dddec310-1795-4750-93bd-5cc0e40e07a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable non-standard characters in branch names, and work around bug with Yarn resolutions with a version in the key",
+  "packageName": "@microsoft/m365-renovate-config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -80,9 +80,10 @@
       "dependencyDashboardApproval": false
     },
     {
-      // follow npm dependency age policy
+      // follow npm dependency age policy and schedule updates
       "matchDepNames": ["renovate"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "schedule": ["before 5am on the 1st and 15th day of the month"]
     },
     {
       "matchDepTypes": ["devDependencies"],

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -97,6 +97,7 @@ Recommended config which is intended to be appropriate for most projects.
   ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
+  "branchNameStrict": true,
   "minimumReleaseAge": "3 days",
   "printConfig": true,
   "configMigration": true,
@@ -113,6 +114,11 @@ Recommended config which is intended to be appropriate for most projects.
     {
       "matchManagers": ["npm"],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchDepTypes": ["resolutions"],
+      "matchDepNames": ["/^[~^]?\\d+\\.\\d+\\.\\d+$/"],
+      "enabled": false
     }
   ]
 }
@@ -138,6 +144,7 @@ Other settings:
 
 - Extend configs to pin GitHub Actions and Docker digests
 - PR limits (`prHourlyLimit` and `prConcurrentLimit`): Prevent Renovate from creating an overwhelming number of PRs all at once. It's _highly encouraged_ to adjust these in your repo to fit your team's needs!
+- `branchNameStrict`: Prevent special characters in branch names
 - `minimumReleaseAge`: Wait 3 or 7 days to auto-create PRs for new releases (they'll be shown on the dependency dashboard earlier), mainly in case of security issues. You should also apply a similar package manager setting to restrict lock file updates from pulling in new versions.
 - `printConfig`: Log the final resolved config to make debugging easier
 - `configMigration`: Automatically make PRs to migrate deprecated config options
@@ -145,6 +152,7 @@ Other settings:
 - `timezone`: Run schedules relative to Pacific time, since many M365 repos are based in that time zone (see [time zone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)).
 - `vulnerabilityAlerts`: Enable PRs to address security vulnerabilities. Note that this only works for GitHub and has limitations.
 - For `devDependencies`: Use "devDependencies" in commit messages (instead of the default "dependencies") to be clearer about what is being modified
+- For Yarn `resolutions` with a version in the key, work around a [Renovate bug](https://github.com/renovatebot/renovate/discussions/44768) which causes the version to be treated as a dependency name
 
 <!-- end extra content -->
 

--- a/renovate/presets/default.json
+++ b/renovate/presets/default.json
@@ -15,12 +15,12 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
 
+  "branchNameStrict": true,
+
   "minimumReleaseAge": "3 days",
 
   "printConfig": true,
-
   "configMigration": true,
-
   "configWarningReuseIssue": false,
 
   "timezone": "America/Los_Angeles",
@@ -37,6 +37,11 @@
     {
       "matchManagers": ["npm"],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchDepTypes": ["resolutions"],
+      "matchDepNames": ["/^[~^]?\\d+\\.\\d+\\.\\d+$/"],
+      "enabled": false
     }
   ]
 }

--- a/renovate/scripts/lintPresets.test.ts
+++ b/renovate/scripts/lintPresets.test.ts
@@ -1,29 +1,34 @@
 import { describe, it, expect } from '@jest/globals';
-import { readPresets } from './utils/readPresets.ts';
+import { readPresets, readRepoConfig } from './utils/readPresets.ts';
 import { getLocalPresetFromExtends } from './utils/extends.ts';
+import type { BasicRenovateConfig } from './utils/types.ts';
 
 // This is more of a lint rule than a test, but it's much easier to hook it in to Jest
 describe('lint presets', () => {
   const schema = 'https://docs.renovatebot.com/renovate-schema.json';
 
   const presets = readPresets();
+  const repoConfig = readRepoConfig();
 
-  describe('required attributes', () => {
-    it.each(presets)('$name', ({ json }) => {
+  function getInvalidExtends(json: BasicRenovateConfig): string[] {
+    return (json.extends || []).filter(extnds => {
+      const extPreset = getLocalPresetFromExtends(extnds);
+      // ignore presets from outside this repo, but ones within the repo must exist
+      return extPreset && !presets.some(p => p.name === extPreset);
+    });
+  }
+
+  describe.each([repoConfig, ...presets])('$name', preset => {
+    const { json } = preset;
+
+    it('has required properties', () => {
       expect(json).toHaveProperty('$schema', schema);
-      expect(json).toHaveProperty('description');
+      preset !== repoConfig && expect(json).toHaveProperty('description');
     });
-  });
 
-  describe('valid extends', () => {
-    const extendsPresets = presets.filter(p => p.json?.extends);
-    it.each(extendsPresets)('$name', ({ json }) => {
-      const invalidExtends = (json.extends || []).filter(extnds => {
-        const extPreset = getLocalPresetFromExtends(extnds);
-        // ignore presets from outside this repo, but ones within the repo must exist
-        return extPreset && !presets.some(p => p.name === extPreset);
+    json.extends &&
+      it('extends only valid presets', () => {
+        expect(getInvalidExtends(json)).toHaveLength(0);
       });
-      expect(invalidExtends).toHaveLength(0);
-    });
   });
 });

--- a/renovate/scripts/serverConfig.ts
+++ b/renovate/scripts/serverConfig.ts
@@ -18,6 +18,7 @@ const config = {
   dryRun: 'extract',
   repositories: [defaultRepo],
   hostRules: [{ abortOnError: true }],
+  username: 'fake-user-do-not-match-prs',
   // For the basic config test to pass, the token must be a string
   token: getToken() || '',
   force: {


### PR DESCRIPTION
- Disable non-standard characters in branch names (breaks a renovate test, and also not ideal in general)
- Work around [Renovate bug](https://github.com/renovatebot/renovate/discussions/44768) with Yarn resolutions with a version in the key
- Try to prevent renovate tests from matching the username of existing PRs
- Schedule Renovate updates