### PR TITLE
Omit email from change files if unavailable instead of using a placeholder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.trimAutoWhitespace": true,
   "editor.insertSpaces": true,
   "editor.tabSize": 2,

--- a/change/@microsoft-beachball-change-file-skill-efd9af9e-45fd-440a-b314-24870c9e4d6d.json
+++ b/change/@microsoft-beachball-change-file-skill-efd9af9e-45fd-440a-b314-24870c9e4d6d.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Handle differences between beachball v2 and v3 change file format",
+  "packageName": "@microsoft/beachball-change-file-skill",
+  "email": "elcraig@microsoft.com"
+}

--- a/change/beachball-e5ea489a-cd04-4a06-aa03-b79a69111ede.json
+++ b/change/beachball-e5ea489a-cd04-4a06-aa03-b79a69111ede.json
@@ -1,0 +1,6 @@
+{
+  "type": "major",
+  "comment": "Omit `email` from change files when not available, and omit `author` from changelog entries",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com"
+}

--- a/docs/overview/v3-migration.md
+++ b/docs/overview/v3-migration.md
@@ -57,7 +57,7 @@ beachball v3 requires **Node.js 22.18.0** or newer, and its published output use
 
 CLI parsing moved from `yargs-parser` to `commander`. Most behavior is preserved, but a few things changed:
 
-- **Unknown options now cause an error** instead of being silently passed through. This should have no impact unless you were passing extra `BeachballOptions` values on the command line that aren't actually specified in `CliOptions`. (If there's some other value you need as a CLI option, please open an issue or PR.)
+- **Unknown options now cause an error** instead of being silently passed through. This should have no impact unless you were passing extra option values on the command line that aren't specified in beachball's internal `CliOptions`. (If there's some other value you need as a CLI option, please open an issue or PR.)
 - **Repeated non-array options use the last value** instead of throwing an error.
 - **String boolean values are no longer supported**: Specifying boolean values like `--push false` or `--push=false` won't work. Use `--push` / `--no-push` (or similar) instead.
 - If you're using `--camelCase` flags, it's recommended to switch to `--kebab-case`. `camelCase` is not supported by default by `commander`, and `beachball`'s workarounds for this may be removed in a future major version.
@@ -89,23 +89,20 @@ To migrate, simply remove the leading `!` from all `exclude` patterns.
 
 The logic for determining the comparison remote and branch is stricter: beachball now throws if no remotes are defined, or if the root `package.json` specifies a `repository` field but no matching remote is found. If your `branch` option contains a `/`, beachball checks whether the leading segment matches a configured remote name, and falls back to the default remote otherwise.
 
-### Custom changelog rendering changes
+### Change file, custom renderer, and `CHANGELOG.json` changes
 
-Only relevant for custom changelog renderers (or if reading `CHANGELOG.json` later): `PackageChangelog.tag` and `ChangelogJsonEntry.tag` are now `undefined` when the package had no associated git tag (previously a value was always present).
+In **change files**:
 
-`ChangelogEntry.commit` will be `undefined` if the package did not have an associated commit.
+- `email` is omitted if `git user.email` is unset (instead of writing `"email not defined"`).
+- `dependentChangeType` is omitted unless a custom value is specified as `--dependent-change-type`. The same defaults as before are applied at bump time: `none` when the change `type` is `none`, or `patch` otherwise.
 
-### Stop writing placeholder commit hashes in changelog
+For **custom changelog renderers** (`BeachballConfig.changelog`):
 
-In v2, Beachball could write `"not available"` to the `commit` field in `CHANGELOG.json` when a commit hash was unavailable.
+- `PackageChangelog.tag` is omitted if the version had no associated git tag (instead of referencing a tag that didn't exist).
+- `ChangelogEntry.commit` is omitted if the package did not have an associated commit (instead of using `"not available"`).
+- `ChangelogEntry.author` is omitted if the original change file's `email` was unset (instead of using `"email not defined"`).
 
-In v3, Beachball omits the `commit` field entirely in those cases instead, including dependent bump entries that do not have a real commit hash yet.
-
-### Stop writing default `dependentChangeType` in change files
-
-Beachball no longer writes the default `dependentChangeType` values to generated change files. The same defaults as before are applied at bump time (`none` when the change `type` is `none`, or `patch` otherwise). Existing change files which specify `dependentChangeType` are still supported, and `--dependent-change-type` continues to write an explicit override.
-
-Custom tools that read change files should allow `dependentChangeType` to be missing and apply the same defaults. Tools that create change files should omit the field unless non-default dependent bump behavior is intended.
+The corresponding values are also unset if reading `CHANGELOG.json` later.
 
 ### Fix fallback behavior for disallowed change types
 

--- a/packages/beachball/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
+++ b/packages/beachball/src/__tests__/changefile/promptForChange_getChangeFileInfoFromResponse.test.ts
@@ -24,14 +24,13 @@ describe('promptForChange _getChangeFileInfoFromResponse', () => {
       type: 'patch',
       comment,
       packageName: pkg,
-      email: 'email not defined',
     });
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 
   it('omits dependentChangeType if response.type is none', () => {
     const change = _getChangeFileInfoFromResponse({ ...defaultParams, response: { comment, type: 'none' } });
-    expect(change).toEqual({ type: 'none', comment, packageName: pkg, email: 'email not defined' });
+    expect(change).toEqual({ type: 'none', comment, packageName: pkg });
     expect(logs.mocks.log).not.toHaveBeenCalled();
   });
 

--- a/packages/beachball/src/__tests__/changelog/getPackageChangelogs.test.ts
+++ b/packages/beachball/src/__tests__/changelog/getPackageChangelogs.test.ts
@@ -154,6 +154,20 @@ describe('getPackageChangelogs', () => {
     expect(changelogs.foo.comments.patch![0]).toMatchObject({ extra: 'prop' });
   });
 
+  it('omits the author property when the change has no email', () => {
+    const changelogs = getPackageChangelogsWrapper({
+      packageInfos: { foo: { version: '1.0.0' } },
+      calculatedChangeTypes: { foo: 'patch' },
+      changes: [{ packageName: 'foo', email: undefined }],
+    });
+
+    expect(changelogs.foo.comments.patch![0]).toEqual({
+      comment: 'comment for foo',
+      commit,
+      package: 'foo',
+    });
+  });
+
   it('records dependent bumps', () => {
     const changelogs = getPackageChangelogsWrapper({
       packageInfos: {

--- a/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
+++ b/packages/beachball/src/__tests__/changelog/renderChangelog.test.ts
@@ -132,6 +132,19 @@ describe('renderChangelog', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it.each<[string, string | undefined]>([
+    ['undefined', undefined],
+    ['empty string', ''],
+    ['"email not defined"', 'email not defined'],
+    ['"beachball"', 'beachball'],
+  ])('omits author when value is %s', async (_, author) => {
+    const options = getOptions();
+    options.newVersionChangelog.comments.minor![0].author = author;
+
+    const result = (await renderChangelog(options)).split('\n');
+    expect(result).toContain('- Awesome change');
+  });
+
   it('uses full custom renderer', async () => {
     const options = getOptions();
     options.changelogOptions.renderPackageChangelog = renderInfo =>

--- a/packages/beachball/src/changefile/promptForChange.ts
+++ b/packages/beachball/src/changefile/promptForChange.ts
@@ -154,7 +154,7 @@ export function _getChangeFileInfoFromResponse(params: {
   return {
     ...(response as Required<ChangePromptResponse>),
     packageName: pkg,
-    email: email || 'email not defined',
+    email: email || undefined,
     ...(options.dependentChangeType !== undefined && { dependentChangeType: options.dependentChangeType }),
   };
 }

--- a/packages/beachball/src/changelog/getPackageChangelogs.ts
+++ b/packages/beachball/src/changelog/getPackageChangelogs.ts
@@ -38,7 +38,7 @@ export function getPackageChangelogs(
     changelogs[packageName].comments ??= {};
     changelogs[packageName].comments[changeType] ??= [];
     changelogs[packageName].comments[changeType].push({
-      author: change.email,
+      ...(!!email && { author: email }),
       package: packageName,
       ...(commit !== undefined && { commit }),
       // This contains the comment and any extra properties added to the change file by

--- a/packages/beachball/src/changelog/renderPackageChangelog.ts
+++ b/packages/beachball/src/changelog/renderPackageChangelog.ts
@@ -108,5 +108,7 @@ function _renderEntry(entry: ChangelogEntry): string {
     comment = comment.replace(/</g, '\\<');
   }
 
-  return entry.author === 'beachball' ? comment : `${comment} (${entry.author})`;
+  return entry.author === 'beachball' || entry.author === 'email not defined' || !entry.author
+    ? comment
+    : `${comment} (${entry.author})`;
 }

--- a/packages/beachball/src/types/ChangeInfo.ts
+++ b/packages/beachball/src/types/ChangeInfo.ts
@@ -10,8 +10,11 @@ export interface ChangeFileInfo {
   comment: string;
   /** Package name the change was in */
   packageName: string;
-  /** Author email */
-  email: string;
+  /**
+   * Author email. In v2, this was "email not defined" if unavailable.
+   * In v3, it's omitted if unavailable.
+   */
+  email?: string;
   /**
    * How to bump packages that depend on this one.
    * At bump time, it defaults to `none` if type is `none`, or `patch` otherwise.

--- a/packages/beachball/src/types/ChangeLog.ts
+++ b/packages/beachball/src/types/ChangeLog.ts
@@ -15,8 +15,11 @@ import type { ChangeType } from './ChangeInfo';
 export interface ChangelogEntry {
   /** Change comment */
   comment: string;
-  /** Author email */
-  author: string;
+  /**
+   * Author email. In v2, this was "email not defined" if unavailable.
+   * In v3, it's omitted if unavailable.
+   */
+  author?: string;
   /**
    * Commit hash, if available.
    *

--- a/skills/beachball-change-file/SKILL.md
+++ b/skills/beachball-change-file/SKILL.md
@@ -79,7 +79,7 @@ Set the remaining values as follows:
   - 2.x: unless explicitly requested by the user, use `none` for change type `none`, and `patch` for all other change types.
   - 3.x: Only include this if the user explicitly requests non-default dependent bump behavior.
 - `comment`: a concise, user-facing description suitable for a changelog. Emphasize API or behavior changes rather than implementation details, and wrap code identifiers in backticks.
-- `email`: `<EMAIL>`. If not available, behavior deepnds on `<BEACHBALL_VERSION>`:
+- `email`: `<EMAIL>`. If not available, behavior depends on `<BEACHBALL_VERSION>`:
   - 2.x: use `email not defined`.
   - 3.x: omit the email
 

--- a/skills/beachball-change-file/SKILL.md
+++ b/skills/beachball-change-file/SKILL.md
@@ -17,12 +17,13 @@ Determine these values once and use them throughout the workflow:
 
 - `<ROOT>`: almost always the git root. It should contain `beachball.config.*` or `.beachballrc.*` or have a `"beachball"` key in `package.json`. If not found, ask the user.
 - `<BEACHBALL_COMMAND>`: the package-manager-specific way to invoke Beachball, such as `yarn beachball`, `pnpm exec beachball`, or `npm exec beachball --`.
+- `<BEACHBALL_VERSION>`: the version from `<BEACHBALL_COMMAND> --version`
 - `<CHECK_COMMAND>`: prefer a root `package.json` script that runs `beachball check`, because it may supply repository-specific arguments. Otherwise use `<BEACHBALL_COMMAND> check`. Include the package-manager-specific argument separator when passing `--verbose` through a script.
 - `<CHANGE_DIR>`: the result of `<BEACHBALL_COMMAND> config get changeDir`, or `change/` if unset.
 - `<GROUP_CHANGES>`: the result of `<BEACHBALL_COMMAND> config get groupChanges`; treat `false` and unset as non-grouped.
 - `<TARGET_BRANCH>`: use the branch specified by the user or pull request. Otherwise use the result of `<BEACHBALL_COMMAND> config get branch`, or the repository's default branch if unset. Ask the user if it cannot be determined reliably.
 - `<MERGE_BASE>`: the local merge-base of `HEAD` and `<TARGET_BRANCH>`. Do not merge the target branch to calculate it.
-- `<EMAIL>`: the result of `git config user.email`, or `email not defined` if unavailable. Never invent an email.
+- `<EMAIL>`: the result of `git config user.email`. Never invent an email.
 
 Run all commands from `<ROOT>` unless the repository's script requires otherwise.
 
@@ -74,9 +75,13 @@ For a stable package, use `prerelease`, `premajor`, `preminor`, or `prepatch` on
 Set the remaining values as follows:
 
 - `packageName`: the exact package name reported by Beachball.
-- `dependentChangeType`: Only include this if the user explicitly requests non-default dependent bump behavior.
+- `dependentChangeType`: Depends on `<BEACHBALL_VERSION>`:
+  - 2.x: unless explicitly requested by the user, use `none` for change type `none`, and `patch` for all other change types.
+  - 3.x: Only include this if the user explicitly requests non-default dependent bump behavior.
 - `comment`: a concise, user-facing description suitable for a changelog. Emphasize API or behavior changes rather than implementation details, and wrap code identifiers in backticks.
-- `email`: `<EMAIL>`.
+- `email`: `<EMAIL>`. If not available, behavior deepnds on `<BEACHBALL_VERSION>`:
+  - 2.x: use `email not defined`.
+  - 3.x: omit the email
 
 Ask the user only about unresolved classifications and any proposed `major` bump. When multiple packages need input, ask about them together.
 


### PR DESCRIPTION
If `git user.email` is unavailable, omit `email` from the change file instead of recording `"not available"`. This also makes `email` optional in change files and `author` optional in changelogs/custom renderers, which is a breaking change.