### PR TITLE
Replace cosmiconfig with custom config loading logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,10 @@ Run all of: `yarn build`, `yarn test`, `yarn lint`, `yarn format`.
 - `src/monorepo/` — package discovery (workspace-tools), dependency graph, package groups.
 - `src/publish/` — npm publish orchestration, git tagging, dependency-ordered publishing.
 - `src/git/` — git operation wrappers using execa.
-- `src/options/` — CLI arg parsing + config loading (cosmiconfig).
+- `src/options/` — CLI arg parsing + config loading.
 - `src/validation/` — pre-command validation.
 - `src/types/` — TypeScript interfaces (`BeachballOptions` is the central config type).
-- **Option resolution:** CLI args > `beachball.config.js` (cosmiconfig) > defaults. `getOptions()` returns both raw `cliOptions` and merged `options`.
+- **Option resolution:** CLI args > config (usually `beachball.config.js`) > defaults. `getOptions()` returns both raw `cliOptions` and merged `options`.
 
 ## Coding standards
 

--- a/change/beachball-04aeb590-397b-449c-9ab6-c8fe673c6415.json
+++ b/change/beachball-04aeb590-397b-449c-9ab6-c8fe673c6415.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Replace `cosmiconfig` with basic custom config loading logic. Support for YAML config files and searching up from the project/repo root is removed, but the config file can now use any JS/TS extension with the same supported names as before (see config docs).",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -19,7 +19,7 @@ The options below apply to most CLI commands.
 | Option | Alias | Default | Description |
 | ------ | ----- | ------- | ----------- |
 | `--branch, -b` | `-b` | | target branch; see [config docs][1] for details |
-| `--config` | `-c` | [cosmiconfig][2] defaults | custom beachball config path |
+| `--config` | `-c` | see [config docs][2] | custom beachball config path |
 | `--no-fetch` | | | skip fetching from the remote |
 | `--change-dir` | | `'change'` | name of the directory to store change files |
 | `--scope` | | | only consider matching package paths (can be specified multiple times); see [config docs][3] |
@@ -27,5 +27,5 @@ The options below apply to most CLI commands.
 | `--verbose` | | | prints additional information to the console |
 
 [1]: ../overview/configuration#specifying-the-target-branch-and-remote
-[2]: https://www.npmjs.com/package/cosmiconfig
+[2]: ../overview/configuration#repository-config
 [3]: ../overview/configuration#scoping

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -15,14 +15,15 @@ There are two types of configurations:
 
 ## Repository config
 
-`beachball` uses [`cosmiconfig`](https://github.com/davidtheclark/cosmiconfig) to read its configuration, so you can specify configuration in several ways (in addition to CLI arguments).
+Most often, Beachball config is stored in `beachball.config.js`, but Beachball will check all the following locations under the project root directory (usually the repo root):
 
 - `"beachball"` key inside `package.json`
-- `.beachballrc`
-- `.beachballrc.json`
-- `beachball.config.js` (CJS or ESM depending on your project setup; explicit `.cjs` or `.mjs` is also supported)
+- `beachball.config.[cm]?[jt]s`
+- `.beachballrc` (JSON) or `.beachballrc.json`
+- `.beachballrc.[cm]?[jt]s`
+- any of the above (except `package.json`) under a `.config` directory
 
-It's most common to use a JavaScript file for the repo-level config, since it's the most flexible and allows comments. Usually this file is at the repo root.
+> ⚠️ Beachball v3 changed the search order and removed support for YAML files and searching up from the project root to find the config file.
 
 The `beachball.config.js` example below uses JSDoc type annotations to enable intellisense in some editors (these are optional).
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=22.18.0"
+    "node": "^22.18.0 || >=24"
   },
   "workspaces": [
     "actions/*",

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@vercel/detect-agent": "^1.2.1",
     "commander": "catalog:prod",
-    "cosmiconfig": "^9.0.1",
     "execa": "catalog:prod",
     "minimatch": "^3.1.5",
     "p-graph": "workspace:^",

--- a/packages/beachball/src/__e2e__/bump.test.ts
+++ b/packages/beachball/src/__e2e__/bump.test.ts
@@ -34,8 +34,8 @@ describe('bump command', () => {
    * Get options. Defaults to the repository root as cwd.
    * Defaults to `fetch: false` since fetching is rarely relevant for these tests and is slow.
    */
-  function getOptions(repoOptions?: Partial<RepoOptions>, cwd?: string) {
-    const parsedOptions = _getOptions({
+  async function getOptions(repoOptions?: Partial<RepoOptions>, cwd?: string) {
+    const parsedOptions = await _getOptions({
       cwd: cwd || repo?.rootPath || '',
       argv: [],
       env: {},
@@ -77,7 +77,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: false,
       generateChangelog: true,
     });
@@ -121,9 +121,9 @@ describe('bump command', () => {
 
     const projectARoot = repo.pathTo('project-a');
     const projectBRoot = repo.pathTo('project-b');
-    const infoA = getOptions({ bumpDeps: true }, projectARoot);
+    const infoA = await getOptions({ bumpDeps: true }, projectARoot);
     const optionsA = infoA.options;
-    const infoB = getOptions({ bumpDeps: true }, projectBRoot);
+    const infoB = await getOptions({ bumpDeps: true }, projectBRoot);
     const optionsB = infoB.options;
 
     generateChangeFiles([{ packageName: '@project-a/foo' }], optionsA);
@@ -156,7 +156,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: false,
       // Incidentally use this to verify generateChangelog: false is respected
       generateChangelog: false,
@@ -203,7 +203,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
     });
@@ -258,7 +258,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       groups: [{ include: 'packages/grp/*', name: 'grp', disallowedChangeTypes: [] }],
       bumpDeps: true,
       generateChangelog: true,
@@ -304,7 +304,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
       scope: ['!packages/bar'],
@@ -341,7 +341,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
       scope: ['!packages/foo'],
@@ -379,7 +379,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
     });
@@ -423,7 +423,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       prereleasePrefix: 'beta',
     });
@@ -462,7 +462,7 @@ describe('bump command', () => {
     repositoryFactory = new RepositoryFactory({ folders: monorepo });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
     });
@@ -513,7 +513,7 @@ describe('bump command', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: true,
       generateChangelog: true,
     });
@@ -549,7 +549,7 @@ describe('bump command', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       bumpDeps: false,
       hooks: {
         prebump: jest.fn<NonNullable<HooksOptions['prebump']>>(async (packagePath, name, version) => {

--- a/packages/beachball/src/__e2e__/change.test.ts
+++ b/packages/beachball/src/__e2e__/change.test.ts
@@ -81,8 +81,8 @@ describe('change command', () => {
   const logs = initMockLogs();
 
   /** Get options and context (`changedPackages` is not filled) */
-  function getOptionsAndContext(repoOptions?: Partial<RepoOptions>, extraArgv?: string[]) {
-    const parsedOptions = getOptions({
+  async function getOptionsAndContext(repoOptions?: Partial<RepoOptions>, extraArgv?: string[]) {
+    const parsedOptions = await getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'change', ...(extraArgv ?? [])],
       env: {},
@@ -132,7 +132,7 @@ describe('change command', () => {
     repo = singleFactory.cloneRepository();
     checkOutTestBranch(repo);
 
-    const { options, context } = getOptionsAndContext();
+    const { options, context } = await getOptionsAndContext();
     await change(options, context);
 
     expect(getChangeFiles(options)).toHaveLength(0);
@@ -143,7 +143,7 @@ describe('change command', () => {
     checkOutTestBranch(repo);
     repo.commitChange('file.js');
 
-    const { options, context } = getOptionsAndContext({ commit: false });
+    const { options, context } = await getOptionsAndContext({ commit: false });
     const changePromise = change(options, context);
     await waitForPrompt();
 
@@ -175,7 +175,7 @@ describe('change command', () => {
     checkOutTestBranch(repo);
     repo.commitChange('file.js');
 
-    const { options, context } = getOptionsAndContext();
+    const { options, context } = await getOptionsAndContext();
     const changePromise = change(options, context);
 
     expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
@@ -201,7 +201,7 @@ describe('change command', () => {
     repo.commitChange('file.js');
 
     const commitMessage = jest.fn<NonNullable<RepoOptions['commitMessage']>>(() => 'custom change commit message');
-    const { options, context } = getOptionsAndContext({ commitMessage });
+    const { options, context } = await getOptionsAndContext({ commitMessage });
     const changePromise = change(options, context);
 
     expect(logs.mocks.log).toHaveBeenLastCalledWith('Please describe the changes for: foo');
@@ -224,7 +224,7 @@ describe('change command', () => {
     repo.commitChange('file.js');
 
     const testChangedir = 'changeDir';
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       changeDir: testChangedir,
     });
     const changePromise = change(options, context);
@@ -250,7 +250,7 @@ describe('change command', () => {
     repo = singleFactory.cloneRepository();
     checkOutTestBranch(repo);
 
-    const { options, context } = getOptionsAndContext({}, [
+    const { options, context } = await getOptionsAndContext({}, [
       '--package',
       singleFactory.fixture.rootPackage.name,
       '--no-commit',
@@ -274,7 +274,7 @@ describe('change command', () => {
     checkOutTestBranch(repo);
     makeMonorepoChanges(repo);
 
-    const { options, context } = getOptionsAndContext();
+    const { options, context } = await getOptionsAndContext();
     const changePromise = change(options, context);
 
     // use custom values for first package
@@ -314,7 +314,7 @@ describe('change command', () => {
     checkOutTestBranch(repo);
     makeMonorepoChanges(repo);
 
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       groupChanges: true,
     });
     const changePromise = change(options, context);
@@ -359,7 +359,7 @@ describe('change command', () => {
       },
     };
 
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       groupChanges: true,
     });
     const changePromise = change(options, context);

--- a/packages/beachball/src/__e2e__/getChangedPackages.test.ts
+++ b/packages/beachball/src/__e2e__/getChangedPackages.test.ts
@@ -63,10 +63,10 @@ describe('getChangedPackages', () => {
   }
 
   /** Get options/context, clear `gitObserver` mock, and call `getChangedPackages` */
-  function getChangedPackagesWrapper(
+  async function getChangedPackagesWrapper(
     params: { repoOptions?: Partial<RepoOptions>; extraArgv?: string[]; cwd?: string } = {}
   ) {
-    const parsedOptions = getOptions(params);
+    const parsedOptions = await getOptions(params);
     const packageInfos = getPackageInfos(parsedOptions);
     const scopedPackages = getScopedPackages(parsedOptions.options, packageInfos);
     gitObserver.mockClear();
@@ -95,13 +95,13 @@ describe('getChangedPackages', () => {
     clearGitObservers();
   });
 
-  it('returns the given package name(s) as-is', () => {
+  it('returns the given package name(s) as-is', async () => {
     repo = getReusedRepoWithBranch('single');
-    expect(getChangedPackagesWrapper({ extraArgv: ['--package', 'foo'] })).toEqual(['foo']);
+    expect(await getChangedPackagesWrapper({ extraArgv: ['--package', 'foo'] })).toEqual(['foo']);
     expect(gitObserver).not.toHaveBeenCalled();
 
     // Currently it doesn't even check validity
-    const result = getChangedPackagesWrapper({
+    const result = await getChangedPackagesWrapper({
       extraArgv: ['--package', 'foo', '--package', 'bar', '--package', 'nope'],
     });
     expect(result).toEqual(['foo', 'bar', 'nope']);
@@ -109,25 +109,25 @@ describe('getChangedPackages', () => {
   });
 
   // do a full test for each major repo structure
-  it('detects changed files in single-package repo', () => {
+  it('detects changed files in single-package repo', async () => {
     repo = getReusedRepoWithBranch('single');
     repo.commitChange('myFilename');
-    expect(getChangedPackagesWrapper()).toEqual(['foo']);
+    expect(await getChangedPackagesWrapper()).toEqual(['foo']);
     expect(gitObserver).toHaveBeenCalled();
   });
 
-  it('detects changed files in monorepo', () => {
+  it('detects changed files in monorepo', async () => {
     repo = getReusedRepoWithBranch('monorepo');
 
     // empty if no changes yet
-    expect(getChangedPackagesWrapper()).toEqual([]);
+    expect(await getChangedPackagesWrapper()).toEqual([]);
 
     repo.writeFile('packages/foo/test.js');
     repo.writeFile('packages/bar/test.js');
     repo.commitAll();
 
     logs.clear();
-    const result = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    const result = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(result.sort()).toEqual(['bar', 'foo']);
     expect(gitObserver).toHaveBeenCalled();
 
@@ -140,7 +140,7 @@ describe('getChangedPackages', () => {
       `);
   });
 
-  it('detects changed files in multi-project monorepo', () => {
+  it('detects changed files in multi-project monorepo', async () => {
     // this is the only multi-project test
     const multiFactory = new RepositoryFactory('multi-project');
     extraFactories.push(multiFactory);
@@ -152,8 +152,8 @@ describe('getChangedPackages', () => {
 
     repo.stageChange('project-a/packages/foo/test.js');
 
-    const changedPackagesA = getChangedPackagesWrapper({ cwd: projectARoot });
-    const changedPackagesB = getChangedPackagesWrapper({ cwd: projectBRoot });
+    const changedPackagesA = await getChangedPackagesWrapper({ cwd: projectARoot });
+    const changedPackagesB = await getChangedPackagesWrapper({ cwd: projectBRoot });
 
     expect(changedPackagesA).toEqual(['@project-a/foo']);
     expect(changedPackagesB).toEqual([]);
@@ -161,7 +161,7 @@ describe('getChangedPackages', () => {
 
   // Do one real combined test with ignores to ensure all the path handling works
   // (the logic is mostly covered by getAllChangedPackages tests)
-  it('ignores CHANGELOG, change files, and ignorePatterns in single-package repo', () => {
+  it('ignores CHANGELOG, change files, and ignorePatterns in single-package repo', async () => {
     repo = getReusedRepoWithBranch('single');
 
     repo.writeFile('change/change-abc123.json', {});
@@ -172,7 +172,7 @@ describe('getChangedPackages', () => {
     repo.writeFile('yarn.lock');
     repo.commitAll();
 
-    const result = getChangedPackagesWrapper({
+    const result = await getChangedPackagesWrapper({
       repoOptions: { ignorePatterns: ['*.test.js', 'tests/**', 'yarn.lock'] },
       extraArgv: ['--verbose'],
     });
@@ -191,7 +191,7 @@ describe('getChangedPackages', () => {
     `);
   });
 
-  it('includes staged files', () => {
+  it('includes staged files', async () => {
     // need a separate repo since it stages changes
     repo = singleFactory.cloneRepository();
     repo.checkout('-b', 'test-staged');
@@ -202,23 +202,23 @@ describe('getChangedPackages', () => {
     repo.writeFile('src/foo.js');
     repo.git(['add', '-A']);
 
-    const result = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    const result = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(result).toEqual(['foo']);
     // src/foo.js is both committed and staged, but should be listed only once
     expect(logs.getMockLines('all')).toContain('Found 2 changed files in current branch (before filtering)');
   });
 
-  it('excludes packages that already have change files', () => {
+  it('excludes packages that already have change files', async () => {
     repo = getReusedRepoWithBranch('monorepo');
 
     // setup: change foo, create a change file, commit
     repo.checkout('-b', 'test');
     repo.commitChange('packages/foo/test.js');
-    generateChangeFiles(['foo'], { ...getOptions().options, commit: true });
+    generateChangeFiles(['foo'], { ...(await getOptions()).options, commit: true });
     logs.clear();
 
     // foo is not included in changed packages
-    let changedPackages = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    let changedPackages = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     const logLines = logs.getMockLines('all', { sanitize: true });
     expect(logLines).toMatch(/Your local repository already has change files for these packages:\s+• foo/);
     expect(logLines).toMatchInlineSnapshot(`
@@ -236,7 +236,7 @@ describe('getChangedPackages', () => {
     // change bar => bar is the only changed package returned
     // (with the reused repo, it must commit the change)
     repo.commitChange('packages/bar/test.js');
-    changedPackages = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    changedPackages = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(logs.getMockLines('all', { sanitize: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
       [log] Found 3 changed files in current branch (before filtering)
@@ -250,28 +250,28 @@ describe('getChangedPackages', () => {
     expect(changedPackages).toEqual(['bar']);
   });
 
-  it('returns all packages with all: true, removing those with change files', () => {
+  it('returns all packages with all: true, removing those with change files', async () => {
     repo = getReusedRepoWithBranch('monorepo');
-    generateChangeFiles(['foo', 'a'], { ...getOptions().options, commit: true });
+    generateChangeFiles(['foo', 'a'], { ...(await getOptions()).options, commit: true });
 
-    const result = getChangedPackagesWrapper({ extraArgv: ['--all'] });
+    const result = await getChangedPackagesWrapper({ extraArgv: ['--all'] });
     expect(result.sort()).toEqual(['b', 'bar', 'baz']);
     expect(gitObserver).toHaveBeenCalled();
   });
 
-  it('throws if the remote is invalid', () => {
+  it('throws if the remote is invalid', async () => {
     repo = getReusedRepoWithBranch('monorepo');
     const customRemote = 'foo';
     repo.git(['remote', 'add', customRemote, 'file:///__nonexistent']);
     repo.commitChange('fake.js');
 
-    expect(() => {
-      getChangedPackagesWrapper({ repoOptions: { fetch: true, branch: `${customRemote}/${defaultBranchName}` } });
-    }).toThrow(`Fetching branch "${defaultBranchName}" from remote "${customRemote}" failed`);
+    await expect(
+      getChangedPackagesWrapper({ repoOptions: { fetch: true, branch: `${customRemote}/${defaultBranchName}` } })
+    ).rejects.toThrow(`Fetching branch "${defaultBranchName}" from remote "${customRemote}" failed`);
     expect(gitObserver).toHaveBeenCalled();
   });
 
-  it('excludes packages with staged (not committed) change files', () => {
+  it('excludes packages with staged (not committed) change files', async () => {
     // this can't use the reused repo because it needs to stage changes
     repo = monorepoFactory.cloneRepository();
 
@@ -279,18 +279,18 @@ describe('getChangedPackages', () => {
     repo.checkout('-b', 'test-staged');
     repo.commitChange('packages/foo/test.js');
     // generate change files but only stage them (don't commit)
-    generateChangeFiles(['foo'], { ...getOptions().options, commit: false });
+    generateChangeFiles(['foo'], { ...(await getOptions()).options, commit: false });
     logs.clear();
 
     // foo is not included in changed packages because its staged change file is found
-    const changedPackages = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    const changedPackages = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(logs.getMockLines('all')).toMatch(
       /Your local repository already has change files for these packages:\s+• foo/
     );
     expect(changedPackages).toEqual([]);
   });
 
-  it('ignores change files that exist in target remote branch', () => {
+  it('ignores change files that exist in target remote branch', async () => {
     // This needs a separate factory since it pushes changes
     const repositoryFactory = new RepositoryFactory('single');
     extraFactories.push(repositoryFactory);
@@ -298,7 +298,7 @@ describe('getChangedPackages', () => {
 
     // create and push a change file in master
     const packageName = getWsPackageInfo(repo.rootPath)!.name;
-    generateChangeFiles([packageName], { ...getOptions().options, commit: true });
+    generateChangeFiles([packageName], { ...(await getOptions()).options, commit: true });
     repo.push();
 
     // create a new branch and stage changes to an existing file
@@ -306,7 +306,7 @@ describe('getChangedPackages', () => {
     repo.stageChange('yarn.lock', 'hi'); // this should already exist
     logs.clear();
 
-    const changedPackages = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    const changedPackages = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(changedPackages).toEqual(['foo']);
     expect(logs.getMockLines('all', { sanitize: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"
@@ -316,7 +316,7 @@ describe('getChangedPackages', () => {
     `);
   });
 
-  it('includes catalog changes in the list of changed packages', () => {
+  it('includes catalog changes in the list of changed packages', async () => {
     // This needs a separate factory since it pushes changes
     const repositoryFactory = new RepositoryFactory('monorepo');
     extraFactories.push(repositoryFactory);
@@ -339,7 +339,7 @@ describe('getChangedPackages', () => {
     repo.writeFile('packages/grouped/a/foo.ts', '');
     repo.commitAll();
 
-    const result = getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
+    const result = await getChangedPackagesWrapper({ extraArgv: ['--verbose'] });
     expect(result.sort()).toEqual(['a', 'bar', 'foo']);
     expect(logs.getMockLines('all', { sanitize: true })).toMatchInlineSnapshot(`
       "[log] Checking for changes against "origin/master"

--- a/packages/beachball/src/__e2e__/publishE2E.test.ts
+++ b/packages/beachball/src/__e2e__/publishE2E.test.ts
@@ -39,8 +39,8 @@ describe('publish command (e2e)', () => {
   // show error logs for these tests
   initMockLogs({ alsoLog: ['error'] });
 
-  function getOptions(repoOptions?: Partial<RepoOptions>, extraArgv?: string[]) {
-    const parsedOptions = _getOptions({
+  async function getOptions(repoOptions?: Partial<RepoOptions>, extraArgv?: string[]) {
+    const parsedOptions = await _getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'publish', '--yes', ...(extraArgv || [])],
       env: {},
@@ -84,7 +84,7 @@ describe('publish command (e2e)', () => {
 
     // Using fetch: false in tests where it's irrelevant should be a bit faster.
     // Use a git observer to verify that no fetch occurs.
-    const { options, parsedOptions } = getOptions({ fetch: false });
+    const { options, parsedOptions } = await getOptions({ fetch: false });
 
     generateChangeFiles(['foo'], options);
     repo.push();
@@ -115,7 +115,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       push: false,
     });
 
@@ -136,7 +136,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
 
     generateChangeFiles(['foo'], options);
     repo.push();
@@ -181,7 +181,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
 
     generateChangeFiles(['foo'], options);
     repo.push();
@@ -228,7 +228,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ bump: false, fetch: false });
+    const { options, parsedOptions } = await getOptions({ bump: false, fetch: false });
 
     generateChangeFiles(['foo'], options);
     repo.push();
@@ -252,7 +252,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ fetch: false });
+    const { options, parsedOptions } = await getOptions({ fetch: false });
 
     // bump baz => dependent bump bar => dependent bump foo
     generateChangeFiles(['baz'], options);
@@ -296,7 +296,7 @@ describe('publish command (e2e)', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ fetch: false });
+    const { options, parsedOptions } = await getOptions({ fetch: false });
 
     generateChangeFiles(['foo', 'bar'], options);
     repo.push();
@@ -323,7 +323,7 @@ describe('publish command (e2e)', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       scope: ['!packages/foo'],
       fetch: false,
     });
@@ -374,7 +374,7 @@ describe('publish command (e2e)', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ bumpDeps: true, fetch: false });
+    const { options, parsedOptions } = await getOptions({ bumpDeps: true, fetch: false });
     generateChangeFiles([{ packageName: 'pkg-1', type: 'minor' }], options);
     repo.push();
 
@@ -439,7 +439,7 @@ describe('publish command (e2e)', () => {
 
     let notified: string | undefined;
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       fetch: false,
       hooks: {
         prepublish: (packagePath, name, version) => {

--- a/packages/beachball/src/__e2e__/publishGit.test.ts
+++ b/packages/beachball/src/__e2e__/publishGit.test.ts
@@ -23,9 +23,9 @@ describe('publish command (git)', () => {
 
   initMockLogs();
 
-  function getOptions(repoOptions?: Partial<RepoOptions>) {
+  async function getOptions(repoOptions?: Partial<RepoOptions>) {
     const cwd = repoOptions?.path || repo!.rootPath;
-    const parsedOptions = _getOptions({
+    const parsedOptions = await _getOptions({
       cwd,
       argv: ['node', 'beachball', 'publish', '--yes'],
       env: {},
@@ -53,7 +53,7 @@ describe('publish command (git)', () => {
     repositoryFactory = new RepositoryFactory('single');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     repo.push();
 
@@ -70,7 +70,7 @@ describe('publish command (git)', () => {
     repositoryFactory = new RepositoryFactory('single');
     // 1. clone a new repo1, write a change file in repo1
     const repo1 = repositoryFactory.cloneRepository();
-    const { options: options1, parsedOptions: parsedOptions1 } = getOptions({ path: repo1.rootPath });
+    const { options: options1, parsedOptions: parsedOptions1 } = await getOptions({ path: repo1.rootPath });
     generateChangeFiles(['foo'], options1);
     repo1.push();
 
@@ -100,7 +100,7 @@ describe('publish command (git)', () => {
     repositoryFactory = new RepositoryFactory('monorepo');
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({
+    const { options, parsedOptions } = await getOptions({
       fetch: false,
       hooks: {
         precommit: jest.fn(async (cwd: string) => {

--- a/packages/beachball/src/__e2e__/publishNpm.test.ts
+++ b/packages/beachball/src/__e2e__/publishNpm.test.ts
@@ -38,8 +38,8 @@ describe('publish command (npm)', () => {
   /**
    * Get options with defaults including skipping git stuff
    */
-  function getOptions(repoOptions?: Partial<RepoOptions>) {
-    const parsedOptions = _getOptions({
+  async function getOptions(repoOptions?: Partial<RepoOptions>) {
+    const parsedOptions = await _getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'publish', '--yes'],
       env: {},
@@ -87,7 +87,7 @@ describe('publish command (npm)', () => {
     repo = repositoryFactory.cloneRepository();
     packToPath = tmpdir({ prefix: 'beachball-pack-' });
 
-    const { options, parsedOptions } = getOptions({ packToPath });
+    const { options, parsedOptions } = await getOptions({ packToPath });
     generateChangeFiles(['foo'], options);
     await publishWrapper(parsedOptions);
 
@@ -108,7 +108,7 @@ describe('publish command (npm)', () => {
     });
     repo = repositoryFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foopkg'], options);
 
     // If there's only the private package with a change file, nothing happens
@@ -190,7 +190,7 @@ describe('publish command (npm)', () => {
     npmMock.publishPackage(repositoryFactory.fixture.folders.packages.bar);
     npmMock.publishPackage(repositoryFactory.fixture.folders.packages.baz);
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo', 'bar'], options);
 
     await publishWrapper(parsedOptions);
@@ -208,7 +208,7 @@ describe('publish command (npm)', () => {
 
     repo.updateJsonFile('packages/bar/package.json', { private: true });
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['bar', 'fake'], options);
 
     // initial validate() isn't relevant here

--- a/packages/beachball/src/__e2e__/syncE2E.test.ts
+++ b/packages/beachball/src/__e2e__/syncE2E.test.ts
@@ -35,8 +35,8 @@ describe('sync command (e2e)', () => {
     npmReadConcurrency: 2,
   };
 
-  function getOptionsAndContext(repoOptions?: Partial<RepoOptions>, extraArgv: string[] = []) {
-    const parsedOptions = getOptions({
+  async function getOptionsAndContext(repoOptions?: Partial<RepoOptions>, extraArgv: string[] = []) {
+    const parsedOptions = await getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'sync', ...extraArgv],
       env: {},
@@ -91,7 +91,7 @@ describe('sync command (e2e)', () => {
     mockNpm.publishPackage({ name: 'barpkg', version: '3.0.0' });
 
     // sync repo to published versions
-    const { options, parsedOptions, context } = getOptionsAndContext();
+    const { options, parsedOptions, context } = await getOptionsAndContext();
     await sync(options, context);
 
     const packageInfosAfterSync = getPackageInfos(parsedOptions);
@@ -121,7 +121,7 @@ describe('sync command (e2e)', () => {
     mockNpm.publishPackage({ name: 'apkg', version: '2.0.0' }, 'beta');
     mockNpm.publishPackage({ name: 'bpkg', version: '3.0.0' });
 
-    const { options, parsedOptions, context } = getOptionsAndContext({
+    const { options, parsedOptions, context } = await getOptionsAndContext({
       tag: 'beta',
     });
     await sync(options, context);
@@ -154,7 +154,7 @@ describe('sync command (e2e)', () => {
     mockNpm.publishPackage({ name: 'epkg', version: '1.0.0-1' }, 'prerelease');
     mockNpm.publishPackage({ name: 'fpkg', version: '3.0.0' });
 
-    const { options, parsedOptions, context } = getOptionsAndContext({}, ['--tag', 'prerelease', '--force']);
+    const { options, parsedOptions, context } = await getOptionsAndContext({}, ['--tag', 'prerelease', '--force']);
     await sync(options, context);
 
     const packageInfosAfterSync = getPackageInfos(parsedOptions);

--- a/packages/beachball/src/__e2e__/validate.test.ts
+++ b/packages/beachball/src/__e2e__/validate.test.ts
@@ -13,8 +13,8 @@ describe('validate', () => {
   let repo: Repository | undefined;
   const logs = initMockLogs();
 
-  function validateWrapper(validateOptions?: ValidateOptions) {
-    const parsedOptions = getOptions({
+  async function validateWrapper(validateOptions?: ValidateOptions) {
+    const parsedOptions = await getOptions({
       cwd: repo!.rootPath,
       argv: [],
       env: {},
@@ -38,32 +38,32 @@ describe('validate', () => {
     repositoryFactory.cleanUp();
   });
 
-  it('succeeds with no changes', () => {
+  it('succeeds with no changes', async () => {
     repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
 
-    const result = validateWrapper({ checkChangeNeeded: true });
+    const result = await validateWrapper({ checkChangeNeeded: true });
 
     expect(result.isChangeNeeded).toBe(false);
     expect(logs.mocks.error).not.toHaveBeenCalled();
     // the success log for the "check" command is done in the main cli file, not validate()
   });
 
-  it('exits with error by default if change files are needed', () => {
+  it('exits with error by default if change files are needed', async () => {
     repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
     repo.stageChange('packages/foo/test.js');
 
-    expect(() => validateWrapper({ checkChangeNeeded: true })).toThrow(BeachballError);
+    await expect(validateWrapper({ checkChangeNeeded: true })).rejects.toThrow(BeachballError);
     expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files are needed!');
   });
 
-  it('returns and does not log an error if change files are needed and allowMissingChangeFiles is true', () => {
+  it('returns and does not log an error if change files are needed and allowMissingChangeFiles is true', async () => {
     repo = repositoryFactory.cloneRepository();
     repo.checkout('-b', 'test');
     repo.stageChange('packages/foo/test.js');
 
-    const result = validateWrapper({ checkChangeNeeded: true, allowMissingChangeFiles: true });
+    const result = await validateWrapper({ checkChangeNeeded: true, allowMissingChangeFiles: true });
     expect(result.isChangeNeeded).toBe(true);
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
@@ -71,12 +71,12 @@ describe('validate', () => {
   // A shouldPublish: false package depending on a private (or shouldPublish: false) package must
   // not be treated as a "published package" during dependency validation. Otherwise `check`
   // produces a false-positive error, since the dependent itself won't be published.
-  it('does not report dependency errors for shouldPublish:false package depending on private package', () => {
+  it('does not report dependency errors for shouldPublish:false package depending on private package', async () => {
     repo = repositoryFactory.cloneRepository();
     repo.updateJsonFile('packages/foo/package.json', { beachball: { shouldPublish: false } });
     repo.updateJsonFile('packages/bar/package.json', { private: true });
 
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       cwd: repo.rootPath,
       argv: [],
       env: {},

--- a/packages/beachball/src/__functional__/changefile/getCatalogChangedPackages.test.ts
+++ b/packages/beachball/src/__functional__/changefile/getCatalogChangedPackages.test.ts
@@ -232,8 +232,8 @@ describe('getCatalogChangedPackages', () => {
   /**
    * Get changed files (only committed) and options, and call `getCatalogChangedPackages`.
    */
-  function getCatalogChangedPackagesWrapper() {
-    const parsedOptions = getOptions({
+  async function getCatalogChangedPackagesWrapper() {
+    const parsedOptions = await getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'change'],
       env: {},
@@ -281,16 +281,16 @@ describe('getCatalogChangedPackages', () => {
     catalogFactory.cleanUp();
   });
 
-  it('returns empty when the catalog file is unchanged', () => {
+  it('returns empty when the catalog file is unchanged', async () => {
     repo = getReusedRepoWithBranch();
     repo.commitChange('packages/alpha/src/x.ts');
 
-    expect(getCatalogChangedPackagesWrapper()).toEqual([]);
+    expect(await getCatalogChangedPackagesWrapper()).toEqual([]);
     // skipped the git step since there were no changes to the catalog file
     expect(mockWorkspaceTools.getFileFromRef).not.toHaveBeenCalled();
   });
 
-  it('returns packages referencing a changed default catalog entry', () => {
+  it('returns packages referencing a changed default catalog entry', async () => {
     repo = getReusedRepoWithBranch();
     const updated: Catalogs = {
       default: { foo: '^1.5.0', baz: '^1.0.0' },
@@ -298,7 +298,7 @@ describe('getCatalogChangedPackages', () => {
     };
     repo.commitChange('.yarnrc.yml', catalogsToYaml(updated));
 
-    expect(getCatalogChangedPackagesWrapper()).toEqual(['alpha']);
+    expect(await getCatalogChangedPackagesWrapper()).toEqual(['alpha']);
     expect(mockWorkspaceTools.getFileFromRef).toHaveBeenCalled();
   });
 });

--- a/packages/beachball/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/packages/beachball/src/__functional__/changefile/readChangeFiles.test.ts
@@ -36,10 +36,10 @@ describe('readChangeFiles', () => {
 
   const logs = initMockLogs();
 
-  function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>) {
+  async function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>) {
     const cwd = repoOptions?.path || tempRoot;
     expect(cwd).toBeTruthy();
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       cwd: cwd!,
       argv: [],
       env: {},
@@ -70,7 +70,7 @@ describe('readChangeFiles', () => {
   it('reads change files and returns in reverse chronological order', async () => {
     // this test doesn't need git
     tempRoot = createTestFileStructureType('monorepo');
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages();
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages();
 
     generateChangeFiles(['bar'], options);
     // Wait slightly to ensure the mtime is different for sorting
@@ -108,9 +108,9 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('reads from a custom changeDir', () => {
+  it('reads from a custom changeDir', async () => {
     tempRoot = createTestFileStructureType('monorepo');
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({ changeDir: 'changeDir' });
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({ changeDir: 'changeDir' });
     generateChangeFiles(['foo'], options);
     expect(getChangeFiles(options)).toHaveLength(1);
 
@@ -119,9 +119,9 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('reads a grouped change file', () => {
+  it('reads a grouped change file', async () => {
     tempRoot = createTestFileStructureType('monorepo');
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({ groupChanges: true });
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({ groupChanges: true });
 
     generateChangeFiles(['foo', 'bar'], options);
     expect(getChangeFiles(options)).toHaveLength(1);
@@ -131,11 +131,11 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('excludes invalid change files', () => {
+  it('excludes invalid change files', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     updateJsonFile('packages/bar/package.json', { private: true });
 
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages();
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages();
 
     // fake doesn't exist, bar is private, foo is okay
     generateChangeFiles(['fake', 'bar', 'foo'], options);
@@ -153,11 +153,11 @@ describe('readChangeFiles', () => {
     `);
   });
 
-  it('excludes invalid changes from grouped change file in monorepo', () => {
+  it('excludes invalid changes from grouped change file in monorepo', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     updateJsonFile('packages/bar/package.json', { private: true });
 
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({ groupChanges: true });
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({ groupChanges: true });
 
     // fake doesn't exist, bar is private, foo is okay
     generateChangeFiles(['fake', 'bar', 'foo'], options);
@@ -172,9 +172,9 @@ describe('readChangeFiles', () => {
     `);
   });
 
-  it('excludes out of scope change files in monorepo', () => {
+  it('excludes out of scope change files in monorepo', async () => {
     tempRoot = createTestFileStructureType('monorepo');
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({ scope: ['packages/foo'] });
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({ scope: ['packages/foo'] });
 
     generateChangeFiles(['bar', 'foo'], options);
     expect(getChangeFiles(options)).toHaveLength(2);
@@ -184,9 +184,9 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('excludes out of scope changes from grouped change file in monorepo', () => {
+  it('excludes out of scope changes from grouped change file in monorepo', async () => {
     tempRoot = createTestFileStructureType('monorepo');
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({
       scope: ['packages/foo'],
       groupChanges: true,
     });
@@ -199,11 +199,11 @@ describe('readChangeFiles', () => {
     expect(logs.mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('runs transform.changeFiles functions if provided', () => {
+  it('runs transform.changeFiles functions if provided', async () => {
     const editedComment = 'Edited comment for testing';
     tempRoot = createTestFileStructureType('monorepo');
 
-    const { options, packageInfos, scopedPackages } = getOptionsAndPackages({
+    const { options, packageInfos, scopedPackages } = await getOptionsAndPackages({
       transform: {
         changeFiles: (changeFile, changeFilePath, { command }) => {
           // For test, we will be changing the comment based on the package name
@@ -275,8 +275,8 @@ describe('readChangeFiles', () => {
       mockStage.mockReset();
     });
 
-    it('filters change files to only those modified since fromRef', () => {
-      const { options: initialOptions } = getRepoOptionsAndPackages({ commit: true });
+    it('filters change files to only those modified since fromRef', async () => {
+      const { options: initialOptions } = await getRepoOptionsAndPackages({ commit: true });
 
       // Create an initial change file and commit it
       repo.commitChange('file1');
@@ -293,15 +293,15 @@ describe('readChangeFiles', () => {
         options: optionsFromRef,
         packageInfos,
         scopedPackages,
-      } = getRepoOptionsAndPackages({ fromRef: firstCommit });
+      } = await getRepoOptionsAndPackages({ fromRef: firstCommit });
 
       const changeSet = readChangeFiles(optionsFromRef, packageInfos, scopedPackages);
       expect(getPackages(changeSet)).toEqual(['bar', 'baz']);
       expect(logs.mocks.warn).not.toHaveBeenCalled();
     });
 
-    it('returns empty set when no change files exist since fromRef', () => {
-      const { options: initialOptions } = getRepoOptionsAndPackages({ commit: true });
+    it('returns empty set when no change files exist since fromRef', async () => {
+      const { options: initialOptions } = await getRepoOptionsAndPackages({ commit: true });
 
       // Create change files and commit them
       repo.commitChange('file1');
@@ -312,15 +312,15 @@ describe('readChangeFiles', () => {
       repo.commitChange('file2');
 
       // Read change files from after the change file commit
-      const { options, packageInfos, scopedPackages } = getRepoOptionsAndPackages({ fromRef: changeCommit });
+      const { options, packageInfos, scopedPackages } = await getRepoOptionsAndPackages({ fromRef: changeCommit });
 
       const changeSet = readChangeFiles(options, packageInfos, scopedPackages);
       expect(getPackages(changeSet)).toEqual([]);
       expect(logs.mocks.warn).not.toHaveBeenCalled();
     });
 
-    it('excludes deleted change files when using fromRef', () => {
-      const { options: initialOptions } = getRepoOptionsAndPackages({ commit: true });
+    it('excludes deleted change files when using fromRef', async () => {
+      const { options: initialOptions } = await getRepoOptionsAndPackages({ commit: true });
 
       // Create two change files
       repo.commitChange('file1');
@@ -339,7 +339,7 @@ describe('readChangeFiles', () => {
       generateChangeFiles(['baz'], initialOptions);
 
       // Read change files with fromRef - should only include foo (bar was deleted)
-      const { options, packageInfos, scopedPackages } = getRepoOptionsAndPackages({ fromRef: firstCommit });
+      const { options, packageInfos, scopedPackages } = await getRepoOptionsAndPackages({ fromRef: firstCommit });
 
       const changeSet = readChangeFiles(options, packageInfos, scopedPackages);
       expect(getPackages(changeSet)).toEqual(['baz']);

--- a/packages/beachball/src/__functional__/changelog/writeChangelog.test.ts
+++ b/packages/beachball/src/__functional__/changelog/writeChangelog.test.ts
@@ -38,8 +38,8 @@ describe('writeChangelog', () => {
   /**
    * Note: `generateChangelog` defaults to `true` here
    */
-  function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>, cwd?: string) {
-    const parsedOptions = getOptions({
+  async function getOptionsAndPackages(repoOptions?: Partial<RepoOptions>, cwd?: string) {
+    const parsedOptions = await getOptions({
       cwd: cwd || repo?.rootPath || '',
       argv: [],
       env: {},
@@ -121,7 +121,7 @@ describe('writeChangelog', () => {
 
   it('does not write changelogs if there are no changes', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     await writeChangelogWrapper({ options, packageInfos });
 
@@ -131,7 +131,7 @@ describe('writeChangelog', () => {
 
   it('generates basic changelog', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     generateChangeFiles([getChange('foo', 'old minor comment')], options);
     generateChangeFiles([getChange('foo', 'patch comment', 'patch')], options);
@@ -178,7 +178,7 @@ describe('writeChangelog', () => {
   it('generates changelog with custom changeDir', async () => {
     repo = sharedSingleRepo;
     const changeDir = 'myChangeDir';
-    const { options, packageInfos } = getOptionsAndPackages({ changeDir });
+    const { options, packageInfos } = await getOptionsAndPackages({ changeDir });
 
     generateChangeFiles([{ packageName: 'foo', comment: 'comment 1' }], options);
     // make sure the setup worked as expected
@@ -192,7 +192,7 @@ describe('writeChangelog', () => {
 
   it('generates changelogs with dependent changes in monorepo', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     generateChangeFiles([{ packageName: 'foo', comment: 'foo comment' }], options);
     generateChangeFiles([{ packageName: 'baz', comment: 'baz comment' }], options);
@@ -262,7 +262,7 @@ describe('writeChangelog', () => {
 
   it('generates changelog in monorepo with grouped change files (groupChanges)', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({ groupChanges: true });
+    const { options, packageInfos } = await getOptionsAndPackages({ groupChanges: true });
 
     // these will be in one change file
     generateChangeFiles([getChange('foo', 'comment 2'), getChange('bar', 'bar comment')], options);
@@ -299,7 +299,7 @@ describe('writeChangelog', () => {
 
   it('generates grouped changelog in monorepo', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({
+    const { options, packageInfos } = await getOptionsAndPackages({
       changelog: {
         groups: [
           {
@@ -371,7 +371,7 @@ describe('writeChangelog', () => {
 
   it('generates grouped changelog when path overlaps with regular changelog', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({
+    const { options, packageInfos } = await getOptionsAndPackages({
       changelog: {
         groups: [
           {
@@ -399,7 +399,7 @@ describe('writeChangelog', () => {
 
   it('does not write grouped changelog if group would only have dependent bumps', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({
+    const { options, packageInfos } = await getOptionsAndPackages({
       changelog: {
         groups: [{ mainPackageName: 'foo', changelogPath: '.', include: ['packages/foo', 'packages/baz'] }],
       },
@@ -419,7 +419,7 @@ describe('writeChangelog', () => {
 
   it('does not write grouped changelog overlapping regular changelog if it would contain only dependent bumps', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({
+    const { options, packageInfos } = await getOptionsAndPackages({
       changelog: {
         groups: [
           // The grouped changelog overlaps with the changelog for packages/foo.
@@ -440,7 +440,7 @@ describe('writeChangelog', () => {
 
   it('includes pre* changes', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     generateChangeFiles(
       [
@@ -463,7 +463,7 @@ describe('writeChangelog', () => {
 
   it('includes pre* changes', async () => {
     repo = repositoryFactory.cloneRepository();
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     generateChangeFiles(
       [
@@ -484,7 +484,7 @@ describe('writeChangelog', () => {
 
   it('writes only CHANGELOG.md if generateChangelog is "md"', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages({ generateChangelog: 'md' });
+    const { options, packageInfos } = await getOptionsAndPackages({ generateChangelog: 'md' });
 
     generateChangeFiles(['foo'], options);
 
@@ -499,7 +499,7 @@ describe('writeChangelog', () => {
 
   it('writes only CHANGELOG.json if generateChangelog is "json"', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages({ generateChangelog: 'json' });
+    const { options, packageInfos } = await getOptionsAndPackages({ generateChangelog: 'json' });
 
     generateChangeFiles(['foo'], options);
 
@@ -516,7 +516,7 @@ describe('writeChangelog', () => {
 
   it('omits tag from grouped CHANGELOG.json when gitTags is disabled', async () => {
     repo = sharedMonoRepo;
-    const { options, packageInfos } = getOptionsAndPackages({
+    const { options, packageInfos } = await getOptionsAndPackages({
       generateChangelog: 'json',
       gitTags: false,
       changelog: {
@@ -539,7 +539,7 @@ describe('writeChangelog', () => {
     // Most of the previous content tests are handled by renderChangelog, but writeChangelog is
     // responsible for reading that content and passing it in.
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     // Write some changes and generate changelogs
     generateChangeFiles(['foo'], options);
@@ -570,7 +570,7 @@ describe('writeChangelog', () => {
 
   it('appends to existing changelog when migrating from uniqueFilenames=false to true', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages();
+    const { options, packageInfos } = await getOptionsAndPackages();
 
     // Write some changes and generate changelogs
     generateChangeFiles(['foo'], options);
@@ -608,7 +608,7 @@ describe('writeChangelog', () => {
 
   it('trims previous changelog entries over maxVersions', async () => {
     repo = sharedSingleRepo;
-    const { options, packageInfos } = getOptionsAndPackages({ changelog: { maxVersions: 2 } });
+    const { options, packageInfos } = await getOptionsAndPackages({ changelog: { maxVersions: 2 } });
 
     // Bump and write three times
     for (let i = 1; i <= 3; i++) {

--- a/packages/beachball/src/__functional__/commands/migrate.test.ts
+++ b/packages/beachball/src/__functional__/commands/migrate.test.ts
@@ -29,7 +29,7 @@ describe('migrate command', () => {
     tempRoot = '';
   });
 
-  it('logs a success message when no config updates are needed', () => {
+  it('logs a success message when no config updates are needed', async () => {
     tempRoot = createTestFileStructureType('monorepo', {
       groups: [{ name: 'test', include: 'packages/test', exclude: ['packages/foo'], disallowedChangeTypes: null }],
       changelog: {
@@ -46,32 +46,34 @@ describe('migrate command', () => {
     // a changelog md file is okay
     fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.md'), '');
 
-    migrate(getOptions());
+    migrate(await getOptions());
     expect(logs.getMockLines('log')).toEqual('No config updates are needed for v3.');
   });
 
-  it('errors on "new" option', () => {
+  it('errors on "new" option', async () => {
     tempRoot = createTestFileStructureType('single');
-    expect(() => migrate(getOptions({ new: true } as unknown as RepoOptions))).toThrow(BeachballError);
+    const options = await getOptions({ new: true } as unknown as RepoOptions);
+    expect(() => migrate(options)).toThrow(BeachballError);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[error] The following updates are needed for v3:
       [error]   • The \`new\` option has been removed. Please remove it from your config."
     `);
   });
 
-  it('errors on "packStyle" option', () => {
+  it('errors on "packStyle" option', async () => {
     tempRoot = createTestFileStructureType('single');
-    expect(() => migrate(getOptions({ packStyle: 'pack' } as unknown as RepoOptions))).toThrow(BeachballError);
+    const options = await getOptions({ packStyle: 'pack' } as unknown as RepoOptions);
+    expect(() => migrate(options)).toThrow(BeachballError);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`
       "[error] The following updates are needed for v3:
       [error]   • The \`packStyle\` option has been removed (packing always uses the layered style now). Please remove it from your config."
     `);
   });
 
-  it('errors on "hooks.prebump" with more than 3 params', () => {
+  it('errors on "hooks.prebump" with more than 3 params', async () => {
     tempRoot = createTestFileStructureType('single');
     const fn: HooksOptions['postbump'] = (_pth, _name, _version, _pkgInfos) => {};
-    const options = getOptions({
+    const options = await getOptions({
       hooks: { prebump: fn as HooksOptions['prebump'] },
     });
 
@@ -82,12 +84,12 @@ describe('migrate command', () => {
     `);
   });
 
-  it('warns on public packages using shouldPublish option', () => {
+  it('warns on public packages using shouldPublish option', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     updateJsonFile(path.join(tempRoot, 'packages/foo/package.json'), { beachball: { shouldPublish: false } });
     updateJsonFile(path.join(tempRoot, 'packages/baz/package.json'), { beachball: { shouldPublish: false } });
 
-    migrate(getOptions());
+    migrate(await getOptions());
 
     const output = logs.getMockLines('all', { root: tempRoot });
     expect(output).toMatchInlineSnapshot(`
@@ -98,12 +100,13 @@ describe('migrate command', () => {
     `);
   });
 
-  it('errors when CHANGELOG.json files exist and generateChangelog is unset', () => {
+  it('errors when CHANGELOG.json files exist and generateChangelog is unset', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.json'), '{}');
     fs.writeFileSync(path.join(tempRoot, 'packages/baz/CHANGELOG.json'), '{}');
+    const options = await getOptions();
 
-    expect(() => migrate(getOptions())).toThrow(BeachballError);
+    expect(() => migrate(options)).toThrow(BeachballError);
 
     const output = logs.getMockLines('all', { root: tempRoot });
     expect(output).toMatchInlineSnapshot(`
@@ -116,11 +119,11 @@ describe('migrate command', () => {
     `);
   });
 
-  it('errors when groups have CHANGELOG.json files and generateChangelog is unset', () => {
+  it('errors when groups have CHANGELOG.json files and generateChangelog is unset', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     fs.mkdirSync(path.join(tempRoot, 'changelogs'));
     fs.writeFileSync(path.join(tempRoot, 'changelogs/CHANGELOG.json'), '{}');
-    const options = getOptions({
+    const options = await getOptions({
       changelog: { groups: [{ changelogPath: 'changelogs', include: true, mainPackageName: 'foo' }] },
     });
 
@@ -136,16 +139,16 @@ describe('migrate command', () => {
     `);
   });
 
-  it('does not error on CHANGELOG.json files when generateChangelog is explicitly set', () => {
+  it('does not error on CHANGELOG.json files when generateChangelog is explicitly set', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     fs.writeFileSync(path.join(tempRoot, 'packages/foo/CHANGELOG.json'), '{}');
 
-    migrate(getOptions({ generateChangelog: true }));
+    migrate(await getOptions({ generateChangelog: true }));
 
     expect(logs.getMockLines('all')).toEqual('[log] No config updates are needed for v3.');
   });
 
-  it('errors on private packages using shouldPublish option', () => {
+  it('errors on private packages using shouldPublish option', async () => {
     tempRoot = createTestFileStructureType('monorepo');
     updateJsonFile(path.join(tempRoot, 'packages/foo/package.json'), {
       private: true,
@@ -155,8 +158,9 @@ describe('migrate command', () => {
       private: true,
       beachball: { shouldPublish: false },
     });
+    const options = await getOptions();
 
-    expect(() => migrate(getOptions())).toThrow(BeachballError);
+    expect(() => migrate(options)).toThrow(BeachballError);
 
     const output = logs.getMockLines('all', { root: tempRoot });
     expect(output).toMatchInlineSnapshot(`
@@ -167,7 +171,7 @@ describe('migrate command', () => {
     `);
   });
 
-  it('errors on negated groups[*].exclude', () => {
+  it('errors on negated groups[*].exclude', async () => {
     const disallowedChangeTypes = null;
     tempRoot = createTestFileStructureType('monorepo', {
       groups: [
@@ -182,7 +186,8 @@ describe('migrate command', () => {
         },
       ],
     });
-    expect(() => migrate(getOptions())).toThrow(BeachballError);
+    const options = await getOptions();
+    expect(() => migrate(options)).toThrow(BeachballError);
 
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "The following updates are needed for v3:
@@ -197,7 +202,7 @@ describe('migrate command', () => {
     `);
   });
 
-  it('errors on changelog.groups[*].masterPackageName', () => {
+  it('errors on changelog.groups[*].masterPackageName', async () => {
     tempRoot = createTestFileStructureType('monorepo', {
       changelog: {
         groups: [
@@ -207,7 +212,8 @@ describe('migrate command', () => {
         ],
       },
     });
-    expect(() => migrate(getOptions())).toThrow(BeachballError);
+    const options = await getOptions();
+    expect(() => migrate(options)).toThrow(BeachballError);
 
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "The following updates are needed for v3:
@@ -219,7 +225,7 @@ describe('migrate command', () => {
     `);
   });
 
-  it('errors on negated changelog.groups[*].exclude and masterPackageName', () => {
+  it('errors on negated changelog.groups[*].exclude and masterPackageName', async () => {
     tempRoot = createTestFileStructureType('monorepo', {
       changelog: {
         groups: [
@@ -234,7 +240,8 @@ describe('migrate command', () => {
         ],
       },
     });
-    expect(() => migrate(getOptions())).toThrow(BeachballError);
+    const options = await getOptions();
+    expect(() => migrate(options)).toThrow(BeachballError);
 
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "The following updates are needed for v3:

--- a/packages/beachball/src/__functional__/commands/publish.test.ts
+++ b/packages/beachball/src/__functional__/commands/publish.test.ts
@@ -37,8 +37,8 @@ describe('publish command', () => {
   let monorepoFactory: RepositoryFactory;
   let repo: Repository | undefined;
 
-  function getOptions(repoOptions?: Partial<RepoOptions>) {
-    const parsedOptions = _getOptions({
+  async function getOptions(repoOptions?: Partial<RepoOptions>) {
+    const parsedOptions = await _getOptions({
       cwd: repo!.rootPath,
       argv: ['node', 'beachball', 'publish', '--yes'],
       env: {},
@@ -89,7 +89,7 @@ describe('publish command', () => {
   it('bumps and pushes when enabled', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ bump: true, push: true });
+    const { options, parsedOptions } = await getOptions({ bump: true, push: true });
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -109,7 +109,7 @@ describe('publish command', () => {
   it('calls publishToRegistry when packToPath is set even if publish is false', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ publish: false, packToPath: '/tmp/fake-pack' });
+    const { options, parsedOptions } = await getOptions({ publish: false, packToPath: '/tmp/fake-pack' });
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -121,7 +121,7 @@ describe('publish command', () => {
   it('returns to original branch and deletes publish branch after completion', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -136,7 +136,7 @@ describe('publish command', () => {
   it('returns to correct hash from detached HEAD', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -152,7 +152,7 @@ describe('publish command', () => {
   it('populates bumpInfo with correct change types', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -170,7 +170,7 @@ describe('publish command', () => {
   it('passes correct bumpInfo to publishToRegistry in a monorepo', async () => {
     repo = monorepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions({ bumpDeps: true });
+    const { options, parsedOptions } = await getOptions({ bumpDeps: true });
     // baz has a minor change; bar depends on baz, foo depends on bar
     generateChangeFiles(['baz'], options);
     logs.clear();
@@ -195,7 +195,7 @@ describe('publish command', () => {
   it('reuses pre-calculated bumpInfo from context', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     logs.clear();
 
@@ -213,7 +213,7 @@ describe('publish command', () => {
   it('logs expected output for a standard publish flow', async () => {
     repo = singleRepoFactory.cloneRepository();
 
-    const { options, parsedOptions } = getOptions();
+    const { options, parsedOptions } = await getOptions();
     generateChangeFiles(['foo'], options);
     logs.clear();
 

--- a/packages/beachball/src/__functional__/options/__snapshots__/getCliOptions.test.ts.snap
+++ b/packages/beachball/src/__functional__/options/__snapshots__/getCliOptions.test.ts.snap
@@ -34,7 +34,7 @@ Advanced options:
                                 default: 1)
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -88,7 +88,7 @@ Advanced options:
                                 default: 1)
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -141,7 +141,7 @@ Advanced options:
                                 "prepatch", "patch", "preminor", "minor", "premajor", "major")
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -181,7 +181,7 @@ Advanced options:
   --change-dir <value>        directory name or path to store change files (default: "change")
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -199,7 +199,7 @@ Arguments:
   name                  beachball config setting name
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -h, --help            display help for command
 "
@@ -214,7 +214,7 @@ Most options can also be specified in the beachball config (command line options
 config). See https://microsoft.github.io/beachball/overview/configuration for more info.
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -h, --help            display help for command
 "
@@ -234,7 +234,7 @@ Commands:
   help [command]        display help for command
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -h, --help            display help for command
 "
@@ -272,7 +272,7 @@ Most options can also be specified in the beachball config (command line options
 config). See https://microsoft.github.io/beachball/overview/configuration for more info.
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -h, --help            display help for command
 "
@@ -336,7 +336,7 @@ Advanced options:
                                 default: 1)
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -358,7 +358,7 @@ npm options:
   -r, --registry <value>  npm registry (must be set with option or config file)
 
 Common options:
-  -c, --config <value>    custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>    custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose          print additional information to the console
   -h, --help              display help for command
 "
@@ -378,7 +378,7 @@ Commands:
   help [command]        display help for command
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -h, --help            display help for command
 "
@@ -408,7 +408,7 @@ npm options:
   -t, --tag <value>           npm dist-tag to sync with (default: defaultNpmTag or "latest")
 
 Common options:
-  -c, --config <value>        custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>        custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose              print additional information to the console
   -h, --help                  display help for command
 "
@@ -432,7 +432,7 @@ Commands:
   help [command]        display help for command
 
 Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig standard paths)
+  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
   --[no-]verbose        print additional information to the console
   -v, --version         output the version number
   -h, --help            display help for command

--- a/packages/beachball/src/__functional__/options/getOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getOptions.test.ts
@@ -23,12 +23,12 @@ describe('getOptions', () => {
     repositoryFactory.cleanUp();
   });
 
-  it('--config overrides configuration path', () => {
+  it('--config overrides configuration path', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('beachball.config.js', 'module.exports = { branch: "origin/main" };');
     repo.writeFile('alternate.config.js', 'module.exports = { branch: "origin/foo" };');
 
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       argv: [...baseArgv(), '--config', 'alternate.config.js'],
       env: {},
       cwd: repo.rootPath,
@@ -36,12 +36,12 @@ describe('getOptions', () => {
     expect(parsedOptions.options.branch).toEqual('origin/foo');
   });
 
-  it('overrides repo options with CLI options', () => {
+  it('overrides repo options with CLI options', async () => {
     const repo = repositoryFactory.cloneRepository();
     const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo', bump: false };
     repo.writeFile('beachball.config.js', `module.exports = ${JSON.stringify(repoOptions)};`);
 
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       argv: [...baseArgv(), '--branch', 'origin/bar', '--bump'],
       cwd: repo.rootPath,
       env: {},

--- a/packages/beachball/src/__functional__/options/getRepoOptions.test.ts
+++ b/packages/beachball/src/__functional__/options/getRepoOptions.test.ts
@@ -26,98 +26,100 @@ describe('getRepoOptions', () => {
     repositoryFactory.cleanUp();
   });
 
-  it('returns empty object if path is not set', () => {
-    expect(getRepoOptions(cliOptions())).toEqual({});
+  it('returns empty object if path is not set', async () => {
+    expect(await getRepoOptions(cliOptions())).toEqual({});
   });
 
-  it('reads config from beachball.config.js', () => {
+  it('reads config from beachball.config.js', async () => {
     const repo = repositoryFactory.cloneRepository();
     const repoOptions: Partial<RepoOptions> = { branch: 'origin/foo', access: 'public' };
     repo.writeFile('beachball.config.js', `module.exports = ${JSON.stringify(repoOptions)};`);
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual(repoOptions);
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual(repoOptions);
   });
 
-  it('reads config from package.json', () => {
+  it('reads config from package.json', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.updateJsonFile('package.json', { beachball: { branch: 'origin/foo' } });
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: 'origin/foo' });
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: 'origin/foo' });
   });
 
-  it('finds a .beachballrc.json file', () => {
+  it('finds a .beachballrc.json file', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('.beachballrc.json', { branch: 'origin/foo' });
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: 'origin/foo' });
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: 'origin/foo' });
   });
 
-  it('loads config from configPath', () => {
+  it('loads config from configPath', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('beachball.config.js', 'module.exports = { branch: "origin/main" };');
     repo.writeFile('alternate.config.js', 'module.exports = { branch: "origin/foo" };');
 
-    const repoOptions = getRepoOptions(cliOptions({ path: repo.rootPath, configPath: 'alternate.config.js' }));
+    const repoOptions = await getRepoOptions(cliOptions({ path: repo.rootPath, configPath: 'alternate.config.js' }));
     expect(repoOptions.branch).toEqual('origin/foo');
   });
 
-  it('loads config from absolute configPath', () => {
+  it('loads config from absolute configPath', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('beachball.config.js', 'module.exports = { branch: "origin/main" };');
     repo.writeFile('nested/alternate.config.js', 'module.exports = { branch: "origin/foo" };');
 
-    const repoOptions = getRepoOptions(
+    const repoOptions = await getRepoOptions(
       cliOptions({ path: repo.rootPath, configPath: path.join(repo.rootPath, 'nested/alternate.config.js') })
     );
     expect(repoOptions.branch).toEqual('origin/foo');
   });
 
-  it('throws if configPath could not be loaded', () => {
+  it('throws if configPath could not be loaded', async () => {
     const repo = repositoryFactory.cloneRepository();
-    // An empty config file loads to an empty result, triggering the error.
-    repo.writeFile('empty.config.js', '');
+    const configName = 'empty.config.js';
+    repo.writeFile(configName, 'throw new Error("oh no")');
 
-    expect(() => getRepoOptions(cliOptions({ path: repo.rootPath, configPath: 'empty.config.js' }))).toThrow(
-      'Config file "empty.config.js" could not be loaded'
+    await expect(getRepoOptions(cliOptions({ path: repo.rootPath, configPath: configName }))).rejects.toThrow(
+      `Failed to load config from ${path.join(repo.rootPath, configName)}: oh no`
     );
   });
 
-  it('resolves the default branch if no branch is specified', () => {
+  it('resolves the default branch if no branch is specified', async () => {
     const repo = repositoryFactory.cloneRepository();
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: defaultRemoteBranchName });
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: defaultRemoteBranchName });
   });
 
-  it('resolves the branch from config to include the remote', () => {
+  it('resolves the branch from config to include the remote', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('beachball.config.js', 'module.exports = { branch: "master" };');
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: defaultRemoteBranchName });
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath }))).toEqual({ branch: defaultRemoteBranchName });
   });
 
-  it('does not modify the branch if specified in cliOptions', () => {
+  it('does not modify the branch if specified in cliOptions', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.writeFile('beachball.config.js', 'module.exports = { branch: "origin/foo" };');
 
-    expect(getRepoOptions(cliOptions({ path: repo.rootPath, branch: 'origin/bar' }))).toEqual({ branch: 'origin/foo' });
+    expect(await getRepoOptions(cliOptions({ path: repo.rootPath, branch: 'origin/bar' }))).toEqual({
+      branch: 'origin/foo',
+    });
   });
 
   // this is logic from workspace-tools with the "strict" option
-  it('throws if no remotes are defined', () => {
+  it('throws if no remotes are defined', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.git(['remote', 'remove', 'origin']);
 
-    expect(() => getRepoOptions(cliOptions({ path: repo.rootPath }))).toThrow(
+    await expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).rejects.toThrow(
       `No remotes defined in git repo at ${repo.rootPath}`
     );
   });
 
   // this is logic from workspace-tools with the "strict" option
-  it('throws if no remote is found matching package.json repository', () => {
+  it('throws if no remote is found matching package.json repository', async () => {
     const repo = repositoryFactory.cloneRepository();
     repo.updateJsonFile('package.json', { repository: { type: 'git', url: 'https://github.com/microsoft/nope.git' } });
 
-    expect(() => getRepoOptions(cliOptions({ path: repo.rootPath }))).toThrow(
+    await expect(getRepoOptions(cliOptions({ path: repo.rootPath }))).rejects.toThrow(
       'Could not find remote pointing to repository "microsoft/nope"'
     );
   });

--- a/packages/beachball/src/__functional__/options/readConfig.test.ts
+++ b/packages/beachball/src/__functional__/options/readConfig.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
+import path from 'path';
+import { createTestFileStructure } from '../../__fixtures__/createTestFileStructure';
+import { removeTempDir } from '../../__fixtures__/tmpdir';
+import { readConfig } from '../../options/readConfig';
+import { BeachballError } from '../../types/BeachballError';
+
+describe('readConfig', () => {
+  let tempDir = '';
+  const packageJson = { name: 'foo', version: '1.0.0' };
+  const sampleConfig = { branch: 'origin/foo' };
+  const sampleJson = JSON.stringify(sampleConfig);
+  const sampleCjs = 'module.exports = ' + sampleJson;
+  const sampleMjs = 'export default ' + sampleJson;
+
+  // Don't reuse a temp dir across tests! If multiple tests load a JS config from the same path,
+  // it will use the version from the module cache, which will have outdated contents.
+  afterEach(() => {
+    tempDir && removeTempDir(tempDir);
+    tempDir = '';
+  });
+
+  it('returns undefined if no config is found', async () => {
+    tempDir = createTestFileStructure({ 'package.json': packageJson });
+
+    expect(await readConfig({ path: tempDir })).toBeUndefined();
+  });
+
+  it('reads config from a package.json property', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': { ...packageJson, beachball: sampleConfig },
+    });
+
+    expect(await readConfig({ path: tempDir })).toEqual(sampleConfig);
+  });
+
+  // The .cts test isn't realistic because it goes through jest, but it ensures readConfig finds the file
+  const cjsExts = ['.js', '.cjs', '.ts', '.cts'] as const;
+  it.each([...cjsExts.map(ext => `beachball.config${ext}`), ...cjsExts.map(ext => `.beachballrc${ext}`)])(
+    'reads CJS %s',
+    async filename => {
+      tempDir = createTestFileStructure({
+        'package.json': packageJson,
+        [filename]: (filename.endsWith('ts') ? 'const foo: number = 1;\n' : '') + sampleCjs,
+      });
+
+      expect(await readConfig({ path: tempDir })).toEqual(sampleConfig);
+    }
+  );
+
+  const mjsExts = ['.js', '.mjs', '.ts', '.mts'] as const;
+  it.each([...mjsExts.map(ext => `beachball.config${ext}`), ...mjsExts.map(ext => `.beachballrc${ext}`)])(
+    'reads ESM %s',
+    async filename => {
+      tempDir = createTestFileStructure({
+        // type: module ensures it reads the .ts
+        'package.json': { ...packageJson, type: 'module' },
+        [filename]: (filename.endsWith('ts') ? 'const foo: number = 1;\n' : '') + sampleMjs,
+      });
+
+      expect(await readConfig({ path: tempDir })).toEqual(sampleConfig);
+    }
+  );
+
+  it.each(['beachball.config.json', '.beachballrc', '.beachballrc.json'])('reads config from %s', async filename => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      [filename]: sampleJson,
+    });
+
+    expect(await readConfig({ path: tempDir })).toEqual(sampleConfig);
+  });
+
+  it('reads config from a .config directory', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      '.config/beachball.config.js': sampleCjs,
+    });
+
+    expect(await readConfig({ path: tempDir })).toEqual(sampleConfig);
+  });
+
+  it('prefers the package.json property over other config files', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': { ...packageJson, beachball: { branch: 'origin/from-package-json' } },
+      'beachball.config.js': 'module.exports = { branch: "origin/from-config-js" };',
+    });
+
+    expect(await readConfig({ path: tempDir })).toEqual({ branch: 'origin/from-package-json' });
+  });
+
+  it('prefers the cwd over the .config directory', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      'beachball.config.js': 'module.exports = { branch: "origin/from-cwd" };',
+      '.config/beachball.config.js': 'module.exports = { branch: "origin/from-config-dir" };',
+    });
+
+    expect(await readConfig({ path: tempDir })).toEqual({ branch: 'origin/from-cwd' });
+  });
+
+  it('loads config from a relative configPath', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      'beachball.config.js': 'module.exports = { branch: "origin/main" };',
+      'alternate.config.js': 'module.exports = { branch: "origin/foo" };',
+    });
+
+    expect(await readConfig({ path: tempDir, configPath: 'alternate.config.js' })).toEqual(sampleConfig);
+  });
+
+  it('loads config from an absolute configPath', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      'nested/alternate.config.js': 'module.exports = { branch: "origin/foo" };',
+    });
+    const configPath = path.join(tempDir, 'nested/alternate.config.js');
+
+    expect(await readConfig({ path: tempDir, configPath })).toEqual(sampleConfig);
+  });
+
+  it('throws if configPath could not be loaded', async () => {
+    const configPath = 'bad.config.js';
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      [configPath]: 'throw new Error("oh no")',
+    });
+    const readBad = () => readConfig({ path: tempDir, configPath });
+
+    await expect(readBad()).rejects.toThrow(BeachballError);
+    await expect(readBad()).rejects.toThrow(`Failed to load config from ${path.join(tempDir, configPath)}: oh no`);
+  });
+
+  it('throws if a JSON config is invalid', async () => {
+    tempDir = createTestFileStructure({
+      'package.json': packageJson,
+      '.beachballrc.json': '{ not valid json',
+    });
+
+    await expect(readConfig({ path: tempDir })).rejects.toThrow(
+      `Failed to load config from ${path.join(tempDir, '.beachballrc.json')}`
+    );
+  });
+});

--- a/packages/beachball/src/__tests__/bump/bumpInMemory.test.ts
+++ b/packages/beachball/src/__tests__/bump/bumpInMemory.test.ts
@@ -13,12 +13,12 @@ describe('bumpInMemory', () => {
   initMockLogs();
   const cwd = path.resolve('/fake-root');
 
-  function gatherBumpInfoWrapper(params: {
+  async function gatherBumpInfoWrapper(params: {
     packageFolders: { [folder: string]: PartialPackageInfo };
     repoOptions?: Partial<RepoOptions>;
     changes: (string | PartialChangeFile)[];
   }) {
-    const { cliOptions, options } = getOptions({
+    const { cliOptions, options } = await getOptions({
       cwd,
       argv: [],
       env: {},
@@ -38,8 +38,8 @@ describe('bumpInMemory', () => {
     return { bumpInfo, options, originalPackageInfos };
   }
 
-  it('bumps only packages with change files with bumpDeps: false', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('bumps only packages with change files with bumpDeps: false', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.0' },
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
@@ -70,8 +70,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-5']).toEqual(originalPackageInfos['pkg-5']);
   });
 
-  it('bumps all dependent packages with bumpDeps: true', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps all dependent packages with bumpDeps: true', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.0' },
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
@@ -113,8 +113,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-5'].optionalDependencies!['pkg-4']).toBe(dependentNewVersion);
   });
 
-  it('bumps all grouped packages', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('bumps all grouped packages', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'packages/pkg-1': { version: '1.0.0' },
         'packages/pkg-2': { version: '1.0.0' },
@@ -144,8 +144,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['unrelated'].version).toBe(originalPackageInfos['unrelated'].version);
   });
 
-  it('bumps all grouped packages to the greatest change type in the group, regardless of change file order', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps all grouped packages to the greatest change type in the group, regardless of change file order', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'packages/commonlib': { name: 'commonlib' },
         'packages/pkg-1': { version: '1.0.0', dependencies: { commonlib: '1.0.0' } },
@@ -167,9 +167,9 @@ describe('bumpInMemory', () => {
     expect(packageInfos['commonlib'].version).toBe('1.1.0');
   });
 
-  it('bumps all grouped AND dependent packages', () => {
+  it('bumps all grouped AND dependent packages', async () => {
     // This is covered E2E in bump.test.ts too
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'packages/app': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
         'packages/commonlib': { version: '1.0.0' },
@@ -216,8 +216,8 @@ describe('bumpInMemory', () => {
 
   // Scope filtering of original changes happens in the readChangeFiles step (so must be tested E2E),
   // but scope filtering of *dependents* happens in the bump step.
-  it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('should not bump out-of-scope package and its dependencies even if dependency of the package has change', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'packages/foo': { name: 'foo', version: '1.0.0', dependencies: { bar: '^1.3.4' } },
         'packages/bar': { name: 'bar', version: '1.3.4', dependencies: { baz: '^1.3.4' } },
@@ -246,8 +246,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['foo'].dependencies!['bar']).toBe('^1.3.4');
   });
 
-  it('bumps dependents with file: deps', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('bumps dependents with file: deps', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.0' },
         'pkg-2': { version: '0.0.0', dependencies: { 'pkg-1': 'file:../pkg-1' } },
@@ -270,8 +270,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-3']).toEqual({ ...originalPackageInfos['pkg-3'], version: '0.0.1' });
   });
 
-  it('bumps dependents with workspace: deps', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('bumps dependents with workspace: deps', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.0' },
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': 'workspace:~', extra: '~1.2.3' } },
@@ -299,8 +299,8 @@ describe('bumpInMemory', () => {
   });
 
   // https://github.com/microsoft/beachball/discussions/940
-  it('keeps workspace: devDependency when the same dependency is versioned in peerDependencies', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('keeps workspace: devDependency when the same dependency is versioned in peerDependencies', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'local-dep': { version: '3.6.1' },
         'package-with-deps': {
@@ -326,8 +326,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['package-with-deps'].peerDependencies).toEqual({ 'local-dep': '^3.7.0' });
   });
 
-  it('bumps dependents with catalog: deps', () => {
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+  it('bumps dependents with catalog: deps', async () => {
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       // Say there's a catalog like this:
       // catalog:
       //   pkg-1: workspace:~
@@ -356,8 +356,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-3']).toEqual({ ...originalPackageInfos['pkg-3'], version: '1.0.1' });
   });
 
-  it('bumps to prerelease using prefix, and uses prerelease version for dependents', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps to prerelease using prefix, and uses prerelease version for dependents', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': {},
         'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
@@ -383,8 +383,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-3'].peerDependencies!['pkg-2']).toBe(newVersion);
   });
 
-  it('bumps to prerelease and uses the specified identifier base', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps to prerelease and uses the specified identifier base', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': {},
         'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
@@ -407,8 +407,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
   });
 
-  it('bumps to prerelease with no identifier base', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps to prerelease with no identifier base', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': {},
         'pkg-2': { dependencies: { 'pkg-1': '1.0.0' } },
@@ -431,8 +431,8 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-2'].dependencies!['pkg-1']).toBe(newVersion);
   });
 
-  it('bumps all packages and increments prefixed versions in dependents', () => {
-    const { bumpInfo } = gatherBumpInfoWrapper({
+  it('bumps all packages and increments prefixed versions in dependents', async () => {
+    const { bumpInfo } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.1-beta.0' },
         'pkg-2': { version: '1.0.0', dependencies: { 'pkg-1': '1.0.0' } },
@@ -458,9 +458,9 @@ describe('bumpInMemory', () => {
     expect(packageInfos['pkg-3'].devDependencies!['pkg-2']).toBe(othersNewVersion);
   });
 
-  it('does not modify dependency ranges of packages that are not bumped', () => {
+  it('does not modify dependency ranges of packages that are not bumped', async () => {
     // This was probably the scenario from https://github.com/microsoft/beachball/issues/1033
-    const { bumpInfo, originalPackageInfos } = gatherBumpInfoWrapper({
+    const { bumpInfo, originalPackageInfos } = await gatherBumpInfoWrapper({
       packageFolders: {
         'pkg-1': { version: '1.0.0' },
         // pkg-2 was bumped to 1.2.3 at some point (with a manual or scoped bump)

--- a/packages/beachball/src/__tests__/bump/performBump.test.ts
+++ b/packages/beachball/src/__tests__/bump/performBump.test.ts
@@ -62,14 +62,14 @@ describe('performBump', () => {
    *
    * `modifiedPackages` defaults to all packages in `packageInfos`.
    */
-  function performBumpWrapper(params: {
+  async function performBumpWrapper(params: {
     packageInfos: PartialPackageInfos;
     modifiedPackages?: BumpInfo['modifiedPackages'];
     /** Names to generate empty `changeFileChangeInfos` */
     changeFileNames?: string[];
     repoOptions?: Partial<RepoOptions>;
   }) {
-    const opts = getOptions({
+    const opts = await getOptions({
       cwd: fakeRoot,
       argv: [],
       env: {},

--- a/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getAllChangedPackages.test.ts
@@ -28,14 +28,14 @@ describe('getAllChangedPackages', () => {
     );
 
   /** Get options/context and call `getAllChangedPackages` */
-  function getAllChangedPackagesWrapper(params: {
+  async function getAllChangedPackagesWrapper(params: {
     packageInfos: PackageInfos;
     repoOptions?: Partial<RepoOptions>;
     extraArgv?: string[];
     allChangedFiles?: string[];
   }) {
     const { repoOptions, extraArgv = [], packageInfos } = params;
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       cwd: fakeRoot,
       argv: ['node', 'beachball', 'change', ...extraArgv],
       env: {},
@@ -54,24 +54,27 @@ describe('getAllChangedPackages', () => {
     });
   }
 
-  it('returns empty list when no changes in single repo', () => {
-    const result = getAllChangedPackagesWrapper({ packageInfos: singlePackageInfo(), extraArgv: ['--verbose'] });
+  it('returns empty list when no changes in single repo', async () => {
+    const result = await getAllChangedPackagesWrapper({ packageInfos: singlePackageInfo(), extraArgv: ['--verbose'] });
     expect(result).toEqual([]);
     expect(logs.getMockLines('all')).toMatchInlineSnapshot(`"[log] Found no changed files in current branch"`);
   });
 
-  it('returns empty list when no changes in monorepo', () => {
-    const result = getAllChangedPackagesWrapper({ packageInfos: monorepoPackageInfos() });
+  it('returns empty list when no changes in monorepo', async () => {
+    const result = await getAllChangedPackagesWrapper({ packageInfos: monorepoPackageInfos() });
     expect(result).toEqual([]);
   });
 
-  it('detects changed files in single-package repo', () => {
-    const result = getAllChangedPackagesWrapper({ packageInfos: singlePackageInfo(), allChangedFiles: ['myFilename'] });
+  it('detects changed files in single-package repo', async () => {
+    const result = await getAllChangedPackagesWrapper({
+      packageInfos: singlePackageInfo(),
+      allChangedFiles: ['myFilename'],
+    });
     expect(result).toEqual(['foo']);
   });
 
-  it('detects changed files in monorepo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('detects changed files in monorepo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: monorepoPackageInfos(),
       extraArgv: ['--verbose'],
       allChangedFiles: ['packages/foo/myFilename', 'not-package/file'],
@@ -85,8 +88,8 @@ describe('getAllChangedPackages', () => {
     `);
   });
 
-  it('ignores CHANGELOG.* in single-package repo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('ignores CHANGELOG.* in single-package repo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: singlePackageInfo(),
       allChangedFiles: ['CHANGELOG.md', 'CHANGELOG.json'],
       extraArgv: ['--verbose'],
@@ -100,8 +103,8 @@ describe('getAllChangedPackages', () => {
     `);
   });
 
-  it('ignores CHANGELOG.* in monorepo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('ignores CHANGELOG.* in monorepo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: monorepoPackageInfos(),
       allChangedFiles: ['packages/foo/CHANGELOG.md', 'packages/foo/CHANGELOG.json', 'packages/bar/foo.ts'],
       extraArgv: ['--verbose'],
@@ -117,8 +120,8 @@ describe('getAllChangedPackages', () => {
   });
 
   // change files are outside a package in a monorepo
-  it('ignores change files in single-package repo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('ignores change files in single-package repo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: singlePackageInfo(),
       allChangedFiles: ['change/change-abc123.json', 'myFilename'],
       extraArgv: ['--verbose'],
@@ -132,8 +135,8 @@ describe('getAllChangedPackages', () => {
     `);
   });
 
-  it('respects ignorePatterns in single-package repo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('respects ignorePatterns in single-package repo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: singlePackageInfo(),
       // change a default-ignored file too, to ensure the ignore patterns merge
       allChangedFiles: ['src/foo.test.js', 'tests/stuff.js', 'yarn.lock', 'CHANGELOG.md'],
@@ -151,8 +154,8 @@ describe('getAllChangedPackages', () => {
     `);
   });
 
-  it('respects ignorePatterns in monorepo', () => {
-    const result = getAllChangedPackagesWrapper({
+  it('respects ignorePatterns in monorepo', async () => {
+    const result = await getAllChangedPackagesWrapper({
       packageInfos: monorepoPackageInfos(),
       allChangedFiles: [
         'packages/foo/foo.test.js',
@@ -179,13 +182,13 @@ describe('getAllChangedPackages', () => {
   });
 
   // This is tested at a lower level by isPackageIncluded.test.ts
-  it('ignores package changes as appropriate', () => {
+  it('ignores package changes as appropriate', async () => {
     const packageInfos = monorepoPackageInfos();
     // Update packages so they'll be ignored
     packageInfos.foo.private = true;
     packageInfos.bar.packageOptions = { shouldPublish: false }; // package.json beachball field
 
-    const result = getAllChangedPackagesWrapper({
+    const result = await getAllChangedPackagesWrapper({
       packageInfos,
       repoOptions: { scope: ['!packages/grouped/*'] },
       extraArgv: ['--verbose'],

--- a/packages/beachball/src/__tests__/changefile/getQuestionsForPackage.test.ts
+++ b/packages/beachball/src/__tests__/changefile/getQuestionsForPackage.test.ts
@@ -19,7 +19,7 @@ describe('getQuestionsForPackage', () => {
 
   const logs = initMockLogs();
 
-  function getQuestionsWrapper(
+  async function getQuestionsWrapper(
     params: {
       options?: Partial<GetQuestionsParams['options']>;
       packageInfo?: PartialPackageInfo;
@@ -32,13 +32,13 @@ describe('getQuestionsForPackage', () => {
 
     const packageInfos = makePackageInfos({ [pkg]: packageInfo });
     // fill in default options
-    const { options } = getOptions({ cwd: '', argv: [], env: {}, testRepoOptions: repoOptions });
+    const { options } = await getOptions({ cwd: '', argv: [], env: {}, testRepoOptions: repoOptions });
 
     return getQuestionsForPackage({ pkg, packageInfos, packageGroups, options, recentMessages });
   }
 
-  it('works in basic case', () => {
-    const questions = getQuestionsWrapper();
+  it('works in basic case', async () => {
+    const questions = await getQuestionsWrapper();
     expect(questions).toEqual([
       {
         choices: [
@@ -64,8 +64,8 @@ describe('getQuestionsForPackage', () => {
   });
 
   // it's somewhat debatable if this is correct (maybe --type should be the override for disallowedChangeTypes?)
-  it('errors if options.type is disallowed', () => {
-    const questions = getQuestionsWrapper({
+  it('errors if options.type is disallowed', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { beachball: { disallowedChangeTypes: ['major'] } },
       options: { type: 'major', message: '' },
     });
@@ -73,24 +73,24 @@ describe('getQuestionsForPackage', () => {
     expect(logs.mocks.error).toHaveBeenCalledWith('Change type "major" is not allowed for package "foo"');
   });
 
-  it('errors if there are no valid change types for package', () => {
-    const questions = getQuestionsWrapper({
+  it('errors if there are no valid change types for package', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { beachball: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] } },
     });
     expect(questions).toBeUndefined();
     expect(logs.mocks.error).toHaveBeenCalledWith('No valid change types available for package "foo"');
   });
 
-  it('respects disallowedChangeTypes', () => {
-    const questions = getQuestionsWrapper({
+  it('respects disallowedChangeTypes', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { beachball: { disallowedChangeTypes: ['major'] } },
     });
     const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['patch', 'minor', 'none']);
   });
 
-  it('allows prerelease change for package with prerelease version', () => {
-    const questions = getQuestionsWrapper({
+  it('allows prerelease change for package with prerelease version', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { version: '1.0.0-beta.1' },
     });
     const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
@@ -98,32 +98,32 @@ describe('getQuestionsForPackage', () => {
   });
 
   // this is a bit weird as well, but documenting current behavior
-  it('excludes prerelease if disallowed', () => {
-    const questions = getQuestionsWrapper({
+  it('excludes prerelease if disallowed', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { version: '1.0.0-beta.1', beachball: { disallowedChangeTypes: ['prerelease'] } },
     });
     const choices = (questions![0].choices as prompts.Choice[]).map(c => c.value as ChangeType);
     expect(choices).toEqual(['patch', 'minor', 'none', 'major']);
   });
 
-  it('excludes the change type question when options.type is specified', () => {
-    const questions = getQuestionsWrapper({
+  it('excludes the change type question when options.type is specified', async () => {
+    const questions = await getQuestionsWrapper({
       options: { type: 'patch', message: '' },
     });
     expect(questions).toHaveLength(1);
     expect(questions![0].name).toBe('comment');
   });
 
-  it('excludes the change type question with only one valid option', () => {
-    const questions = getQuestionsWrapper({
+  it('excludes the change type question with only one valid option', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: { beachball: { disallowedChangeTypes: ['major', 'minor', 'none'] } },
     });
     expect(questions).toHaveLength(1);
     expect(questions![0].name).toBe('comment');
   });
 
-  it('excludes the change type question when prerelease is implicitly the only valid option', () => {
-    const questions = getQuestionsWrapper({
+  it('excludes the change type question when prerelease is implicitly the only valid option', async () => {
+    const questions = await getQuestionsWrapper({
       packageInfo: {
         version: '1.0.0-beta.1',
         beachball: { disallowedChangeTypes: ['major', 'minor', 'patch', 'none'] },
@@ -133,19 +133,19 @@ describe('getQuestionsForPackage', () => {
     expect(questions![0].name).toBe('comment');
   });
 
-  it('excludes the comment question when options.message is set', () => {
-    const questions = getQuestionsWrapper({
+  it('excludes the comment question when options.message is set', async () => {
+    const questions = await getQuestionsWrapper({
       options: { message: 'message' },
     });
     expect(questions).toHaveLength(1);
     expect(questions![0].name).toBe('type');
   });
 
-  it('uses options.changeFilePrompt if set', () => {
+  it('uses options.changeFilePrompt if set', async () => {
     const customQuestions: prompts.PromptObject[] = [{ name: 'custom', message: 'custom prompt', type: 'text' }];
     const changePrompt: ChangeFilePromptOptions['changePrompt'] = jest.fn(() => customQuestions);
 
-    const questions = getQuestionsWrapper({
+    const questions = await getQuestionsWrapper({
       options: { changeFilePrompt: { changePrompt } },
     });
 
@@ -163,7 +163,7 @@ describe('getQuestionsForPackage', () => {
   it('does case-insensitive filtering on description suggestions', async () => {
     const recentMessages = ['Foo', 'Bar', 'Baz'];
     const recentMessageChoices = [{ title: 'Foo' }, { title: 'Bar' }, { title: 'Baz' }];
-    const questions = getQuestionsWrapper({ recentMessages });
+    const questions = await getQuestionsWrapper({ recentMessages });
     expect(questions).toEqual([
       expect.anything(),
       expect.objectContaining({

--- a/packages/beachball/src/__tests__/commands/publish.mock.test.ts
+++ b/packages/beachball/src/__tests__/commands/publish.mock.test.ts
@@ -32,7 +32,7 @@ describe('publish command (all helpers mocked)', () => {
    * Get options and context. The context has a completely empty `bumpInfo`, but the `changeSet`
    * contains a change for each package (since it's looked at directly by logic within `publish()`).
    */
-  function getOptionsAndContext(params: {
+  async function getOptionsAndContext(params: {
     /** bump, push, and publish are true by default */
     repoOptions?: Partial<RepoOptions>;
     packageInfos: PartialPackageInfos;
@@ -40,7 +40,7 @@ describe('publish command (all helpers mocked)', () => {
   }) {
     const { repoOptions, packageInfos, context: partialContext } = params;
 
-    const parsedOptions = getOptions({
+    const parsedOptions = await getOptions({
       cwd: '',
       argv: ['node', 'beachball', 'publish', '--yes'],
       env: {},
@@ -83,7 +83,7 @@ describe('publish command (all helpers mocked)', () => {
   });
 
   it('returns early when there are no change files', async () => {
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       packageInfos: { foo: {} },
       context: { changeSet: [] },
     });
@@ -101,7 +101,7 @@ describe('publish command (all helpers mocked)', () => {
   });
 
   it('skips bumpAndPush when push is false', async () => {
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       repoOptions: { push: false },
       packageInfos: { foo: {} },
     });
@@ -118,7 +118,7 @@ describe('publish command (all helpers mocked)', () => {
   });
 
   it('skips bumpAndPush when bump is false', async () => {
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       repoOptions: { bump: false },
       packageInfos: { foo: {} },
     });
@@ -134,7 +134,7 @@ describe('publish command (all helpers mocked)', () => {
   });
 
   it('skips publishToRegistry when publish is false', async () => {
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       repoOptions: { publish: false },
       packageInfos: { foo: {} },
     });
@@ -150,7 +150,7 @@ describe('publish command (all helpers mocked)', () => {
   });
 
   it('calls publishToRegistry when packToPath is set even if publish is false', async () => {
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       repoOptions: { publish: false, packToPath: '/tmp/fake-pack' },
       packageInfos: { foo: {} },
     });
@@ -169,7 +169,7 @@ describe('publish command (all helpers mocked)', () => {
   it('returns to original branch and deletes publish branch after completion', async () => {
     const currentBranch = 'fake-branch';
     wsToolsMocks.getBranchName.mockReturnValue(currentBranch);
-    const { options, context } = getOptionsAndContext({
+    const { options, context } = await getOptionsAndContext({
       packageInfos: { foo: {} },
     });
 
@@ -183,7 +183,7 @@ describe('publish command (all helpers mocked)', () => {
   it('returns to correct hash from detached HEAD', async () => {
     wsToolsMocks.getBranchName.mockReturnValue('HEAD');
 
-    const { options, context } = getOptionsAndContext({ packageInfos: { foo: {} } });
+    const { options, context } = await getOptionsAndContext({ packageInfos: { foo: {} } });
 
     await publish(options, context);
 

--- a/packages/beachball/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/packages/beachball/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -110,14 +110,14 @@ describe('list npm versions', () => {
   });
 
   describe('listPackageVersionsByTag', () => {
-    function getOptionsAndPackages(params: {
+    async function getOptionsAndPackages(params: {
       packages: PartialPackageInfos;
       /** CLI options which override any package-specific options */
       extraArgv?: string[];
       /** Options to override the defaults */
       repoOptions?: Partial<RepoOptions>;
     }) {
-      const parsedOptions = getOptions({
+      const parsedOptions = await getOptions({
         argv: ['node', 'beachball', ...(params.extraArgv || [])],
         env: {},
         cwd: '',
@@ -135,7 +135,7 @@ describe('list npm versions', () => {
 
     describe('defaults and repo options', () => {
       it('succeeds with no packages', async () => {
-        const { packages, options } = getOptionsAndPackages({ packages: {} });
+        const { packages, options } = await getOptionsAndPackages({ packages: {} });
         expect(await listPackageVersionsByTag(packages, options)).toEqual({});
         expect(npmMock.mock).not.toHaveBeenCalled();
         // expect(npmMock.mockFetchJson).not.toHaveBeenCalled();
@@ -143,7 +143,7 @@ describe('list npm versions', () => {
 
       it('returns latest tag by default', async () => {
         npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
         });
         // currently this is how the default to "latest" works in realistic scenarios
@@ -164,7 +164,7 @@ describe('list npm versions', () => {
           foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
           bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {}, bar: {} },
           repoOptions: { tag: 'beta' },
         });
@@ -183,7 +183,7 @@ describe('list npm versions', () => {
         const packages = 'abcdefghij'.split('');
         const showData = Object.fromEntries(packages.map((x, i) => [x, { 'dist-tags': { latest: `${i}.0.0` } }]));
         npmMock.setRegistryData(showData);
-        const { packages: packageInfos, options } = getOptionsAndPackages({
+        const { packages: packageInfos, options } = await getOptionsAndPackages({
           packages: Object.fromEntries(packages.map(x => [x, {}])),
           repoOptions: { tag: 'latest' },
         });
@@ -197,7 +197,7 @@ describe('list npm versions', () => {
 
       it('returns empty if no dist-tags available', async () => {
         npmMock.setRegistryData({});
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
         });
 
@@ -209,7 +209,7 @@ describe('list npm versions', () => {
 
       it('returns empty if no matching dist-tags available', async () => {
         npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
           repoOptions: { tag: 'missing' },
         });
@@ -222,7 +222,7 @@ describe('list npm versions', () => {
 
       it("omits packages that don't exist in registry", async () => {
         npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0' } } });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {}, bar: {} },
         });
 
@@ -233,7 +233,7 @@ describe('list npm versions', () => {
       });
 
       it('does nothing if both tag and defaultNpmTag are empty', async () => {
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
           repoOptions: { tag: '', defaultNpmTag: '' },
         });
@@ -251,7 +251,7 @@ describe('list npm versions', () => {
           foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
           bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: {
             foo: { beachball: { tag: 'beta', defaultNpmTag: 'nope' } },
             bar: {},
@@ -269,7 +269,7 @@ describe('list npm versions', () => {
           foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
           bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: { beachball: { defaultNpmTag: 'beta' } }, bar: {} },
         });
 
@@ -280,7 +280,7 @@ describe('list npm versions', () => {
       });
 
       it('does nothing if package override tag and defaultNpmTag are empty', async () => {
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: { beachball: { tag: '', defaultNpmTag: '' } } },
           repoOptions: { tag: 'latest', defaultNpmTag: 'latest' },
         });
@@ -296,7 +296,7 @@ describe('list npm versions', () => {
       // it's expected that token is only specified as a CLI arg
       it('respects token auth args', async () => {
         npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
           extraArgv: ['--token', 'pass'],
         });
@@ -317,7 +317,7 @@ describe('list npm versions', () => {
 
       it('respects password auth args', async () => {
         npmMock.setRegistryData({ foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } } });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
           extraArgv: ['--authType', 'password', '--token', 'pass'],
         });
@@ -340,7 +340,7 @@ describe('list npm versions', () => {
         npmMock.setRegistryData({
           foo: { 'dist-tags': { latest: '1.0.0', alpha: '1.5.0-alpha', beta: '2.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: {} },
           repoOptions: { tag: 'alpha' },
           extraArgv: ['--tag', 'beta'],
@@ -356,7 +356,7 @@ describe('list npm versions', () => {
         npmMock.setRegistryData({
           foo: { 'dist-tags': { latest: '1.0.0', alpha: '1.5.0-alpha', beta: '2.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: { beachball: { tag: 'alpha' } } },
           extraArgv: ['--tag', 'beta'], // CLI args should take precedence
         });
@@ -372,7 +372,7 @@ describe('list npm versions', () => {
           foo: { 'dist-tags': { latest: '1.0.0', alpha: '1.5.0-alpha', beta: '2.0.0-beta' } },
           bar: { 'dist-tags': { latest: '1.0.0', beta: '3.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: { beachball: { tag: 'alpha' } }, bar: {} },
           extraArgv: ['--tag', 'beta'], // CLI args should take precedence
         });
@@ -388,7 +388,7 @@ describe('list npm versions', () => {
         npmMock.setRegistryData({
           foo: { 'dist-tags': { latest: '1.0.0', beta: '2.0.0-beta' } },
         });
-        const { packages, options } = getOptionsAndPackages({
+        const { packages, options } = await getOptionsAndPackages({
           packages: { foo: { beachball: { tag: '', defaultNpmTag: '' } } },
           extraArgv: ['--tag', 'beta'],
         });

--- a/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
+++ b/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
@@ -64,8 +64,8 @@ describe('bumpAndPush', () => {
     } as GitProcessOutput;
   }
 
-  function callBumpAndPush(optionOverrides?: Partial<BeachballOptions>, maxRetries?: number) {
-    const { options } = getOptions({
+  async function callBumpAndPush(optionOverrides?: Partial<BeachballOptions>, maxRetries?: number) {
+    const { options } = await getOptions({
       cwd: fakeRoot,
       argv: [],
       env: {},

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -27,7 +27,7 @@ const version = getPackageInfo(findPackageRoot(__dirname)!)?.version;
     throw new BeachballError('beachball only works in a git repository. Please initialize git and try again.');
   }
 
-  const parsedOptions = getOptions({ cwd: processCwd, argv: process.argv, env: process.env, version });
+  const parsedOptions = await getOptions({ cwd: processCwd, argv: process.argv, env: process.env, version });
   const options = parsedOptions.options;
 
   // TODO port remaining help elements and remove help.ts

--- a/packages/beachball/src/githubAuth/appTokenBin.ts
+++ b/packages/beachball/src/githubAuth/appTokenBin.ts
@@ -1,12 +1,18 @@
 import { env } from '../env';
+import { BeachballError } from '../types/BeachballError';
 import { runAppTokenCli } from './appTokenCli';
-import { AuthError } from './validationHelpers';
 
 // This is a separate file so most of the CLI can be tested in Jest
 void runAppTokenCli({ argv: process.argv }).catch((err: unknown) => {
-  const message =
-    err instanceof AuthError ? err.message : err instanceof Error ? err.stack || err.message : String(err);
+  let message: string;
+  let shouldLog = true;
+  if (err instanceof BeachballError) {
+    message = err.message;
+    shouldLog = !err.alreadyLogged;
+  } else {
+    message = err instanceof Error ? err.stack || err.message : String(err);
+  }
   const errorPrefix = env.isAzurePipelines ? '##vso[task.logissue type=error] ' : '';
-  console.error(`${errorPrefix}${message}`);
+  shouldLog && console.error(`${errorPrefix}${message}`);
   process.exitCode = 1;
 });

--- a/packages/beachball/src/githubAuth/appTokenCli.ts
+++ b/packages/beachball/src/githubAuth/appTokenCli.ts
@@ -1,9 +1,10 @@
 import { Command, Option, type OutputConfiguration } from 'commander';
 import { createAppTokenHelper } from './createAppTokenHelper';
 import type { AppTokenHelperOptions, GetInstallationTokenOptions, RevokeAppTokenOptions } from './types';
-import { AuthError, parsePermissionsArg } from './validationHelpers';
+import { parsePermissionsArg } from './validationHelpers';
 import { defaultGitHubApiUrl } from './requestHelpers';
 import { revokeAppToken } from './revokeAppToken';
+import { BeachballError } from '../types/BeachballError';
 
 /** Injectable dependencies so the CLI can be driven and observed in tests. */
 export interface CliContext {
@@ -28,10 +29,12 @@ async function runCreateToken(options: TokenCliOptions): Promise<void> {
 
   if (output !== 'stdout') {
     if (!azureTokenVariable) {
-      throw new AuthError('--azure-token-variable (AZURE_TOKEN_VARIABLE) is required unless --output is stdout');
+      throw new BeachballError('--azure-token-variable (AZURE_TOKEN_VARIABLE) is required unless --output is stdout');
     }
     if (!/^[A-Za-z_]\w*$/.test(azureTokenVariable)) {
-      throw new AuthError('--azure-token-variable (AZURE_TOKEN_VARIABLE) must be an environment-style variable name');
+      throw new BeachballError(
+        '--azure-token-variable (AZURE_TOKEN_VARIABLE) must be an environment-style variable name'
+      );
     }
   }
 

--- a/packages/beachball/src/githubAuth/requestHelpers.ts
+++ b/packages/beachball/src/githubAuth/requestHelpers.ts
@@ -1,10 +1,10 @@
-import { AuthError } from './validationHelpers';
+import { BeachballError } from '../types/BeachballError';
 
 export const defaultGitHubApiUrl = 'https://api.github.com';
 
 const transientRetryCount = 3;
 
-export class GitHubRequestError extends AuthError {
+export class GitHubRequestError extends BeachballError {
   public readonly status: number;
   public constructor(message: string, status: number) {
     super(message);
@@ -46,7 +46,7 @@ export async function requestJson<T = unknown>(
   try {
     return JSON.parse(body) as T;
   } catch {
-    throw new AuthError(`${failureMessage}: GitHub returned invalid JSON`);
+    throw new BeachballError(`${failureMessage}: GitHub returned invalid JSON`);
   }
 }
 

--- a/packages/beachball/src/githubAuth/signWithAzureCli.ts
+++ b/packages/beachball/src/githubAuth/signWithAzureCli.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import execa from 'execa';
-import { AuthError } from './validationHelpers';
+import { BeachballError } from '../types/BeachballError';
 
 function base64ToBase64url(value: string): string {
   return value.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
@@ -34,11 +34,13 @@ async function signDigest(keyId: string, digest: string): Promise<string> {
     // `code` is the spawn error code (e.g. `ENOENT`), which isn't on the `ExecaError` type.
     const execaError = error as execa.ExecaError & { code?: string };
     if (execaError.code === 'ENOENT') {
-      throw new AuthError('Azure CLI (`az`) was not found on PATH');
+      throw new BeachballError('Azure CLI (`az`) was not found on PATH');
     }
 
     const output = execaError.all || '';
-    throw new AuthError(`Azure Key Vault signing failed. ${output ? `Output:\n${output}` : execaError.shortMessage}`);
+    throw new BeachballError(
+      `Azure Key Vault signing failed. ${output ? `Output:\n${output}` : execaError.shortMessage}`
+    );
   }
 }
 
@@ -58,7 +60,7 @@ export async function signWithAzureCli(keyId: string, signingInput: string): Pro
   const digest = createHash('sha256').update(signingInput).digest('base64');
   const signature = await signDigest(keyId, digest);
   if (!signature) {
-    throw new AuthError('Azure Key Vault did not return a signature');
+    throw new BeachballError('Azure Key Vault did not return a signature');
   }
   return base64ToBase64url(signature);
 }

--- a/packages/beachball/src/githubAuth/validationHelpers.ts
+++ b/packages/beachball/src/githubAuth/validationHelpers.ts
@@ -1,8 +1,6 @@
 import { InvalidArgumentError } from 'commander';
 import type { PermissionLevel, Permissions } from './types';
-
-/** Generic error thrown from this code (don't show the stack) */
-export class AuthError extends Error {}
+import { BeachballError } from '../types/BeachballError';
 
 const permissionLevels = Object.keys({
   read: true,
@@ -17,7 +15,7 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 export function requiredIntegerProperty(value: unknown, property: string, failureMessage: string): number {
   const propertyValue = isRecord(value) ? value[property] : undefined;
   if (typeof propertyValue !== 'number' || !Number.isInteger(propertyValue)) {
-    throw new AuthError(failureMessage);
+    throw new BeachballError(failureMessage);
   }
   return propertyValue;
 }
@@ -25,7 +23,7 @@ export function requiredIntegerProperty(value: unknown, property: string, failur
 export function requiredStringProperty(value: unknown, property: string, failureMessage: string): string {
   const propertyValue = isRecord(value) ? value[property] : undefined;
   if (typeof propertyValue !== 'string' || !propertyValue) {
-    throw new AuthError(failureMessage);
+    throw new BeachballError(failureMessage);
   }
   return propertyValue;
 }
@@ -39,23 +37,23 @@ export function parsePermissions(value: string | undefined): Permissions | undef
   for (const entry of splitList(value)) {
     const parts = entry.split(':');
     if (parts.length !== 2) {
-      throw new AuthError(`Permission entry must include an explicit level: ${entry}`);
+      throw new BeachballError(`Permission entry must include an explicit level: ${entry}`);
     }
 
     const key = parts[0]?.trim();
     const rawLevel = parts[1]?.trim();
     if (!key) {
-      throw new AuthError(`Permission entry must include a permission name: ${entry}`);
+      throw new BeachballError(`Permission entry must include a permission name: ${entry}`);
     }
     if (!/^[A-Za-z_]\w*$/.test(key)) {
-      throw new AuthError(`Invalid permission name: ${key}`);
+      throw new BeachballError(`Invalid permission name: ${key}`);
     }
     if (Object.hasOwn(permissions, key)) {
-      throw new AuthError(`Duplicate permission: ${key}`);
+      throw new BeachballError(`Duplicate permission: ${key}`);
     }
 
     if (!permissionLevels.includes(rawLevel)) {
-      throw new AuthError(`Invalid permission level for ${key}: ${rawLevel}`);
+      throw new BeachballError(`Invalid permission level for ${key}: ${rawLevel}`);
     }
     permissions[key] = rawLevel as PermissionLevel;
   }
@@ -94,5 +92,5 @@ export function parseRepository(repository: string): { owner: string; name: stri
   if (parts.length === 2 && parts[0] && parts[1]) {
     return { owner: parts[0], name: parts[1] };
   }
-  throw new AuthError(`Invalid repository '${repository}'. Expected 'owner/repository'.`);
+  throw new BeachballError(`Invalid repository '${repository}'. Expected 'owner/repository'.`);
 }

--- a/packages/beachball/src/options/getOptions.ts
+++ b/packages/beachball/src/options/getOptions.ts
@@ -8,10 +8,12 @@ import { BeachballError } from '../types/BeachballError';
  * Get merged and unmerged options, for reuse by `getPackageInfos`.
  * @param testRepoOptions Repo options for testing purposes
  */
-export function getOptions(params: ProgramContext & { testRepoOptions?: Partial<RepoOptions> }): ParsedOptions {
+export async function getOptions(
+  params: ProgramContext & { testRepoOptions?: Partial<RepoOptions> }
+): Promise<ParsedOptions> {
   const { testRepoOptions, ...processInfo } = params;
   const cliOptions = getCliOptions(processInfo);
-  const repoOptions = testRepoOptions || getRepoOptions(cliOptions);
+  const repoOptions = testRepoOptions || (await getRepoOptions(cliOptions));
   const result: ParsedOptions = {
     cliOptions,
     repoOptions,

--- a/packages/beachball/src/options/getRepoOptions.ts
+++ b/packages/beachball/src/options/getRepoOptions.ts
@@ -9,19 +9,14 @@ import { readConfig } from './readConfig';
  * and returns an empty object.
  */
 export async function getRepoOptions(cliOptions: ParsedOptions['cliOptions']): Promise<Partial<RepoOptions>> {
-  const { configPath, path: cwd } = cliOptions;
+  const { path: cwd } = cliOptions;
 
   if (!cwd) {
     // If cwd is empty, it's probably running in a test without a filesystem.
     return {};
   }
 
-  const result = await readConfig<Partial<RepoOptions>>({
-    name: 'beachball',
-    cwd,
-    customPath: configPath,
-  });
-  const repoOptions = result?.config || {};
+  const repoOptions = (await readConfig<Partial<RepoOptions>>({ path: cwd, configPath: cliOptions.configPath })) || {};
 
   // Only if the branch isn't specified in cliOptions (which takes precedence), fix it up or add it
   // in repoOptions

--- a/packages/beachball/src/options/getRepoOptions.ts
+++ b/packages/beachball/src/options/getRepoOptions.ts
@@ -1,9 +1,6 @@
-import { cosmiconfigSync } from 'cosmiconfig';
-import path from 'path';
-import { findGitRoot } from 'workspace-tools';
-import { BeachballError } from '../types/BeachballError';
 import type { ParsedOptions, RepoOptions } from '../types/BeachballOptions';
 import { resolveBranchOption } from './getCliOptions';
+import { readConfig } from './readConfig';
 
 /**
  * Find the beachball config file and return the repo options.
@@ -11,7 +8,7 @@ import { resolveBranchOption } from './getCliOptions';
  * If `cliOptions.path` is empty, it's assumed to be running in a test without a filesystem
  * and returns an empty object.
  */
-export function getRepoOptions(cliOptions: ParsedOptions['cliOptions']): Partial<RepoOptions> {
+export async function getRepoOptions(cliOptions: ParsedOptions['cliOptions']): Promise<Partial<RepoOptions>> {
   const { configPath, path: cwd } = cliOptions;
 
   if (!cwd) {
@@ -19,30 +16,12 @@ export function getRepoOptions(cliOptions: ParsedOptions['cliOptions']): Partial
     return {};
   }
 
-  let repoOptions: Partial<RepoOptions> | null | undefined;
-
-  let rootDir: string;
-  try {
-    rootDir = findGitRoot(cwd);
-  } catch {
-    rootDir = cwd;
-  }
-  const configExplorer = cosmiconfigSync('beachball', {
-    cache: false,
-    // cosmiconfig v9 doesn't search up by default. For a mix of preserving old behavior and
-    // improving efficiency, only search up to the git root (if available) or cwd.
-    stopDir: rootDir,
-    searchStrategy: 'global',
+  const result = await readConfig<Partial<RepoOptions>>({
+    name: 'beachball',
+    cwd,
+    customPath: configPath,
   });
-
-  if (configPath) {
-    repoOptions = configExplorer.load(path.resolve(cwd, configPath))?.config as Partial<RepoOptions> | undefined;
-    if (!repoOptions) {
-      throw new BeachballError(`Config file "${configPath}" could not be loaded`);
-    }
-  } else {
-    repoOptions = (configExplorer.search(cwd)?.config as Partial<RepoOptions> | undefined) || {};
-  }
+  const repoOptions = result?.config || {};
 
   // Only if the branch isn't specified in cliOptions (which takes precedence), fix it up or add it
   // in repoOptions

--- a/packages/beachball/src/options/optionDefinitions.ts
+++ b/packages/beachball/src/options/optionDefinitions.ts
@@ -109,7 +109,7 @@ export const optionDefinitions: Record<
     group: 'common',
     short: 'c',
     alias: 'config',
-    desc: 'custom beachball config path (default: cosmiconfig standard paths)',
+    desc: 'custom beachball config path (default: cosmiconfig-like paths)',
   },
   verbose: {
     commands: () => true,

--- a/packages/beachball/src/options/readConfig.ts
+++ b/packages/beachball/src/options/readConfig.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { getPackageInfo } from 'workspace-tools';
+import { BeachballError } from '../types/BeachballError';
+
+/** Module file extensions supported for config files */
+const moduleExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
+
+interface ConfigResult<TConfig> {
+  /** The loaded config value. */
+  config: TConfig;
+  /** Absolute path to the file the config was loaded from. */
+  filepath: string;
+}
+
+/**
+ * Search `cwd` (only, not parent directories) for a config file for `name`.
+ * This implements a subset of `cosmiconfig`'s behavior, considering these locations (in order):
+ * - a package.json property `<name>`
+ * - a `<name>.config.<ext>` with extensions `.[cm]?[jt]s`
+ * - a JSON extensionless "rc file" `.<name>rc`
+ * - an "rc file" `.<name>rc.<ext>` with the extensions `.json`, `.[cm]?[jt]s`
+ * - any of the above (except package.json) under a `.config` directory
+ *
+ * @returns The loaded config and the file it came from, or null if no config was found
+ */
+export async function readConfig<TConfig = unknown>(params: {
+  /** The name of the config (e.g., `beachball`) */
+  name: string;
+  /** The directory to search in */
+  cwd: string;
+  /** If provided, read this path instead of searching in `cwd` */
+  customPath?: string;
+}): Promise<ConfigResult<TConfig> | null> {
+  const { name, cwd, customPath } = params;
+
+  if (customPath) {
+    const filepath = path.resolve(cwd, customPath);
+    const config = await loadConfig<TConfig>(filepath);
+    return { config, filepath };
+  }
+
+  // package.json "<name>" property
+  const packageInfo = getPackageInfo(cwd);
+  if (packageInfo?.[name]) {
+    return { config: packageInfo?.[name] as TConfig, filepath: packageInfo.packageJsonPath };
+  }
+
+  const result = await searchDir<TConfig>(name, cwd);
+  return result || (await searchDir<TConfig>(name, path.join(cwd, '.config')));
+}
+
+async function searchDir<TConfig>(name: string, dir: string): Promise<ConfigResult<TConfig> | null> {
+  const searchPlaces = [
+    `.${name}rc`,
+    ...moduleExtensions.map(ext => `${name}.config.${ext}`),
+    `.${name}rc.json`,
+    ...moduleExtensions.map(ext => `.${name}rc.${ext}`),
+  ];
+
+  for (const searchPlace of searchPlaces) {
+    const filepath = path.join(dir, searchPlace);
+    if (isFile(filepath)) {
+      const config = await loadConfig<TConfig>(filepath);
+      return { config, filepath };
+    }
+  }
+
+  return null;
+}
+
+/** Whether `filepath` exists and is a regular file. */
+function isFile(filepath: string): boolean {
+  try {
+    return fs.statSync(filepath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Try to load the file, or throw if there's an error */
+async function loadConfig<TConfig>(filepath: string): Promise<TConfig> {
+  try {
+    // `.json` and the extensionless `.<name>rc` files are JSON; the rest are JS/TS modules.
+    const ext = path.extname(filepath);
+    if (ext === '.json' || !ext) {
+      return JSON.parse(fs.readFileSync(filepath, 'utf8')) as TConfig;
+    } else {
+      // import() works most reliably with URLs on Windows
+      const url = pathToFileURL(filepath).href;
+      const imported = (await import(url)) as { default?: TConfig };
+      return imported.default ?? (imported as TConfig);
+    }
+  } catch (err) {
+    throw new BeachballError(
+      `Failed to load config from ${filepath}: ${err instanceof Error ? err.stack || err.message : String(err)}`,
+      { cause: err }
+    );
+  }
+}

--- a/packages/beachball/src/options/readConfig.ts
+++ b/packages/beachball/src/options/readConfig.ts
@@ -53,8 +53,8 @@ export async function readConfig<TConfig = unknown>(params: {
 
 async function searchDir<TConfig>(name: string, dir: string): Promise<ConfigResult<TConfig> | null> {
   const searchPlaces = [
-    `.${name}rc`,
     ...moduleExtensions.map(ext => `${name}.config.${ext}`),
+    `.${name}rc`,
     `.${name}rc.json`,
     ...moduleExtensions.map(ext => `.${name}rc.${ext}`),
   ];
@@ -94,7 +94,7 @@ async function loadConfig<TConfig>(filepath: string): Promise<TConfig> {
     }
   } catch (err) {
     throw new BeachballError(
-      `Failed to load config from ${filepath}: ${err instanceof Error ? err.stack || err.message : String(err)}`,
+      `Failed to load config from ${filepath}: ${err instanceof Error ? err.message : String(err)}`,
       { cause: err }
     );
   }

--- a/packages/beachball/src/options/readConfig.ts
+++ b/packages/beachball/src/options/readConfig.ts
@@ -3,71 +3,57 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { getPackageInfo } from 'workspace-tools';
 import { BeachballError } from '../types/BeachballError';
+import type { BeachballOptions } from '../types/BeachballOptions';
+
+const name = 'beachball';
 
 /** Module file extensions supported for config files */
-const moduleExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
-
-interface ConfigResult<TConfig> {
-  /** The loaded config value. */
-  config: TConfig;
-  /** Absolute path to the file the config was loaded from. */
-  filepath: string;
-}
+const moduleExtensions = ['json', 'js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
 
 /**
- * Search `cwd` (only, not parent directories) for a config file for `name`.
+ * Search `cwd` (only, not parent directories) for a `beachball` config file.
  * This implements a subset of `cosmiconfig`'s behavior, considering these locations (in order):
- * - a package.json property `<name>`
- * - a `<name>.config.<ext>` with extensions `.[cm]?[jt]s`
- * - a JSON extensionless "rc file" `.<name>rc`
- * - an "rc file" `.<name>rc.<ext>` with the extensions `.json`, `.[cm]?[jt]s`
+ * - a package.json property `beachball`
+ * - a `beachball.config.<ext>` with extensions `.[cm]?[jt]s`
+ * - a JSON extensionless "rc file" `.beachballrc`
+ * - an "rc file" `.beachballrc.<ext>` with the extensions `.json`, `.[cm]?[jt]s`
  * - any of the above (except package.json) under a `.config` directory
  *
- * @returns The loaded config and the file it came from, or null if no config was found
+ * @returns The loaded config, or undefined if no config was found
  */
-export async function readConfig<TConfig = unknown>(params: {
-  /** The name of the config (e.g., `beachball`) */
-  name: string;
-  /** The directory to search in */
-  cwd: string;
-  /** If provided, read this path instead of searching in `cwd` */
-  customPath?: string;
-}): Promise<ConfigResult<TConfig> | null> {
-  const { name, cwd, customPath } = params;
+export async function readConfig<TConfig = unknown>(
+  options: Pick<BeachballOptions, 'path' | 'configPath'>
+): Promise<TConfig | undefined> {
+  const { path: cwd, configPath: customPath } = options;
 
   if (customPath) {
-    const filepath = path.resolve(cwd, customPath);
-    const config = await loadConfig<TConfig>(filepath);
-    return { config, filepath };
+    return await loadConfig<TConfig>(path.resolve(cwd, customPath));
   }
 
-  // package.json "<name>" property
+  // package.json "beachball" property
   const packageInfo = getPackageInfo(cwd);
   if (packageInfo?.[name]) {
-    return { config: packageInfo?.[name] as TConfig, filepath: packageInfo.packageJsonPath };
+    return packageInfo?.[name] as TConfig;
   }
 
-  const result = await searchDir<TConfig>(name, cwd);
-  return result || (await searchDir<TConfig>(name, path.join(cwd, '.config')));
+  const result = await searchDir<TConfig>(cwd);
+  return result || (await searchDir<TConfig>(path.join(cwd, '.config')));
 }
 
-async function searchDir<TConfig>(name: string, dir: string): Promise<ConfigResult<TConfig> | null> {
+async function searchDir<TConfig>(dir: string): Promise<TConfig | undefined> {
   const searchPlaces = [
     ...moduleExtensions.map(ext => `${name}.config.${ext}`),
     `.${name}rc`,
-    `.${name}rc.json`,
     ...moduleExtensions.map(ext => `.${name}rc.${ext}`),
   ];
 
   for (const searchPlace of searchPlaces) {
     const filepath = path.join(dir, searchPlace);
     if (isFile(filepath)) {
-      const config = await loadConfig<TConfig>(filepath);
-      return { config, filepath };
+      return await loadConfig<TConfig>(filepath);
     }
   }
-
-  return null;
+  return undefined;
 }
 
 /** Whether `filepath` exists and is a regular file. */
@@ -89,8 +75,9 @@ async function loadConfig<TConfig>(filepath: string): Promise<TConfig> {
     } else {
       // import() works most reliably with URLs on Windows
       const url = pathToFileURL(filepath).href;
-      const imported = (await import(url)) as { default?: TConfig };
-      return imported.default ?? (imported as TConfig);
+      const imported = (await import(url)) as { default?: TConfig | { default?: TConfig } };
+      // double default is probably a jest-transform-specific issue
+      return ((imported.default as { default?: TConfig })?.default ?? imported.default ?? imported) as TConfig;
     }
   } catch (err) {
     throw new BeachballError(

--- a/packages/beachball/src/types/BeachballError.ts
+++ b/packages/beachball/src/types/BeachballError.ts
@@ -1,5 +1,6 @@
 /**
  * Custom error class for expected/handled beachball errors.
+ * Only the message is logged on exit, not the stack.
  *
  * When `alreadyLogged` is true, it means the detailed error information has
  * already been printed to stderr before the error was thrown. The top-level
@@ -9,8 +10,8 @@ export class BeachballError extends Error {
   /** If true, detailed error info was already logged via console.error before throwing. */
   public readonly alreadyLogged: boolean;
 
-  public constructor(message: string, options?: { alreadyLogged?: boolean }) {
-    super(message);
+  public constructor(message: string, options?: { alreadyLogged?: boolean } & ErrorOptions) {
+    super(message, options);
     this.name = 'BeachballError';
     this.alreadyLogged = !!options?.alreadyLogged;
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "tsc --noEmit --pretty",
+    "build": "yarn run -T tsc --noEmit --pretty",
     "lint:skills": "node ./lintSkills.ts",
     "lint:versions": "cd .. && yarn syncpack:check",
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' yarn run -T jest"

--- a/scripts/showDependencyTree.ts
+++ b/scripts/showDependencyTree.ts
@@ -1,0 +1,140 @@
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import { findPackageRoot, getPackageInfo } from 'workspace-tools';
+
+/**
+ * Prints the production dependency tree of a package using the versions actually
+ * installed under `node_modules` (resolved via Node's module resolution).
+ *
+ * Usage:
+ *   node scripts/showDependencyTree.ts <package-name> [--dev]
+ *
+ * - `<package-name>` may be a workspace package (e.g. `beachball`) or any
+ *   installed dependency. Defaults to resolving from the current working dir.
+ * - `--dev` includes the root package's devDependencies (transitive dev deps are
+ *   never installed, so they can't be shown regardless).
+ */
+
+/**
+ * Resolve the package directory of `depName` as installed relative to `fromDir`,
+ * walking up parent `node_modules` folders (matching Node's resolution).
+ * Returns undefined if it can't be resolved (e.g. an unmet optional dependency).
+ */
+function resolvePackage(depName: string, fromDir: string): string | undefined {
+  const require = createRequire(path.join(fromDir, 'noop.js'));
+  try {
+    return path.dirname(require.resolve(`${depName}/package.json`));
+  } catch {
+    try {
+      const resolved = require.resolve(depName);
+      return findPackageRoot(resolved);
+    } catch {
+      // Some packages don't expose package.json via `exports`. Fall back to
+      // walking node_modules folders manually.
+      let dir = fromDir;
+      while (true) {
+        const candidate = path.join(dir, 'node_modules', depName, 'package.json');
+        if (fs.existsSync(candidate)) {
+          return path.dirname(fs.realpathSync(candidate));
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+          return undefined;
+        }
+        dir = parent;
+      }
+    }
+  }
+}
+
+function printTree(params: {
+  packageRoot: string;
+  includeDev: boolean;
+  prefix?: string;
+  isLast: boolean;
+  seen?: Set<string>;
+  isRoot: boolean;
+}): boolean {
+  const { packageRoot, includeDev, prefix = '', isLast, seen = new Set(), isRoot } = params;
+  const packageInfo = getPackageInfo(packageRoot)!;
+  const id = `${packageInfo.name}@${packageInfo.version}`;
+
+  // Whether any node in this render was collapsed because it was already shown.
+  let dedupedAny = false;
+
+  if (isRoot) {
+    console.log(id);
+  } else {
+    const connector = isLast ? '└── ' : '├── ';
+    // If this exact name@version was already expanded elsewhere, show a
+    // placeholder instead of repeating the (possibly large) subtree.
+    if (seen.has(id)) {
+      console.log(`${prefix}${connector}${id} (*)`);
+      return true;
+    }
+    console.log(`${prefix}${connector}${id}`);
+  }
+
+  seen.add(id);
+
+  const deps = {
+    ...packageInfo.dependencies,
+    ...packageInfo.peerDependencies,
+    ...packageInfo.optionalDependencies,
+    ...(isRoot && includeDev ? packageInfo.devDependencies : undefined),
+  };
+  const names = Object.keys(deps).sort();
+
+  const childPrefix = isRoot ? '' : prefix + (isLast ? '    ' : '│   ');
+
+  names.forEach((depName, index) => {
+    const childIsLast = index === names.length - 1;
+    const childRoot = resolvePackage(depName, packageRoot);
+    if (!childRoot) {
+      const connector = childIsLast ? '└── ' : '├── ';
+      console.log(`${childPrefix}${connector}${depName} (unmet)`);
+      return;
+    }
+    dedupedAny =
+      printTree({
+        packageRoot: childRoot,
+        includeDev,
+        prefix: childPrefix,
+        isLast: childIsLast,
+        seen,
+        isRoot: false,
+      }) || dedupedAny;
+  });
+
+  return dedupedAny;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const includeDev = args.includes('--dev');
+  const target = args.find(arg => !arg.startsWith('--'));
+
+  let packageRoot: string | undefined;
+  if (target) {
+    packageRoot = resolvePackage(target, process.cwd());
+    if (!packageRoot) {
+      console.error(`Unable to resolve installed package "${target}" from ${process.cwd()}`);
+      process.exit(1);
+    }
+  } else {
+    packageRoot = findPackageRoot(process.cwd());
+    if (!packageRoot) {
+      console.error(`No package.json found in ${process.cwd()}`);
+      process.exit(1);
+    }
+  }
+
+  const dedupedAny = printTree({ packageRoot, includeDev, isLast: true, isRoot: true });
+
+  if (dedupedAny) {
+    console.log('\n(*) already shown above; subtree omitted to avoid repetition');
+  }
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,7 +3686,6 @@ __metadata:
     "@vercel/detect-agent": "npm:^1.2.1"
     "@verdaccio/types": "npm:^13.0.0"
     commander: "catalog:prod"
-    cosmiconfig: "npm:^9.0.1"
     cross-env: "catalog:dev"
     execa: "catalog:prod"
     get-port: "npm:^7.0.0"
@@ -4233,23 +4232,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^9.0.1":
-  version: 9.0.2
-  resolution: "cosmiconfig@npm:9.0.2"
-  dependencies:
-    env-paths: "npm:^2.2.1"
-    import-fresh: "npm:^3.3.0"
-    js-yaml: "npm:^4.1.0"
-    parse-json: "npm:^5.2.0"
-  peerDependencies:
-    typescript: ">=4.9.5"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/132d32863c0b3d9ace7010a10011e09089532b36e3b11e02004d671dcbd8b8f2f16293b82d510d9c15890f30358baf8722127c7b1c011449c90b6a178f9c6594
-  languageName: node
-  linkType: hard
-
 "cross-env@npm:^10.1.0":
   version: 10.1.0
   resolution: "cross-env@npm:10.1.0"
@@ -4584,7 +4566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
+"env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
@@ -5967,7 +5949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
+"import-fresh@npm:^3.2.1":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
   dependencies:
@@ -6729,7 +6711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0":
+"js-yaml@npm:^4.2.0":
   version: 4.3.0
   resolution: "js-yaml@npm:4.3.0"
   dependencies:


### PR DESCRIPTION
Instead of using [`cosmiconfig`](https://www.npmjs.com/package/cosmiconfig), implement basic custom config loading logic. Overall behavior is similar, but support for YAML config files is removed, and it won't search up from the project/repo root.

> Most often, Beachball config is stored in `beachball.config.js`, but Beachball will check all the following locations under the project root directory (usually the repo root):
>
> - `"beachball"` key inside `package.json`
> - `beachball.config.[cm]?[jt]s`
> - `.beachballrc` (JSON) or `.beachballrc.json`
> - `.beachballrc.[cm]?[jt]s`
> - any of the above (except `package.json`) under a `.config` directory