### PR TITLE
[renovate] Fix lage and backfill groups

### DIFF
--- a/change/@microsoft-m365-renovate-config-e14a82b7-88da-4c15-a84f-2326c7e33d98.json
+++ b/change/@microsoft-m365-renovate-config-e14a82b7-88da-4c15-a84f-2326c7e33d98.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Fix lage and backfill groups",
+  "packageName": "@microsoft/m365-renovate-config",
+  "email": "elcraig@microsoft.com"
+}

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -696,12 +696,14 @@ Group Lage and Backfill packages (separate group for each).
 {
   "packageRules": [
     {
-      "groupName": "lage monorepo",
-      "matchSourceUrls": ["https://github.com/microsoft/lage"]
+      "groupName": "lage packages",
+      "matchSourceUrls": ["https://github.com/microsoft/lage"],
+      "matchPackageNames": ["lage", "@lage-run/*"]
     },
     {
-      "groupName": "backfill monorepo",
-      "matchSourceUrls": ["https://github.com/microsoft/backfill"]
+      "groupName": "backfill packages",
+      "matchSourceUrls": ["https://github.com/microsoft/backfill", "https://github.com/microsoft/lage"],
+      "matchPackageNames": ["backfill", "backfill-*"]
     }
   ]
 }

--- a/renovate/presets/groupLageBackfill.json
+++ b/renovate/presets/groupLageBackfill.json
@@ -5,12 +5,14 @@
 
   "packageRules": [
     {
-      "groupName": "lage monorepo",
-      "matchSourceUrls": ["https://github.com/microsoft/lage"]
+      "groupName": "lage packages",
+      "matchSourceUrls": ["https://github.com/microsoft/lage"],
+      "matchPackageNames": ["lage", "@lage-run/*"]
     },
     {
-      "groupName": "backfill monorepo",
-      "matchSourceUrls": ["https://github.com/microsoft/backfill"]
+      "groupName": "backfill packages",
+      "matchSourceUrls": ["https://github.com/microsoft/backfill", "https://github.com/microsoft/lage"],
+      "matchPackageNames": ["backfill", "backfill-*"]
     }
   ]
 }


### PR DESCRIPTION
Update groups to reflect new repo structure. Omit `workspace-tools` from the groups since it typically should be updated separately.