### PR TITLE
Temporarily stop publishing proper-changelog

### DIFF
--- a/change/proper-changelog-c61091c0-154c-4b66-aee1-21ab957c07be.json
+++ b/change/proper-changelog-c61091c0-154c-4b66-aee1-21ab957c07be.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add public visibility modifiers to types of class members (same behavior as before)",
-  "packageName": "proper-changelog",
-  "email": "elcraig@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/proper-changelog-d5b2df66-df95-418d-92e8-6380f24a5fd6.json
+++ b/change/proper-changelog-d5b2df66-df95-418d-92e8-6380f24a5fd6.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Use catalog dependencies",
-  "packageName": "proper-changelog",
-  "email": "elcraig@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/packages/proper-changelog/package.json
+++ b/packages/proper-changelog/package.json
@@ -1,7 +1,8 @@
 {
   "name": "proper-changelog",
   "version": "0.1.1",
-  "description": "Make a readable changelog from GitHub releases",
+  "description": "TODO start publishing again once ownership is fixed - Make a readable changelog from GitHub releases",
+  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
STILL waiting on an ownership request for this package, so it's blocking testing...