### PR TITLE
Replace execa with nano-spawn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,7 +23,7 @@ catalogs:
   prod:
     '@yarnpkg/core': ^4.7.0
     commander: ^14.0.3
-    execa: ^5.1.1
+    nano-spawn: '^2.1.0'
     semver: ^7.7.4
     workspace-tools: ^0.42.0
   dev:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Run all of: `yarn build`, `yarn test`, `yarn lint`, `yarn format`.
 - `src/changelog/` — changelog generation (markdown + JSON).
 - `src/monorepo/` — package discovery (workspace-tools), dependency graph, package groups.
 - `src/publish/` — npm publish orchestration, git tagging, dependency-ordered publishing.
-- `src/git/` — git operation wrappers using execa.
+- `src/git/` — git operation wrappers using nano-spawn.
 - `src/options/` — CLI arg parsing + config loading.
 - `src/validation/` — pre-command validation.
 - `src/types/` — TypeScript interfaces (`BeachballOptions` is the central config type).

--- a/change/@microsoft-m365-renovate-config-46af51be-4370-459a-a581-0c0ffb68a7e1.json
+++ b/change/@microsoft-m365-renovate-config-46af51be-4370-459a-a581-0c0ffb68a7e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace `execa` with `nano-spawn`",
+  "packageName": "@microsoft/m365-renovate-config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/beachball-5fe8a429-fb8f-450a-9264-385de76bc02d.json
+++ b/change/beachball-5fe8a429-fb8f-450a-9264-385de76bc02d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace execa with nano-spawn",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/beachball/package.json
+++ b/packages/beachball/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@vercel/detect-agent": "^1.2.1",
     "commander": "catalog:prod",
-    "execa": "catalog:prod",
+    "nano-spawn": "catalog:prod",
     "p-graph": "workspace:^",
     "p-limit": "^3.1.0",
     "prompts": "^2.4.2",

--- a/packages/beachball/src/__fixtures__/mockNpm.test.ts
+++ b/packages/beachball/src/__fixtures__/mockNpm.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 // import fetch from 'npm-registry-fetch';
-import { type NpmResult, npm } from '../packageManager/npm';
+import { npm } from '../packageManager/npm';
 import type { PackageJson } from '../types/PackageInfo';
 import {
   initNpmMock,
@@ -13,10 +13,11 @@ import {
   _mockNpmPack,
   _mockNpmPublish,
   _mockNpmShow,
-  type MockNpmResult,
   type MockNpmCommand,
 } from './mockNpm';
 import * as readJsonModule from '../object/readJson';
+import { mockSpawnSuccess, MockSubprocessError } from './mockSpawnResult';
+import type { SpawnResult } from '../spawn';
 
 jest.mock('fs');
 // jest.mock('npm-registry-fetch');
@@ -95,16 +96,6 @@ describe('_makeRegistryData', () => {
 });
 
 describe('_mockNpmShow', () => {
-  function getErrorResult(errorMessage: string) {
-    return {
-      stdout: '',
-      stderr: errorMessage,
-      all: errorMessage,
-      success: false,
-      failed: true,
-    } as NpmResult;
-  }
-
   function getShowResult(params: { name: string; version: string }) {
     const { name, version } = params;
     const output = JSON.stringify({
@@ -113,13 +104,7 @@ describe('_mockNpmShow', () => {
       versions: Object.keys(data[name].versions),
     });
 
-    return {
-      stdout: output,
-      stderr: '',
-      all: output,
-      success: true,
-      failed: false,
-    } as NpmResult;
+    return mockSpawnSuccess({ output });
   }
 
   const data = _makeRegistryData({
@@ -136,7 +121,7 @@ describe('_mockNpmShow', () => {
   it("errors if package doesn't exist", async () => {
     const emptyData = _makeRegistryData({});
     const result = await _mockNpmShow(emptyData, ['foo'], { cwd: '' });
-    expect(result).toEqual(getErrorResult('[fake] code E404 - foo - not found'));
+    expect(result).toEqual(new MockSubprocessError({ output: '[fake] code E404 - foo - not found' }));
   });
 
   it('returns requested version plus dist-tags and version list', async () => {
@@ -171,7 +156,7 @@ describe('_mockNpmShow', () => {
 
   it("errors if requested version doesn't exist", async () => {
     const result = await _mockNpmShow(data, ['foo@2.0.0'], { cwd: '' });
-    expect(result).toEqual(getErrorResult('[fake] code E404 - foo@2.0.0 - not found'));
+    expect(result).toEqual(new MockSubprocessError({ output: '[fake] code E404 - foo@2.0.0 - not found' }));
   });
 
   // support for this could be added later
@@ -181,17 +166,14 @@ describe('_mockNpmShow', () => {
 });
 
 describe('_mockNpmPublish', () => {
-  function getPublishResult(params: { error?: string; tag?: string }) {
+  function getPublishResult(params: { error?: string; tag?: string }): SpawnResult {
     const { error, tag } = params;
     if (!error && !packageJson) throw new Error('packageJson not set');
-    const stdout = error ? '' : `[fake] published ${packageJson?.name}@${packageJson?.version} with tag ${tag}`;
-    return {
-      stdout,
-      stderr: error || '',
-      all: stdout || error,
-      success: !error,
-      failed: !!error,
-    } as NpmResult;
+    if (error) {
+      return new MockSubprocessError({ output: error });
+    }
+    const output = `[fake] published ${packageJson?.name}@${packageJson?.version} with tag ${tag}`;
+    return mockSpawnSuccess({ output });
   }
 
   let packageJson: PackageJson | undefined;
@@ -317,10 +299,9 @@ describe('_mockNpmPack', () => {
     const registryData = {};
     packageJson = { name: 'foo', version: '1.0.0' };
     const result = await _mockNpmPack(registryData, [], { cwd: 'fake' });
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
-      failed: false,
-      all: 'foo-1.0.0.tgz',
+      output: 'foo-1.0.0.tgz',
       stdout: 'foo-1.0.0.tgz',
       stderr: '',
     });
@@ -332,10 +313,9 @@ describe('_mockNpmPack', () => {
     const registryData = {};
     packageJson = { name: '@foo/bar', version: '2.0.0' };
     const result = await _mockNpmPack(registryData, [], { cwd: 'fake' });
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
-      failed: false,
-      all: 'foo-bar-2.0.0.tgz',
+      output: 'foo-bar-2.0.0.tgz',
       stdout: 'foo-bar-2.0.0.tgz',
       stderr: '',
     });
@@ -470,10 +450,9 @@ describe('mockNpm', () => {
     it('mocks npm pack command', async () => {
       packageJson = { name: 'foo', version: '2.0.0' };
       const result = await npm(['pack'], { cwd: 'fake' });
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         success: true,
-        failed: false,
-        all: 'foo-2.0.0.tgz',
+        output: 'foo-2.0.0.tgz',
         stdout: 'foo-2.0.0.tgz',
         stderr: '',
       });
@@ -506,7 +485,7 @@ describe('mockNpm', () => {
     const fakePublishResult = 'hi';
 
     it('respects mocked command override', async () => {
-      const mockPublish = jest.fn<MockNpmCommand>(() => Promise.resolve(fakePublishResult as unknown as MockNpmResult));
+      const mockPublish = jest.fn<MockNpmCommand>(() => Promise.resolve(fakePublishResult as unknown as SpawnResult));
       npmMock.setCommandOverride('publish', mockPublish);
       const result = await npm(['publish', 'foo'], { cwd: '' });
       expect(result).toEqual(fakePublishResult);
@@ -514,7 +493,7 @@ describe('mockNpm', () => {
     });
 
     it("respects extra mocked command that's not normally supported", async () => {
-      const mockFoo = jest.fn<MockNpmCommand>(() => Promise.resolve('hi' as unknown as MockNpmResult));
+      const mockFoo = jest.fn<MockNpmCommand>(() => Promise.resolve('hi' as unknown as SpawnResult));
       npmMock.setCommandOverride('foo', mockFoo);
       const result = await npm(['foo'], { cwd: '' });
       expect(result).toEqual('hi');

--- a/packages/beachball/src/__fixtures__/mockNpm.ts
+++ b/packages/beachball/src/__fixtures__/mockNpm.ts
@@ -3,23 +3,22 @@ import fs from 'fs';
 // import fetch from 'npm-registry-fetch';
 import path from 'path';
 import semver from 'semver';
-import { npm, type NpmResult } from '../packageManager/npm';
-import type { PackageJson } from '../types/PackageInfo';
-import type { PackageManagerOptions } from '../packageManager/packageManager';
 import { readJson } from '../object/readJson';
 import {
   _npmShowProperties,
   type NpmPackageVersionsData,
   type NpmRegistryFetchJson,
 } from '../packageManager/getNpmPackageInfo';
+import { npm } from '../packageManager/npm';
+import type { SpawnOptions, SpawnResult } from '../spawn';
+import type { PackageJson } from '../types/PackageInfo';
+import { mockSpawnSuccess, MockSubprocessError } from './mockSpawnResult';
 
 /** Mapping from package name to registry data */
 type MockNpmRegistry = Record<string, NpmRegistryFetchJson>;
 
 /** Mapping from package name to partial registry data (easier to specify in tests) */
 type PartialRegistryData = Record<string, Partial<NpmPackageVersionsData>>;
-
-export type MockNpmResult = Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'success' | 'failed'>;
 
 /**
  * Mock implementation of an npm command.
@@ -30,8 +29,8 @@ export type MockNpmResult = Pick<NpmResult, 'stdout' | 'stderr' | 'all' | 'succe
 export type MockNpmCommand = (
   registryData: MockNpmRegistry,
   args: string[],
-  opts: PackageManagerOptions
-) => Promise<MockNpmResult>;
+  opts: SpawnOptions & { cwd: string }
+) => Promise<SpawnResult>;
 
 export type NpmMock = {
   /**
@@ -125,7 +124,7 @@ export function initNpmMock(): NpmMock {
       if (!func) {
         throw new Error(`Command not supported by mock npm: ${command}`);
       }
-      return (await func(registryData, args, opts)) as NpmResult;
+      return await func(registryData, args, opts);
     });
 
     // const fetchJson = (url: string): Promise<NpmRegistryFetchJson> => {
@@ -233,8 +232,7 @@ export const _mockNpmShow: MockNpmCommand = async (registryData, args) => {
   const pkgData = registryData[name];
 
   if (!pkgData) {
-    const stderr = `[fake] code E404 - ${name} - not found`;
-    return { stdout: '', stderr, all: stderr, success: false, failed: true };
+    return new MockSubprocessError({ output: `[fake] code E404 - ${name} - not found` });
   }
 
   let finalVersion: string | undefined;
@@ -253,8 +251,7 @@ export const _mockNpmShow: MockNpmCommand = async (registryData, args) => {
   if (!versionData) {
     // Some versions for this package exist, but the specified version or tag doesn't
     // (note that "E404" matches the actual npm output, but the rest of the message is different)
-    const stderr = `[fake] code E404 - ${name}@${version} - not found`;
-    return { stdout: '', stderr, all: stderr, success: false, failed: true };
+    return new MockSubprocessError({ output: `[fake] code E404 - ${name}@${version} - not found` });
   }
 
   const stdout = JSON.stringify({
@@ -262,7 +259,7 @@ export const _mockNpmShow: MockNpmCommand = async (registryData, args) => {
     'dist-tags': pkgData['dist-tags'],
     versions: Object.keys(pkgData.versions),
   });
-  return { stdout, stderr: '', all: stdout, success: true, failed: false };
+  return mockSpawnSuccess({ output: stdout });
 };
 
 /** (exported for testing) Mock npm publish to the registry data */
@@ -280,11 +277,10 @@ export const _mockNpmPublish: MockNpmCommand = async (registryData, args, opts) 
   const tag = args.includes('--tag') ? args[args.indexOf('--tag') + 1] : 'latest';
 
   try {
-    const stdout = mockPublishPackage(registryData, packageJson, tag);
-    return { stdout, stderr: '', all: stdout, success: true, failed: false };
+    const output = mockPublishPackage(registryData, packageJson, tag);
+    return mockSpawnSuccess({ output });
   } catch (err) {
-    const stderr = (err as Error).message;
-    return { stdout: '', stderr, all: stderr, success: false, failed: true };
+    return new MockSubprocessError({ output: (err as Error).message });
   }
 };
 
@@ -329,5 +325,5 @@ export const _mockNpmPack: MockNpmCommand = async (registryData, args, opts) => 
   const packFileName = getMockNpmPackName(packageJson);
   fs.writeFileSync(path.join(opts.cwd, packFileName), 'fake package contents');
 
-  return { stdout: packFileName, stderr: '', all: packFileName, success: true, failed: false };
+  return mockSpawnSuccess({ output: packFileName });
 };

--- a/packages/beachball/src/__fixtures__/mockSpawnResult.ts
+++ b/packages/beachball/src/__fixtures__/mockSpawnResult.ts
@@ -1,0 +1,46 @@
+import type { SpawnFailureResult, SpawnSuccessResult } from '../spawn';
+
+/**
+ * Make a generic spawn success result. `output` is used as `stdout` by default.
+ */
+export function mockSpawnSuccess(options?: Partial<Omit<SpawnSuccessResult, 'success'>>): SpawnSuccessResult {
+  return {
+    success: true,
+    stdout: options?.output ?? '',
+    stderr: '',
+    output: '',
+    command: '',
+    durationMs: 0,
+    ...options,
+  };
+}
+
+/**
+ * Fake version of `nano-spawn`'s `SubprocessError` for testing.
+ *
+ * NOTE: not a realistic implementation of all properties!
+ */
+export class MockSubprocessError extends Error implements SpawnFailureResult {
+  public name = 'MockSubprocessError';
+  public success = false as const;
+  public stdout = '';
+  public stderr = '';
+  public output = '';
+  public command = '';
+  public durationMs = 0;
+  public exitCode: number | undefined;
+  public isCanceled = false;
+  public timedOut = false;
+
+  /**
+   * `output` is used as `stderr` by default. If `timedOut` is true, `exitCode` will be undefined.
+   */
+  public constructor(options?: Partial<Pick<SpawnFailureResult, 'output' | 'timedOut'>> & ErrorOptions) {
+    const { output, timedOut, ...rest } = options ?? {};
+    super('Command failed', rest);
+    this.output = output ?? '';
+    this.stderr = this.output;
+    this.timedOut = !!timedOut;
+    this.exitCode = this.timedOut ? undefined : 1;
+  }
+}

--- a/packages/beachball/src/__fixtures__/registry.ts
+++ b/packages/beachball/src/__fixtures__/registry.ts
@@ -103,11 +103,15 @@ export class Registry {
   /** Write the auth token to the user .npmrc so npm commands pick it up, or remove it if `token` is null. */
   private writeAuthToken(token: string | null): void {
     const npmrcPath = path.join(os.homedir(), '.npmrc');
-    const lines = fs.existsSync(npmrcPath) ? fs.readFileSync(npmrcPath, 'utf-8').split(/\r?\n/g).filter(Boolean) : [];
+    const npmrcContent = fs.existsSync(npmrcPath) ? fs.readFileSync(npmrcPath, 'utf-8') : '';
+    const eol = npmrcContent.match(/\r?\n/)?.[0] ?? os.EOL;
     const authKey = `${this.getUrl().replace(/^https?:/, '')}/:_authToken`;
-    const filtered = lines.filter(line => !line.startsWith(authKey));
+    const filtered = npmrcContent
+      .trim()
+      .split(/\r?\n/g)
+      .filter(line => !line.startsWith(authKey));
     token && filtered.push(`${authKey}=${token}`);
-    fs.writeFileSync(npmrcPath, filtered.join(os.EOL) + os.EOL);
+    fs.writeFileSync(npmrcPath, filtered.join(eol) + eol);
   }
 
   /** Write the current token to `.npmrc` to emulate logging in. */

--- a/packages/beachball/src/__fixtures__/registry.ts
+++ b/packages/beachball/src/__fixtures__/registry.ts
@@ -1,13 +1,12 @@
 import { ConfigBuilder } from '@verdaccio/config';
 import { fork, type ChildProcess } from 'child_process';
-import execa from 'execa';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { removeTempDir, tmpdir } from './tmpdir';
 
 const verdaccioUser = {
-  username: 'fake',
+  name: 'fake',
   password: 'fake',
 };
 
@@ -30,7 +29,6 @@ export class Registry {
   private testName: string;
   private tempRoot: string | undefined;
   private token: string | undefined;
-  private isLoggedIn = false;
 
   public constructor(filename: string) {
     this.testName = path.basename(filename, '.test.ts');
@@ -72,100 +70,57 @@ export class Registry {
     this.port = tryPort;
   }
 
-  /**
-   * Log in as the fake user.
-   */
-  public async login(): Promise<void> {
-    // Something about npm 8 makes publishing fail with anonymous access, so log in with a fake user
-    if (this.isLoggedIn) {
-      console.log('already logged in');
-      return;
-    }
-    try {
-      const registry = this.getUrl();
-      console.log(`logging in to ${registry}`);
-      const npm = execa('npm', ['login', '--registry', registry, '--verbose']);
-      // If this is failing or hanging and you need to debug:
-      //   npm.stdout?.pipe(process.stdout);
-      //   npm.stderr?.pipe(process.stderr);
-      // With Node 22+ and verdaccio 5, the npm login HTTP request fails for some reason.
-      // This is fixed with latest verdaccio, which we can bump when bumping Node.
-
-      // for some reason there's no way to supply the username, password, and email besides stdin
-      npm.stdout?.on('data', chunk => {
-        const chunkStr = String(chunk);
-        if (chunkStr.includes('Username:')) {
-          npm.stdin?.write(verdaccioUser.username + '\r\n');
-        } else if (chunkStr.includes('Password:')) {
-          npm.stdin?.write(verdaccioUser.password + '\r\n');
-        } else if (chunkStr.includes('Email:') || chunkStr.includes('Email (')) {
-          npm.stdin?.write('fake@example.com\r\n');
-        }
-      });
-      await npm;
-      console.log('logged in');
-      this.isLoggedIn = true;
-    } catch (err) {
-      throw new Error(
-        `Error logging in to registry: ${(err as Error).stack || err}\n${(err as execa.ExecaError).stderr}`,
-        { cause: err }
-      );
-    }
-  }
-
-  /**
-   * Run `npm whoami` on the fake registry.
-   */
-  public async whoami(): Promise<string | undefined> {
-    try {
-      const registry = this.getUrl();
-      const result = await execa('npm', ['whoami', '--registry', registry]);
-      return result.stdout.trim();
-    } catch {
-      return undefined;
-    }
-  }
-
-  /**
-   * Get the current token after running `npm login` on the fake registry (workaround for lack of
-   * `npm token create` support in verdaccio). Caches the token after first retrieval.
-   */
-  public getToken(): string {
+  /** Get a token for the fake user. */
+  public async getToken(): Promise<string> {
     if (this.token) {
-      // Cache the token even if logged out (it seems to stay the same when logging back in)
       return this.token;
     }
 
-    if (!this.isLoggedIn) {
-      throw new Error('Must be logged in to get the token');
-    }
-
-    const registryUrl = this.getUrl().replace(/^https?:/, '');
-    const npmrcPath = path.join(os.homedir(), '.npmrc');
-    const npmrcContent = fs
-      .readFileSync(npmrcPath, 'utf-8')
-      .split(/\r?\n/g)
-      .find(line => line.startsWith(registryUrl) && line.includes('_authToken'));
-
-    if (!npmrcContent) {
-      throw new Error(`Failed to find auth token in .npmrc for registry ${registryUrl}`);
-    }
-
-    this.token = npmrcContent.split('=')[1].replace(/"/g, '');
-    return this.token;
-  }
-
-  /** Run `npm logout` on the fake registry */
-  public async logout(): Promise<void> {
-    // Conservatively set to false even if it fails partway (logging in again is harmless).
-    // Also go ahead and log out even if not flagged as logged in since it could be out of sync.
-    this.isLoggedIn = false;
     try {
       const registry = this.getUrl();
-      await execa('npm', ['logout', '--registry', registry]);
-    } catch {
-      console.warn('Logging out of registry failed');
+      // There are issues with using stdin to script `npm login`, plus it's slow, so use the
+      // registry API directly to get a token.
+      // https://github.com/npm/registry/blob/main/docs/user/authentication.md#login
+      const response = await fetch(`${registry}/-/user/org.couchdb.user:${verdaccioUser.name}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...verdaccioUser, type: 'user', roles: [], date: new Date().toISOString() }),
+      });
+      if (!response.ok) {
+        throw new Error(`login request failed with ${response.status}: ${await response.text()}`);
+      }
+      const { token } = (await response.json()) as { token: string };
+      if (!token) {
+        throw new Error('login response did not include a token');
+      }
+      this.token = token;
+      return this.token;
+    } catch (err) {
+      throw new Error(`Error logging in to registry: ${(err as Error).stack || err}`, { cause: err });
     }
+  }
+
+  /** Write the auth token to the user .npmrc so npm commands pick it up, or remove it if `token` is null. */
+  private writeAuthToken(token: string | null): void {
+    const npmrcPath = path.join(os.homedir(), '.npmrc');
+    const lines = fs.existsSync(npmrcPath) ? fs.readFileSync(npmrcPath, 'utf-8').split(/\r?\n/g).filter(Boolean) : [];
+    const authKey = `${this.getUrl().replace(/^https?:/, '')}/:_authToken`;
+    const filtered = lines.filter(line => !line.startsWith(authKey));
+    token && filtered.push(`${authKey}=${token}`);
+    fs.writeFileSync(npmrcPath, filtered.join(os.EOL) + os.EOL);
+  }
+
+  /** Write the current token to `.npmrc` to emulate logging in. */
+  public login(): void {
+    if (!this.token) {
+      throw new Error('No token available (login should have set it)');
+    }
+    this.writeAuthToken(this.token);
+  }
+
+  /** Clear the token from `.npmrc` to emulate logging out. */
+  public logout(): void {
+    this.writeAuthToken(null);
   }
 
   /** Delete the temp directory used for the config file. */
@@ -207,7 +162,7 @@ export class Registry {
 
         this.server.stderr?.on('data', data => {
           const dataStr = String(data);
-          if (!dataStr.includes('Debugger attached')) {
+          if (!dataStr.includes('Debugger attached') && !dataStr.includes('Starting inspector')) {
             rejectWrapper(new Error(dataStr));
           }
         });

--- a/packages/beachball/src/__functional__/packageManager/getNpmPackageInfo.test.ts
+++ b/packages/beachball/src/__functional__/packageManager/getNpmPackageInfo.test.ts
@@ -99,7 +99,7 @@ maybeDescribe('getNpmPackageInfo', () => {
     expect(npmSpy).toHaveBeenCalledTimes(1);
     expect(npmSpy).toHaveBeenCalledWith(
       ['show', '--registry', registry, '--json', shouldNotExist, ..._npmShowProperties],
-      expect.objectContaining({ env: { ...process.env, 'npm_config_//registry.npmjs.org/:_authToken': 'fake' } })
+      expect.objectContaining({ env: { 'npm_config_//registry.npmjs.org/:_authToken': 'fake' } })
     );
 
     // expect(fetchJsonSpy).toHaveBeenCalledTimes(1);

--- a/packages/beachball/src/__functional__/packageManager/npmAuthEnvPassthrough.test.ts
+++ b/packages/beachball/src/__functional__/packageManager/npmAuthEnvPassthrough.test.ts
@@ -54,22 +54,22 @@ describe('checkNpmAuthEnvPassthrough', () => {
     wrapperDir = undefined;
   });
 
-  it('passes when the real node binary is on PATH', async () => {
+  it('passes when the real node binary is on PATH', () => {
     // process.execPath's directory is on PATH in the test environment
-    await checkNpmAuthEnvPassthrough({ ...commonOptions });
+    checkNpmAuthEnvPassthrough({ ...commonOptions });
     expect(logs.getMockLines('error')).toEqual('');
   });
 
-  it('passes when PATH is given explicitly with node on it', async () => {
+  it('passes when PATH is given explicitly with node on it', () => {
     const nodeBinDir = path.dirname(process.execPath);
-    await checkNpmAuthEnvPassthrough({ ...commonOptions, pathEnv: nodeBinDir });
+    checkNpmAuthEnvPassthrough({ ...commonOptions, pathEnv: nodeBinDir });
     expect(logs.getMockLines('error')).toEqual('');
   });
 
   // A shebang-based wrapper only works on POSIX
   // eslint-disable-next-line no-restricted-properties
   const itPosixLike = path.delimiter === ':' ? it : it.skip;
-  itPosixLike('throws when node is wrapped by a script that drops special env vars', async () => {
+  itPosixLike('throws when node is wrapped by a script that drops special env vars', () => {
     wrapperDir = tmpdir({ prefix: 'beachball-test-wrapper-' });
     const wrapperScript = path.join(wrapperDir, 'node');
 
@@ -92,9 +92,7 @@ describe('checkNpmAuthEnvPassthrough', () => {
 
     const pathWithWrapper = wrapperDir + path.delimiter + process.env.PATH!;
 
-    await expect(checkNpmAuthEnvPassthrough({ ...commonOptions, pathEnv: pathWithWrapper })).rejects.toThrow(
-      BeachballError
-    );
+    expect(() => checkNpmAuthEnvPassthrough({ ...commonOptions, pathEnv: pathWithWrapper })).toThrow(BeachballError);
     const errorLogs = logs.getMockLines('error');
     expect(errorLogs).toContain('The environment variable used to pass the npm auth token');
     expect(errorLogs).toContain(`Your PATH:\n${pathWithWrapper}`);

--- a/packages/beachball/src/__functional__/packageManager/packPackage.test.ts
+++ b/packages/beachball/src/__functional__/packageManager/packPackage.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it, beforeEach, jest, afterEach } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
+import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
+import { writeJson } from '../../object/writeJson';
 import type * as npmModuleType from '../../packageManager/npm';
-import type { NpmResult } from '../../packageManager/npm';
 import { packPackage } from '../../packageManager/packPackage';
 import type { PackageInfo } from '../../types/PackageInfo';
-import { getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
-import { writeJson } from '../../object/writeJson';
 
 // Spawning actual npm is slow, so mock it for most of these tests.
 // A couple tests also use the real npm command.
@@ -170,9 +170,7 @@ describe('packPackage', () => {
   it('handles failure packing', async () => {
     const testPkg = getTestPackage('testpkg');
     // It's difficult to simulate actual error conditions, so mock an npm call failure.
-    npmMock.setCommandOverride('pack', () =>
-      Promise.resolve({ success: false, stdout: 'oh no', all: 'oh no' } as NpmResult)
-    );
+    npmMock.setCommandOverride('pack', () => Promise.resolve(new MockSubprocessError({ output: 'oh no' })));
 
     const packResult = await packPackage(testPkg.info, {
       packToPath: tempPackPath,
@@ -190,9 +188,7 @@ describe('packPackage', () => {
 
   it('handles if filename is missing from output', async () => {
     const testPkg = getTestPackage('testpkg');
-    npmMock.setCommandOverride('pack', () =>
-      Promise.resolve({ success: true, stdout: 'not a file', all: 'not a file' } as NpmResult)
-    );
+    npmMock.setCommandOverride('pack', () => Promise.resolve(mockSpawnSuccess({ output: 'not a file' })));
 
     const packResult = await packPackage(testPkg.info, {
       packToPath: tempPackPath,
@@ -210,9 +206,7 @@ describe('packPackage', () => {
 
   it('handles if filename in output does not exist', async () => {
     const testPkg = getTestPackage('testpkg');
-    npmMock.setCommandOverride('pack', () =>
-      Promise.resolve({ success: true, stdout: 'nope.tgz', all: 'nope.tgz' } as NpmResult)
-    );
+    npmMock.setCommandOverride('pack', () => Promise.resolve(mockSpawnSuccess({ output: 'nope.tgz' })));
 
     const packResult = await packPackage(testPkg.info, {
       packToPath: tempPackPath,

--- a/packages/beachball/src/__functional__/packageManager/packagePublish.test.ts
+++ b/packages/beachball/src/__functional__/packageManager/packagePublish.test.ts
@@ -1,15 +1,16 @@
-import { describe, expect, it, beforeAll, afterAll, beforeEach, jest, afterEach } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
 import { Registry } from '../../__fixtures__/registry';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
+import { env } from '../../env';
+import { writeJson } from '../../object/writeJson';
+import { getNpmPackageInfo } from '../../packageManager/getNpmPackageInfo';
+import type { npm } from '../../packageManager/npm';
 import * as npmModule from '../../packageManager/npm';
 import { packagePublish } from '../../packageManager/packagePublish';
 import type { PackageInfo } from '../../types/PackageInfo';
-import type { npm, NpmResult } from '../../packageManager/npm';
-import { writeJson } from '../../object/writeJson';
-import { getNpmPackageInfo } from '../../packageManager/getNpmPackageInfo';
-import { env } from '../../env';
 
 type PackagePublishOptions = Parameters<typeof packagePublish>[1];
 
@@ -79,9 +80,7 @@ describe('packagePublish', () => {
 
       // Get the token once upfront (unfortunately verdaccio doesn't support `npm token create`)
       await registry.start();
-      await registry.login();
-      token = registry.getToken();
-      await registry.logout();
+      token = await registry.getToken();
       registry.stop();
 
       // Create a test package.json in a temporary location for use in tests.
@@ -95,10 +94,10 @@ describe('packagePublish', () => {
       jest.clearAllMocks();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       npmSpy.mockRestore();
       // no-op if already logged out
-      await registry.logout();
+      registry.logout();
       registry.stop();
     });
 
@@ -109,10 +108,6 @@ describe('packagePublish', () => {
 
     // Do a basic publishing test against the real registry
     it('can publish with a token', async () => {
-      // Pass the token as an arg this time to verify it's translated to an environment variable
-      // and picked up by npm
-      expect(await registry.whoami()).toBeFalsy();
-
       const testPackageInfo = getTestPackageInfo();
       const publishResult = await packagePublish(testPackageInfo, {
         ...defaultOptions,
@@ -142,7 +137,7 @@ describe('packagePublish', () => {
     });
 
     it('can publish when logged in', async () => {
-      await registry.login();
+      registry.login();
 
       const testPackageInfo = getTestPackageInfo();
       const publishResult = await packagePublish(testPackageInfo, {
@@ -183,7 +178,7 @@ describe('packagePublish', () => {
     });
 
     it('handles auth error and does not retry', async () => {
-      await registry.logout();
+      registry.logout();
 
       const testPackageInfo = getTestPackageInfo();
       const publishResult = await packagePublish(testPackageInfo, {
@@ -201,7 +196,7 @@ describe('packagePublish', () => {
   describe('with mocked npm', () => {
     it('logs commands and progress', async () => {
       const testPackageInfo = getTestPackageInfo();
-      npmSpy.mockResolvedValue({ success: true, all: 'not logged' } as NpmResult);
+      npmSpy.mockResolvedValue(mockSpawnSuccess({ output: 'not logged' }));
 
       const publishResult = await packagePublish(testPackageInfo, {
         ...defaultOptions,
@@ -226,12 +221,12 @@ describe('packagePublish', () => {
       // so mock all npm calls for this test.
       const testPackageInfo = getTestPackageInfo();
       // mock success by default, except for the two mocked failures below
-      npmSpy.mockImplementation(() => Promise.resolve({ success: true } as NpmResult));
+      npmSpy.mockImplementation(() => Promise.resolve(mockSpawnSuccess()));
       // first call: arbitrary error
-      npmSpy.mockImplementationOnce(() => Promise.resolve({ success: false, all: 'some errors' } as NpmResult));
+      npmSpy.mockImplementationOnce(() => Promise.resolve(new MockSubprocessError({ output: 'some errors' })));
       // second call: timeout
       npmSpy.mockImplementationOnce(() =>
-        Promise.resolve({ success: false, all: 'sloooow', timedOut: true } as NpmResult)
+        Promise.resolve(new MockSubprocessError({ output: 'sloooow', timedOut: true }))
       );
 
       const publishResult = await packagePublish(testPackageInfo, {
@@ -251,7 +246,7 @@ describe('packagePublish', () => {
 
     it('fails if out of retries', async () => {
       // Again, mock all npm calls for this test instead of simulating an actual error condition.
-      npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'some errors' } as NpmResult));
+      npmSpy.mockImplementation(() => Promise.resolve(new MockSubprocessError({ output: 'some errors' })));
 
       const publishResult = await packagePublish(getTestPackageInfo(), {
         ...defaultOptions,
@@ -270,7 +265,7 @@ describe('packagePublish', () => {
     it('does not retry on auth error (mock)', async () => {
       // Mock an auth error
       const testPackageInfo = getTestPackageInfo();
-      npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code ENEEDAUTH' } as NpmResult));
+      npmSpy.mockImplementation(() => Promise.resolve(new MockSubprocessError({ output: 'ERR! code ENEEDAUTH' })));
 
       const publishResult = await packagePublish(testPackageInfo, {
         ...defaultOptions,
@@ -288,7 +283,7 @@ describe('packagePublish', () => {
       // E404 most commonly indicates an issue with a token, which is hard to simulate,
       // so just mock the npm call.
       const testPackageInfo = getTestPackageInfo();
-      npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code E404' } as NpmResult));
+      npmSpy.mockImplementation(() => Promise.resolve(new MockSubprocessError({ output: 'ERR! code E404' })));
 
       const publishResult = await packagePublish(testPackageInfo, {
         ...defaultOptions,
@@ -302,7 +297,7 @@ describe('packagePublish', () => {
 
     it('does not retry on E403', async () => {
       const testPackageInfo = getTestPackageInfo();
-      npmSpy.mockImplementation(() => Promise.resolve({ success: false, all: 'ERR! code E403' } as NpmResult));
+      npmSpy.mockImplementation(() => Promise.resolve(new MockSubprocessError({ output: 'ERR! code E403' })));
 
       const publishResult = await packagePublish(testPackageInfo, {
         ...defaultOptions,

--- a/packages/beachball/src/__functional__/publish/publishToRegistry.test.ts
+++ b/packages/beachball/src/__functional__/publish/publishToRegistry.test.ts
@@ -3,15 +3,16 @@ import fs from 'fs';
 import path from 'path';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { _mockNpmPublish, getMockNpmPackName, initNpmMock } from '../../__fixtures__/mockNpm';
+import { MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import { removeTempDir, tmpdir } from '../../__fixtures__/tmpdir';
+import { writeChangelog } from '../../changelog/writeChangelog';
 import { writeJson } from '../../object/writeJson';
 import { getDefaultOptions } from '../../options/getDefaultOptions';
 import { publishToRegistry, type LayerVersionsJson } from '../../publish/publishToRegistry';
 import type { BeachballOptions, HooksOptions } from '../../types/BeachballOptions';
 import type { BumpInfo } from '../../types/BumpInfo';
 import type { PackageJson } from '../../types/PackageInfo';
-import { writeChangelog } from '../../changelog/writeChangelog';
 
 // Mock npm calls (publish, pack, show)
 jest.mock('../../packageManager/npm');
@@ -155,9 +156,7 @@ describe('publishToRegistry', () => {
     const bumpInfo = makeBumpInfo({ foo: {} });
 
     // Make the publish command fail
-    npmMock.setCommandOverride('publish', () =>
-      Promise.resolve({ success: false, stdout: '', stderr: 'network error', all: 'network error', failed: true })
-    );
+    npmMock.setCommandOverride('publish', () => Promise.resolve(new MockSubprocessError({ output: 'network error' })));
 
     await expect(publishToRegistry(bumpInfo, defaultOptions)).rejects.toThrow('Error publishing');
 
@@ -319,7 +318,7 @@ describe('publishToRegistry', () => {
       npmMock.setCommandOverride('publish', async (registryData, args, opts) => {
         const packageName = path.basename(opts.cwd);
         if (packageName === 'pkg2' || packageName === 'pkg5') {
-          return { success: false, stdout: '', stderr: 'oh no', all: 'oh no', failed: true };
+          return new MockSubprocessError({ output: 'oh no' });
         }
         // Use a small delay to verify that the started tasks are awaited even if others fail
         await new Promise(resolve => setTimeout(resolve, 20));

--- a/packages/beachball/src/__functional__/spawn.test.ts
+++ b/packages/beachball/src/__functional__/spawn.test.ts
@@ -27,12 +27,17 @@ describe('spawn', () => {
     expect((result as SpawnFailureResult).message).toContain('Command failed');
   });
 
+  // this indirectly tests an assumption in signWithAzureCli
   it('returns a failure result with an ENOENT cause for a missing binary', async () => {
     const result = await spawn('beachball-nonexistent-binary-xyz', [], { env: { PATH: '' } });
     expect(result.success).toBe(false);
     const failure = result as SpawnFailureResult;
-    // nano-spawn wraps the original spawn error as `cause`, so the code lives there.
-    expect((failure.cause as NodeJS.ErrnoException | undefined)?.code).toBe('ENOENT');
+    if (process.platform === 'win32') {
+      expect((failure.cause as NodeJS.ErrnoException | undefined)?.message).toContain('ENOENT');
+    } else {
+      // nano-spawn wraps the original spawn error as `cause`, so the code lives there.
+      expect((failure.cause as NodeJS.ErrnoException | undefined)?.code).toBe('ENOENT');
+    }
   });
 
   it('passes the env option, merged with process.env', async () => {

--- a/packages/beachball/src/__functional__/spawn.test.ts
+++ b/packages/beachball/src/__functional__/spawn.test.ts
@@ -33,9 +33,12 @@ describe('spawn', () => {
     expect(result.success).toBe(false);
     const failure = result as SpawnFailureResult;
     if (process.platform === 'win32') {
-      console.log('failure:', failure);
-      console.log('cause:', failure.cause);
-      expect((failure.cause as NodeJS.ErrnoException | undefined)?.message).toContain('ENOENT');
+      try {
+        // this is probably localized
+        expect(failure.stderr).toContain('not recognized');
+      } catch {
+        console.warn('stderr did not contain "not recognized" on Windows:\n', failure.stderr);
+      }
     } else {
       // nano-spawn wraps the original spawn error as `cause`, so the code lives there.
       expect((failure.cause as NodeJS.ErrnoException | undefined)?.code).toBe('ENOENT');

--- a/packages/beachball/src/__functional__/spawn.test.ts
+++ b/packages/beachball/src/__functional__/spawn.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from '@jest/globals';
+import { spawn, type SpawnFailureResult } from '../spawn';
+
+describe('spawn', () => {
+  it('resolves with a success result for a successful command', async () => {
+    const result = await spawn('node', ['-e', `process.stdout.write('hello world')`]);
+    expect(result).toMatchObject({
+      success: true,
+      stdout: 'hello world',
+      // stringContaining only matters in the debugger
+      output: expect.stringContaining('hello world'),
+    });
+    expect((result as SpawnFailureResult).exitCode).toBeUndefined();
+  });
+
+  it('returns a failure result (does not throw) for a non-zero exit code', async () => {
+    const result = await spawn('node', ['-e', `process.stderr.write('oh no'); process.exit(3)`]);
+    expect(result).toMatchObject({
+      success: false,
+      name: 'SubprocessError', // checking instanceof would require async importing SubprocessError
+      exitCode: 3,
+      stderr: expect.stringContaining('oh no'),
+      output: expect.stringContaining('oh no'),
+      timedOut: undefined,
+    });
+    // message can't be checked in toMatchObject since it's not enumerable
+    expect((result as SpawnFailureResult).message).toContain('Command failed');
+  });
+
+  it('returns a failure result with an ENOENT cause for a missing binary', async () => {
+    const result = await spawn('beachball-nonexistent-binary-xyz', [], { env: { PATH: '' } });
+    expect(result.success).toBe(false);
+    const failure = result as SpawnFailureResult;
+    // nano-spawn wraps the original spawn error as `cause`, so the code lives there.
+    expect((failure.cause as NodeJS.ErrnoException | undefined)?.code).toBe('ENOENT');
+  });
+
+  it('passes the env option, merged with process.env', async () => {
+    const result = await spawn(
+      'node',
+      ['-e', `process.stdout.write(process.env.BEACHBALL_TEST_VAR + '|' + Boolean(process.env.PATH))`],
+      { env: { BEACHBALL_TEST_VAR: 'custom-value' } }
+    );
+    expect(result).toMatchObject({ success: true, stdout: 'custom-value|true' });
+  });
+
+  it('sets timedOut when the timeout is exceeded', async () => {
+    const result = await spawn('node', ['-e', 'setTimeout(() => {}, 10000)'], { timeout: 20 });
+    expect(result).toMatchObject({ success: false, timedOut: true });
+  });
+
+  it('throws when both timeout and signal are specified', async () => {
+    const controller = new AbortController();
+    await expect(spawn('node', ['-e', ''], { timeout: 100, signal: controller.signal })).rejects.toThrow(
+      'Cannot specify both timeout and signal'
+    );
+  });
+});

--- a/packages/beachball/src/__functional__/spawn.test.ts
+++ b/packages/beachball/src/__functional__/spawn.test.ts
@@ -33,6 +33,8 @@ describe('spawn', () => {
     expect(result.success).toBe(false);
     const failure = result as SpawnFailureResult;
     if (process.platform === 'win32') {
+      console.log('failure:', failure);
+      console.log('cause:', failure.cause);
       expect((failure.cause as NodeJS.ErrnoException | undefined)?.message).toContain('ENOENT');
     } else {
       // nano-spawn wraps the original spawn error as `cause`, so the code lives there.

--- a/packages/beachball/src/__tests__/bump/updateLockFile.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateLockFile.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
-import { updateLockFile } from '../../bump/updateLockFile';
-import { packageManager, type PackageManagerResult } from '../../packageManager/packageManager';
 import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
+import { updateLockFile } from '../../bump/updateLockFile';
+import { packageManager } from '../../packageManager/packageManager';
 
 jest.mock('fs');
 jest.mock('../../packageManager/packageManager');
@@ -21,7 +22,7 @@ describe('updateLockFile', () => {
   const mockPackageManager = packageManager as jest.MockedFunction<typeof packageManager>;
 
   beforeEach(() => {
-    mockPackageManager.mockResolvedValue({ success: true } as PackageManagerResult);
+    mockPackageManager.mockResolvedValue(mockSpawnSuccess());
     mockFs.existsSync.mockReturnValue(false);
   });
 
@@ -51,8 +52,8 @@ describe('updateLockFile', () => {
 
   it('updates yarn.lock for yarn v2+', async () => {
     mockFs.existsSync.mockImplementation(p => p === path.join(mockRoot, 'yarn.lock'));
-    mockPackageManager.mockResolvedValueOnce({ success: true, stdout: '3.6.0' } as PackageManagerResult);
-    mockPackageManager.mockResolvedValueOnce({ success: true } as PackageManagerResult);
+    mockPackageManager.mockResolvedValueOnce(mockSpawnSuccess({ stdout: '3.6.0' }));
+    mockPackageManager.mockResolvedValueOnce(mockSpawnSuccess());
 
     await updateLockFile({ path: mockRoot });
 
@@ -67,7 +68,7 @@ describe('updateLockFile', () => {
 
   it('skips yarn.lock update for yarn v1', async () => {
     mockFs.existsSync.mockImplementation(p => p === path.join(mockRoot, 'yarn.lock'));
-    mockPackageManager.mockResolvedValue({ success: true, stdout: '1.22.19' } as PackageManagerResult);
+    mockPackageManager.mockResolvedValue(mockSpawnSuccess({ stdout: '1.22.19' }));
 
     await updateLockFile({ path: mockRoot });
 
@@ -79,7 +80,7 @@ describe('updateLockFile', () => {
 
   it('warns when yarn version check fails', async () => {
     mockFs.existsSync.mockImplementation(p => p === path.join(mockRoot, 'yarn.lock'));
-    mockPackageManager.mockResolvedValue({ success: false, stdout: '', stderr: 'error' } as PackageManagerResult);
+    mockPackageManager.mockResolvedValue(new MockSubprocessError({ output: 'error' }));
 
     await updateLockFile({ path: mockRoot });
 
@@ -88,7 +89,7 @@ describe('updateLockFile', () => {
 
   it('warns when lock file update fails', async () => {
     mockFs.existsSync.mockImplementation(p => p === path.join(mockRoot, 'package-lock.json'));
-    mockPackageManager.mockResolvedValue({ success: false, stdout: '', stderr: 'error' } as PackageManagerResult);
+    mockPackageManager.mockResolvedValue(new MockSubprocessError({ output: 'error' }));
 
     await updateLockFile({ path: mockRoot });
 

--- a/packages/beachball/src/__tests__/githubAuth/signWithAzureCli.test.ts
+++ b/packages/beachball/src/__tests__/githubAuth/signWithAzureCli.test.ts
@@ -1,14 +1,12 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { createHash } from 'node:crypto';
-import _execa from 'execa';
+import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
 import { signWithAzureCli } from '../../githubAuth/signWithAzureCli';
+import { spawn as _spawn } from '../../spawn';
 
-jest.mock('execa');
+jest.mock('../../spawn');
 
-// execa's overloaded types are too complex for jest.Mock, so we cast it to the signature that's used.
-const mockExeca = _execa as unknown as jest.MockedFunction<
-  (file: string, args?: readonly string[], options?: _execa.Options) => Promise<{ stdout: string; all?: string }>
->;
+const mockSpawn = _spawn as jest.MockedFunction<typeof _spawn>;
 
 const keyId = 'https://my-vault.vault.azure.net/keys/my-github-app-key';
 const signingInput = 'header.payload';
@@ -18,19 +16,19 @@ const expectedDigest = createHash('sha256').update(signingInput).digest('base64'
 
 describe('signWithAzureCli', () => {
   beforeEach(() => {
-    mockExeca.mockReset();
+    mockSpawn.mockReset();
   });
 
   it('signs the sha256 digest and returns a base64url signature', async () => {
     // Azure CLI returns standard base64 (with +, /, =), which must be converted to base64url.
-    mockExeca.mockResolvedValue({ stdout: 'ab+/cd==\n' });
+    mockSpawn.mockResolvedValue(mockSpawnSuccess({ output: 'ab+/cd==\n' }));
 
     const signature = await signWithAzureCli(keyId, signingInput);
 
     expect(signature).toBe('ab-_cd');
 
-    expect(mockExeca).toHaveBeenCalledTimes(1);
-    const [file, args] = mockExeca.mock.calls[0];
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [file, args] = mockSpawn.mock.calls[0];
     expect(file).toBe('az');
     expect(args).toEqual([
       'keyvault',
@@ -51,13 +49,15 @@ describe('signWithAzureCli', () => {
   });
 
   it('throws a helpful error when the Azure CLI is not installed', async () => {
-    mockExeca.mockRejectedValue(Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' }));
+    const cause = new Error('spawn az ENOENT');
+    (cause as { code?: string }).code = 'ENOENT';
+    mockSpawn.mockResolvedValue(new MockSubprocessError({ cause }));
 
     await expect(signWithAzureCli(keyId, signingInput)).rejects.toThrow(/Azure CLI \(`az`\) was not found on PATH/);
   });
 
   it('includes the CLI output when signing fails', async () => {
-    mockExeca.mockRejectedValue(Object.assign(new Error('Command failed'), { all: 'ERROR: forbidden' }));
+    mockSpawn.mockResolvedValue(new MockSubprocessError({ output: 'ERROR: forbidden' }));
 
     await expect(signWithAzureCli(keyId, signingInput)).rejects.toThrow(
       /Azure Key Vault signing failed\. Output:\nERROR: forbidden/
@@ -65,15 +65,15 @@ describe('signWithAzureCli', () => {
   });
 
   it('falls back to the short message when there is no output', async () => {
-    mockExeca.mockRejectedValue(Object.assign(new Error('Command failed'), { shortMessage: 'Command failed: az' }));
+    mockSpawn.mockResolvedValue(new MockSubprocessError());
 
     await expect(signWithAzureCli(keyId, signingInput)).rejects.toThrow(
-      /Azure Key Vault signing failed\. Command failed: az/
+      /Azure Key Vault signing failed\. Command failed/
     );
   });
 
   it('throws when Azure Key Vault returns an empty signature', async () => {
-    mockExeca.mockResolvedValue({ stdout: '   \n' });
+    mockSpawn.mockResolvedValue(mockSpawnSuccess({ output: '   \n' }));
 
     await expect(signWithAzureCli(keyId, signingInput)).rejects.toThrow(/did not return a signature/);
   });

--- a/packages/beachball/src/__tests__/githubAuth/signWithAzureCli.test.ts
+++ b/packages/beachball/src/__tests__/githubAuth/signWithAzureCli.test.ts
@@ -49,6 +49,7 @@ describe('signWithAzureCli', () => {
   });
 
   it('throws a helpful error when the Azure CLI is not installed', async () => {
+    // This is NOT the error Windows gives, but it's still reasonable to test this path
     const cause = new Error('spawn az ENOENT');
     (cause as { code?: string }).code = 'ENOENT';
     mockSpawn.mockResolvedValue(new MockSubprocessError({ cause }));

--- a/packages/beachball/src/__tests__/packageManager/listPackageVersions.test.ts
+++ b/packages/beachball/src/__tests__/packageManager/listPackageVersions.test.ts
@@ -86,7 +86,7 @@ describe('list npm versions', () => {
       expect(versions).toEqual({ foo: ['1.0.0', '1.0.1'] });
       expect(npmMock.mock).toHaveBeenCalledWith(
         [...commonArgs, 'foo', ..._npmShowProperties],
-        expect.objectContaining({ env: { ...process.env, 'npm_config_//fake/:_password': 'pass' } })
+        expect.objectContaining({ env: { 'npm_config_//fake/:_password': 'pass' } })
       );
       // expect(npmMock.mockFetchJson).toHaveBeenCalledWith(
       //   '/foo',
@@ -100,7 +100,7 @@ describe('list npm versions', () => {
       expect(versions).toEqual({ foo: ['1.0.0', '1.0.1'] });
       expect(npmMock.mock).toHaveBeenCalledWith(
         [...commonArgs, 'foo', ..._npmShowProperties],
-        expect.objectContaining({ env: { ...process.env, 'npm_config_//fake/:_authToken': 'pass' } })
+        expect.objectContaining({ env: { 'npm_config_//fake/:_authToken': 'pass' } })
       );
       // expect(npmMock.mockFetchJson).toHaveBeenCalledWith(
       //   '/foo',
@@ -307,7 +307,7 @@ describe('list npm versions', () => {
         expect(versions).toEqual({ foo: '1.0.0' });
         expect(npmMock.mock).toHaveBeenCalledWith(
           [...commonArgs, 'foo', ..._npmShowProperties],
-          expect.objectContaining({ env: { ...process.env, 'npm_config_//fake/:_authToken': 'pass' } })
+          expect.objectContaining({ env: { 'npm_config_//fake/:_authToken': 'pass' } })
         );
         // expect(npmMock.mockFetchJson).toHaveBeenCalledWith(
         //   '/foo',
@@ -327,7 +327,7 @@ describe('list npm versions', () => {
         expect(versions).toEqual({ foo: '1.0.0' });
         expect(npmMock.mock).toHaveBeenCalledWith(
           [...commonArgs, 'foo', ..._npmShowProperties],
-          expect.objectContaining({ env: { ...process.env, 'npm_config_//fake/:_password': 'pass' } })
+          expect.objectContaining({ env: { 'npm_config_//fake/:_password': 'pass' } })
         );
         // expect(npmMock.mockFetchJson).toHaveBeenCalledWith(
         //   '/foo',

--- a/packages/beachball/src/__tests__/publish/__snapshots__/bumpAndPush.test.ts.snap
+++ b/packages/beachball/src/__tests__/publish/__snapshots__/bumpAndPush.test.ts.snap
@@ -19,30 +19,30 @@ exports[`bumpAndPush retries on fetch failure then succeeds 2`] = `
 Merging with origin/master...
 [log] Running: git merge -X theirs origin/master
 [log]
-[log] git merge -X theirs origin/master completed successfully
+[log] Command completed: git merge -X theirs origin/master
 [log]
 Bumping versions locally (and writing changelogs if requested)
 [log]
 Merging publish_12345 into origin/master...
 [log] Running: git add .
 [log]
-[log] git add . completed successfully
+[log] Command completed: git add .
 [log] Running: git commit -m apply package updates
 [log]
-[log] git commit -m apply package updates completed successfully
+[log] Command completed: git commit -m apply package updates
 [log] Running: git checkout origin/master
 [log]
-[log] git checkout origin/master completed successfully
+[log] Command completed: git checkout origin/master
 [log] Running: git merge -X ours publish_12345
 [log]
-[log] git merge -X ours publish_12345 completed successfully
+[log] Command completed: git merge -X ours publish_12345
 [log]
 Creating git tags for new versions...
 [log]
 Pushing to origin/master...
 [log] Running: git push --no-verify --follow-tags --verbose origin HEAD:master
 [log]
-[log] git push --no-verify --follow-tags --verbose origin HEAD:master completed successfully"
+[log] Command completed: git push --no-verify --follow-tags --verbose origin HEAD:master"
 `;
 
 exports[`bumpAndPush succeeds on first attempt 1`] = `
@@ -56,30 +56,30 @@ exports[`bumpAndPush succeeds on first attempt 1`] = `
 Merging with origin/master...
 [log] Running: git merge -X theirs origin/master
 [log]
-[log] git merge -X theirs origin/master completed successfully
+[log] Command completed: git merge -X theirs origin/master
 [log]
 Bumping versions locally (and writing changelogs if requested)
 [log]
 Merging publish_12345 into origin/master...
 [log] Running: git add .
 [log]
-[log] git add . completed successfully
+[log] Command completed: git add .
 [log] Running: git commit -m apply package updates
 [log]
-[log] git commit -m apply package updates completed successfully
+[log] Command completed: git commit -m apply package updates
 [log] Running: git checkout origin/master
 [log]
-[log] git checkout origin/master completed successfully
+[log] Command completed: git checkout origin/master
 [log] Running: git merge -X ours publish_12345
 [log]
-[log] git merge -X ours publish_12345 completed successfully
+[log] Command completed: git merge -X ours publish_12345
 [log]
 Creating git tags for new versions...
 [log]
 Pushing to origin/master...
 [log] Running: git push --no-verify --follow-tags --verbose origin HEAD:master
 [log]
-[log] git push --no-verify --follow-tags --verbose origin HEAD:master completed successfully"
+[log] Command completed: git push --no-verify --follow-tags --verbose origin HEAD:master"
 `;
 
 exports[`bumpAndPush throws and calls displayManualRecovery after all retries exhausted 1`] = `

--- a/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
+++ b/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
@@ -8,7 +8,6 @@ import { initMockLogs } from '../../__fixtures__/mockLogs';
 import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
 import { makePackageInfos } from '../../__fixtures__/packageInfos';
 import { performBump as _performBump } from '../../bump/performBump';
-import { gitAsync as _gitAsync } from '../../git/gitAsync';
 import { getOptions } from '../../options/getOptions';
 import { bumpAndPush } from '../../publish/bumpAndPush';
 import { tagPackages as _tagPackages } from '../../publish/tagPackages';

--- a/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
+++ b/packages/beachball/src/__tests__/publish/bumpAndPush.test.ts
@@ -1,28 +1,28 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+/* eslint-disable @typescript-eslint/require-await -- matching async mock signatures */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
-import * as wsTools from 'workspace-tools';
 import type { GitProcessOutput } from 'workspace-tools';
-import _execa from 'execa';
-import { bumpAndPush } from '../../publish/bumpAndPush';
-import { performBump as _performBump } from '../../bump/performBump';
-import { tagPackages as _tagPackages } from '../../publish/tagPackages';
-import { initMockLogs } from '../../__fixtures__/mockLogs';
-import { makePackageInfos } from '../../__fixtures__/packageInfos';
-import type { BumpInfo } from '../../types/BumpInfo';
+import * as wsTools from 'workspace-tools';
 import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+import { initMockLogs } from '../../__fixtures__/mockLogs';
+import { mockSpawnSuccess, MockSubprocessError } from '../../__fixtures__/mockSpawnResult';
+import { makePackageInfos } from '../../__fixtures__/packageInfos';
+import { performBump as _performBump } from '../../bump/performBump';
+import { gitAsync as _gitAsync } from '../../git/gitAsync';
 import { getOptions } from '../../options/getOptions';
+import { bumpAndPush } from '../../publish/bumpAndPush';
+import { tagPackages as _tagPackages } from '../../publish/tagPackages';
+import { spawn as _spawn } from '../../spawn';
 import { BeachballError } from '../../types/BeachballError';
 import type { BeachballOptions } from '../../types/BeachballOptions';
+import type { BumpInfo } from '../../types/BumpInfo';
 
-jest.mock('execa');
 jest.mock('workspace-tools');
 jest.mock('../../bump/performBump'); // this has a bunch of logic which is tested separately
 jest.mock('../../publish/tagPackages');
+jest.mock('../../spawn');
 
-// execa's overloaded types are too complex for jest.Mock, so we cast it to the signature that's used
-const mockExeca = _execa as unknown as jest.MockedFunction<
-  (file: string, args?: readonly string[], options?: _execa.Options) => _execa.ExecaChildProcess
->;
+const mockSpawn = _spawn as jest.MockedFunction<typeof _spawn>;
 const mockPerformBump = _performBump as jest.MockedFunction<typeof _performBump>;
 const mockTagPackages = _tagPackages as jest.MockedFunction<typeof _tagPackages>;
 const wsToolsMocks = wsTools as jest.Mocked<typeof wsTools>;
@@ -33,21 +33,8 @@ describe('bumpAndPush', () => {
   const fakeRoot = path.resolve('/fake/root');
   const publishBranch = 'publish_12345';
 
-  /** Create a mock execa result that resolves like a real ExecaChildProcess */
-  function makeExecaResult(opts: { success: boolean; output?: string; timedOut?: boolean }) {
-    const result = {
-      failed: !opts.success,
-      all: opts.output ?? '',
-      exitCode: opts.success ? 0 : 1,
-      stdout: opts.output ?? '',
-      stderr: '',
-      timedOut: opts.timedOut ?? false,
-    } as _execa.ExecaReturnValue;
-    return Object.assign(Promise.resolve(result), { stdout: null, stderr: null }) as _execa.ExecaChildProcess;
-  }
-
   function getExecaCalls() {
-    return mockExeca.mock.calls.map(([file, args]) => `${file} ${args?.join(' ')}`);
+    return mockSpawn.mock.calls.map(([file, args]) => `${file} ${args?.join(' ')}`);
   }
 
   function getWsToolsGitCalls() {
@@ -92,7 +79,7 @@ describe('bumpAndPush', () => {
     wsToolsMocks.parseRemoteBranch.mockReturnValue({ remote: 'origin', remoteBranch: 'master' });
     wsToolsMocks.revertLocalChanges.mockReturnValue(true);
     wsToolsMocks.git.mockReturnValue(makeGitResult({ success: true }));
-    mockExeca.mockImplementation(() => makeExecaResult({ success: true }));
+    mockSpawn.mockImplementation(() => Promise.resolve(mockSpawnSuccess()));
     mockPerformBump.mockResolvedValue(undefined);
   });
 
@@ -159,13 +146,13 @@ describe('bumpAndPush', () => {
     // First attempt: merge with branch succeeds, but commit in mergePublishBranch fails
     // (merge is call 1, add is call 2, commit is call 3)
     let callCount = 0;
-    mockExeca.mockImplementation(() => {
+    mockSpawn.mockImplementation(async () => {
       callCount++;
       // Fail on 3rd call (commit) in first attempt
       if (callCount === 3) {
-        return makeExecaResult({ success: false, output: 'commit failed' });
+        return new MockSubprocessError({ output: 'commit failed' });
       }
-      return makeExecaResult({ success: true });
+      return mockSpawnSuccess();
     });
 
     await callBumpAndPush();
@@ -175,19 +162,19 @@ describe('bumpAndPush', () => {
 
     expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
       "commit failed
-      git commit -m apply package updates failed (code 1)
+      Command failed (code 1): git commit -m apply package updates
       [WARN 1/5]: Merging to target has failed! (see above for details)"
     `);
   });
 
   it('retries on push failure then succeeds', async () => {
     let pushCount = 0;
-    mockExeca.mockImplementation((_cmd, args) => {
+    mockSpawn.mockImplementation(async (_cmd, args) => {
       if (args?.[0] === 'push') {
         pushCount++;
-        if (pushCount === 1) return makeExecaResult({ success: false, output: 'push rejected' });
+        if (pushCount === 1) return new MockSubprocessError({ output: 'push rejected' });
       }
-      return makeExecaResult({ success: true });
+      return mockSpawnSuccess();
     });
 
     await callBumpAndPush();
@@ -198,25 +185,26 @@ describe('bumpAndPush', () => {
 
     expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
       "push rejected
-      git push --no-verify --follow-tags --verbose origin HEAD:master failed (code 1)
+      Command failed (code 1): git push --no-verify --follow-tags --verbose origin HEAD:master
       [WARN 1/5]: Pushing to origin/master has failed! (see above for details)"
     `);
   });
 
   it('shows timeout message on push timeout', async () => {
     let pushCount = 0;
-    mockExeca.mockImplementation((_cmd, args) => {
+    mockSpawn.mockImplementation(async (_cmd, args) => {
       if (args?.[0] === 'push') {
         pushCount++;
-        if (pushCount === 1) return makeExecaResult({ success: false, timedOut: true });
+        if (pushCount === 1) return new MockSubprocessError({ output: 'push timed out', timedOut: true });
       }
-      return makeExecaResult({ success: true });
+      return mockSpawnSuccess();
     });
 
     await callBumpAndPush();
 
     expect(logs.getMockLines('warn')).toMatchInlineSnapshot(`
-      "git push --no-verify --follow-tags --verbose origin HEAD:master failed (code 1)
+      "push timed out
+      Command failed (timed out): git push --no-verify --follow-tags --verbose origin HEAD:master
       [WARN 1/5]: Pushing to origin/master has timed out! (see above for details)"
     `);
   });
@@ -254,7 +242,6 @@ describe('bumpAndPush', () => {
   });
 
   it('calls precommit hook before merge steps', async () => {
-    // eslint-disable-next-line @typescript-eslint/require-await
     const precommit = jest.fn<(cwd: string) => Promise<void>>(async () => console.log('hello from hook'));
     await callBumpAndPush({ hooks: { precommit } });
 
@@ -267,9 +254,10 @@ describe('bumpAndPush', () => {
 
   it('calls precommit hook on each retry', async () => {
     const precommit = jest.fn<(cwd: string) => Promise<void>>();
-    mockExeca.mockImplementation((_cmd, args) =>
-      args?.[0] === 'push' ? makeExecaResult({ success: false, output: 'oh no' }) : makeExecaResult({ success: true })
-    );
+    mockSpawn.mockImplementation(async (_cmd, args) => {
+      if (args?.[0] === 'push') return new MockSubprocessError({ output: 'push rejected' });
+      return mockSpawnSuccess();
+    });
 
     await expect(() => callBumpAndPush({ hooks: { precommit } }, 3)).rejects.toThrow(BeachballError);
 

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -30,12 +30,6 @@ const version = getPackageInfo(findPackageRoot(__dirname)!)?.version;
   const parsedOptions = await getOptions({ cwd: processCwd, argv: process.argv, env: process.env, version });
   const options = parsedOptions.options;
 
-  // TODO port remaining help elements and remove help.ts
-  // if (options.help) {
-  //   showHelp();
-  //   return;
-  // }
-
   // Run the commands
   switch (options.command) {
     case 'check': {

--- a/packages/beachball/src/commands/publish.ts
+++ b/packages/beachball/src/commands/publish.ts
@@ -64,7 +64,7 @@ export async function publish(options: BeachballOptions, context: CommandContext
 
   if (options.token) {
     // Verify that passing the npm auth token via env vars works (see function comment...)
-    await checkNpmAuthEnvPassthrough(options);
+    checkNpmAuthEnvPassthrough(options);
   }
 
   // checkout publish branch

--- a/packages/beachball/src/env.ts
+++ b/packages/beachball/src/env.ts
@@ -23,7 +23,6 @@ export const env = Object.freeze({
 
   // These are borrowed from workspace-tools
   workspaceToolsGitDebug: !!process.env.GIT_DEBUG,
-  workspaceToolsGitMaxBuffer: (process.env.GIT_MAX_BUFFER && parseInt(process.env.GIT_MAX_BUFFER, 10)) || undefined,
   /** @deprecated Use `options.npmReadConcurrency` */
   // if this is removed, default logic should go to getDefaultOptions
   // TODO change back to 10 after https://github.com/microsoft/beachball/issues/1143

--- a/packages/beachball/src/git/gitAsync.ts
+++ b/packages/beachball/src/git/gitAsync.ts
@@ -1,70 +1,47 @@
-import execa from 'execa';
 import { env } from '../env';
+import { spawn, type SpawnOptions, type SpawnResult } from '../spawn';
 
 // cwd is required here
 // stdio behavior is overridden
-// reject is always false
-export type GitAsyncOptions = Omit<
-  execa.Options,
-  'cwd' | 'all' | 'stdio' | 'stdout' | 'stderr' | 'stdin' | 'reject'
-> & {
+type GitAsyncOptions = Omit<SpawnOptions, 'cwd' | 'stdio' | 'stdout' | 'stderr' | 'stdin'> & {
   cwd: string;
   verbose?: boolean;
 };
-
-export type GitAsyncResult = (
-  | (Omit<execa.ExecaReturnValue<string>, 'failed'> & { success: true })
-  | (Omit<execa.ExecaError<string>, 'failed'> & { success: false })
-) & { errorMessage?: string };
 
 /**
  * Run a git command asynchronously. If `verbose` is true, log the command before starting, and display
  * output on stdout (except in tests) *and* return it in the result. For tests with `verbose`, the output
  * will be logged all together to `console.log` when the command finishes (for easier mocking/capturing).
- *
- * (This utility should potentially be moved to `workspace-tools`, but it uses `execa` to capture
- * interleaved stdout/stderr, and `execa` is a large-ish dep not currently used there.)
  */
-export async function gitAsync(args: string[], options: GitAsyncOptions): Promise<GitAsyncResult> {
-  const { verbose, ...execaOpts } = options;
-  const { shouldLog, maxBuffer } = getGitEnv(verbose);
+export async function gitAsync(args: string[], options: GitAsyncOptions): Promise<SpawnResult> {
+  const { verbose, ...spawnOpts } = options;
+  const { shouldLog } = getGitEnv(verbose);
 
   const gitCmd = `git ${args.join(' ')}`;
 
   shouldLog && console.log(`Running: ${gitCmd}`);
 
-  const child = execa('git', args, {
-    maxBuffer,
-    ...execaOpts,
-    stdio: 'pipe',
-    all: true,
-    reject: false,
+  const result = await spawn('git', args, {
+    ...spawnOpts,
+    stdio: shouldLog === 'live' ? 'inherit' : 'pipe',
   });
-
-  if (shouldLog === 'live') {
-    child.stdout?.pipe(process.stdout);
-    child.stderr?.pipe(process.stderr);
-  }
-
-  const execaResult = await child;
-  const result = { ...execaResult, success: !execaResult.failed } as GitAsyncResult;
 
   const log = result.success ? console.log : console.warn;
 
   if (shouldLog === 'end') {
     // do the jest logging all at once in a way that can be captured by mocks
-    log(result.all);
+    log(result.output);
   }
 
-  let message = `${gitCmd} ${result.success ? 'completed successfully' : `failed (code ${result.exitCode})`}`;
+  let message = `Command ${result.success ? 'completed' : `failed (${result.timedOut ? 'timed out' : `code ${result.exitCode}`})`}: ${gitCmd}`;
   if (shouldLog) {
     log(message);
-  } else {
-    message += ` - output:\n${result.all}`;
+  } else if (result.output) {
+    message += ` - output:\n${result.output}`;
   }
 
   if (!result.success) {
-    result.errorMessage = message;
+    result.message = message;
   }
 
   return result;
@@ -78,11 +55,8 @@ export function getGitEnv(verbose: boolean | undefined): {
    * - 'end': log command, and log output at the end (for tests, if `verbose` or `process.env.GIT_DEBUG`)
    */
   shouldLog: false | 'live' | 'end';
-  /** Max buffer for git operations, copied from workspace-tools implementation */
-  maxBuffer: number;
 } {
   return {
     shouldLog: verbose || env.workspaceToolsGitDebug ? (env.isJest ? 'end' : 'live') : false,
-    maxBuffer: env.workspaceToolsGitMaxBuffer || 500 * 1024 * 1024,
   };
 }

--- a/packages/beachball/src/git/gitAsync.ts
+++ b/packages/beachball/src/git/gitAsync.ts
@@ -10,8 +10,8 @@ type GitAsyncOptions = Omit<SpawnOptions, 'cwd' | 'stdio' | 'stdout' | 'stderr' 
 
 /**
  * Run a git command asynchronously. If `verbose` is true, log the command before starting, and display
- * output on stdout (except in tests) *and* return it in the result. For tests with `verbose`, the output
- * will be logged all together to `console.log` when the command finishes (for easier mocking/capturing).
+ * output on stdout. For tests with `verbose`, the output will be logged all together to `console.log`
+ * when the command finishes (for easier mocking/capturing).
  */
 export async function gitAsync(args: string[], options: GitAsyncOptions): Promise<SpawnResult> {
   const { verbose, ...spawnOpts } = options;

--- a/packages/beachball/src/githubAuth/signWithAzureCli.ts
+++ b/packages/beachball/src/githubAuth/signWithAzureCli.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import execa from 'execa';
+import { spawn } from '../spawn';
 import { BeachballError } from '../types/BeachballError';
 
 function base64ToBase64url(value: string): string {
@@ -7,41 +7,39 @@ function base64ToBase64url(value: string): string {
 }
 
 async function signDigest(keyId: string, digest: string): Promise<string> {
-  try {
-    // execa (via cross-spawn) handles PATH lookup and Windows `.cmd`/`.bat`/`.exe` resolution.
-    const { stdout } = await execa(
-      'az',
-      [
-        'keyvault',
-        'key',
-        'sign',
-        '--id',
-        keyId,
-        '--algorithm',
-        'RS256',
-        '--digest',
-        digest,
-        '--query',
-        'signature',
-        '--output',
-        'tsv',
-        '--only-show-errors',
-      ],
-      { all: true, stdio: ['ignore', 'pipe', 'pipe'] }
-    );
-    return stdout.trim();
-  } catch (error) {
-    // `code` is the spawn error code (e.g. `ENOENT`), which isn't on the `ExecaError` type.
-    const execaError = error as execa.ExecaError & { code?: string };
-    if (execaError.code === 'ENOENT') {
-      throw new BeachballError('Azure CLI (`az`) was not found on PATH');
-    }
+  const result = await spawn(
+    'az',
+    [
+      'keyvault',
+      'key',
+      'sign',
+      '--id',
+      keyId,
+      '--algorithm',
+      'RS256',
+      '--digest',
+      digest,
+      '--query',
+      'signature',
+      '--output',
+      'tsv',
+      '--only-show-errors',
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  );
 
-    const output = execaError.all || '';
-    throw new BeachballError(
-      `Azure Key Vault signing failed. ${output ? `Output:\n${output}` : execaError.shortMessage}`
-    );
+  if (result.success) {
+    return result.stdout.trim();
   }
+
+  // `code` is the original spawn error code (e.g. `ENOENT`)
+  if ((result.cause as { code?: string } | undefined)?.code === 'ENOENT') {
+    throw new BeachballError('Azure CLI (`az`) was not found on PATH');
+  }
+
+  throw new BeachballError(
+    `Azure Key Vault signing failed. ${result.output ? `Output:\n${result.output}` : result.message}`
+  );
 }
 
 /**

--- a/packages/beachball/src/githubAuth/signWithAzureCli.ts
+++ b/packages/beachball/src/githubAuth/signWithAzureCli.ts
@@ -32,9 +32,10 @@ async function signDigest(keyId: string, digest: string): Promise<string> {
     return result.stdout.trim();
   }
 
-  // `code` is the original spawn error code (e.g. `ENOENT`)
-  const cause = result.cause as (Error & { code?: string }) | undefined;
-  if (cause?.code === 'ENOENT' || cause?.message?.includes('ENOENT')) {
+  // `code` is the original spawn error code such as `ENOENT`.
+  // (It's missing on Windows, so that will get the generic error with the stderr output.)
+  const cause = result.cause as { code?: string } | undefined;
+  if (cause?.code === 'ENOENT') {
     throw new BeachballError('Azure CLI (`az`) was not found on PATH');
   }
 

--- a/packages/beachball/src/githubAuth/signWithAzureCli.ts
+++ b/packages/beachball/src/githubAuth/signWithAzureCli.ts
@@ -33,7 +33,8 @@ async function signDigest(keyId: string, digest: string): Promise<string> {
   }
 
   // `code` is the original spawn error code (e.g. `ENOENT`)
-  if ((result.cause as { code?: string } | undefined)?.code === 'ENOENT') {
+  const cause = result.cause as (Error & { code?: string }) | undefined;
+  if (cause?.code === 'ENOENT' || cause?.message?.includes('ENOENT')) {
     throw new BeachballError('Azure CLI (`az`) was not found on PATH');
   }
 

--- a/packages/beachball/src/packageManager/getNpmPackageInfo.ts
+++ b/packages/beachball/src/packageManager/getNpmPackageInfo.ts
@@ -68,7 +68,7 @@ export async function getNpmPackageInfo(
       {
         timeout: options.timeout,
         cwd: options.path,
-        env: { ...process.env, ...getNpmAuthEnv(options) },
+        env: getNpmAuthEnv(options),
       }
     );
 

--- a/packages/beachball/src/packageManager/getNpmPackageInfo.ts
+++ b/packages/beachball/src/packageManager/getNpmPackageInfo.ts
@@ -3,6 +3,7 @@ import type { NpmOptions } from '../types/NpmOptions';
 import { getNpmAuthEnv, type NpmAuthOptions } from './npmArgs';
 import type { PackageJson } from '../types/PackageInfo';
 import { npm } from './npm';
+import { BeachballError } from '../types/BeachballError';
 
 /** Published versions and dist-tags for a package */
 export interface NpmPackageVersionsData {
@@ -71,15 +72,21 @@ export async function getNpmPackageInfo(
       }
     );
 
-    if (showResult.success && showResult.stdout !== '') {
-      const data = JSON.parse(showResult.stdout) as NpmPackageVersionsData;
+    if (showResult.success) {
+      const stdout = showResult.stdout.trim();
+      if (!stdout) throw new BeachballError(`Error getting info about "${packageName}": npm show returned no output`);
+
+      const data = JSON.parse(stdout) as NpmPackageVersionsData;
       // Weird thing showing up in tests only with npm 8: sometimes `versions` is a single string?
       if (typeof data.versions === 'string') {
         data.versions = [data.versions];
       }
       return data;
     }
-    throw new Error(showResult.output ? `Output:\n${showResult.output}` : 'unknown error');
+
+    throw new BeachballError(`Getting info about "${packageName}" failed. Output:\n${showResult.output}`, {
+      cause: showResult,
+    });
 
     // const result = (await fetch.json(`/${encodeURIComponent(packageName)}`, {
     //   registry: options.registry,

--- a/packages/beachball/src/packageManager/getNpmPackageInfo.ts
+++ b/packages/beachball/src/packageManager/getNpmPackageInfo.ts
@@ -67,7 +67,6 @@ export async function getNpmPackageInfo(
       {
         timeout: options.timeout,
         cwd: options.path,
-        all: true,
         env: { ...process.env, ...getNpmAuthEnv(options) },
       }
     );
@@ -80,7 +79,7 @@ export async function getNpmPackageInfo(
       }
       return data;
     }
-    throw new Error(showResult.all ? `Output:\n${showResult.all}` : 'unknown error');
+    throw new Error(showResult.output ? `Output:\n${showResult.output}` : 'unknown error');
 
     // const result = (await fetch.json(`/${encodeURIComponent(packageName)}`, {
     //   registry: options.registry,

--- a/packages/beachball/src/packageManager/npm.ts
+++ b/packages/beachball/src/packageManager/npm.ts
@@ -1,9 +1,6 @@
-import type { PackageManagerResult } from './packageManager';
 import { packageManager } from './packageManager';
 
 // The npm wrapper for packageManager is preserved for convenience.
-
-export type NpmResult = PackageManagerResult;
 
 /**
  * Run an npm command. Returns the error result instead of throwing on failure.

--- a/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
+++ b/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
@@ -1,9 +1,9 @@
-import execa from 'execa';
+import { execFileSync } from 'child_process';
 import path from 'path';
+import { findPackageRoot, getPackageInfo } from 'workspace-tools';
+import { BeachballError } from '../types/BeachballError';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { getNpmAuthEnv } from './npmArgs';
-import { BeachballError } from '../types/BeachballError';
-import { findPackageRoot, getPackageInfo } from 'workspace-tools';
 
 /**
  * Filter PATH for running npm commands, removing entries that contain shell-script node wrappers.
@@ -40,12 +40,19 @@ export function filterPathForNpm(pathEnv: string): string {
  * PATH filtering applied to actual npm commands, so a failure here means the fix in
  * `filterPathForNpm` doesn't cover this platform/environment variant.
  */
-export async function checkNpmAuthEnvPassthrough(
+export function checkNpmAuthEnvPassthrough(
   options: Pick<BeachballOptions, 'registry' | 'path'> & {
     /** PATH override only for testing */
     pathEnv?: string;
   }
-): Promise<void> {
+): void {
+  // Windows doesn't have the special-char env var drop issue, and as of writing yarn doesn't have a
+  // special case for posix-like shells on Windows, so skip the check.
+  // https://github.com/yarnpkg/yarn/blob/c2dda503f3759b5be5f0e24ecd9cf5c97a540147/src/util/portable-script.js#L40
+  if (process.platform === 'win32') {
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const pathEnv = options.pathEnv ?? process.env.PATH!;
   const fakeToken = 'fake-token';
@@ -55,11 +62,13 @@ export async function checkNpmAuthEnvPassthrough(
 
   const filteredPath = filterPathForNpm(pathEnv);
   try {
-    const result = await execa('node', ['-e', `process.stdout.write(process.env[${JSON.stringify(envName)}] || '')`], {
-      env: { ...tokenEnv, PATH: filteredPath },
-      extendEnv: true,
+    // This must use native execFileSync because nano-spawn's spawn() rewrites `node` to
+    // process.execPath, which would bypass any PATH wrapper we're trying to detect.
+    const result = execFileSync('node', ['-e', `process.stdout.write(process.env[${JSON.stringify(envName)}] || '')`], {
+      env: { ...process.env, ...tokenEnv, PATH: filteredPath },
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
-    if (result.stdout === fakeToken) {
+    if (result.toString() === fakeToken) {
       return;
     }
   } catch {

--- a/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
+++ b/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
@@ -65,7 +65,7 @@ export function checkNpmAuthEnvPassthrough(
     // This must use native execFileSync because nano-spawn's spawn() rewrites `node` to
     // process.execPath, which would bypass any PATH wrapper we're trying to detect.
     const result = execFileSync('node', ['-e', `process.stdout.write(process.env[${JSON.stringify(envName)}] || '')`], {
-      env: { ...process.env, ...tokenEnv, PATH: filteredPath },
+      env: { ...tokenEnv, PATH: filteredPath },
       stdio: ['ignore', 'pipe', 'ignore'],
     });
     if (result.toString() === fakeToken) {

--- a/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
+++ b/packages/beachball/src/packageManager/npmAuthEnvPassthrough.ts
@@ -65,7 +65,7 @@ export function checkNpmAuthEnvPassthrough(
     // This must use native execFileSync because nano-spawn's spawn() rewrites `node` to
     // process.execPath, which would bypass any PATH wrapper we're trying to detect.
     const result = execFileSync('node', ['-e', `process.stdout.write(process.env[${JSON.stringify(envName)}] || '')`], {
-      env: { ...tokenEnv, PATH: filteredPath },
+      env: { ...process.env, ...tokenEnv, PATH: filteredPath },
       stdio: ['ignore', 'pipe', 'ignore'],
     });
     if (result.toString() === fakeToken) {

--- a/packages/beachball/src/packageManager/packPackage.ts
+++ b/packages/beachball/src/packageManager/packPackage.ts
@@ -28,9 +28,9 @@ export async function packPackage(
   console.log(`  (cwd: ${packageRoot})\n`);
 
   // Run npm pack in the package directory
-  const result = await npm(packArgs, { cwd: packageRoot, all: true });
+  const result = await npm(packArgs, { cwd: packageRoot });
   // log afterwards instead of piping because we need to access the output to get the filename
-  console.log((result.all || '') + '\n');
+  console.log((result.output || '') + '\n');
 
   if (!result.success) {
     console.error(`Packing ${packageSpec} failed (see above for details)\n`);

--- a/packages/beachball/src/packageManager/packageManager.ts
+++ b/packages/beachball/src/packageManager/packageManager.ts
@@ -1,8 +1,5 @@
-import execa from 'execa';
+import { spawn, type SpawnOptions, type SpawnResult } from '../spawn';
 import { filterPathForNpm } from './npmAuthEnvPassthrough';
-
-export type PackageManagerResult = execa.ExecaReturnValue & { success: boolean };
-export type PackageManagerOptions = execa.Options & { cwd: string };
 
 /**
  * Run a package manager command. Returns the error result instead of throwing on failure.
@@ -14,29 +11,15 @@ export type PackageManagerOptions = execa.Options & { cwd: string };
 export async function packageManager(
   manager: 'npm' | 'yarn' | 'pnpm',
   args: string[],
-  options: PackageManagerOptions
-): Promise<PackageManagerResult> {
+  options: SpawnOptions & { cwd: string }
+): Promise<SpawnResult> {
   let pathEnv = options.env?.PATH || process.env.PATH;
   if (manager === 'npm' && pathEnv) {
     pathEnv = filterPathForNpm(pathEnv);
   }
 
-  try {
-    const result = await execa(manager, args, {
-      ...options,
-      env: { ...options.env, PATH: pathEnv },
-      // This is required for Windows due to https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-      // but only provide it on Windows because it breaks the auth env var on Linux...
-      ...(process.platform === 'win32' && { shell: true }),
-    });
-    return {
-      ...result,
-      success: !result.failed,
-    };
-  } catch (e) {
-    return {
-      ...(e as execa.ExecaError),
-      success: false,
-    };
-  }
+  return await spawn(manager, args, {
+    ...options,
+    env: { ...process.env, ...options.env, PATH: pathEnv },
+  });
 }

--- a/packages/beachball/src/packageManager/packageManager.ts
+++ b/packages/beachball/src/packageManager/packageManager.ts
@@ -20,6 +20,6 @@ export async function packageManager(
 
   return await spawn(manager, args, {
     ...options,
-    env: { ...process.env, ...options.env, PATH: pathEnv },
+    env: { ...options.env, PATH: pathEnv },
   });
 }

--- a/packages/beachball/src/packageManager/packagePublish.ts
+++ b/packages/beachball/src/packageManager/packagePublish.ts
@@ -1,9 +1,10 @@
 import type { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
-import { npm, type NpmResult } from './npm';
+import { npm } from './npm';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { getNpmAuthEnv, getNpmPublishArgs } from './npmArgs';
 import type { NpmOptions } from '../types/NpmOptions';
+import type { SpawnResult } from '../spawn';
 
 /**
  * Attempt to publish the package with retries. Returns the result of the final npm publish call
@@ -12,7 +13,7 @@ import type { NpmOptions } from '../types/NpmOptions';
 export async function packagePublish(
   packageInfo: PackageInfo,
   options: NpmOptions & Pick<BeachballOptions, 'retries'>
-): Promise<NpmResult> {
+): Promise<SpawnResult> {
   const publishArgs = getNpmPublishArgs(packageInfo, options);
   const authEnv = getNpmAuthEnv(options);
 
@@ -24,7 +25,7 @@ export async function packagePublish(
   console.log(`  publish command: ${publishArgs.join(' ')}`);
   console.log(`  (cwd: ${packageRoot}${authEnv ? `, auth env var: ${Object.keys(authEnv)[0]}=****` : ''})\n`);
 
-  let result: NpmResult;
+  let result: SpawnResult;
 
   // Unclear whether `options.retries` should be interpreted as "X attempts" or "initial attempt + X retries"...
   // It was previously implemented as the latter, so keep that for now.
@@ -37,10 +38,8 @@ export async function packagePublish(
       // Run npm publish in the package directory
       cwd: packageRoot,
       timeout: options.timeout,
-      all: true,
       preferLocal: false,
-      extendEnv: true,
-      env: authEnv,
+      env: { ...process.env, ...authEnv },
     });
 
     if (result.success) {
@@ -48,20 +47,20 @@ export async function packagePublish(
       return result;
     }
 
-    const output = `Output:\n\n${result.all}\n`;
+    const output = `Output:\n\n${result.output}\n`;
 
     // First check the output for specific cases where retries are unlikely to help.
     // NOTE: much of npm's output is localized, so it's best to only check for error codes.
     // (but in later versions, the error codes unfortunately are omitted...)
     if (
-      result.all?.includes('EPUBLISHCONFLICT') ||
-      result.all?.includes('E409') ||
-      result.all?.includes('previously published')
+      result.output?.includes('EPUBLISHCONFLICT') ||
+      result.output?.includes('E409') ||
+      result.output?.includes('previously published')
     ) {
       console.error(`${packageSpec} already exists in the registry. ${output}`);
       break;
     }
-    if (result.all?.includes('code E403')) {
+    if (result.output?.includes('code E403')) {
       // This is apparently a less common variant of trying to publish over an existing version
       // (not sure when this error is used vs. EPUBLISHCONFLICT). Keep the message generic since
       // there may be other possible causes for 403 errors.
@@ -73,12 +72,12 @@ export async function packagePublish(
       console.error(`Publishing ${packageSpec} failed due to a 403 error. ${output}`);
       break;
     }
-    if (result.all?.includes('ENEEDAUTH')) {
+    if (result.output?.includes('ENEEDAUTH')) {
       // ENEEDAUTH only happens if no auth was attempted (no token/password provided).
       console.error(`Publishing ${packageSpec} failed due to an auth error. ${output}`);
       break;
     }
-    if (result.all?.includes('code E404')) {
+    if (result.output?.includes('code E404')) {
       // All types of invalid credentials appear to cause E404.
       // validate() already checks for the most common ways invalid variable names might show up,
       // so log a slightly more generic message instead of details about the token.

--- a/packages/beachball/src/packageManager/packagePublish.ts
+++ b/packages/beachball/src/packageManager/packagePublish.ts
@@ -1,10 +1,10 @@
-import type { PackageInfo } from '../types/PackageInfo';
 import path from 'path';
-import { npm } from './npm';
-import type { BeachballOptions } from '../types/BeachballOptions';
-import { getNpmAuthEnv, getNpmPublishArgs } from './npmArgs';
-import type { NpmOptions } from '../types/NpmOptions';
 import type { SpawnResult } from '../spawn';
+import type { BeachballOptions } from '../types/BeachballOptions';
+import type { NpmOptions } from '../types/NpmOptions';
+import type { PackageInfo } from '../types/PackageInfo';
+import { npm } from './npm';
+import { getNpmAuthEnv, getNpmPublishArgs } from './npmArgs';
 
 /**
  * Attempt to publish the package with retries. Returns the result of the final npm publish call
@@ -39,7 +39,7 @@ export async function packagePublish(
       cwd: packageRoot,
       timeout: options.timeout,
       preferLocal: false,
-      env: { ...process.env, ...authEnv },
+      env: authEnv,
     });
 
     if (result.success) {

--- a/packages/beachball/src/spawn.ts
+++ b/packages/beachball/src/spawn.ts
@@ -26,7 +26,7 @@ export async function spawn(bin: string, args: string[], options?: SpawnOptions)
   }
 
   // Use a signal to precisely track whether the process was aborted due to timeout
-  const timeoutSignal = options?.timeout ? AbortSignal.timeout(options.timeout) : options?.signal;
+  const timeoutSignal = options?.timeout ? AbortSignal.timeout(options.timeout) : undefined;
   try {
     const result = await nanoSpawn(bin, args, { signal: timeoutSignal, ...options, timeout: undefined });
     return { ...result, success: true };

--- a/packages/beachball/src/spawn.ts
+++ b/packages/beachball/src/spawn.ts
@@ -11,7 +11,7 @@ let nanoSpawn: typeof import('nano-spawn').default | undefined;
 /**
  * Wrapper for `nano-spawn` implementing some `execa`-like behaviors.
  * Instead of rejecting on failure, it returns a result with `success: false` and the error details.
- * (`env` is NOT extended by default.)
+ * Similar to `execa`, internally `nano-spawn` merges the `env` option with `process.env`.
  *
  * Note that if you need the subprocess object, you can't use this wrapper since it must await the
  * module import first.
@@ -26,15 +26,15 @@ export async function spawn(bin: string, args: string[], options?: SpawnOptions)
   }
 
   // Use a signal to precisely track whether the process was aborted due to timeout
-  const signal = options?.timeout ? AbortSignal.timeout(options.timeout) : options?.signal;
+  const timeoutSignal = options?.timeout ? AbortSignal.timeout(options.timeout) : options?.signal;
   try {
-    const result = await nanoSpawn(bin, args, { ...options, timeout: undefined, signal });
+    const result = await nanoSpawn(bin, args, { signal: timeoutSignal, ...options, timeout: undefined });
     return { ...result, success: true };
   } catch (e) {
     const err = e as SpawnFailureResult;
     err.success = false;
     // The only case where timedOut is already set is by MockSubprocessError
-    err.timedOut ??= signal?.aborted;
+    err.timedOut ??= timeoutSignal?.aborted;
     return err;
   }
 }

--- a/packages/beachball/src/spawn.ts
+++ b/packages/beachball/src/spawn.ts
@@ -1,0 +1,40 @@
+import type { Options, Result, SubprocessError } from 'nano-spawn';
+
+export type SpawnOptions = Options;
+export type SpawnSuccessResult = Result & { success: true };
+export type SpawnFailureResult = SubprocessError & { success: false; timedOut?: boolean };
+/** `nano-spawn` results with added convenience properties like `execa`. */
+export type SpawnResult = SpawnSuccessResult | SpawnFailureResult;
+
+let nanoSpawn: typeof import('nano-spawn').default | undefined;
+
+/**
+ * Wrapper for `nano-spawn` implementing some `execa`-like behaviors.
+ * Instead of rejecting on failure, it returns a result with `success: false` and the error details.
+ * (`env` is NOT extended by default.)
+ *
+ * Note that if you need the subprocess object, you can't use this wrapper since it must await the
+ * module import first.
+ */
+export async function spawn(bin: string, args: string[], options?: SpawnOptions): Promise<SpawnResult> {
+  // The delayed async import can be removed once upgraded to Node 24 (there are jest + CJS issues
+  // with 22) or if the package is converted fully to ESM.
+  nanoSpawn ??= (await import('nano-spawn')).default;
+
+  if (options?.timeout && options?.signal) {
+    throw new Error('Cannot specify both timeout and signal in spawn options');
+  }
+
+  // Use a signal to precisely track whether the process was aborted due to timeout
+  const signal = options?.timeout ? AbortSignal.timeout(options.timeout) : options?.signal;
+  try {
+    const result = await nanoSpawn(bin, args, { ...options, timeout: undefined, signal });
+    return { ...result, success: true };
+  } catch (e) {
+    const err = e as SpawnFailureResult;
+    err.success = false;
+    // The only case where timedOut is already set is by MockSubprocessError
+    err.timedOut ??= signal?.aborted;
+    return err;
+  }
+}

--- a/packages/esrp-npm-release/package.json
+++ b/packages/esrp-npm-release/package.json
@@ -34,8 +34,8 @@
     "@azure/core-auth": "^1.10.1",
     "@azure/msal-node": "^5.1.5",
     "@azure/storage-blob": "^12.31.0",
-    "execa": "catalog:prod",
     "jws": "patch:jws@npm%3A4.0.1#~/.yarn/patches/jws-npm-4.0.1-0d8c257cbe.patch",
+    "nano-spawn": "catalog:prod",
     "yazl": "^3.3.1"
   },
   "devDependencies": {

--- a/packages/esrp-npm-release/src/ESRPReleaseService.ts
+++ b/packages/esrp-npm-release/src/ESRPReleaseService.ts
@@ -71,7 +71,19 @@ export class ESRPReleaseService {
     } catch (err) {
       throw new ReleaseError(`Error ensuring staging container "${stagingContainerName}" exists`, { cause: err });
     }
-    return new ESRPReleaseService({ ...params, stagingContainerClient });
+
+    try {
+      logger.log('Extracting request signing key and certificates from PFX');
+      const { key, certificates } = await getKeyAndCertificatesFromPFX(params.requestSigningCertificatePfx, logger);
+      return new ESRPReleaseService({
+        ...params,
+        stagingContainerClient,
+        requestSigningKey: key,
+        requestSigningCertificates: certificates,
+      });
+    } catch (err) {
+      throw new ReleaseError(`Error extracting request signing key and certificates from PFX`, { cause: err });
+    }
   }
 
   readonly #logger: Logger;
@@ -83,21 +95,21 @@ export class ESRPReleaseService {
   readonly #stagingBlobServiceClient: BlobServiceClient;
   readonly #stagingContainerClient: ContainerClient;
 
-  private constructor(params: CreateESRPReleaseServiceParams & { stagingContainerClient: ContainerClient }) {
+  private constructor(
+    params: Omit<CreateESRPReleaseServiceParams, 'requestSigningCertificatePfx'> & {
+      stagingContainerClient: ContainerClient;
+      requestSigningKey: string;
+      requestSigningCertificates: string[];
+    }
+  ) {
     this.#logger = params.logger;
     this.#clientId = params.clientId;
     this.#tenantId = params.tenantId;
     this.#authCertificatePfx = params.authCertificatePfx;
     this.#stagingBlobServiceClient = params.stagingBlobServiceClient;
     this.#stagingContainerClient = params.stagingContainerClient;
-    try {
-      this.#logger.log('Extracting request signing key and certificates from PFX');
-      const { key, certificates } = getKeyAndCertificatesFromPFX(params.requestSigningCertificatePfx, this.#logger);
-      this.#requestSigningKey = key;
-      this.#requestSigningCertificates = certificates;
-    } catch (err) {
-      throw new ReleaseError(`Error extracting request signing key and certificates from PFX`, { cause: err });
-    }
+    this.#requestSigningKey = params.requestSigningKey;
+    this.#requestSigningCertificates = params.requestSigningCertificates;
   }
 
   /**

--- a/packages/esrp-npm-release/src/__fixtures__/testCert.ts
+++ b/packages/esrp-npm-release/src/__fixtures__/testCert.ts
@@ -1,4 +1,4 @@
-import execa from 'execa';
+import spawn from 'nano-spawn';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -10,10 +10,10 @@ let opensslAvailableCache: boolean | undefined;
  * Synchronously check whether `openssl` is available on PATH. The result is cached so the
  * subprocess is only spawned once per Jest worker.
  */
-export function isOpensslAvailable(): boolean {
+export async function isOpensslAvailable(): Promise<boolean> {
   if (opensslAvailableCache === undefined) {
     try {
-      execa.sync('openssl', ['version']);
+      await spawn('openssl', ['version']);
       opensslAvailableCache = true;
     } catch {
       opensslAvailableCache = false;
@@ -51,8 +51,8 @@ export interface TestCert {
  *
  * Throws if openssl is not available; callers should skip the suite first.
  */
-export function generateTestCert(): TestCert {
-  if (!isOpensslAvailable()) {
+export async function generateTestCert(): Promise<TestCert> {
+  if (!(await isOpensslAvailable())) {
     throw new Error('openssl is not available on PATH');
   }
 
@@ -68,7 +68,7 @@ export function generateTestCert(): TestCert {
     const pfxPath = path.join(tempDir, 'chain.pfx');
 
     // 1. Generate the CA: self-signed cert + its private key.
-    execa.sync('openssl', [
+    await spawn('openssl', [
       'req',
       '-x509',
       '-newkey',
@@ -85,7 +85,7 @@ export function generateTestCert(): TestCert {
     ]);
 
     // 2. Generate the leaf private key + a CSR for it.
-    execa.sync('openssl', [
+    await spawn('openssl', [
       'req',
       '-newkey',
       'rsa:2048',
@@ -99,7 +99,7 @@ export function generateTestCert(): TestCert {
     ]);
 
     // 3. Sign the leaf CSR with the CA to produce the leaf certificate.
-    execa.sync('openssl', [
+    await spawn('openssl', [
       'x509',
       '-req',
       '-in',
@@ -117,7 +117,7 @@ export function generateTestCert(): TestCert {
 
     // 4. Bundle leaf key + leaf cert + CA cert into a PFX (empty password matches the
     //    `getKeyAndCertificatesFromPFX` invocation).
-    execa.sync('openssl', [
+    await spawn('openssl', [
       'pkcs12',
       '-export',
       '-inkey',
@@ -140,8 +140,8 @@ export function generateTestCert(): TestCert {
     // Independently compute thumbprints of the leaf using openssl so tests don't rely on the
     // implementation under test for expected values. `openssl x509 -fingerprint` emits
     // "sha256 Fingerprint=AB:CD:..." — we strip the colons and lowercase to match `getThumbprint`.
-    const sha1ThumbprintHex = computeFingerprint(leafCertPath, 'sha1');
-    const sha256ThumbprintHex = computeFingerprint(leafCertPath, 'sha256');
+    const sha1ThumbprintHex = await computeFingerprint(leafCertPath, 'sha1');
+    const sha256ThumbprintHex = await computeFingerprint(leafCertPath, 'sha256');
 
     return { leafCertPem, caCertPem, keyPem, pfxBase64, sha1ThumbprintHex, sha256ThumbprintHex };
   } finally {
@@ -149,8 +149,8 @@ export function generateTestCert(): TestCert {
   }
 }
 
-function computeFingerprint(certPath: string, algorithm: 'sha1' | 'sha256'): string {
-  const result = execa.sync('openssl', ['x509', '-in', certPath, '-noout', '-fingerprint', `-${algorithm}`]);
+async function computeFingerprint(certPath: string, algorithm: 'sha1' | 'sha256'): Promise<string> {
+  const result = await spawn('openssl', ['x509', '-in', certPath, '-noout', '-fingerprint', `-${algorithm}`]);
   // Output: "sha256 Fingerprint=AB:CD:..." — extract the hex part and strip colons
   const match = result.stdout.match(/Fingerprint=([A-F0-9:]+)/i);
   if (!match) {

--- a/packages/esrp-npm-release/src/__fixtures__/testCert.ts
+++ b/packages/esrp-npm-release/src/__fixtures__/testCert.ts
@@ -7,8 +7,8 @@ import { removeTempDir } from './tempDir.ts';
 let opensslAvailableCache: boolean | undefined;
 
 /**
- * Synchronously check whether `openssl` is available on PATH. The result is cached so the
- * subprocess is only spawned once per Jest worker.
+ * Check whether `openssl` is available on PATH.
+ * The result is cached so the subprocess is only spawned once per Jest worker.
  */
 export async function isOpensslAvailable(): Promise<boolean> {
   if (opensslAvailableCache === undefined) {
@@ -44,7 +44,7 @@ export interface TestCert {
  * Used for LOCAL TEST FIXTURES ONLY (not actual authentication).
  *
  * Generate a fresh test certificate chain (leaf signed by a CA), private key, and PFX bundle
- * synchronously via openssl. Use in a `beforeAll` after gating with `isOpensslAvailable()`.
+ * using openssl. Use in a `beforeAll` after gating with `isOpensslAvailable()`.
  *
  * The PFX contains both the leaf and the CA certificate so tests can exercise the multi-cert
  * extraction path in `getKeyAndCertificatesFromPFX` (including its `.reverse()` ordering).

--- a/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
@@ -37,7 +37,7 @@ jest.unstable_mockModule('../esrpApi/releaseHttp.ts', () => mockEsrpHttp);
 const { ESRPReleaseService } = await import('../ESRPReleaseService.ts');
 
 // eslint-disable-next-line no-restricted-properties
-const describeIfOpenssl = isOpensslAvailable() ? describe : describe.skip;
+const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
 describeIfOpenssl('ESRPReleaseService.createRelease', () => {
   let testCert: TestCert;
@@ -53,8 +53,8 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
   // The staged "zip" file is a real file on disk for e2e testing
   const fileDir = setupTempDir({ cleanup: 'afterAll' });
 
-  beforeAll(() => {
-    testCert = generateTestCert();
+  beforeAll(async () => {
+    testCert = await generateTestCert();
     zipFilePath = path.join(fileDir.getTempDir(), zipName);
     fs.writeFileSync(zipFilePath, 'mock zip contents');
   });

--- a/packages/esrp-npm-release/src/__tests__/generateJwsToken.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/generateJwsToken.test.ts
@@ -4,13 +4,13 @@ import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtur
 import { generateJwsToken } from '../auth/generateJwsToken.ts';
 
 // eslint-disable-next-line no-restricted-properties -- intentional skip when openssl is unavailable
-const describeIfOpenssl = isOpensslAvailable() ? describe : describe.skip;
+const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
 describeIfOpenssl('generateJwsToken', () => {
   let testCert: TestCert;
 
-  beforeAll(() => {
-    testCert = generateTestCert();
+  beforeAll(async () => {
+    testCert = await generateTestCert();
   });
 
   /** `jws.decode` returns `null | undefined` for invalid tokens; throw to keep test types simple. */

--- a/packages/esrp-npm-release/src/__tests__/getAadToken.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/getAadToken.test.ts
@@ -18,7 +18,7 @@ jest.unstable_mockModule('@azure/msal-node', () => ({
 const { getAadToken } = await import('../auth/getAadToken.ts');
 
 // eslint-disable-next-line no-restricted-properties
-const describeIfOpenssl = isOpensslAvailable() ? describe : describe.skip;
+const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
 describe('getAadToken', () => {
   let logger: MockLogger;
@@ -84,8 +84,8 @@ describe('getAadToken', () => {
   describeIfOpenssl('certificate (client-credentials) auth', () => {
     let testCert: TestCert;
 
-    beforeAll(() => {
-      testCert = generateTestCert();
+    beforeAll(async () => {
+      testCert = await generateTestCert();
     });
 
     it('extracts the leaf cert and key from the PFX and passes them as clientCertificate', async () => {

--- a/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
@@ -9,7 +9,7 @@ import { FileHashType, type ReleaseFileInfo, type ReleaseRequestMessage } from '
 import { ReleaseError } from '../utils/ReleaseError.ts';
 
 // eslint-disable-next-line no-restricted-properties -- intentional skip when openssl is unavailable
-const describeIfOpenssl = isOpensslAvailable() ? describe : describe.skip;
+const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
 describe('redactReleaseRequest', () => {
   const blobUrl = 'https://acct.blob.core.windows.net/staging/someblob';
@@ -71,8 +71,8 @@ describeIfOpenssl('createNpmReleaseRequest', () => {
   let testCert: TestCert;
   const fileDir = setupTempDir({ cleanup: 'afterAll' });
 
-  beforeAll(() => {
-    testCert = generateTestCert();
+  beforeAll(async () => {
+    testCert = await generateTestCert();
   });
 
   function makeFile(name: string, contents: string): string {

--- a/packages/esrp-npm-release/src/__tests__/signing.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/signing.test.ts
@@ -4,14 +4,14 @@ import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtur
 import { getKeyAndCertificatesFromPFX, getThumbprint, pemToDer } from '../auth/signing.ts';
 
 // eslint-disable-next-line no-restricted-properties -- intentional skip when openssl is unavailable
-const describeIfOpenssl = isOpensslAvailable() ? describe : describe.skip;
+const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
 describeIfOpenssl('signing utilities (openssl-based)', () => {
   let testCert: TestCert;
   let logger: MockLogger;
 
-  beforeAll(() => {
-    testCert = generateTestCert();
+  beforeAll(async () => {
+    testCert = await generateTestCert();
   });
 
   beforeEach(() => {
@@ -19,8 +19,8 @@ describeIfOpenssl('signing utilities (openssl-based)', () => {
   });
 
   describe('getKeyAndCertificatesFromPFX', () => {
-    it('extracts the private key and the full certificate chain from a valid PFX', () => {
-      const { key, certificates } = getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
+    it('extracts the private key and the full certificate chain from a valid PFX', async () => {
+      const { key, certificates } = await getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
 
       expect(key).toMatch(/^-----BEGIN PRIVATE KEY-----[\s\S]+-----END PRIVATE KEY-----$/);
       expect(certificates).toEqual([
@@ -29,15 +29,15 @@ describeIfOpenssl('signing utilities (openssl-based)', () => {
       ]);
     });
 
-    it('returns certificates with the leaf (key-matching) cert at index 0, regardless of openssl output order', () => {
-      const { certificates } = getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
+    it('returns certificates with the leaf (key-matching) cert at index 0, regardless of openssl output order', async () => {
+      const { certificates } = await getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
       expect(certificates).toHaveLength(2);
       expect(pemToDer(certificates[0]).toString('hex')).toBe(pemToDer(testCert.leafCertPem).toString('hex'));
       expect(pemToDer(certificates[1]).toString('hex')).toBe(pemToDer(testCert.caCertPem).toString('hex'));
     });
 
-    it('logs which position the leaf was found at', () => {
-      getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
+    it('logs which position the leaf was found at', async () => {
+      await getKeyAndCertificatesFromPFX(testCert.pfxBase64, logger);
 
       // Exactly one log line should report the leaf position
       const positionLines = logger.lines.filter(l => l.includes('leaf is at'));
@@ -48,8 +48,8 @@ describeIfOpenssl('signing utilities (openssl-based)', () => {
       expect(positionLines[0]).toContain('Found 2 certificate(s) in PFX');
     });
 
-    it('throws an informative error when the input is not valid base64 PFX content', () => {
-      expect(() => getKeyAndCertificatesFromPFX('not-a-real-pfx', logger)).toThrow(
+    it('throws an informative error when the input is not valid base64 PFX content', async () => {
+      await expect(getKeyAndCertificatesFromPFX('not-a-real-pfx', logger)).rejects.toThrow(
         'Error processing PFX with `openssl'
       );
     });

--- a/packages/esrp-npm-release/src/auth/getAadToken.ts
+++ b/packages/esrp-npm-release/src/auth/getAadToken.ts
@@ -30,7 +30,7 @@ export async function getAadToken(params: GetAadTokenParams): Promise<AccessToke
     authOptions.clientAssertion = auth.idToken;
   } else {
     try {
-      const { key, certificates } = getKeyAndCertificatesFromPFX(auth.certPfxContent, logger);
+      const { key, certificates } = await getKeyAndCertificatesFromPFX(auth.certPfxContent, logger);
       const thumbprintSha256 = getThumbprint(certificates[0], 'sha256').toString('hex');
       authOptions.clientCertificate = {
         thumbprintSha256,

--- a/packages/esrp-npm-release/src/auth/signing.ts
+++ b/packages/esrp-npm-release/src/auth/signing.ts
@@ -37,6 +37,7 @@ export async function getKeyAndCertificatesFromPFX(
   let result: SpawnResult;
   try {
     const subprocess = spawn('openssl', ['pkcs12', '-nodes', '-passin', 'pass:']);
+    subprocess.catch(() => {}); // prevent unhandled rejection if the below throws
     // nano-spawn's `{ string }` stdin option writes as utf8 and can't carry binary data
     // losslessly, so write the raw PFX bytes straight to the child's stdin stream instead.
     const child = await subprocess.nodeChildProcess;

--- a/packages/esrp-npm-release/src/auth/signing.ts
+++ b/packages/esrp-npm-release/src/auth/signing.ts
@@ -45,7 +45,11 @@ export async function getKeyAndCertificatesFromPFX(
     result = await subprocess;
   } catch (_err) {
     const err = _err as SubprocessError;
-    throw new Error(`Error processing PFX with \`${err.command}\`:\n${err.stderr}`, { cause: _err });
+    // On a normal openssl failure, stderr has the detail. On a startup failure (e.g. ENOENT),
+    // stderr/output are empty and the reason is on the wrapped `cause` (`err.message` only has
+    // the command), so fall back to that.
+    const detail = err.stderr || (err.cause as Error | undefined)?.message || err.message;
+    throw new Error(`Error processing PFX with \`${err.command}\`:\n${detail}`, { cause: _err });
   }
 
   const key = result.stdout.match(/-----BEGIN PRIVATE KEY-----[\s\S]+?-----END PRIVATE KEY-----/)?.[0];

--- a/packages/esrp-npm-release/src/auth/signing.ts
+++ b/packages/esrp-npm-release/src/auth/signing.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import execa from 'execa';
+import spawn, { type Result as SpawnResult, type SubprocessError } from 'nano-spawn';
 import type { Logger } from '../utils/Logger.ts';
 
 /**
@@ -29,17 +29,22 @@ export function getThumbprint(certPem: string, algorithm: 'sha1' | 'sha256'): Bu
  *
  * Throws an informative plain `Error` on any failure.
  */
-export function getKeyAndCertificatesFromPFX(
+export async function getKeyAndCertificatesFromPFX(
   pfxContent: string,
   logger: Logger
-): { key: string; certificates: string[] } {
+): Promise<{ key: string; certificates: string[] }> {
   const pfxCertificate = Buffer.from(pfxContent, 'base64');
-  let result: execa.ExecaSyncReturnValue;
+  let result: SpawnResult;
   try {
-    result = execa.sync('openssl', ['pkcs12', '-nodes', '-passin', 'pass:'], { input: pfxCertificate });
+    const subprocess = spawn('openssl', ['pkcs12', '-nodes', '-passin', 'pass:']);
+    // nano-spawn's `{ string }` stdin option writes as utf8 and can't carry binary data
+    // losslessly, so write the raw PFX bytes straight to the child's stdin stream instead.
+    const child = await subprocess.nodeChildProcess;
+    child.stdin?.end(pfxCertificate);
+    result = await subprocess;
   } catch (_err) {
-    const err = _err as execa.ExecaSyncError;
-    throw new Error(`Error processing PFX with \`${err.command}\`:\n${err.message}`, { cause: _err });
+    const err = _err as SubprocessError;
+    throw new Error(`Error processing PFX with \`${err.command}\`:\n${err.stderr}`, { cause: _err });
   }
 
   const key = result.stdout.match(/-----BEGIN PRIVATE KEY-----[\s\S]+?-----END PRIVATE KEY-----/)?.[0];

--- a/packages/proper-changelog/package.json
+++ b/packages/proper-changelog/package.json
@@ -36,6 +36,6 @@
   },
   "dependencies": {
     "commander": "catalog:prod",
-    "nano-spawn": "^2.1.0"
+    "nano-spawn": "catalog:prod"
   }
 }

--- a/renovate/package.json
+++ b/renovate/package.json
@@ -22,8 +22,8 @@
     "@types/jju": "^1.4.2",
     "@types/semver": "catalog:dev",
     "cross-env": "catalog:dev",
-    "execa": "catalog:prod",
     "jju": "^1.4.0",
+    "nano-spawn": "catalog:prod",
     "semver": "catalog:prod",
     "workspace-tools": "catalog:prod"
   }

--- a/renovate/scripts/processLog.ts
+++ b/renovate/scripts/processLog.ts
@@ -1,4 +1,4 @@
-import execa from 'execa';
+import spawn from 'nano-spawn';
 import { parseRenovateLogs } from './utils/renovateLogs.ts';
 import type { RenovateLog } from './utils/types.ts';
 import { updateAndFormat } from './utils/runBin.ts';
@@ -20,4 +20,4 @@ const outPath = filePath.replace(/\.log$/, '') + '.json';
 await updateAndFormat(outPath, JSON.stringify(logs));
 
 console.log(`Wrote logs to "${outPath}"`);
-open && execa.sync('code', [outPath]);
+open && (await spawn('code', [outPath]));

--- a/renovate/scripts/testPresetsBasic.ts
+++ b/renovate/scripts/testPresetsBasic.ts
@@ -130,7 +130,7 @@ async function checkFile(preset: ConfigData, isServerConfig: boolean): Promise<R
     return 'error';
   }
 
-  if (runResult.failed) {
+  if (!runResult) {
     // No errors specific to this preset were logged in the expected format, but the process
     // exited non-0. Most likely the log format has changed and parsing has failed.
     logError(`Unknown error validating ${relPath}. See logs for details.`, relPath);

--- a/renovate/scripts/testPresetsFull.ts
+++ b/renovate/scripts/testPresetsFull.ts
@@ -31,7 +31,7 @@ async function runTests() {
   logEndGroup();
 
   const parsed = parseRenovateLogs(paths.logFileFull);
-  if (result.failed || parsed.errors.length || parsed.warnings.length || parsed.repoProblems?.length) {
+  if (!result || parsed.errors.length || parsed.warnings.length || parsed.repoProblems?.length) {
     logRenovateError(parsed);
     process.exit(1);
   }

--- a/renovate/scripts/utils/runBin.ts
+++ b/renovate/scripts/utils/runBin.ts
@@ -1,23 +1,22 @@
-import execa from 'execa';
+import type { Options as NanoSpawnOptions, Result as NanoSpawnResult } from 'nano-spawn';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 import { paths } from './paths.ts';
 import { getRenovateEnv, type RenovateEnvParams } from './renovateLogs.ts';
 
-const defaults: execa.Options = {
+const defaults: NanoSpawnOptions = {
   preferLocal: true,
   cwd: paths.renovateRoot,
   stdio: 'inherit',
-  all: true,
-  reject: true,
 };
 
 /**
  * Run a binary provided by a node module (see {@link defaults})
  */
-function runBin(bin: string, args: string[], opts?: execa.Options): execa.ExecaChildProcess {
-  return execa(bin, args, { ...defaults, ...opts });
+async function runBin(bin: string, args: string[], opts?: NanoSpawnOptions) {
+  const nanoSpawn = (await import('nano-spawn')).default;
+  return nanoSpawn(bin, args, { ...defaults, ...opts });
 }
 
 /**
@@ -34,11 +33,12 @@ let hasMatchingRenovate: true | undefined;
 /**
  * Run Renovate from the configured working directory. Must call `verifyRenovate` first.
  * Does not reject on error.
+ * @returns whether it succeeded
  */
-export function runRenovate(
+export async function runRenovate(
   bin: 'renovate' | 'renovate-config-validator',
   params: RenovateEnvParams & { args?: string[] }
-): execa.ExecaChildProcess {
+): Promise<boolean> {
   const { args = [], ...envParams } = params;
 
   if (!hasMatchingRenovate) {
@@ -47,11 +47,17 @@ export function runRenovate(
 
   console.log(`Running: ${[bin, ...args].join(' ')}`);
 
-  return runBin(bin, args, { env: getRenovateEnv(envParams), reject: false });
+  try {
+    await runBin(bin, args, { env: { ...process.env, ...getRenovateEnv(envParams) } });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Verify that Renovate is globally installed and the version is at least `renovate/.renovate-version`.
+ * Throws if not installed.
  */
 export async function verifyRenovate(): Promise<void> {
   if (hasMatchingRenovate) {
@@ -62,12 +68,13 @@ export async function verifyRenovate(): Promise<void> {
 
   console.log(`Verifying that Renovate is globally installed with version >= ${expectedVersion}...`);
 
-  const renovateVersionResult = await runBin('renovate', ['--version'], {
-    cwd: paths.renovateRoot,
-    stdio: 'pipe',
-    reject: false,
-  });
-  if (renovateVersionResult.failed) {
+  let renovateVersionResult: NanoSpawnResult;
+  try {
+    renovateVersionResult = await runBin('renovate', ['--version'], {
+      cwd: paths.renovateRoot,
+      stdio: 'pipe',
+    });
+  } catch {
     throw new Error(
       `Renovate is not installed or not available in PATH. Install Renovate globally and try again:\n` +
         `  npm i --min-release-age=7 -g renovate@${expectedVersion}`

--- a/renovate/scripts/utils/runBin.ts
+++ b/renovate/scripts/utils/runBin.ts
@@ -48,7 +48,7 @@ export async function runRenovate(
   console.log(`Running: ${[bin, ...args].join(' ')}`);
 
   try {
-    await runBin(bin, args, { env: { ...process.env, ...getRenovateEnv(envParams) } });
+    await runBin(bin, args, { env: getRenovateEnv(envParams) });
     return true;
   } catch {
     return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,8 +1578,8 @@ __metadata:
     "@types/jws": "npm:^3.2.11"
     "@types/yazl": "npm:^3.3.1"
     cross-env: "catalog:dev"
-    execa: "catalog:prod"
     jws: "patch:jws@npm%3A4.0.1#~/.yarn/patches/jws-npm-4.0.1-0d8c257cbe.patch"
+    nano-spawn: "catalog:prod"
     yazl: "npm:^3.3.1"
   bin:
     esrp-npm-release: bin/esrp-npm-release.mjs
@@ -1594,8 +1594,8 @@ __metadata:
     "@types/jju": "npm:^1.4.2"
     "@types/semver": "catalog:dev"
     cross-env: "catalog:dev"
-    execa: "catalog:prod"
     jju: "npm:^1.4.0"
+    nano-spawn: "catalog:prod"
     semver: "catalog:prod"
     workspace-tools: "catalog:prod"
   languageName: unknown
@@ -3686,8 +3686,8 @@ __metadata:
     "@verdaccio/types": "npm:^13.0.0"
     commander: "catalog:prod"
     cross-env: "catalog:dev"
-    execa: "catalog:prod"
     get-port: "npm:^7.0.0"
+    nano-spawn: "catalog:prod"
     normalized-tmpdir: "npm:^1.1.0"
     p-graph: "workspace:^"
     p-limit: "npm:^3.1.0"
@@ -8155,7 +8155,7 @@ __metadata:
     "@octokit/openapi-types": "npm:^27.0.0"
     commander: "catalog:prod"
     cross-env: "catalog:dev"
-    nano-spawn: "npm:^2.1.0"
+    nano-spawn: "catalog:prod"
   bin:
     proper-changelog: ./bin/proper-changelog.js
   languageName: unknown


### PR DESCRIPTION
Switch to the simpler library with no dependencies, but still preserving important behavior such as Windows workarounds and the ability to run binaries from local npm packages.

The wrapper `spawn.ts` provides some execa-like behavior, such as returning rather than rejecting on error, and explicitly indicating if the process timed out. For now, it also encapsulates the async import of `nano-spawn` that's currently necessary due to Jest + CJS + Node 22 limitations and provides an easy point for mocking without worrying about CJS/ESM interop in Jest.