### PR TITLE
Stop writing default dependentChangeType in change files

### DIFF
--- a/change/@microsoft-beachball-change-file-skill-ba33783c-4380-41f5-baf6-4c49507c2837.json
+++ b/change/@microsoft-beachball-change-file-skill-ba33783c-4380-41f5-baf6-4c49507c2837.json
@@ -1,0 +1,6 @@
+{
+  "packageName": "@microsoft/beachball-change-file-skill",
+  "type": "patch",
+  "comment": "Omit `dependentChangeType` when generating change files unless the user explicitly requests non-default dependent bump behavior",
+  "email": "elcraig@microsoft.com"
+}

--- a/change/beachball-cddc125a-9fbf-42ac-9343-261e46698091.json
+++ b/change/beachball-cddc125a-9fbf-42ac-9343-261e46698091.json
@@ -1,0 +1,6 @@
+{
+  "packageName": "beachball",
+  "type": "major",
+  "comment": "`dependentChangeType` is omitted from change files unless the user provides a non-default value. The same defaults as before are applied at bump time (`none` for `none` changes and `patch` otherwise).",
+  "email": "elcraig@microsoft.com"
+}

--- a/docs/overview/v3-migration.md
+++ b/docs/overview/v3-migration.md
@@ -101,6 +101,12 @@ In v2, Beachball could write `"not available"` to the `commit` field in `CHANGEL
 
 In v3, Beachball omits the `commit` field entirely in those cases instead, including dependent bump entries that do not have a real commit hash yet.
 
+### Stop writing default `dependentChangeType` in change files
+
+Beachball no longer writes the default `dependentChangeType` values to generated change files. The same defaults as before are applied at bump time (`none` when the change `type` is `none`, or `patch` otherwise). Existing change files which specify `dependentChangeType` are still supported, and `--dependent-change-type` continues to write an explicit override.
+
+Custom tools that read change files should allow `dependentChangeType` to be missing and apply the same defaults. Tools that create change files should omit the field unless non-default dependent bump behavior is intended.
+
 ### Fix fallback behavior for disallowed change types
 
 Fallback behavior for disallowed change types now keeps stable and prerelease types separate. Stable types fall back from `major -> minor -> patch -> none`; prerelease types fall back from `premajor -> preminor -> prepatch -> prerelease -> none`. (Previously, the combined ordering could cause a disallowed stable type to fall back to a prerelease type, such as `minor` becoming `preminor` rather than `patch`.)

--- a/packages/beachball/src/__fixtures__/changeFiles.ts
+++ b/packages/beachball/src/__fixtures__/changeFiles.ts
@@ -17,7 +17,6 @@ export const fakeEmail = 'test@test.com';
  * Generate a change file for the given package.
  * Default values:
  * - `type: 'minor'`
- * - `dependentChangeType: 'patch'`
  * - `comment: '<packageName> comment'`
  * - `email: 'test@test.com'`
  */
@@ -31,7 +30,6 @@ export function getChange(
     email: fakeEmail,
     packageName,
     type,
-    dependentChangeType: 'patch',
   };
 }
 
@@ -68,7 +66,6 @@ export function generateChangeSet(changes: (string | PartialChangeFile)[]): Chan
  *
  * Default change info values:
  * - `type: 'minor'`
- * - `dependentChangeType: 'patch'`
  * - `comment: '<packageName> comment'`
  * - `email: 'test@test.com'`
  *

--- a/packages/beachball/src/__functional__/changefile/readChangeFiles.test.ts
+++ b/packages/beachball/src/__functional__/changefile/readChangeFiles.test.ts
@@ -77,7 +77,6 @@ describe('readChangeFiles', () => {
       {
         change: {
           comment: 'foo comment',
-          dependentChangeType: 'patch',
           email: 'test@test.com',
           packageName: 'foo',
           type: 'minor',
@@ -87,7 +86,6 @@ describe('readChangeFiles', () => {
       {
         change: {
           comment: 'bar comment',
-          dependentChangeType: 'patch',
           email: 'test@test.com',
           packageName: 'bar',
           type: 'minor',

--- a/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
+++ b/packages/beachball/src/__tests__/bump/updateRelatedChangeType.test.ts
@@ -69,6 +69,21 @@ describe('updateRelatedChangeType', () => {
     return params.bumpInfo;
   }
 
+  it.each([
+    { type: 'patch' as const, expected: { dep: 'patch', consumer: 'patch' } },
+    { type: 'none' as const, expected: { dep: 'none' } },
+  ])('defaults omitted dependentChangeType for a $type change', ({ type, expected }) => {
+    const bumpInfo = callUpdateRelatedChangeType({
+      changes: [{ packageName: 'dep', type }],
+      packages: {
+        dep: {},
+        consumer: { dependencies: { dep: '1.0.0' } },
+      },
+    });
+
+    expect(bumpInfo.calculatedChangeTypes).toEqual(expected);
+  });
+
   it('should bump dependent packages according to the dependentChangeTypes', () => {
     const bumpInfo = callUpdateRelatedChangeType({
       changes: [{ packageName: 'foo', type: 'patch', dependentChangeType: 'minor' }],

--- a/packages/beachball/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
+++ b/packages/beachball/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
@@ -25,14 +25,13 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
       comment,
       packageName: pkg,
       email: 'email not defined',
-      dependentChangeType: 'patch',
     });
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
-  it('uses dependentChangeType none if response.type is none', () => {
+  it('omits dependentChangeType if response.type is none', () => {
     const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'none' } });
-    expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+    expect(change).toEqual({ type: 'none', comment, packageName: pkg, email: 'email not defined' });
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
@@ -42,7 +41,8 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
       response: { comment },
       options: { type: 'minor', message: '' },
     });
-    expect(change).toMatchObject({ type: 'minor', dependentChangeType: 'patch' });
+    expect(change).toMatchObject({ type: 'minor' });
+    expect(change).not.toHaveProperty('dependentChangeType');
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
@@ -58,7 +58,8 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
 
   it('warns and defaults to none if response.type and options.type are unspecified', () => {
     const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment } });
-    expect(change).toMatchObject({ type: 'none', dependentChangeType: 'none' });
+    expect(change).toMatchObject({ type: 'none' });
+    expect(change).not.toHaveProperty('dependentChangeType');
     expect(logs.mocks.log).toHaveBeenCalledTimes(2);
     expect(logs.getMockLines('log')).toMatchInlineSnapshot(`
         "WARN: change type 'none' assumed by default

--- a/packages/beachball/src/bump/updateRelatedChangeType.ts
+++ b/packages/beachball/src/bump/updateRelatedChangeType.ts
@@ -37,8 +37,10 @@ export function updateRelatedChangeType(params: {
   const { change, bumpInfo, dependents } = params;
   const { calculatedChangeTypes, packageGroups, packageInfos } = bumpInfo;
 
-  // If dependentChangeType is none (or somehow unset), there's nothing to do.
-  const dependentChangeType = getMaxChangeType([change.dependentChangeType]);
+  // Get the user-specified dependentChangeType (rare) or use the default.
+  const dependentChangeType = change.dependentChangeType ?? (change.type === 'none' ? 'none' : 'patch');
+
+  // If dependentChangeType is none, there's nothing to do.
   if (dependentChangeType === 'none') {
     return;
   }

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -155,6 +155,6 @@ export function _getChangeFileInfoFromResponse(params: {
     ...(response as Required<ChangePromptResponse>),
     packageName: pkg,
     email: email || 'email not defined',
-    dependentChangeType: options.dependentChangeType || (response.type === 'none' ? 'none' : 'patch'),
+    ...(options.dependentChangeType !== undefined && { dependentChangeType: options.dependentChangeType }),
   };
 }

--- a/packages/beachball/src/types/ChangeInfo.ts
+++ b/packages/beachball/src/types/ChangeInfo.ts
@@ -12,8 +12,14 @@ export interface ChangeFileInfo {
   packageName: string;
   /** Author email */
   email: string;
-  /** How to bump packages that depend on this one */
-  dependentChangeType: ChangeType;
+  /**
+   * How to bump packages that depend on this one.
+   * At bump time, it defaults to `none` if type is `none`, or `patch` otherwise.
+   *
+   * As of beachball v3, the default value is no longer written to the change file.
+   */
+  // The default is set in updateRelatedChangeType
+  dependentChangeType?: ChangeType;
   /** Extra info added to the change file via custom prompts */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [extraInfo: string]: any;

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -169,10 +169,10 @@ export function validate(parsedOptions: ParsedOptions, validateOptions: Validate
       hasError = true;
     }
 
-    if (!change.dependentChangeType) {
-      logValidationError(`dependentChangeType is missing in ${changeFile}`);
-      hasError = true;
-    } else if (!isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)) {
+    if (
+      change.dependentChangeType !== undefined &&
+      !isValidDependentChangeType(change.dependentChangeType, disallowedChangeTypes)
+    ) {
       logValidationError(`Invalid dependentChangeType detected in ${changeFile}: "${change.dependentChangeType}"`);
       hasError = true;
     }

--- a/skills/beachball-change-file/SKILL.md
+++ b/skills/beachball-change-file/SKILL.md
@@ -74,7 +74,7 @@ For a stable package, use `prerelease`, `premajor`, `preminor`, or `prepatch` on
 Set the remaining values as follows:
 
 - `packageName`: the exact package name reported by Beachball.
-- `dependentChangeType`: `none` when `type` is `none`; otherwise `patch`. Beachball handles the special case of prerelease packages internally.
+- `dependentChangeType`: Only include this if the user explicitly requests non-default dependent bump behavior.
 - `comment`: a concise, user-facing description suitable for a changelog. Emphasize API or behavior changes rather than implementation details, and wrap code identifiers in backticks.
 - `email`: `<EMAIL>`.
 
@@ -90,7 +90,6 @@ If `<GROUP_CHANGES>` is false or unset, create `<CHANGE_DIR>/<packageName>-<uuid
 {
   "packageName": "example-package",
   "type": "patch",
-  "dependentChangeType": "patch",
   "comment": "Fix an issue affecting consumers",
   "email": "user@example.com"
 }
@@ -104,7 +103,6 @@ If `<GROUP_CHANGES>` is true, create one `<CHANGE_DIR>/change-<uuid>.json` conta
     {
       "packageName": "example-package",
       "type": "patch",
-      "dependentChangeType": "patch",
       "comment": "Fix an issue affecting consumers",
       "email": "user@example.com"
     }


### PR DESCRIPTION
If no custom value is specified for `dependentChangeType` when generating change files, omit the default value from the written file, and instead fill it in during bumping.

This is related to #947 and opens up options for some potential future improvements (plus reducing the amount written to many small files in a large repo isn't a bad thing).