### PR TITLE
[renovate] Fix custom tag action recognition

### DIFF
--- a/change/@microsoft-m365-renovate-config-fe022345-364e-4aef-998b-51e939890d03.json
+++ b/change/@microsoft-m365-renovate-config-fe022345-364e-4aef-998b-51e939890d03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix custom tag action recognition",
+  "packageName": "@microsoft/m365-renovate-config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1001,14 +1001,15 @@ Update GitHub Actions in subfolders that use a `<name>_v<version>` tag naming sc
 {
   "customManagers": [
     {
+      "description": "GitHub Actions using a `<name>_v<major>` or `<name>_v<major>.<minor>.<patch>` tag (digest refresh + version updates)",
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/(workflows|actions)/.+\\.ya?ml$/", "/(^|/)action\\.ya?ml$/"],
       "matchStrings": [
-        "(?m)^\\s*uses:\\s+(?<depName>(?<packageName>[^/\\s]+/[^/\\s]+)/[^@\\s]+)@(?<currentValue>[\\w.-]+_v\\d+(?:\\.\\d+){0,2})[ \t]*($|#)",
-        "(?m)^\\s*uses:\\s+(?<depName>(?<packageName>[^/\\s]+/[^/\\s]+)/[^@\\s]+)@(?<currentDigest>[0-9a-f]{40})[ \t]+#\\s*(?<currentValue>[\\w.-]+_v\\d+(?:\\.\\d+){0,2})$"
+        "(?m)^[ \t]*(?:-[ \t]+)?uses:[ \t]+[\"']?(?<depName>(?<packageName>[^/\\s\"']+/[^/\\s\"']+)/[^@\\s\"']+)@(?<currentValue>[\\w.-]+_v(?<version>\\d+(?:\\.\\d+\\.\\d+)?))[\"']?($|[\\s#])",
+        "(?m)^[ \t]*(?:-[ \t]+)?uses:[ \t]+[\"']?(?<depName>(?<packageName>[^/\\s\"']+/[^/\\s\"']+)/[^@\\s\"']+)@(?<currentDigest>[0-9a-f]{40})[\"']?[ \t]+#[ \t]*(?<currentValue>[\\w.-]+_v(?<version>\\d+(?:\\.\\d+\\.\\d+)?))$"
       ],
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^(?<compatibility>[\\w.-]+)_v(?<major>\\d+)(?:\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?$"
+      "versioningTemplate": "regex:^(?<compatibility>[\\w.-]+)_v(?<major>\\d+){{#if (containsString version '.')}}\\.(?<minor>\\d+)\\.(?<patch>\\d+){{/if}}$"
     }
   ],
   "packageRules": [
@@ -1026,19 +1027,30 @@ Update GitHub Actions in subfolders that use a `<name>_v<version>` tag naming sc
 
 <!-- start extra content (EDITABLE between these comments) -->
 
-Some repos publish multiple actions and tag each one with a `<name>_v<version>` scheme (e.g. `foo_v1` or `foo_v1.2.3`) rather than a plain `v1`. Renovate's built-in [`github-actions` manager](https://docs.renovatebot.com/modules/manager/github-actions/) already understands actions in a repo subdirectory, but it can't follow this custom tag scheme: the tag isn't a version it recognizes, and all of the repo's action tags are mixed together. This [custom manager](https://docs.renovatebot.com/configuration-options/#custommanagers) handles tags with names, such as the following:
+Some repos publish multiple actions and tag each one with a `<name>_v<version>` scheme (e.g. `foo_v1` or `foo_v1.2.3`) rather than a plain `v1`. For example:
 
 ```yaml
 - uses: microsoft/beachball/actions/should-release@should-release_v3
 - uses: microsoft/beachball/actions/should-release@826cebb873f064d29134f1bbf39f2b7634cb47cb # should-release_v3
 ```
 
-The custom manager pulls out each piece of the reference to achieve similar behavior to the built-in `github-actions` manager: update the digest when a moving tag (like `_v3`) moves, and propose version-update PRs as new semver tags in the same family appear. How the pieces map:
+Renovate's built-in [`github-actions` manager](https://docs.renovatebot.com/modules/manager/github-actions/) already understands actions in a repo subdirectory, but it can't follow this custom tag scheme. This preset uses a [custom manager](https://docs.renovatebot.com/configuration-options/#custommanagers) to implement similar behavior for tags with a name prefix: update the digest when a moving tag (like `_v3`) moves, and open a separate version-update PR only when a genuinely newer tag in the same family appears. It can also follow a tag with an exact version (like `_v1.2.3`) and provide all version-bump PRs.
 
-- `depName` is the full action path (`microsoft/beachball/actions/should-release`), used only for display.
-- `packageName` is the repo (`microsoft/beachball`), which is what the [`github-tags` datasource](https://docs.renovatebot.com/modules/datasource/github-tags/) actually queries, since tags live on the repo rather than the subdirectory.
-- `currentDigest` is the pinned SHA, and `currentValue` is the tag to follow (`should-release_v3`).
-- The [`regex` `versioningTemplate`](https://docs.renovatebot.com/modules/versioning/#regex-versioning) parses the `<currentValue>` (`foo_v1` or `foo_v1.2.3`): it uses the name as `<compatibility>` (separating different action names within the same repo) and the number(s) after `_v` as the version.
+**Implementation details:** The `matchStrings` setting uses the [regex custom manager](https://docs.renovatebot.com/modules/manager/regex/)'s named capture groups to extract each piece of the reference:
+
+- `<depName>` is the full action path (`microsoft/beachball/actions/should-release`), used only for display.
+- `<packageName>` is the repo (`microsoft/beachball`), which is what the [`github-tags` datasource](https://docs.renovatebot.com/modules/datasource/github-tags/) queries.
+- `<currentDigest>` is the pinned SHA, if relevant.
+- `<currentValue>` is the tag to follow (`should-release_v3` or `should-release_v1.2.3`).
+- The non-standard named group `<version>` is just the numeric part of the tag (`3` or `1.2.3`), which the `versioningTemplate` uses to pick a scheme (see below).
+
+The `versioningTemplate` translates `<currentValue>` into a version using Renovate's [`regex` versioning](https://docs.renovatebot.com/modules/versioning/regex/):
+
+- `<compatibility>` is the action name prefix (e.g. `should-release`), which keeps different actions in the same repo separate.
+- `<major>` is the major version.
+- Since `regex` versioning translates an empty minor/patch to `0`, the `.<minor>.<patch>` is gated by a [template condition](https://docs.renovatebot.com/templates/) on whether `<version>` (see above) contains `.`. Otherwise Renovate would consider `_v3.1.1` newer than `_v3` and open a redundant version-bump PR.
+
+The preset also contains a rule disabling the `github-actions` manager for matching tag references, to prevent double PRs.
 
 <!-- end extra content -->
 

--- a/renovate/presets/customTagActions.json
+++ b/renovate/presets/customTagActions.json
@@ -5,14 +5,15 @@
 
   "customManagers": [
     {
+      "description": "GitHub Actions using a `<name>_v<major>` or `<name>_v<major>.<minor>.<patch>` tag (digest refresh + version updates)",
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/(workflows|actions)/.+\\.ya?ml$/", "/(^|/)action\\.ya?ml$/"],
       "matchStrings": [
-        "(?m)^\\s*uses:\\s+(?<depName>(?<packageName>[^/\\s]+/[^/\\s]+)/[^@\\s]+)@(?<currentValue>[\\w.-]+_v\\d+(?:\\.\\d+){0,2})[ \t]*($|#)",
-        "(?m)^\\s*uses:\\s+(?<depName>(?<packageName>[^/\\s]+/[^/\\s]+)/[^@\\s]+)@(?<currentDigest>[0-9a-f]{40})[ \t]+#\\s*(?<currentValue>[\\w.-]+_v\\d+(?:\\.\\d+){0,2})$"
+        "(?m)^[ \t]*(?:-[ \t]+)?uses:[ \t]+[\"']?(?<depName>(?<packageName>[^/\\s\"']+/[^/\\s\"']+)/[^@\\s\"']+)@(?<currentValue>[\\w.-]+_v(?<version>\\d+(?:\\.\\d+\\.\\d+)?))[\"']?($|[\\s#])",
+        "(?m)^[ \t]*(?:-[ \t]+)?uses:[ \t]+[\"']?(?<depName>(?<packageName>[^/\\s\"']+/[^/\\s\"']+)/[^@\\s\"']+)@(?<currentDigest>[0-9a-f]{40})[\"']?[ \t]+#[ \t]*(?<currentValue>[\\w.-]+_v(?<version>\\d+(?:\\.\\d+\\.\\d+)?))$"
       ],
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^(?<compatibility>[\\w.-]+)_v(?<major>\\d+)(?:\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?$"
+      "versioningTemplate": "regex:^(?<compatibility>[\\w.-]+)_v(?<major>\\d+){{#if (containsString version '.')}}\\.(?<minor>\\d+)\\.(?<patch>\\d+){{/if}}$"
     }
   ],
 

--- a/renovate/scripts/__tests__/customTagActions.test.ts
+++ b/renovate/scripts/__tests__/customTagActions.test.ts
@@ -11,10 +11,16 @@ const regExp = (s: string) => {
   return new RegExp(multiline ? s.slice(4) : s, multiline ? 'm' : undefined);
 };
 
-const customManager = customTagPreset.customManagers![0];
-const [tagRe, digestRe] = customManager.matchStrings!.map(regExp);
-// versioningTemplate is prefixed with "regex:"
-const versioningRe = regExp(customManager.versioningTemplate!.replace(/^regex:/, ''));
+// A single manager handles both major-only (foo_v1) and full semver (foo_v1.2.3) tags.
+const [manager] = customTagPreset.customManagers!;
+const [tagRe, digestRe] = manager.matchStrings!.map(regExp);
+// The versioningTemplate is a single regex whose `.<minor>.<patch>` part is gated by a Handlebars
+// conditional on whether the captured `version` contains a `.`. Render both branches.
+const versioningTemplate = manager.versioningTemplate!.replace(/^regex:/, '');
+const fullVersioningRe = new RegExp(versioningTemplate.replace(/{{#if.*?}}|{{\/if}}/g, ''));
+const majorVersioningRe = new RegExp(versioningTemplate.replace(/{{#if.*?}}.*?{{\/if}}/g, ''));
+// Mimic Renovate's per-dependency template selection: `.` in the version => full-semver scheme.
+const chooseVersioningRe = (version: string) => (version.includes('.') ? fullVersioningRe : majorVersioningRe);
 // matchCurrentValue is wrapped in slashes to indicate a regex
 const disableRule = customTagPreset.packageRules!.find(r => r.matchCurrentValue)!;
 const disableValueRe = regExp(disableRule.matchCurrentValue!.slice(1, -1));
@@ -26,12 +32,13 @@ const shortPath = 'foo/actions/bar';
 
 describe('customTagActions', () => {
   describe('tag-ref match string', () => {
-    it('supports a plain tag ref', () => {
+    it('supports a plain major-only tag ref', () => {
       const match = tagRe.exec(`uses: ${actionPath}@should-release_v3`);
       expect(match?.groups).toEqual({
         depName: 'microsoft/beachball/actions/should-release',
         packageName: 'microsoft/beachball',
         currentValue: 'should-release_v3',
+        version: '3',
       });
     });
 
@@ -41,6 +48,7 @@ describe('customTagActions', () => {
         depName: 'microsoft/beachball/actions/should-release',
         packageName: 'microsoft/beachball',
         currentValue: 'should-release_v1.2.3',
+        version: '1.2.3',
       });
     });
 
@@ -50,7 +58,18 @@ describe('customTagActions', () => {
         depName: 'foo/actions/bar',
         packageName: 'foo/actions',
         currentValue: 'bar_v3',
+        version: '3',
       });
+    });
+
+    it('supports the YAML list-item step form (- uses:)', () => {
+      const match = tagRe.exec(`    - uses: ${actionPath}@should-release_v3`);
+      expect(match?.groups?.currentValue).toBe('should-release_v3');
+    });
+
+    it.each(['"', "'"])('supports a quoted scalar value (%s)', quote => {
+      const match = tagRe.exec(`    - uses: ${quote}${actionPath}@should-release_v3${quote}`);
+      expect(match?.groups?.currentValue).toBe('should-release_v3');
     });
 
     it('supports tag ref with surrounding content', () => {
@@ -68,13 +87,16 @@ describe('customTagActions', () => {
       expect(match).not.toBeNull();
     });
 
+    it('does not match a major.minor tag ref', () => {
+      expect(tagRe.exec(`uses: ${actionPath}@should-release_v1.2`)).toBeNull();
+    });
+
     it('does not match a digest-pinned ref', () => {
       expect(tagRe.exec(`uses: ${actionPath}@${sha} # should-release_v3`)).toBeNull();
     });
 
     it('does not match a prerelease tag ref', () => {
-      // could maybe be added if needed, but it complicates the regex
-      expect(tagRe.exec(`uses: ${actionPath}@should-release_v3.2.1-beta`)).toBeNull();
+      expect(tagRe.exec(`uses: ${actionPath}@should-release_v3-beta`)).toBeNull();
     });
 
     it('does not match a top-level action tag ref', () => {
@@ -84,52 +106,53 @@ describe('customTagActions', () => {
 
   describe('digest-pinned match string', () => {
     it('supports a major version tag comment', () => {
-      const match = digestRe.exec(`uses: microsoft/beachball/actions/should-release@${sha} # should-release_v3`);
+      const match = digestRe.exec(`uses: ${actionPath}@${sha} # should-release_v3`);
       expect(match?.groups).toEqual({
         depName: 'microsoft/beachball/actions/should-release',
         packageName: 'microsoft/beachball',
         currentDigest: sha,
         currentValue: 'should-release_v3',
+        version: '3',
       });
     });
 
     it('supports a major.minor.patch tag comment', () => {
-      const match = digestRe.exec(`uses: microsoft/beachball/actions/should-release@${sha} # should-release_v1.2.3`);
+      const match = digestRe.exec(`uses: ${actionPath}@${sha} # should-release_v1.2.3`);
       expect(match?.groups).toEqual({
         depName: 'microsoft/beachball/actions/should-release',
         packageName: 'microsoft/beachball',
         currentDigest: sha,
         currentValue: 'should-release_v1.2.3',
+        version: '1.2.3',
       });
     });
 
     it('supports single folder with tag ref', () => {
       const match = digestRe.exec(`uses: foo/actions/bar@${sha} # bar_v3`);
-      expect(match?.groups).toEqual({
-        depName: 'foo/actions/bar',
-        packageName: 'foo/actions',
-        currentDigest: sha,
-        currentValue: 'bar_v3',
-      });
+      expect(match?.groups?.currentValue).toBe('bar_v3');
     });
 
-    it('supports tag ref with surrounding content', () => {
-      const match = digestRe.exec(`stuff\nuses: ${actionPath}@${sha} # should-release_v3\nnext`);
-      expect(match).not.toBeNull();
+    it('supports the YAML list-item step form (- uses:)', () => {
+      const match = digestRe.exec(`    - uses: ${actionPath}@${sha} # should-release_v3`);
+      expect(match?.groups?.currentValue).toBe('should-release_v3');
     });
 
-    it('supports indented tag ref', () => {
+    it.each(['"', "'"])('supports a quoted scalar value (%s), comment outside the quotes', quote => {
+      const match = digestRe.exec(`    - uses: ${quote}${actionPath}@${sha}${quote} # should-release_v3`);
+      expect(match?.groups?.currentValue).toBe('should-release_v3');
+    });
+
+    it('supports indented tag ref with surrounding content', () => {
       const match = digestRe.exec(`stuff\n  uses: ${actionPath}@${sha} # should-release_v3\nnext`);
       expect(match).not.toBeNull();
     });
 
     it('requires the comment on the same line as the ref', () => {
-      // The comment is on the following line, so it must not be matched
-      expect(digestRe.exec(`uses: microsoft/beachball/actions/should-release@${sha}\n# should-release_v3`)).toBeNull();
+      expect(digestRe.exec(`uses: ${actionPath}@${sha}\n# should-release_v3`)).toBeNull();
     });
 
     it('does not match a digest pin without a version comment', () => {
-      expect(digestRe.exec(`uses: microsoft/beachball/actions/should-release@${sha}`)).toBeNull();
+      expect(digestRe.exec(`uses: ${actionPath}@${sha}`)).toBeNull();
     });
 
     it('does not match a top-level action', () => {
@@ -142,33 +165,39 @@ describe('customTagActions', () => {
     });
   });
 
-  describe('versioning template', () => {
-    it('parses a major-only tag', () => {
-      expect(versioningRe.exec('should-release_v3')?.groups).toEqual({
-        compatibility: 'should-release',
-        major: '3',
-      });
+  describe('conditional versioning template', () => {
+    it('selects the major-only scheme for a major-only pin and parses it', () => {
+      const groups = chooseVersioningRe('3').exec('should-release_v3')?.groups;
+      expect(groups).toEqual({ compatibility: 'should-release', major: '3' });
     });
 
-    it('parses a major.minor.patch tag', () => {
-      expect(versioningRe.exec('should-release_v1.2.3')?.groups).toEqual({
-        compatibility: 'should-release',
-        major: '1',
-        minor: '2',
-        patch: '3',
-      });
+    it('selects the full-semver scheme for a full pin and parses it', () => {
+      const groups = chooseVersioningRe('1.2.3').exec('should-release_v1.2.3')?.groups;
+      expect(groups).toEqual({ compatibility: 'should-release', major: '1', minor: '2', patch: '3' });
+    });
+
+    it('is not fooled by a dot in the action name (dotted name, major-only version)', () => {
+      // `version` is only the numeric part, so a dotted action name still uses the major-only scheme
+      expect(chooseVersioningRe('3').exec('foo.bar_v3')?.groups).toEqual({ compatibility: 'foo.bar', major: '3' });
     });
 
     it('uses the action name as the compatibility to keep tag families separate', () => {
-      expect(versioningRe.exec('check-for-modified-files_v3')?.groups?.compatibility).toBe('check-for-modified-files');
+      expect(chooseVersioningRe('3').exec('check-for-modified-files_v3')?.groups?.compatibility).toBe(
+        'check-for-modified-files'
+      );
     });
 
-    it('rejects a value with a non-numeric suffix', () => {
-      expect(versioningRe.test('should-release_v3-beta')).toBe(false);
+    it('major-only scheme rejects a full semver tag (so it is not offered as an upgrade)', () => {
+      expect(majorVersioningRe.exec('should-release_v1.2.3')).toBeNull();
+    });
+
+    it('full-semver scheme rejects a major-only tag', () => {
+      expect(fullVersioningRe.exec('should-release_v3')).toBeNull();
     });
 
     it('rejects a plain version without the name prefix', () => {
-      expect(versioningRe.test('v3')).toBe(false);
+      expect(majorVersioningRe.exec('v3')).toBeNull();
+      expect(fullVersioningRe.exec('v1.2.3')).toBeNull();
     });
   });
 


### PR DESCRIPTION
Initial version wouldn't recognize `- using:...` and was opening duplicate PRs. Fix those issues.