### PR TITLE
Prevent accidental dependentChangeType fallback to prerelease versions

### DIFF
--- a/change/beachball-bddc125a-9fbf-42ac-9343-261e46698091.json
+++ b/change/beachball-bddc125a-9fbf-42ac-9343-261e46698091.json
@@ -1,0 +1,7 @@
+{
+  "packageName": "beachball",
+  "type": "major",
+  "comment": "Fix fallback behavior for disallowed change types in dependent and grouped package calculations: stable types now fall back from `major -> minor -> patch -> none`, while prerelease types fall back from `premajor -> preminor -> prepatch -> prerelease -> none`. This prevents a disallowed stable type from unexpectedly producing a prerelease version bump.",
+  "dependentChangeType": "patch",
+  "email": "elcraig@microsoft.com"
+}

--- a/docs/overview/v3-migration.md
+++ b/docs/overview/v3-migration.md
@@ -95,11 +95,17 @@ Only relevant for custom changelog renderers (or if reading `CHANGELOG.json` lat
 
 `ChangelogEntry.commit` will be `undefined` if the package did not have an associated commit.
 
-### Stop writing placeholder commit hashes
+### Stop writing placeholder commit hashes in changelog
 
 In v2, Beachball could write `"not available"` to the `commit` field in `CHANGELOG.json` when a commit hash was unavailable.
 
 In v3, Beachball omits the `commit` field entirely in those cases instead, including dependent bump entries that do not have a real commit hash yet.
+
+### Fix fallback behavior for disallowed change types
+
+Fallback behavior for disallowed change types now keeps stable and prerelease types separate. Stable types fall back from `major -> minor -> patch -> none`; prerelease types fall back from `premajor -> preminor -> prepatch -> prerelease -> none`. (Previously, the combined ordering could cause a disallowed stable type to fall back to a prerelease type, such as `minor` becoming `preminor` rather than `patch`.)
+
+This is technically a breaking change, but really it's more of a bug fix, since the behavior was probably not intentional and is almost never desirable.
 
 ### `shouldPublish` behavior change
 

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -252,11 +252,7 @@ describe('updateRelatedChangeType', () => {
 
     expect(bumpInfo.calculatedChangeTypes).toEqual({
       bar: 'major',
-      // This points out an interesting artifact of the new pre* support that should probably be
-      // better rationalized... (prior to that change, this would have been 'patch', which is
-      // more likely the expected behavior in general)
-      // https://github.com/microsoft/beachball/issues/947
-      foo: 'preminor',
+      foo: 'patch',
     });
   });
 
@@ -274,11 +270,25 @@ describe('updateRelatedChangeType', () => {
 
     expect(bumpInfo.calculatedChangeTypes).toEqual({
       bar: 'major',
-      // This points out an interesting artifact of the new pre* support that should probably be
-      // better rationalized... (prior to that change, this would have been 'patch', which is
-      // more likely the expected behavior in general)
-      // https://github.com/microsoft/beachball/issues/947
-      foo: 'preminor',
+      foo: 'patch',
+    });
+  });
+
+  it('keeps prerelease dependent fallback in the prerelease lane', () => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type: 'premajor', dependentChangeType: 'premajor' }],
+      packages: {
+        dep: {},
+        consumer: {
+          dependencies: { dep: '1.0.0' },
+          beachball: { disallowedChangeTypes: ['premajor', 'preminor'] },
+        },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual({
+      dep: 'premajor',
+      consumer: 'prepatch',
     });
   });
 
@@ -419,12 +429,12 @@ describe('updateRelatedChangeType', () => {
       },
     });
 
-    // 'a' gets preminor because minor is disallowed for it.
-    // 'b' gets minor (not preminor) because the original dependentChangeType propagates,
+    // 'a' gets patch because minor is disallowed for it.
+    // 'b' gets minor (not patch) because the original dependentChangeType propagates,
     // not the downgraded type.
     expect(bumpInfo.calculatedChangeTypes).toEqual({
       dep: 'major',
-      a: 'preminor',
+      a: 'patch',
       b: 'minor',
     });
   });
@@ -448,7 +458,7 @@ describe('updateRelatedChangeType', () => {
     expect(bumpInfo.calculatedChangeTypes).toEqual({
       dep: 'major',
       foo: 'minor',
-      bar: 'preminor',
+      bar: 'patch',
     });
   });
 

--- a/packages/beachball/src/__tests__/changefile/changeTypes.test.ts
+++ b/packages/beachball/src/__tests__/changefile/changeTypes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { getMaxChangeType, initializePackageChangeTypes } from '../../changefile/changeTypes';
-import type { ChangeSet } from '../../types/ChangeInfo';
+import type { ChangeSet, ChangeType } from '../../types/ChangeInfo';
 
 describe('getMaxChangeType', () => {
   it('handles empty change type array', () => {
@@ -44,12 +44,27 @@ describe('getMaxChangeType', () => {
     expect(changeType).toBe('minor');
   });
 
-  it('handles prerelease only case', () => {
-    const changeType = getMaxChangeType(
-      ['patch', 'major'],
-      ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch']
-    );
-    expect(changeType).toBe('prerelease');
+  it.each<{ changeType: ChangeType; disallowedChangeTypes: ChangeType[]; expected: ChangeType }>([
+    { changeType: 'major', disallowedChangeTypes: ['major'], expected: 'minor' },
+    { changeType: 'major', disallowedChangeTypes: ['major', 'minor'], expected: 'patch' },
+    { changeType: 'major', disallowedChangeTypes: ['major', 'minor', 'patch'], expected: 'none' },
+    { changeType: 'premajor', disallowedChangeTypes: ['premajor'], expected: 'preminor' },
+    { changeType: 'premajor', disallowedChangeTypes: ['premajor', 'preminor'], expected: 'prepatch' },
+    { changeType: 'premajor', disallowedChangeTypes: ['premajor', 'preminor', 'prepatch'], expected: 'prerelease' },
+    {
+      changeType: 'premajor',
+      disallowedChangeTypes: ['premajor', 'preminor', 'prepatch', 'prerelease'],
+      expected: 'none',
+    },
+  ])(
+    'demotes $changeType only within its lane (disallowed $disallowedChangeTypes)',
+    ({ changeType, disallowedChangeTypes, expected }) => {
+      expect(getMaxChangeType([changeType], disallowedChangeTypes)).toBe(expected);
+    }
+  );
+
+  it('uses the global ordering after demoting within each lane', () => {
+    expect(getMaxChangeType(['major', 'premajor'], ['major', 'premajor'])).toBe('minor');
   });
 });
 

--- a/packages/beachball/src/changefile/changeTypes.ts
+++ b/packages/beachball/src/changefile/changeTypes.ts
@@ -15,6 +15,15 @@ export const SortedChangeTypes = [
   'major',
 ] as const satisfies readonly ChangeType[];
 
+const stableFallbackTypes = ['none', 'patch', 'minor', 'major'] as const satisfies readonly ChangeType[];
+const prereleaseFallbackTypes = [
+  'none',
+  'prerelease',
+  'prepatch',
+  'preminor',
+  'premajor',
+] as const satisfies readonly ChangeType[];
+
 /** `'none'` change type (smallest weight) */
 export const MinChangeType: ChangeType = 'none';
 
@@ -51,9 +60,13 @@ function getAllowedChangeType(changeType: ChangeType, disallowedChangeTypes: Rea
     return 'none'; // this would be from invalid user input
   }
 
+  const fallbackTypes: readonly ChangeType[] = changeType.startsWith('pre')
+    ? prereleaseFallbackTypes
+    : stableFallbackTypes;
+
   while (disallowedChangeTypes.includes(changeType) && changeType !== 'none') {
-    const nextChangeTypeWeight = ChangeTypeWeights[changeType] - 1;
-    changeType = SortedChangeTypes[nextChangeTypeWeight];
+    const nextChangeTypeWeight = fallbackTypes.indexOf(changeType) - 1;
+    changeType = fallbackTypes[nextChangeTypeWeight];
   }
 
   return changeType;


### PR DESCRIPTION
Fix fallback behavior for disallowed change types in dependent and grouped package calculations: stable types now fall back from `major -> minor -> patch -> none`, while prerelease types fall back from `premajor -> preminor -> prepatch -> prerelease -> none`. This prevents a disallowed stable type from unexpectedly producing a prerelease version bump.

Part of #947, though there's still some room for more improvements (this is the most critical).