### PR TITLE
Run migration checks during validation

### DIFF
--- a/change/beachball-aab575cc-851c-4753-b6c8-4dafdf73e64e.json
+++ b/change/beachball-aab575cc-851c-4753-b6c8-4dafdf73e64e.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Run migration checks as part of pre-command validation, and fail on migration errors",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/beachball/src/__e2e__/validate.test.ts
+++ b/packages/beachball/src/__e2e__/validate.test.ts
@@ -6,6 +6,7 @@ import type { Repository } from '../__fixtures__/repository';
 import { RepositoryFactory } from '../__fixtures__/repositoryFactory';
 import { getOptions } from '../options/getOptions';
 import { BeachballError } from '../types/BeachballError';
+import type { RepoOptions } from '../types/BeachballOptions';
 import { validate, type ValidateOptions } from '../validation/validate';
 
 describe('validate', () => {
@@ -13,13 +14,14 @@ describe('validate', () => {
   let repo: Repository | undefined;
   const logs = initMockLogs();
 
-  async function validateWrapper(validateOptions?: ValidateOptions) {
+  async function validateWrapper(validateOptions?: ValidateOptions, repoOptions?: Partial<RepoOptions>) {
     const parsedOptions = await getOptions({
       cwd: repo!.rootPath,
       argv: [],
       env: {},
       testRepoOptions: {
         branch: defaultRemoteBranchName,
+        ...repoOptions,
       },
     });
     return validate(parsedOptions, validateOptions || {});
@@ -101,5 +103,15 @@ describe('validate', () => {
         • Found private packages using \`"shouldPublish": false\`. This setting does nothing with private packages and should be removed.
           ▪ <root>/packages/foo/package.json"
     `);
+  });
+
+  it('reports malformed groups through validation instead of throwing a TypeError', async () => {
+    repo = repositoryFactory.cloneRepository();
+    const groups = { name: 'group', include: true } as unknown as RepoOptions['groups'];
+
+    await expect(validateWrapper(undefined, { groups })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Expected "groups" configuration setting to be an array')
+    );
   });
 });

--- a/packages/beachball/src/__e2e__/validate.test.ts
+++ b/packages/beachball/src/__e2e__/validate.test.ts
@@ -90,4 +90,16 @@ describe('validate', () => {
     expect(result.isChangeNeeded).toBe(false);
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
+
+  it('reports error-level migration checks', async () => {
+    repo = repositoryFactory.cloneRepository();
+    repo.updateJsonFile('packages/foo/package.json', { private: true, beachball: { shouldPublish: false } });
+
+    await expect(validateWrapper()).rejects.toThrow(BeachballError);
+    expect(logs.getMockLines('error', { root: repo.rootPath })).toMatchInlineSnapshot(`
+      "ERROR: The following config updates are needed for v3:
+        • Found private packages using \`"shouldPublish": false\`. This setting does nothing with private packages and should be removed.
+          ▪ <root>/packages/foo/package.json"
+    `);
+  });
 });

--- a/packages/beachball/src/__functional__/validation/areChangeFilesDeleted.test.ts
+++ b/packages/beachball/src/__functional__/validation/areChangeFilesDeleted.test.ts
@@ -58,7 +58,7 @@ describe('areChangeFilesDeleted', () => {
     expect(result).toBeTruthy();
   });
 
-  it('deletes change files when changeDir option is specified', () => {
+  it('respects changeDir option', () => {
     const testChangedir = 'changeDir';
     const options = getOptions({ changeDir: testChangedir });
 

--- a/packages/beachball/src/__tests__/validate/isValidChangelogOptions.test.ts
+++ b/packages/beachball/src/__tests__/validate/isValidChangelogOptions.test.ts
@@ -26,23 +26,6 @@ describe('isValidChangelogOptions', () => {
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
-  it('returns false for groups with masterPackageName', () => {
-    const options = {
-      groups: [
-        {
-          changelogPath: 'path/to/changelog',
-          masterPackageName: 'package-name',
-          include: ['pkg1', 'pkg2'],
-        },
-      ],
-    } as unknown as ChangelogOptions;
-    expect(isValidChangelogOptions(options)).toBe(false);
-    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
-      "ERROR: "changelog.groups[*].masterPackageName" is renamed to "mainPackageName" in v3. Invalid groups:
-        • masterPackageName "package-name""
-    `);
-  });
-
   it('returns false when group is missing changelogPath', () => {
     const options = {
       groups: [
@@ -121,23 +104,6 @@ describe('isValidChangelogOptions', () => {
     expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
       "ERROR: "changelog.groups" entries must define "changelogPath", "mainPackageName", and "include". Invalid groups:
         • { "changelogPath": "path/to/changelog2" }"
-    `);
-  });
-
-  it('returns false when exclude patterns start with "!"', () => {
-    const options: ChangelogOptions = {
-      // these groups don't make sense in combination; just test that the ones with bad exclude patterns are caught
-      groups: [
-        { changelogPath: 'path', mainPackageName: 'pkg', include: true, exclude: ['ok', '!invalid-array'] },
-        { changelogPath: 'path2', mainPackageName: 'pkg2', include: true, exclude: '!invalid-string' },
-        { changelogPath: 'path3', mainPackageName: 'pkg3', include: true, exclude: ['ok', 'also-ok'] },
-      ],
-    };
-    expect(isValidChangelogOptions(options)).toBe(false);
-    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
-      "ERROR: "changelog.groups[*].exclude" patterns must not start with "!" in v3. Found invalid groups:
-        • mainPackageName "pkg": [ "ok", "!invalid-array" ]
-        • mainPackageName "pkg2": "!invalid-string""
     `);
   });
 });

--- a/packages/beachball/src/__tests__/validate/isValidChangelogOptions.test.ts
+++ b/packages/beachball/src/__tests__/validate/isValidChangelogOptions.test.ts
@@ -26,6 +26,15 @@ describe('isValidChangelogOptions', () => {
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 
+  it('returns false when groups is not an array', () => {
+    const options = { groups: { mainPackageName: 'package-name' } } as unknown as ChangelogOptions;
+    expect(isValidChangelogOptions(options)).toBe(false);
+    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
+      "ERROR: Expected "changelog.groups" configuration setting to be an array. Received:
+      { "mainPackageName": "package-name" }"
+    `);
+  });
+
   it('returns false when group is missing changelogPath', () => {
     const options = {
       groups: [

--- a/packages/beachball/src/__tests__/validate/isValidGroupOptions.test.ts
+++ b/packages/beachball/src/__tests__/validate/isValidGroupOptions.test.ts
@@ -59,21 +59,6 @@ describe('isValidGroupOptions', () => {
         • { "include": ["pkg1"] }"
     `);
   });
-
-  it('returns false when a group has an exclude pattern starting with "!"', () => {
-    const groups: VersionGroupOptions[] = [
-      { name: 'group1', include: ['pkg1'], exclude: '!badpattern', disallowedChangeTypes: null },
-      { name: 'group2', include: ['pkg2'], disallowedChangeTypes: null },
-      { name: 'group3', include: ['pkg3'], exclude: ['goodpattern', '!badpattern2'], disallowedChangeTypes: null },
-    ];
-    expect(isValidGroupOptions(groups)).toBe(false);
-    expect(logs.mocks.error).toHaveBeenCalledTimes(1);
-    expect(logs.mocks.error.mock.calls[0].join(' ')).toMatchInlineSnapshot(`
-      "ERROR: "groups[*].exclude" patterns must not start with "!". Found invalid groups:
-        • group1: "!badpattern"
-        • group3: [ "goodpattern", "!badpattern2" ]"
-    `);
-  });
 });
 
 describe('isValidGroupedPackageOptions', () => {

--- a/packages/beachball/src/__tests__/validate/validate.test.ts
+++ b/packages/beachball/src/__tests__/validate/validate.test.ts
@@ -99,6 +99,7 @@ describe('validate', () => {
         changeSet: [],
       },
     });
+    expect(mockGetMigrationIssues).toHaveBeenCalledWith(expect.objectContaining({ skipMigrations: ['changelogJson'] }));
     expect(logs.mocks.error).not.toHaveBeenCalled();
   });
 

--- a/packages/beachball/src/__tests__/validate/validate.test.ts
+++ b/packages/beachball/src/__tests__/validate/validate.test.ts
@@ -1,0 +1,358 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { initMockLogs } from '@microsoft/beachball-test-utilities';
+import * as wsTools from 'workspace-tools';
+import { generateChangeSet } from '../../__fixtures__/changeFiles';
+import type { PartialPackageInfos } from '../../__fixtures__/packageInfos';
+import { bumpInMemory } from '../../bump/bumpInMemory';
+import { getChangedPackages } from '../../changefile/getChangedPackages';
+import { readChangeFiles } from '../../changefile/readChangeFiles';
+import { getMigrationIssues } from '../../commands/migrate';
+import { getRawPackageInfos } from '../../monorepo/getPackageInfos';
+import { getPackagesToPublish } from '../../publish/getPackagesToPublish';
+import { BeachballError } from '../../types/BeachballError';
+import type { BeachballOptions, RepoOptions } from '../../types/BeachballOptions';
+import type { ChangeType } from '../../types/ChangeInfo';
+import { areChangeFilesDeleted } from '../../validation/areChangeFilesDeleted';
+import { validate, type ValidateOptions } from '../../validation/validate';
+import type { AuthType } from '../../types/Auth';
+import { getOptions } from '../../options/getOptions';
+import { defaultRemoteBranchName } from '../../__fixtures__/gitDefaults';
+
+jest.mock('workspace-tools');
+jest.mock('../../bump/bumpInMemory');
+jest.mock('../../changefile/getChangedPackages');
+jest.mock('../../changefile/readChangeFiles');
+jest.mock('../../commands/migrate');
+jest.mock('../../monorepo/getPackageInfos', () => ({
+  ...jest.requireActual<typeof import('../../monorepo/getPackageInfos')>('../../monorepo/getPackageInfos'),
+  getRawPackageInfos: jest.fn(),
+}));
+jest.mock('../../publish/getPackagesToPublish');
+jest.mock('../../validation/areChangeFilesDeleted');
+
+const mockWsTools = wsTools as jest.Mocked<typeof wsTools>;
+const mockBumpInMemory = bumpInMemory as jest.MockedFunction<typeof bumpInMemory>;
+const mockGetChangedPackages = getChangedPackages as jest.MockedFunction<typeof getChangedPackages>;
+const mockReadChangeFiles = readChangeFiles as jest.MockedFunction<typeof readChangeFiles>;
+const mockGetMigrationIssues = getMigrationIssues as jest.MockedFunction<typeof getMigrationIssues>;
+const mockGetRawPackageInfos = getRawPackageInfos as jest.MockedFunction<typeof getRawPackageInfos>;
+const mockGetPackagesToPublish = getPackagesToPublish as jest.MockedFunction<typeof getPackagesToPublish>;
+const mockAreChangeFilesDeleted = areChangeFilesDeleted as jest.MockedFunction<typeof areChangeFilesDeleted>;
+
+describe('validate', () => {
+  const logs = initMockLogs();
+
+  async function validateWrapper(params?: {
+    repoOptions?: Partial<RepoOptions>;
+    validateOptions?: ValidateOptions;
+    cliOptions?: string[];
+  }) {
+    const { repoOptions, validateOptions = {}, cliOptions = [] } = params || {};
+    const options = await getOptions({
+      argv: ['node', 'beachball', ...cliOptions],
+      cwd: '',
+      env: {},
+      testRepoOptions: { branch: defaultRemoteBranchName, registry: 'https://fake', ...repoOptions },
+    });
+    return validate(options, validateOptions);
+  }
+
+  function setMockPackageInfos(packageInfos: PartialPackageInfos) {
+    mockGetRawPackageInfos.mockReturnValue(
+      Object.entries(packageInfos).map(([name, pkg]) => ({
+        name,
+        version: '1.0.0',
+        packageJsonPath: `packages/${name}/package.json`,
+        ...pkg,
+      }))
+    );
+  }
+
+  beforeEach(() => {
+    mockWsTools.getUntrackedChanges.mockReturnValue([]);
+    mockGetRawPackageInfos.mockReturnValue([]);
+    mockGetMigrationIssues.mockReturnValue({ updates: [], warnings: [] });
+    mockReadChangeFiles.mockReturnValue([]);
+    mockGetChangedPackages.mockReturnValue([]);
+    mockAreChangeFilesDeleted.mockReturnValue(false);
+    mockGetPackagesToPublish.mockReturnValue([]);
+    mockBumpInMemory.mockImplementation((options, context) => ({
+      packageInfos: context.originalPackageInfos,
+      calculatedChangeTypes: {},
+      changeFileChangeInfos: context.changeSet,
+      dependentChangedBy: {},
+      modifiedPackages: new Set(),
+      packageGroups: context.packageGroups,
+      packageTags: {},
+      scopedPackages: context.scopedPackages,
+    }));
+  });
+
+  it('returns context when basic validation succeeds', async () => {
+    const result = await validateWrapper();
+    expect(result).toEqual({
+      isChangeNeeded: false,
+      context: {
+        originalPackageInfos: {},
+        packageGroups: {},
+        scopedPackages: new Set(),
+        changeSet: [],
+      },
+    });
+    expect(logs.mocks.error).not.toHaveBeenCalled();
+  });
+
+  it('errors if migration updates are needed', async () => {
+    mockGetMigrationIssues.mockReturnValue({
+      updates: ['The `new` option has been removed. Please remove it from your config.'],
+      warnings: [],
+    });
+
+    await expect(validateWrapper()).rejects.toThrow(BeachballError);
+    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
+      "ERROR: The following config updates are needed for v3:
+        • The \`new\` option has been removed. Please remove it from your config."
+    `);
+  });
+
+  it('does not fail on migration warnings', async () => {
+    mockGetMigrationIssues.mockReturnValue({
+      updates: [],
+      warnings: ['Potential migration issue'],
+    });
+
+    const result = await validateWrapper();
+    expect(result.isChangeNeeded).toBe(false);
+    expect(logs.mocks.error).not.toHaveBeenCalled();
+  });
+
+  it('warns about untracked files', async () => {
+    mockWsTools.getUntrackedChanges.mockReturnValue(['new-file.ts']);
+
+    await validateWrapper();
+
+    expect(logs.mocks.warn).toHaveBeenCalledWith(
+      'WARN: There are untracked changes in your repository:\n  • new-file.ts'
+    );
+  });
+
+  it('errors if a specified package is missing or private', async () => {
+    setMockPackageInfos({ private: { private: true } });
+    const cliOptions = ['--package', 'missing', '--package', 'private'];
+
+    await expect(validateWrapper({ cliOptions })).rejects.toThrow(BeachballError);
+    expect(logs.getMockLines('error')).toMatchInlineSnapshot(`
+      "ERROR: Invalid package(s) specified:
+        • "missing" was not found
+        • "private" is marked as private"
+    `);
+  });
+
+  it('errors if an invalid change type is detected in existing change file', async () => {
+    mockReadChangeFiles.mockReturnValue(generateChangeSet([{ packageName: 'foo', type: 'invalid' as ChangeType }]));
+
+    await expect(validateWrapper()).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Invalid change type detected in change0.json: "invalid"');
+  });
+
+  it('errors if change files are needed', async () => {
+    mockGetChangedPackages.mockReturnValue(['foo']);
+
+    await expect(validateWrapper({ validateOptions: { checkChangeNeeded: true } })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files are needed!');
+  });
+
+  it('returns changed packages when missing change files are allowed', async () => {
+    mockGetChangedPackages.mockReturnValue(['foo']);
+
+    const result = await validateWrapper({
+      validateOptions: { checkChangeNeeded: true, allowMissingChangeFiles: true },
+    });
+    expect(result).toMatchObject({
+      isChangeNeeded: true,
+      context: { changedPackages: ['foo'] },
+    });
+  });
+
+  it('errors if --all is used with an unsupported command', async () => {
+    await expect(validateWrapper({ cliOptions: ['publish', '--all'] })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: "all" option is not supported for the "publish" command');
+  });
+
+  it('errors if --package is used with an unsupported command', async () => {
+    await expect(validateWrapper({ cliOptions: ['canary', '--package', 'foo'] })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: "package" option is not supported for the "canary" command');
+  });
+
+  it.each<[Partial<BeachballOptions>, string]>([
+    [{ authType: 'invalid' as AuthType }, 'ERROR: authType "invalid" is not valid'],
+    [{ dependentChangeType: 'invalid' as ChangeType }, 'ERROR: dependentChangeType "invalid" is not valid'],
+    [{ type: 'invalid' as ChangeType }, 'ERROR: Change type "invalid" is not valid'],
+  ] as const)('throws for invalid option %o', async (option, expectedError) => {
+    await expect(validateWrapper({ repoOptions: option })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(expectedError);
+  });
+
+  it('errors if publish token is empty', async () => {
+    await expect(validateWrapper({ cliOptions: ['publish', '--token', ''] })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(expect.stringContaining('token should not be an empty string'));
+  });
+
+  it('errors if publish token is a variable reference with token auth', async () => {
+    await expect(
+      validateWrapper({ cliOptions: ['publish', '--token', '$TOKEN'], repoOptions: { authType: 'authtoken' } })
+    ).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(
+      'ERROR: token appears to be a variable reference: "$TOKEN" -- please check your workflow configuration.'
+    );
+  });
+
+  it('allows a variable reference token with password auth', async () => {
+    await validateWrapper({ cliOptions: ['publish', '--token', '$PASSWORD'], repoOptions: { authType: 'password' } });
+    expect(logs.mocks.error).not.toHaveBeenCalled();
+  });
+
+  it('errors on invalid changelog options', async () => {
+    const repoOptions = { changelog: { groups: [{}] } } as unknown as Partial<RepoOptions>;
+    await expect(validateWrapper({ repoOptions })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(expect.stringContaining('"changelog.groups" entries must define'));
+  });
+
+  it('errors on invalid group options', async () => {
+    const repoOptions = { groups: [{}] } as unknown as Partial<RepoOptions>;
+    await expect(validateWrapper({ repoOptions })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('"groups" configuration entries must define')
+    );
+  });
+
+  it('throws for package options that conflict with a group', async () => {
+    setMockPackageInfos({ foo: { beachball: { disallowedChangeTypes: ['major'] } } });
+
+    await expect(
+      validateWrapper({ repoOptions: { groups: [{ name: 'group', include: true, disallowedChangeTypes: [] }] } })
+    ).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Found package configs that define disallowedChangeTypes')
+    );
+  });
+
+  it('errors if a change type is missing', async () => {
+    mockReadChangeFiles.mockReturnValue(
+      generateChangeSet([{ packageName: 'foo', type: undefined as unknown as ChangeType }])
+    );
+
+    await expect(validateWrapper()).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change type is missing in change0.json');
+  });
+
+  it('throws for a disallowed change type', async () => {
+    setMockPackageInfos({ foo: {} });
+    mockReadChangeFiles.mockReturnValue(generateChangeSet([{ packageName: 'foo', type: 'major' }]));
+
+    await expect(validateWrapper({ repoOptions: { disallowedChangeTypes: ['major'] } })).rejects.toThrow(
+      BeachballError
+    );
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Disallowed change type detected in change0.json: "major"');
+  });
+
+  it('throws for an invalid dependent change type', async () => {
+    mockReadChangeFiles.mockReturnValue(
+      generateChangeSet([{ packageName: 'foo', dependentChangeType: 'invalid' as ChangeType }])
+    );
+
+    await expect(validateWrapper()).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(
+      'ERROR: Invalid dependentChangeType detected in change0.json: "invalid"'
+    );
+  });
+
+  it('errors if change files were deleted', async () => {
+    mockAreChangeFilesDeleted.mockReturnValue(true);
+
+    await expect(
+      validateWrapper({
+        repoOptions: { disallowDeletedChangeFiles: true },
+        validateOptions: { checkChangeNeeded: true },
+      })
+    ).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith('ERROR: Change files must not be deleted!');
+  });
+
+  it('logs the packages needing changes', async () => {
+    setMockPackageInfos({ foo: {}, bar: {}, baz: {} });
+    mockGetChangedPackages.mockReturnValue(['foo', 'bar']);
+
+    await validateWrapper({ validateOptions: { checkChangeNeeded: true, allowMissingChangeFiles: true } });
+
+    expect(logs.mocks.log).toHaveBeenCalledWith('Found changes in the following packages:\n  • bar\n  • foo');
+  });
+
+  // --all is handled internally by getChangedPackages, which is mocked
+  it('passes --all and scoped packages through to getChangedPackages', async () => {
+    setMockPackageInfos({ foo: {}, bar: {}, baz: {} });
+    // this would respect all and scope
+    mockGetChangedPackages.mockReturnValue(['foo', 'bar']);
+
+    const result = await validateWrapper({
+      cliOptions: ['--all'],
+      repoOptions: { scope: ['!packages/baz'] },
+      validateOptions: { checkChangeNeeded: true, allowMissingChangeFiles: true },
+    });
+    expect(result.context.changedPackages?.sort()).toEqual(['bar', 'foo']);
+    expect(logs.mocks.log).toHaveBeenCalledWith('Considering the following packages due to --all:\n  • bar\n  • foo');
+    expect(mockGetChangedPackages).toHaveBeenCalledWith(
+      expect.objectContaining({ all: true }),
+      expect.anything(),
+      new Set(['bar', 'foo'])
+    );
+  });
+
+  // --package is handled internally by getChangedPackages, which is mocked
+  it('passes --package through to getChangedPackages', async () => {
+    setMockPackageInfos({ foo: {}, bar: {} });
+    mockGetChangedPackages.mockReturnValue(['foo']);
+
+    const result = await validateWrapper({
+      cliOptions: ['--package', 'foo'],
+      validateOptions: { checkChangeNeeded: true, allowMissingChangeFiles: true },
+    });
+    expect(result.context.changedPackages?.sort()).toEqual(['foo']);
+    expect(logs.mocks.log).toHaveBeenCalledWith('Considering the specific --package:\n  • foo');
+    expect(mockGetChangedPackages).toHaveBeenCalledWith(
+      expect.objectContaining({ package: ['foo'] }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('returns bump info if dependency validation succeeds', async () => {
+    setMockPackageInfos({ foo: {} });
+    const changeSet = generateChangeSet(['foo']);
+    mockReadChangeFiles.mockReturnValue(changeSet);
+
+    const result = await validateWrapper({ validateOptions: { checkDependencies: true } });
+    expect(result.context.bumpInfo).toBeTruthy();
+    // just validate one property that gets passed through from mocks created above
+    expect(result.context.bumpInfo?.changeFileChangeInfos).toBe(changeSet);
+  });
+
+  it('errors if dependency validation fails', async () => {
+    setMockPackageInfos({ foo: { dependencies: { bar: '1.0.0' } }, bar: { private: true } });
+    mockReadChangeFiles.mockReturnValue(generateChangeSet(['foo']));
+    mockGetPackagesToPublish.mockReturnValue(['foo']);
+
+    await expect(validateWrapper({ validateOptions: { checkDependencies: true } })).rejects.toThrow(BeachballError);
+    expect(logs.mocks.error).toHaveBeenCalledWith(expect.stringContaining('One or more published packages depend'));
+  });
+
+  it('skips dependency validation when changes are still needed', async () => {
+    mockReadChangeFiles.mockReturnValue(generateChangeSet(['foo']));
+    mockGetChangedPackages.mockReturnValue(['foo']);
+
+    await validateWrapper({
+      validateOptions: { checkChangeNeeded: true, allowMissingChangeFiles: true, checkDependencies: true },
+    });
+    expect(mockBumpInMemory).not.toHaveBeenCalled();
+  });
+});

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -1,10 +1,28 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { findPackageRoot, type PackageInfo as WSPackageInfo } from 'workspace-tools';
+import type { PackageInfo as WSPackageInfo } from 'workspace-tools';
 import { bulletedList, type BulletList } from '../logging/bulletedList';
 import { getRawPackageInfos } from '../monorepo/getPackageInfos';
 import { BeachballError } from '../types/BeachballError';
-import type { BeachballOptions, PackageOptions, ParsedOptions } from '../types/BeachballOptions';
+import type { PackageOptions, ParsedOptions } from '../types/BeachballOptions';
+
+type Migration = (params: {
+  parsedOptions: ParsedOptions;
+  rawPackageInfos: WSPackageInfo[] | undefined;
+  updates: BulletList;
+  warnings: BulletList;
+}) => void;
+type MigrationName =
+  | 'groups'
+  | 'changelogGroups'
+  | 'new'
+  | 'changeFilePrompt'
+  | 'packStyle'
+  | 'prebump'
+  | 'shouldPublish'
+  | 'changelogJson'
+  | 'nullTag';
+// WARNING: If adding a new migration, consider whether it should be skipped in validate()
 
 /**
  * Handles the `beachball migrate` command.
@@ -13,80 +31,8 @@ import type { BeachballOptions, PackageOptions, ParsedOptions } from '../types/B
  * If no updates are needed, a success message is printed.
  */
 export function migrate(parsedOptions: ParsedOptions): void {
-  const { options, repoOptions, configPath } = parsedOptions;
-  const updates: BulletList = [];
-  const warnings: BulletList = [];
-
-  const rawPackageInfos = getRawPackageInfos({
-    projectRoot: options.path,
-    packageRoot: findPackageRoot(options.path),
-    options,
-  });
-
-  const groupUpdates: BulletList = [];
-  for (const group of options.groups ?? []) {
-    const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
-    const negatedExclude = exclude.filter(p => p.startsWith('!'));
-    if (negatedExclude.length) {
-      groupUpdates.push(`Group "${group.name}"`, [
-        'Remove the leading "!" from these `exclude` patterns:',
-        negatedExclude,
-      ]);
-    }
-  }
-  if (groupUpdates.length) {
-    updates.push('`groups`', groupUpdates);
-  }
-
-  const changelogGroupUpdates: BulletList = [];
-  for (const group of options.changelog?.groups ?? []) {
-    const thisGroupUpdates: BulletList = [];
-    let mainPkg = group.mainPackageName as string | undefined;
-    if (!mainPkg) {
-      mainPkg = (group as { masterPackageName?: string }).masterPackageName;
-      if (mainPkg) {
-        thisGroupUpdates.push('Rename `masterPackageName` to `mainPackageName`');
-      }
-    }
-
-    const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
-    const negatedExclude = exclude.filter(p => p.startsWith('!'));
-    if (negatedExclude.length) {
-      thisGroupUpdates.push(`Remove the leading "!" from these \`exclude\` patterns:`, negatedExclude);
-    }
-
-    if (thisGroupUpdates.length) {
-      changelogGroupUpdates.push(`Group for package "${mainPkg ?? '(missing)'}"`, thisGroupUpdates);
-    }
-  }
-  if (changelogGroupUpdates.length) {
-    updates.push('`changelog.groups`', changelogGroupUpdates);
-  }
-
-  if ((repoOptions as { new?: boolean }).new !== undefined) {
-    updates.push('The `new` option has been removed. Please remove it from your config.');
-  }
-
-  if ((repoOptions as { packStyle?: unknown }).packStyle !== undefined) {
-    updates.push(
-      'The `packStyle` option has been removed (packing always uses the layered style now). ' +
-        'Please remove it from your config.'
-    );
-  }
-
-  if ((repoOptions as { changeFilePrompt?: unknown }).changeFilePrompt !== undefined) {
-    updates.push('The `changeFilePrompt` option has been renamed to `changeFile`.');
-  }
-
-  if (repoOptions.hooks?.prebump?.length ?? 0 > 3) {
-    updates.push('`hooks.prebump` no longer receives `packageInfos`. See migration guide.');
-  }
-
-  if (rawPackageInfos) {
-    checkShouldPublish({ rawPackageInfos, warnings, updates });
-    checkChangelogJson({ rawPackageInfos, options, repoOptions, updates });
-    checkNullTag({ rawPackageInfos, repoOptions, configPath, warnings, updates });
-  }
+  const rawPackageInfos = getRawPackageInfos(parsedOptions.options);
+  const { updates, warnings } = getMigrationIssues({ parsedOptions, rawPackageInfos });
 
   if (!updates.length && !warnings.length) {
     console.log('No config updates are needed for v3.');
@@ -102,111 +48,195 @@ export function migrate(parsedOptions: ParsedOptions): void {
   }
 }
 
-function checkShouldPublish(params: {
-  rawPackageInfos: WSPackageInfo[];
+/**
+ * Get a list of migration issues for the given config and packageInfos.
+ *
+ * **WARNING:** This is also run during pre-command `validate()`, so any file reads should be shared
+ * (why `rawPackageInfos` are passed in), or disabled in `validate()` with `skipMigrations`.
+ */
+export function getMigrationIssues(params: {
+  parsedOptions: ParsedOptions;
+  rawPackageInfos: WSPackageInfo[] | undefined;
+  skipMigrations?: MigrationName[];
+}): {
+  /** Required updates which will also cause `validate()` to fail */
+  updates: BulletList;
+  /** Warnings about potential issues */
   warnings: BulletList;
-  updates: BulletList;
-}): void {
-  const { rawPackageInfos, warnings, updates } = params;
+} {
+  const { parsedOptions, rawPackageInfos, skipMigrations } = params;
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const packagesWithShouldPublish = rawPackageInfos.filter(pkg => pkg.beachball?.shouldPublish === false);
-  const privatePackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => pkg.private);
-  const publicPackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => !pkg.private);
+  const updates: BulletList = [];
+  const warnings: BulletList = [];
 
-  if (privatePackagesWithShouldPublish.length) {
-    updates.push(
-      'Found private packages using `"shouldPublish": false`. ' +
-        'This setting does nothing with private packages and should be removed.',
-      privatePackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
-    );
+  for (const [migrationName, migration] of Object.entries(migrations)) {
+    if (!skipMigrations?.includes(migrationName as MigrationName)) {
+      migration({ parsedOptions, rawPackageInfos, updates, warnings });
+    }
   }
 
-  if (publicPackagesWithShouldPublish.length) {
-    warnings.push(
-      'Found non-private packages using `"shouldPublish": false`. The behavior of this setting has changed--' +
-        'please see the v3 migration guide for details and verify it still works for your scenario.',
-      publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
-    );
-  }
+  return { updates, warnings };
 }
 
-function checkChangelogJson(params: {
-  rawPackageInfos: WSPackageInfo[];
-  options: Pick<BeachballOptions, 'path'>;
-  repoOptions: Pick<ParsedOptions['repoOptions'], 'generateChangelog' | 'changelog'>;
-  updates: BulletList;
-}): void {
-  const { rawPackageInfos, options, repoOptions, updates } = params;
-  if (repoOptions.generateChangelog !== undefined) {
-    // skip the check if they have any explicit setting
-    return;
-  }
+const migrations: Record<MigrationName, Migration> = {
+  groups: ({ parsedOptions: { options }, updates }) => {
+    const groupUpdates: BulletList = [];
+    for (const group of options.groups ?? []) {
+      const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
+      const negatedExclude = exclude.filter(p => p.startsWith('!'));
+      if (negatedExclude.length) {
+        groupUpdates.push(`Group "${group.name}"`, [
+          'Remove the leading "!" from these `exclude` patterns:',
+          negatedExclude,
+        ]);
+      }
+    }
+    if (groupUpdates.length) {
+      updates.push('`groups`', groupUpdates);
+    }
+  },
+  changelogGroups: ({ parsedOptions: { options }, updates }) => {
+    const changelogGroupUpdates: BulletList = [];
+    for (const group of options.changelog?.groups ?? []) {
+      const thisGroupUpdates: BulletList = [];
+      let mainPkg = group.mainPackageName as string | undefined;
+      if (!mainPkg) {
+        mainPkg = (group as { masterPackageName?: string }).masterPackageName;
+        if (mainPkg) {
+          thisGroupUpdates.push('Rename `masterPackageName` to `mainPackageName`');
+        }
+      }
 
-  const allChangelogJsons = [
-    ...rawPackageInfos.map(pkg => path.join(path.dirname(pkg.packageJsonPath), 'CHANGELOG.json')),
-    ...(repoOptions.changelog?.groups?.map(group =>
-      path.resolve(options.path, group.changelogPath, 'CHANGELOG.json')
-    ) ?? []),
-  ];
-  const changelogJsons = allChangelogJsons.filter(file => fs.existsSync(file));
+      const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
+      const negatedExclude = exclude.filter(p => p.startsWith('!'));
+      if (negatedExclude.length) {
+        thisGroupUpdates.push(`Remove the leading "!" from these \`exclude\` patterns:`, negatedExclude);
+      }
 
-  if (changelogJsons.length) {
-    updates.push(
-      'Found CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, ' +
-        "since most repos don't use them (CHANGELOG.md is still generated).",
-      [
-        'If you DO want CHANGELOG.json files, set `generateChangelog: true` in your beachball config',
-        'If you are NOT using CHANGELOG.json, delete these files:',
-        changelogJsons.sort(),
-      ]
-    );
-  }
-}
+      if (thisGroupUpdates.length) {
+        changelogGroupUpdates.push(`Group for package "${mainPkg ?? '(missing)'}"`, thisGroupUpdates);
+      }
+    }
+    if (changelogGroupUpdates.length) {
+      updates.push('`changelog.groups`', changelogGroupUpdates);
+    }
+  },
+  new: ({ parsedOptions: { repoOptions }, updates }) => {
+    if (Object.hasOwn(repoOptions, 'new')) {
+      updates.push('The `new` option has been removed. Please remove it from your config.');
+    }
+  },
+  packStyle: ({ parsedOptions: { repoOptions }, updates }) => {
+    if (Object.hasOwn(repoOptions, 'packStyle')) {
+      updates.push(
+        'The `packStyle` option has been removed (packing always uses the layered style now). ' +
+          'Please remove it from your config.'
+      );
+    }
+  },
+  prebump: ({ parsedOptions: { repoOptions }, updates }) => {
+    if ((repoOptions.hooks?.prebump?.length ?? 0) > 3) {
+      updates.push('`hooks.prebump` no longer receives `packageInfos`. See migration guide.');
+    }
+  },
+  changeFilePrompt: ({ parsedOptions: { repoOptions }, updates }) => {
+    if ((repoOptions as { changeFilePrompt?: unknown }).changeFilePrompt !== undefined) {
+      updates.push('The `changeFilePrompt` option has been renamed to `changeFile`.');
+    }
+  },
+  shouldPublish: ({ rawPackageInfos, updates, warnings }) => {
+    if (!rawPackageInfos) return;
 
-function checkNullTag(
-  params: Pick<ParsedOptions, 'repoOptions' | 'configPath'> & {
-    rawPackageInfos: WSPackageInfo[];
-    warnings: BulletList;
-    updates: BulletList;
-  }
-): void {
-  const { repoOptions, configPath, rawPackageInfos, warnings, updates } = params;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const packagesWithShouldPublish = rawPackageInfos.filter(pkg => pkg.beachball?.shouldPublish === false);
+    const privatePackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => pkg.private);
+    const publicPackagesWithShouldPublish = packagesWithShouldPublish.filter(pkg => !pkg.private);
 
-  const packagesWithNullTag = rawPackageInfos
-    .filter(pkg => (pkg.beachball as PackageOptions)?.tag === null)
-    .map(p => p.packageJsonPath);
-  const packagesWithEmptyTag = rawPackageInfos
-    .filter(pkg => (pkg.beachball as PackageOptions)?.tag === '')
-    .map(p => p.packageJsonPath);
-  const packagesWithEmptyDefaultTag = rawPackageInfos
-    .filter(pkg => (pkg.beachball as PackageOptions)?.defaultNpmTag === '')
-    .map(p => p.packageJsonPath);
+    if (privatePackagesWithShouldPublish.length) {
+      updates.push(
+        'Found private packages using `"shouldPublish": false`. ' +
+          'This setting does nothing with private packages and should be removed.',
+        privatePackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
+      );
+    }
 
-  repoOptions.tag === null && packagesWithNullTag.unshift(configPath ?? 'repo config');
-  repoOptions.tag === '' && packagesWithEmptyTag.unshift(configPath ?? 'repo config');
-  repoOptions.defaultNpmTag === '' && packagesWithEmptyDefaultTag.unshift(configPath ?? 'repo config');
+    if (publicPackagesWithShouldPublish.length) {
+      warnings.push(
+        'Found non-private packages using `"shouldPublish": false`. The behavior of this setting has changed--' +
+          'please see the v3 migration guide for details and verify it still works for your scenario.',
+        publicPackagesWithShouldPublish.map(pkg => pkg.packageJsonPath).sort()
+      );
+    }
 
-  if (packagesWithNullTag.length) {
-    updates.push(
-      'Found setting(s) `tag: null`. This is ignored. ' +
-        '(You can set "tag": "" to fall back to defaultNpmTag or "latest", ' +
-        "but it's not possible to publish a new version without an npm dist-tag.)",
-      packagesWithNullTag.sort()
-    );
-  }
-  if (packagesWithEmptyTag.length) {
-    warnings.push(
-      'Found setting(s) `tag: ""`. This is valid, but it will fall back to defaultNpmTag or "latest". ' +
-        "(It's not possible to publish a new version without an npm dist-tag.)",
-      packagesWithEmptyTag.sort()
-    );
-  }
-  if (packagesWithEmptyDefaultTag.length) {
-    updates.push(
-      'Found setting(s) `defaultNpmTag: ""`. This is invalid. ' +
-        "(It's not possible to publish a new version without an npm dist-tag.)",
-      packagesWithEmptyDefaultTag.sort()
-    );
-  }
-}
+    return { updates, warnings };
+  },
+  changelogJson: ({ rawPackageInfos, parsedOptions: { repoOptions, options }, updates }) => {
+    if (!rawPackageInfos || repoOptions.generateChangelog !== undefined) {
+      // skip the check if they have any explicit setting
+      return;
+    }
+
+    const allChangelogJsons = new Set([
+      ...rawPackageInfos.map(pkg => path.join(path.dirname(pkg.packageJsonPath), 'CHANGELOG.json')),
+      ...(repoOptions.changelog?.groups?.map(group =>
+        path.resolve(options.path, group.changelogPath, 'CHANGELOG.json')
+      ) ?? []),
+    ]);
+    const changelogJsons = Array.from(allChangelogJsons).filter(file => fs.existsSync(file));
+
+    if (changelogJsons.length) {
+      // This is handled as an error because an explicit setting is required to keep the old behavior,
+      // so it's good to fail loudly in case a repo is actually using CHANGELOG.json instead of
+      // silently no longer updating it.
+      updates.push(
+        'Found CHANGELOG.json files. In v3, CHANGELOG.json generation is disabled by default, ' +
+          "since most repos don't use them (CHANGELOG.md is still generated).",
+        [
+          'If you DO want CHANGELOG.json files, set `generateChangelog: true` in your beachball config',
+          'If you are NOT using CHANGELOG.json, delete these files:',
+          changelogJsons.sort(),
+        ]
+      );
+    }
+  },
+  nullTag: ({ rawPackageInfos, parsedOptions: { repoOptions, configPath }, updates, warnings }) => {
+    if (!rawPackageInfos) return;
+
+    const packagesWithNullTag = rawPackageInfos
+      .filter(pkg => (pkg.beachball as PackageOptions)?.tag === null)
+      .map(p => p.packageJsonPath);
+    const packagesWithEmptyTag = rawPackageInfos
+      .filter(pkg => (pkg.beachball as PackageOptions)?.tag === '')
+      .map(p => p.packageJsonPath);
+    const packagesWithEmptyDefaultTag = rawPackageInfos
+      .filter(pkg => (pkg.beachball as PackageOptions)?.defaultNpmTag === '')
+      .map(p => p.packageJsonPath);
+
+    repoOptions.tag === null && packagesWithNullTag.unshift(configPath ?? 'repo config');
+    repoOptions.tag === '' && packagesWithEmptyTag.unshift(configPath ?? 'repo config');
+    repoOptions.defaultNpmTag === '' && packagesWithEmptyDefaultTag.unshift(configPath ?? 'repo config');
+
+    if (packagesWithNullTag.length) {
+      updates.push(
+        'Found setting(s) `tag: null`. This is ignored. ' +
+          '(You can set "tag": "" to fall back to defaultNpmTag or "latest", ' +
+          "but it's not possible to publish a new version without an npm dist-tag.)",
+        packagesWithNullTag.sort()
+      );
+    }
+    if (packagesWithEmptyTag.length) {
+      warnings.push(
+        'Found setting(s) `tag: ""`. This is valid, but it will fall back to defaultNpmTag or "latest". ' +
+          "(It's not possible to publish a new version without an npm dist-tag.)",
+        packagesWithEmptyTag.sort()
+      );
+    }
+    if (packagesWithEmptyDefaultTag.length) {
+      updates.push(
+        'Found setting(s) `defaultNpmTag: ""`. This is invalid. ' +
+          "(It's not possible to publish a new version without an npm dist-tag.)",
+        packagesWithEmptyDefaultTag.sort()
+      );
+    }
+  },
+};

--- a/packages/beachball/src/commands/migrate.ts
+++ b/packages/beachball/src/commands/migrate.ts
@@ -80,8 +80,10 @@ export function getMigrationIssues(params: {
 
 const migrations: Record<MigrationName, Migration> = {
   groups: ({ parsedOptions: { options }, updates }) => {
+    if (!Array.isArray(options.groups)) return;
+
     const groupUpdates: BulletList = [];
-    for (const group of options.groups ?? []) {
+    for (const group of options.groups) {
       const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
       const negatedExclude = exclude.filter(p => p.startsWith('!'));
       if (negatedExclude.length) {
@@ -96,8 +98,10 @@ const migrations: Record<MigrationName, Migration> = {
     }
   },
   changelogGroups: ({ parsedOptions: { options }, updates }) => {
+    if (!Array.isArray(options.changelog?.groups)) return;
+
     const changelogGroupUpdates: BulletList = [];
-    for (const group of options.changelog?.groups ?? []) {
+    for (const group of options.changelog.groups) {
       const thisGroupUpdates: BulletList = [];
       let mainPkg = group.mainPackageName as string | undefined;
       if (!mainPkg) {

--- a/packages/beachball/src/monorepo/getPackageInfos.ts
+++ b/packages/beachball/src/monorepo/getPackageInfos.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import {
-  findPackageRoot,
   getWorkspaceInfos,
   getPackageInfo as getWSPackageInfo,
   listAllTrackedFiles,
@@ -25,17 +24,13 @@ type PackageInfosOptions = Pick<ParsedOptions, 'cliOptions'> & {
  * The CLI options are needed so they can be properly merged with the package options
  * into `PackageInfo.packageOptions` without going back through the whole process of
  * getting CLI options.
+ *
+ * @param rawPackageInfos Can be pre-calculated if the raw version is needed previously
  */
-export function getPackageInfos(parsedOptions: PackageInfosOptions): PackageInfos {
-  const cwd = parsedOptions?.options.path;
-
-  // If cwd comes from processed CLI options, it's already the root
-  const projectRoot = cwd;
-  const packageRoot = findPackageRoot(cwd);
-
-  const wsPackageInfos = getRawPackageInfos({ projectRoot, packageRoot, options: parsedOptions?.options });
-  if (wsPackageInfos) {
-    return getPackageInfosWithOptions(wsPackageInfos, parsedOptions.cliOptions);
+export function getPackageInfos(parsedOptions: PackageInfosOptions, rawPackageInfos?: WSPackageInfo[]): PackageInfos {
+  rawPackageInfos ??= getRawPackageInfos(parsedOptions.options);
+  if (rawPackageInfos) {
+    return getPackageInfosWithOptions(rawPackageInfos, parsedOptions.cliOptions);
   }
   return {};
 }
@@ -43,21 +38,15 @@ export function getPackageInfos(parsedOptions: PackageInfosOptions): PackageInfo
 /**
  * Internal helper to get raw package infos.
  */
-export function getRawPackageInfos(params: {
-  projectRoot: string;
-  packageRoot: string | undefined;
-  options: PackageInfosOptions['options'] | undefined;
-}): WSPackageInfo[] | undefined {
-  const { projectRoot, packageRoot, options } = params;
+export function getRawPackageInfos(options: PackageInfosOptions['options']): WSPackageInfo[] | undefined {
+  // If cwd comes from processed CLI options, it's already the root
+  const projectRoot = options.path;
 
-  let wsPackageInfos: WSPackageInfo[] | undefined;
-  if (projectRoot) {
-    wsPackageInfos =
-      getPackageInfosFromMonorepoManager(projectRoot) || getPackageInfosFromOtherMonorepo(projectRoot, options);
-  }
+  let wsPackageInfos =
+    getPackageInfosFromMonorepoManager(projectRoot) || getPackageInfosFromOtherMonorepo(projectRoot, options);
 
-  if (!wsPackageInfos?.length && packageRoot) {
-    const singlePackage = getWSPackageInfo(packageRoot);
+  if (!wsPackageInfos?.length) {
+    const singlePackage = getWSPackageInfo(projectRoot);
     if (singlePackage) {
       wsPackageInfos = [singlePackage];
     }

--- a/packages/beachball/src/validation/isValidChangelogOptions.ts
+++ b/packages/beachball/src/validation/isValidChangelogOptions.ts
@@ -2,51 +2,19 @@ import { bulletedList } from '../logging/bulletedList';
 import { singleLineStringify } from '../logging/singleLineStringify';
 import type { ChangelogOptions } from '../types/ChangelogOptions';
 
+/**
+ * Verify that any `options.groups` contain the required properties.
+ */
 export function isValidChangelogOptions(options: ChangelogOptions): boolean {
-  if (!options.groups) {
-    return true;
-  }
-
-  let isValid = true;
-
-  const oldGroups = options.groups.filter(group => 'masterPackageName' in group);
-  if (oldGroups.length) {
-    isValid = false;
-    console.error(
-      'ERROR: "changelog.groups[*].masterPackageName" is renamed to "mainPackageName" in v3. ' +
-        'Invalid groups:\n' +
-        bulletedList(oldGroups.map(group => `masterPackageName "${group.masterPackageName as string}"`))
-    );
-  }
-
-  const badGroups = options.groups.filter(
-    group => !('masterPackageName' in group) && (!group.changelogPath || !group.mainPackageName || !group.include)
-  );
-  if (badGroups.length) {
-    isValid = false;
+  const badGroups = options.groups?.filter(group => !group.changelogPath || !group.mainPackageName || !group.include);
+  if (badGroups?.length) {
     console.error(
       'ERROR: "changelog.groups" entries must define "changelogPath", "mainPackageName", and "include". ' +
         'Invalid groups:\n' +
         bulletedList(badGroups.map(group => singleLineStringify(group)))
     );
+    return false;
   }
 
-  const badExcludeGroups = options.groups.filter(group => {
-    const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
-    return exclude.some((pattern: string) => pattern.startsWith('!'));
-  });
-  if (badExcludeGroups.length) {
-    isValid = false;
-    console.error(
-      'ERROR: "changelog.groups[*].exclude" patterns must not start with "!" in v3. ' +
-        'Found invalid groups:\n' +
-        bulletedList(
-          badExcludeGroups.map(
-            group => `mainPackageName "${group.mainPackageName}": ${singleLineStringify(group.exclude)}`
-          )
-        )
-    );
-  }
-
-  return isValid;
+  return true;
 }

--- a/packages/beachball/src/validation/isValidChangelogOptions.ts
+++ b/packages/beachball/src/validation/isValidChangelogOptions.ts
@@ -6,6 +6,14 @@ import type { ChangelogOptions } from '../types/ChangelogOptions';
  * Verify that any `options.groups` contain the required properties.
  */
 export function isValidChangelogOptions(options: ChangelogOptions): boolean {
+  if (options.groups !== undefined && !Array.isArray(options.groups)) {
+    console.error(
+      'ERROR: Expected "changelog.groups" configuration setting to be an array. Received:\n' +
+        singleLineStringify(options.groups)
+    );
+    return false;
+  }
+
   const badGroups = options.groups?.filter(group => !group.changelogPath || !group.mainPackageName || !group.include);
   if (badGroups?.length) {
     console.error(

--- a/packages/beachball/src/validation/isValidGroupOptions.ts
+++ b/packages/beachball/src/validation/isValidGroupOptions.ts
@@ -21,18 +21,6 @@ export function isValidGroupOptions(groups: VersionGroupOptions[]): boolean {
     return false;
   }
 
-  const badExcludeGroups = groups.filter(group => {
-    const exclude = typeof group.exclude === 'string' ? [group.exclude] : group.exclude || [];
-    return exclude.some((pattern: string) => pattern.startsWith('!'));
-  });
-  if (badExcludeGroups.length) {
-    console.error(
-      'ERROR: "groups[*].exclude" patterns must not start with "!". Found invalid groups:\n' +
-        bulletedList(badExcludeGroups.map(group => `${group.name}: ${singleLineStringify(group.exclude)}`))
-    );
-    return false;
-  }
-
   // TODO: validate disallowedChangeTypes? (they're not currently validated anywhere)
 
   return true;

--- a/packages/beachball/src/validation/validate.ts
+++ b/packages/beachball/src/validation/validate.ts
@@ -1,25 +1,26 @@
 import { getUntrackedChanges } from 'workspace-tools';
-import { isValidAuthType } from './isValidAuthType';
-import { isValidChangeType } from './isValidChangeType';
-import { isValidGroupedPackageOptions, isValidGroupOptions } from './isValidGroupOptions';
-import type { ParsedOptions } from '../types/BeachballOptions';
-import { isValidChangelogOptions } from './isValidChangelogOptions';
-import { readChangeFiles } from '../changefile/readChangeFiles';
-import { getPackageInfos } from '../monorepo/getPackageInfos';
-import { getPackageGroups } from '../monorepo/getPackageGroups';
-import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes';
-import { areChangeFilesDeleted } from './areChangeFilesDeleted';
-import { validatePackageDependencies } from '../publish/validatePackageDependencies';
 import { bumpInMemory } from '../bump/bumpInMemory';
-import { isValidDependentChangeType } from './isValidDependentChangeType';
-import { getPackagesToPublish } from '../publish/getPackagesToPublish';
+import { getChangedPackages } from '../changefile/getChangedPackages';
+import { getDisallowedChangeTypes } from '../changefile/getDisallowedChangeTypes';
+import { readChangeFiles } from '../changefile/readChangeFiles';
+import { getMigrationIssues } from '../commands/migrate';
 import { env } from '../env';
 import { bulletedList } from '../logging/bulletedList';
+import { getPackageGroups } from '../monorepo/getPackageGroups';
+import { getPackageInfos, getRawPackageInfos } from '../monorepo/getPackageInfos';
+import { getScopedPackages } from '../monorepo/getScopedPackages';
+import { getPackagesToPublish } from '../publish/getPackagesToPublish';
+import { validatePackageDependencies } from '../publish/validatePackageDependencies';
 import { BeachballError } from '../types/BeachballError';
+import type { ParsedOptions } from '../types/BeachballOptions';
 import type { BumpInfo } from '../types/BumpInfo';
 import type { ChangeCommandContext, CommandContext } from '../types/CommandContext';
-import { getScopedPackages } from '../monorepo/getScopedPackages';
-import { getChangedPackages } from '../changefile/getChangedPackages';
+import { areChangeFilesDeleted } from './areChangeFilesDeleted';
+import { isValidAuthType } from './isValidAuthType';
+import { isValidChangelogOptions } from './isValidChangelogOptions';
+import { isValidChangeType } from './isValidChangeType';
+import { isValidDependentChangeType } from './isValidDependentChangeType';
+import { isValidGroupedPackageOptions, isValidGroupOptions } from './isValidGroupOptions';
 
 export type ValidateOptions = {
   /**
@@ -76,7 +77,19 @@ export function validate(parsedOptions: ParsedOptions, validateOptions: Validate
     !env.isCI && console.warn('Changes in these files will not trigger a prompt for change descriptions');
   }
 
-  const originalPackageInfos = getPackageInfos(parsedOptions);
+  const rawPackageInfos = getRawPackageInfos(parsedOptions.options);
+  const { updates: migrationUpdates } = getMigrationIssues({
+    parsedOptions,
+    rawPackageInfos,
+    skipMigrations: [
+      'changelogJson', // skip additional filesystem check
+    ],
+  });
+  if (migrationUpdates.length) {
+    logValidationError(`The following config updates are needed for v3:\n${bulletedList(migrationUpdates)}`);
+  }
+
+  const originalPackageInfos = getPackageInfos(parsedOptions, rawPackageInfos);
 
   // options.all and options.package are marked with .conflicts() in optionDefinitions.
   // TODO ideally options invalid for command should also be handled in parsing
@@ -140,11 +153,6 @@ export function validate(parsedOptions: ParsedOptions, validateOptions: Validate
 
   if (options.groups && !isValidGroupedPackageOptions(originalPackageInfos, packageGroups)) {
     hasError = true; // the helper logs this
-  }
-
-  if (options.hooks?.prebump?.length ?? 0 > 3) {
-    logValidationError('prebump hook does not receive packageInfos - see the beachball v3 migration guide');
-    hasError = true;
   }
 
   const scopedPackages = getScopedPackages(options, originalPackageInfos);


### PR DESCRIPTION
Run most `migrate` checks during standard pre-command validation, and fail on errors (ignore and don't log warnings). Skip the CHANGELOG.json check since it requires extra file reads and isn't critical.