### PR TITLE
Use `path.matchesGlob` instead of `minimatch`

### DIFF
--- a/change/beachball-f8f24ac1-633e-4fb6-b94b-2d5fd99acfee.json
+++ b/change/beachball-f8f24ac1-633e-4fb6-b94b-2d5fd99acfee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use `path.matchesGlob` instead of `minimatch`. Behavior should stay the same, but if not, please open an issue.",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -118,15 +118,17 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 
 Glob matching is implemented using Node's built-in glob support, which is based on [`minimatch`](https://www.npmjs.com/package/minimatch) with [these options](https://github.com/nodejs/node/blob/6a3d80fb49c50494fe987a22708634ce720e9272/lib/internal/fs/glob.js#L112) and supports most glob syntax.
 
-All glob patterns are relative to the repo or monorepo root and must use **forward slashes only**.
-
-Unless otherwise noted (such as for `scope`), using gitignore-style negated patterns to modify previous matches is not supported.
+- Patterns are relative to the repo or project root.
+- Patterns without a `/` will match against filenames at any depth.
+- Patterns should use forward slashes.
+- Case-sensitive matching behavior varies by OS, so it's best to ensure the patterns follow the actual casing used by files.
+- Unless otherwise noted (such as for `scope`), using gitignore-style negated patterns to modify previous matches is not supported.
 
 ### Scoping
 
 The `scope` option allows limiting which packages are considered. You can set it in the config file if it should always apply, or on the command line for a specific operation.
 
-This option takes a list of patterns which are matched against package paths. Patterns are relative to the monorepo root and must use forward slashes. Negations are supported, similar to how gitignore works.
+This option takes a list of patterns which are matched against package paths. Patterns are relative to the monorepo root and should use forward slashes. Negations **are** supported, similar to how gitignore works.
 
 Example: with this config, `beachball` will only consider packages under `packages/foo` (excluding `packages/foo/bar`).
 

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -119,7 +119,6 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 Glob matching is implemented using Node's built-in glob support, which is based on [`minimatch`](https://www.npmjs.com/package/minimatch) with [these options](https://github.com/nodejs/node/blob/6a3d80fb49c50494fe987a22708634ce720e9272/lib/internal/fs/glob.js#L112) and supports most glob syntax.
 
 - Patterns are relative to the repo or project root.
-- Patterns without a `/` will match against filenames at any depth.
 - Patterns should use forward slashes.
 - Case-sensitive matching behavior varies by OS, so it's best to ensure the patterns follow the actual casing used by files.
 - Unless otherwise noted (such as for `scope`), using gitignore-style negated patterns to modify previous matches is not supported.

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -116,7 +116,7 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 
 ### Glob matching
 
-Glob matching is implemented using [`minimatch`](https://www.npmjs.com/package/minimatch), which supports most glob syntax.
+Glob matching is implemented using Node's built-in glob support, which is based on [`minimatch`](https://www.npmjs.com/package/minimatch) with [these options](https://github.com/nodejs/node/blob/6a3d80fb49c50494fe987a22708634ce720e9272/lib/internal/fs/glob.js#L112) and supports most glob syntax.
 
 All glob patterns are relative to the repo or monorepo root and must use **forward slashes only**.
 

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -40,7 +40,6 @@
     "@vercel/detect-agent": "^1.2.1",
     "commander": "catalog:prod",
     "execa": "catalog:prod",
-    "minimatch": "^3.1.5",
     "p-graph": "workspace:^",
     "p-limit": "^3.1.0",
     "prompts": "^2.4.2",
@@ -50,7 +49,6 @@
   "devDependencies": {
     "@microsoft/beachball-scripts": "workspace:^",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/minimatch": "^3.0.0",
     "@types/prompts": "^2.4.2",
     "@types/semver": "catalog:dev",
     "@types/tmp": "^0.2.3",

--- a/packages/beachball/src/__tests__/monorepo/filterIgnoredFiles.test.ts
+++ b/packages/beachball/src/__tests__/monorepo/filterIgnoredFiles.test.ts
@@ -75,6 +75,104 @@ describe('filterIgnoredFiles', () => {
       });
       expect(result).toEqual(['src/c.ts', 'foo/README.md']);
     });
+
+    it('"foo/**/bar.ts" matches bar.ts directly under foo (globstar matches zero dirs)', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['foo/bar.ts', 'foo/sub/bar.ts', 'foo/x.ts'],
+        ignorePatterns: ['foo/**/bar.ts'],
+      });
+      expect(result).toEqual(['foo/x.ts']);
+    });
+
+    it('"**" matches every path', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['a', 'b/c', 'd/e/f'],
+        ignorePatterns: ['**'],
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  // These document behavior that commonly differs between glob libraries/options and should stay
+  // consistent if switching implementations.
+  describe('edge cases', () => {
+    it('matches basenames even inside dot-directories (matchBase parity)', () => {
+      // `**` alone does not descend into dot-directories, but the basename fallback restores
+      // minimatch's matchBase behavior, so slashless patterns still match files nested under them.
+      const result = filterIgnoredFiles({
+        filePaths: ['.git/config', 'src/.hidden/a.ts', 'src/a.ts', '.config/app.log'],
+        ignorePatterns: ['*.ts', '*.log', 'config'],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('does not match leading-dot basenames with a non-dot wildcard', () => {
+      // `*` does not match a leading dot, so `.env` and `.env.local` are kept.
+      const result = filterIgnoredFiles({
+        filePaths: ['.env', '.env.local', 'env.ts', 'a.env'],
+        ignorePatterns: ['*.env'],
+      });
+      expect(result).toEqual(['.env', '.env.local', 'env.ts']);
+    });
+
+    it('matches leading-dot basenames with an explicit dot pattern', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['.env', 'x/.npmrc', 'keep.ts'],
+        ignorePatterns: ['.*'],
+      });
+      expect(result).toEqual(['keep.ts']);
+    });
+
+    it('matches a directory basename but not its contents (matchBase is basename-only)', () => {
+      // A slashless pattern matches the directory entry itself, but not files under it.
+      const result = filterIgnoredFiles({
+        filePaths: ['node_modules', 'node_modules/a.js', 'src/node_modules/b.js'],
+        ignorePatterns: ['node_modules'],
+      });
+      expect(result).toEqual(['node_modules/a.js', 'src/node_modules/b.js']);
+    });
+
+    it('supports character classes', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['a.ts', 'b.ts', 'c.ts', 'd.ts'],
+        ignorePatterns: ['[ab].ts'],
+      });
+      expect(result).toEqual(['c.ts', 'd.ts']);
+    });
+
+    it('supports the ? single-character wildcard', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['a.ts', 'ab.ts', 'b.ts'],
+        ignorePatterns: ['?.ts'],
+      });
+      expect(result).toEqual(['ab.ts']);
+    });
+
+    it('supports nested brace expansion', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['a1.ts', 'a2.ts', 'b1.ts'],
+        ignorePatterns: ['{a,b}{1,2}.ts'],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('supports extglob patterns', () => {
+      const result = filterIgnoredFiles({
+        filePaths: ['ab.ts', 'aab.ts', 'b.ts'],
+        ignorePatterns: ['+(a)b.ts'],
+      });
+      expect(result).toEqual(['b.ts']);
+    });
+
+    it('a trailing-slash pattern matches nothing', () => {
+      // Known quirk: "foo/" has a slash so it is not treated as a basename pattern, and it does
+      // not match the "foo" entry or files under foo.
+      const result = filterIgnoredFiles({
+        filePaths: ['foo', 'foo/a.ts', 'bar'],
+        ignorePatterns: ['foo/'],
+      });
+      expect(result).toEqual(['foo', 'foo/a.ts', 'bar']);
+    });
   });
 
   describe('logIgnored', () => {

--- a/packages/beachball/src/__tests__/monorepo/isPathIncluded.test.ts
+++ b/packages/beachball/src/__tests__/monorepo/isPathIncluded.test.ts
@@ -42,4 +42,57 @@ describe('isPathIncluded', () => {
   it('ignores empty exclude path array', () => {
     expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/*', exclude: [] })).toBeTruthy();
   });
+
+  // These document glob behavior that commonly differs between glob libraries/options and should
+  // stay consistent if switching implementations. Patterns are anchored to the relative path (no matchBase).
+  describe('glob pattern matching', () => {
+    it('"packages/*" matches direct children only, not nested paths', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/*' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/a/b', include: 'packages/*' })).toBeFalsy();
+    });
+
+    it('"packages/**" matches nested paths but not the "packages" entry itself', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a/b', include: 'packages/**' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages', include: 'packages/**' })).toBeFalsy();
+    });
+
+    it('does not match a slashless pattern against the basename (no matchBase)', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'a' })).toBeFalsy();
+    });
+
+    it('supports basic brace expansion', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/{a,b}' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/c', include: 'packages/{a,b}' })).toBeFalsy();
+    });
+
+    it('supports character classes', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/[ab]' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/c', include: 'packages/[ab]' })).toBeFalsy();
+    });
+
+    it('supports the ? single-character wildcard', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/?' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/ab', include: 'packages/?' })).toBeFalsy();
+    });
+
+    it('supports extglob patterns', () => {
+      expect(isPathIncluded({ relativePath: 'packages/foofoo', include: 'packages/+(foo)' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/!(b)' })).toBeTruthy();
+      expect(isPathIncluded({ relativePath: 'packages/b', include: 'packages/!(b)' })).toBeFalsy();
+    });
+
+    it('does not traverse dot-directories with **', () => {
+      expect(isPathIncluded({ relativePath: 'packages/.hidden/a', include: 'packages/**' })).toBeFalsy();
+    });
+
+    it('a trailing-slash pattern does not match a path without one', () => {
+      expect(isPathIncluded({ relativePath: 'packages/a', include: 'packages/a/' })).toBeFalsy();
+    });
+
+    it('excludes nested paths with a globstar exclude pattern', () => {
+      expect(
+        isPathIncluded({ relativePath: 'packages/a/b', include: 'packages/**', exclude: 'packages/a/**' })
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/beachball/src/monorepo/filterIgnoredFiles.ts
+++ b/packages/beachball/src/monorepo/filterIgnoredFiles.ts
@@ -1,7 +1,5 @@
-import minimatch from 'minimatch';
+import path from 'path';
 import type { BeachballOptions } from '../types/BeachballOptions';
-
-const minimatchOptions: minimatch.IOptions = { matchBase: true };
 
 /**
  * Filter `filePaths` to exclude any paths matching `ignorePatterns`.
@@ -21,7 +19,16 @@ export function filterIgnoredFiles(
 
   const filtered: string[] = [];
   for (const filePath of filePaths) {
-    const ignorePattern = ignorePatterns.find(pattern => minimatch(filePath, pattern, minimatchOptions));
+    const basename = path.basename(filePath);
+    // Emulate the minimatch `matchBase` option:
+    // - Patterns without a slash are matched against the basename, even if under a .dot directory.
+    // - Patterns containing a slash are matched as-is, relative to the repo root.
+    // (Node sets windowsPathsNoEscape to treat \ exclusively as a path separator.)
+    // https://github.com/nodejs/node/blob/6a3d80fb49c50494fe987a22708634ce720e9272/lib/internal/fs/glob.js#L112
+    const ignorePattern = ignorePatterns.find(pattern =>
+      path.matchesGlob(pattern.includes('/') || pattern.includes('\\') ? filePath : basename, pattern)
+    );
+
     if (ignorePattern) {
       logIgnored?.(filePath, `ignored by pattern "${ignorePattern}"`);
     } else {

--- a/packages/beachball/src/monorepo/isPathIncluded.ts
+++ b/packages/beachball/src/monorepo/isPathIncluded.ts
@@ -1,7 +1,7 @@
-import minimatch from 'minimatch';
+import path from 'path';
 
 /**
- * Check if a relative package path should be included given include and exclude patterns using minimatch.
+ * Check if a relative package path should be included given include and exclude patterns.
  */
 export function isPathIncluded(params: {
   /** Relative path to the package from the repo root. */
@@ -18,12 +18,12 @@ export function isPathIncluded(params: {
     shouldInclude = true;
   } else {
     const includePatterns = typeof include === 'string' ? [include] : include;
-    shouldInclude = includePatterns.some(pattern => minimatch(relativePath, pattern));
+    shouldInclude = includePatterns.some(pattern => path.matchesGlob(relativePath, pattern));
   }
 
   if (exclude?.length && shouldInclude) {
     const excludePatterns = typeof exclude === 'string' ? [exclude] : exclude;
-    shouldInclude = !excludePatterns.some(pattern => minimatch(relativePath, pattern));
+    shouldInclude = !excludePatterns.some(pattern => path.matchesGlob(relativePath, pattern));
   }
 
   return shouldInclude;

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -223,8 +223,9 @@ export interface RepoOptions {
   /** Custom pre/post publish actions */
   hooks?: HooksOptions;
   /**
-   * Ignore changes in these files (minimatch patterns; negations not supported).
+   * Ignore changes in these files (glob patterns; negations not supported).
    * Patterns are relative to the repo root and must use forward slashes.
+   * Patterns without a `/` will match against filenames at any depth.
    *
    * In repos that don't use a supported monorepo manager (npm/yarn/pnpm workspaces, rush, lerna),
    * this is also applied to `package.json` paths when globbing for packages. The most common case
@@ -282,7 +283,7 @@ export interface RepoOptions {
    */
   retries: number;
   /**
-   * Only apply commands to package paths matching these minimatch patterns.
+   * Only apply commands to package paths matching these glob patterns.
    * Patterns are relative to the monorepo root and must use forward slashes.
    *
    * Negations are supported: e.g. `['packages/foo/*', '!packages/foo/bar']`
@@ -336,14 +337,14 @@ export interface VersionGroupOptions {
   name: string;
 
   /**
-   * minimatch pattern(s) for package paths to include in this group.
+   * Glob pattern(s) for package paths to include in this group.
    * Patterns are relative to the repo root and must use forward slashes.
    * If `true`, include all packages except those matching `exclude`.
    */
   include: string | string[] | true;
 
   /**
-   * minimatch pattern(s) for package paths to exclude from this group.
+   * Glob pattern(s) for package paths to exclude from this group.
    * Patterns are relative to the repo root and must use forward slashes.
    *
    * NOTE: As of v3, you should use non-negated patterns here (the previous bug requiring

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -289,7 +289,6 @@ export interface RepoOptions {
    * Only apply commands to package paths matching these glob patterns.
    * - Negations ARE supported: e.g. `['packages/foo/*', '!packages/foo/bar']`
    * - Patterns are relative to the repo root and should use forward slashes.
-   * - Patterns without a `/` will match against filenames at any depth.
    * - Case-sensitive matching behavior varies by OS, so it's best to ensure the patterns follow
    *   the actual casing used by files.
    *

--- a/packages/beachball/src/types/BeachballOptions.ts
+++ b/packages/beachball/src/types/BeachballOptions.ts
@@ -223,9 +223,12 @@ export interface RepoOptions {
   /** Custom pre/post publish actions */
   hooks?: HooksOptions;
   /**
-   * Ignore changes in these files (glob patterns; negations not supported).
-   * Patterns are relative to the repo root and must use forward slashes.
-   * Patterns without a `/` will match against filenames at any depth.
+   * Ignore changes in these files matching these glob patterns.
+   * - Patterns are relative to the repo root and should use forward slashes.
+   * - Patterns without a `/` will match against filenames at any depth.
+   * - Negations are not supported.
+   * - Case-sensitive matching behavior varies by OS, so it's best to ensure the patterns follow
+   *   the actual casing used by files.
    *
    * In repos that don't use a supported monorepo manager (npm/yarn/pnpm workspaces, rush, lerna),
    * this is also applied to `package.json` paths when globbing for packages. The most common case
@@ -284,9 +287,11 @@ export interface RepoOptions {
   retries: number;
   /**
    * Only apply commands to package paths matching these glob patterns.
-   * Patterns are relative to the monorepo root and must use forward slashes.
-   *
-   * Negations are supported: e.g. `['packages/foo/*', '!packages/foo/bar']`
+   * - Negations ARE supported: e.g. `['packages/foo/*', '!packages/foo/bar']`
+   * - Patterns are relative to the repo root and should use forward slashes.
+   * - Patterns without a `/` will match against filenames at any depth.
+   * - Case-sensitive matching behavior varies by OS, so it's best to ensure the patterns follow
+   *   the actual casing used by files.
    *
    * Note that if you have multiple sets of packages with different scopes,
    * `groupChanges` is not supported.
@@ -338,16 +343,18 @@ export interface VersionGroupOptions {
 
   /**
    * Glob pattern(s) for package paths to include in this group.
-   * Patterns are relative to the repo root and must use forward slashes.
+   * Patterns are relative to the repo root and should use forward slashes.
+   * Negations are handled with `exclude`.
+   *
    * If `true`, include all packages except those matching `exclude`.
    */
   include: string | string[] | true;
 
   /**
    * Glob pattern(s) for package paths to exclude from this group.
-   * Patterns are relative to the repo root and must use forward slashes.
+   * Patterns are relative to the repo root and should use forward slashes.
    *
-   * NOTE: As of v3, you should use non-negated patterns here (the previous bug requiring
+   * NOTE: As of v3, you must use non-negated patterns here (the previous bug requiring
    * negated patterns has been fixed).
    */
   exclude?: string | string[];

--- a/packages/beachball/src/types/ChangelogOptions.ts
+++ b/packages/beachball/src/types/ChangelogOptions.ts
@@ -75,14 +75,14 @@ export interface ChangelogOptions {
  */
 export interface ChangelogGroupOptions {
   /**
-   * minimatch pattern(s) for package paths to include in this group.
+   * Glob pattern(s) for package paths to include in this group.
    * Patterns are relative to the repo root and must use forward slashes.
    * If `true`, include all packages except those matching `exclude`.
    */
   include: string | string[] | true;
 
   /**
-   * minimatch pattern(s) for package paths to exclude from this group.
+   * Glob pattern(s) for package paths to exclude from this group.
    * Patterns are relative to the repo root and must use forward slashes.
    *
    * NOTE: As of v3, you must use non-negated patterns here (the previous bug requiring

--- a/scripts/showDependencyTree.ts
+++ b/scripts/showDependencyTree.ts
@@ -17,25 +17,30 @@ import { findPackageRoot, getPackageInfo } from 'workspace-tools';
  */
 
 /**
- * Resolve the package directory of `depName` as installed relative to `fromDir`,
+ * Resolve the realpath of the package directory of `depName` as installed relative to `fromDir`,
  * walking up parent `node_modules` folders (matching Node's resolution).
  * Returns undefined if it can't be resolved (e.g. an unmet optional dependency).
  */
 function resolvePackage(depName: string, fromDir: string): string | undefined {
   const require = createRequire(path.join(fromDir, 'noop.js'));
+  let result: string | undefined;
   try {
-    return path.dirname(require.resolve(`${depName}/package.json`));
+    result = path.dirname(require.resolve(`${depName}/package.json`));
   } catch {
     try {
       const resolved = require.resolve(depName);
-      return findPackageRoot(resolved);
+      result = findPackageRoot(resolved);
     } catch {
+      // continue
+    }
+    if (!result) {
       // Some packages don't expose package.json via `exports`, so try walking node_modules
       let dir = fromDir;
       while (true) {
         const candidate = path.join(dir, 'node_modules', depName, 'package.json');
         if (fs.existsSync(candidate)) {
-          return path.dirname(candidate);
+          result = path.dirname(candidate);
+          break;
         }
         const parent = path.dirname(dir);
         if (parent === dir) {
@@ -45,6 +50,7 @@ function resolvePackage(depName: string, fromDir: string): string | undefined {
       }
     }
   }
+  return fs.realpathSync(result);
 }
 
 function printTree(params: {
@@ -59,9 +65,6 @@ function printTree(params: {
   const { packageRoot, includeDev, prefix = '', isLast, seenPaths = new Set(), seenIds = new Set(), isRoot } = params;
   const packageInfo = getPackageInfo(packageRoot)!;
   const id = `${packageInfo.name}@${packageInfo.version}`;
-  // Key dedup on the package's real install location so that distinct copies of
-  // the same name@version (installed at different paths) are each expanded.
-  const seenKey = fs.realpathSync(packageRoot);
 
   // Whether any node in this render was collapsed (deduped) or flagged as a
   // duplicate copy of an already-shown version.
@@ -74,7 +77,7 @@ function printTree(params: {
     const connector = isLast ? '└── ' : '├── ';
     // If this exact install location was already expanded elsewhere, show a
     // placeholder instead of repeating the (possibly large) subtree.
-    if (seenPaths.has(seenKey)) {
+    if (seenPaths.has(packageRoot)) {
       console.log(`${prefix}${connector}${id} (deduped)`);
       return { deduped: true, duped: false };
     }
@@ -84,7 +87,7 @@ function printTree(params: {
     console.log(`${prefix}${connector}${id}${duped ? ' (❗️ dupe)' : ''}`);
   }
 
-  seenPaths.add(seenKey);
+  seenPaths.add(packageRoot);
   seenIds.add(id);
 
   const deps = {
@@ -103,7 +106,7 @@ function printTree(params: {
     if (!childRoot) {
       const connector = childIsLast ? '└── ' : '├── ';
       console.log(`${childPrefix}${connector}${depName} (unmet)`);
-continue;
+      continue;
     }
     const child = printTree({
       packageRoot: childRoot,

--- a/scripts/showDependencyTree.ts
+++ b/scripts/showDependencyTree.ts
@@ -30,13 +30,12 @@ function resolvePackage(depName: string, fromDir: string): string | undefined {
       const resolved = require.resolve(depName);
       return findPackageRoot(resolved);
     } catch {
-      // Some packages don't expose package.json via `exports`. Fall back to
-      // walking node_modules folders manually.
+      // Some packages don't expose package.json via `exports`, so try walking node_modules
       let dir = fromDir;
       while (true) {
         const candidate = path.join(dir, 'node_modules', depName, 'package.json');
         if (fs.existsSync(candidate)) {
-          return path.dirname(fs.realpathSync(candidate));
+          return path.dirname(candidate);
         }
         const parent = path.dirname(dir);
         if (parent === dir) {
@@ -53,30 +52,40 @@ function printTree(params: {
   includeDev: boolean;
   prefix?: string;
   isLast: boolean;
-  seen?: Set<string>;
-  isRoot: boolean;
-}): boolean {
-  const { packageRoot, includeDev, prefix = '', isLast, seen = new Set(), isRoot } = params;
+  seenPaths?: Set<string>;
+  seenIds?: Set<string>;
+  isRoot?: boolean;
+}): { deduped: boolean; duped: boolean } {
+  const { packageRoot, includeDev, prefix = '', isLast, seenPaths = new Set(), seenIds = new Set(), isRoot } = params;
   const packageInfo = getPackageInfo(packageRoot)!;
   const id = `${packageInfo.name}@${packageInfo.version}`;
+  // Key dedup on the package's real install location so that distinct copies of
+  // the same name@version (installed at different paths) are each expanded.
+  const seenKey = fs.realpathSync(packageRoot);
 
-  // Whether any node in this render was collapsed because it was already shown.
-  let dedupedAny = false;
+  // Whether any node in this render was collapsed (deduped) or flagged as a
+  // duplicate copy of an already-shown version.
+  let deduped = false;
+  let duped = false;
 
   if (isRoot) {
     console.log(id);
   } else {
     const connector = isLast ? '└── ' : '├── ';
-    // If this exact name@version was already expanded elsewhere, show a
+    // If this exact install location was already expanded elsewhere, show a
     // placeholder instead of repeating the (possibly large) subtree.
-    if (seen.has(id)) {
-      console.log(`${prefix}${connector}${id} (*)`);
-      return true;
+    if (seenPaths.has(seenKey)) {
+      console.log(`${prefix}${connector}${id} (deduped)`);
+      return { deduped: true, duped: false };
     }
-    console.log(`${prefix}${connector}${id}`);
+    // New install path, but if this exact name@version was already shown at a
+    // different path, it's a duplicate copy of the same version.
+    duped = seenIds.has(id);
+    console.log(`${prefix}${connector}${id}${duped ? ' (❗️ dupe)' : ''}`);
   }
 
-  seen.add(id);
+  seenPaths.add(seenKey);
+  seenIds.add(id);
 
   const deps = {
     ...packageInfo.dependencies,
@@ -88,26 +97,27 @@ function printTree(params: {
 
   const childPrefix = isRoot ? '' : prefix + (isLast ? '    ' : '│   ');
 
-  names.forEach((depName, index) => {
-    const childIsLast = index === names.length - 1;
+  for (const depName of names) {
+    const childIsLast = depName === names.at(-1);
     const childRoot = resolvePackage(depName, packageRoot);
     if (!childRoot) {
       const connector = childIsLast ? '└── ' : '├── ';
       console.log(`${childPrefix}${connector}${depName} (unmet)`);
-      return;
+      return { deduped, duped };
     }
-    dedupedAny =
-      printTree({
-        packageRoot: childRoot,
-        includeDev,
-        prefix: childPrefix,
-        isLast: childIsLast,
-        seen,
-        isRoot: false,
-      }) || dedupedAny;
-  });
+    const child = printTree({
+      packageRoot: childRoot,
+      includeDev,
+      prefix: childPrefix,
+      isLast: childIsLast,
+      seenPaths,
+      seenIds,
+    });
+    deduped = deduped || child.deduped;
+    duped = duped || child.duped;
+  }
 
-  return dedupedAny;
+  return { deduped, duped };
 }
 
 function main(): void {
@@ -130,10 +140,13 @@ function main(): void {
     }
   }
 
-  const dedupedAny = printTree({ packageRoot, includeDev, isLast: true, isRoot: true });
+  const { deduped, duped } = printTree({ packageRoot, includeDev, isLast: true, isRoot: true });
 
-  if (dedupedAny) {
-    console.log('\n(*) already shown above; subtree omitted to avoid repetition');
+  if (deduped) {
+    console.log('\ndeduped = multiple references to a single copy on disk');
+  }
+  if (duped) {
+    console.log('❗️ dupe = multiple copies of the same name@version installed at different paths');
   }
 }
 

--- a/scripts/showDependencyTree.ts
+++ b/scripts/showDependencyTree.ts
@@ -103,7 +103,7 @@ function printTree(params: {
     if (!childRoot) {
       const connector = childIsLast ? '└── ' : '├── ';
       console.log(`${childPrefix}${connector}${depName} (unmet)`);
-      return { deduped, duped };
+continue;
     }
     const child = printTree({
       packageRoot: childRoot,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,7 +2229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:^3.0.0, @types/minimatch@npm:^3.0.3":
+"@types/minimatch@npm:^3.0.3":
   version: 3.0.5
   resolution: "@types/minimatch@npm:3.0.5"
   checksum: 10c0/a1a19ba342d6f39b569510f621ae4bbe972dc9378d15e9a5e47904c440ee60744f5b09225bc73be1c6490e3a9c938eee69eb53debf55ce1f15761201aa965f97
@@ -3679,7 +3679,6 @@ __metadata:
   dependencies:
     "@microsoft/beachball-scripts": "workspace:^"
     "@types/jsonwebtoken": "npm:^9.0.10"
-    "@types/minimatch": "npm:^3.0.0"
     "@types/prompts": "npm:^2.4.2"
     "@types/semver": "catalog:dev"
     "@types/tmp": "npm:^0.2.3"
@@ -3689,7 +3688,6 @@ __metadata:
     cross-env: "catalog:dev"
     execa: "catalog:prod"
     get-port: "npm:^7.0.0"
-    minimatch: "npm:^3.1.5"
     normalized-tmpdir: "npm:^1.1.0"
     p-graph: "workspace:^"
     p-limit: "npm:^3.1.0"
@@ -7305,7 +7303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.5":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:


### PR DESCRIPTION
`path.matchesGlob` was added in Node 22 and internally uses `minimatch`. The behavior is mostly the same as `minimatch` v3, aside from a manual workaround being required to support `matchBase`-like behavior for `ignorePatterns`.