### PR TITLE
Fix iterative deepening for detached git HEAD

### DIFF
--- a/change/beachball-5f708894-f6df-4c63-bfe7-f350cd1cfe65.json
+++ b/change/beachball-5f708894-f6df-4c63-bfe7-f350cd1cfe65.json
@@ -1,0 +1,6 @@
+{
+  "type": "none",
+  "comment": "Fix iterative deepening for detached HEAD",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/beachball/src/__functional__/git/ensureSharedHistory.test.ts
+++ b/packages/beachball/src/__functional__/git/ensureSharedHistory.test.ts
@@ -304,6 +304,25 @@ describe('ensureSharedHistory', () => {
     expect(filteredGitCalls()).toEqual([`fetch --no-tags --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
   });
 
+  it('deepens history from a detached HEAD', () => {
+    const repo = repositoryFactory.cloneRepository({ depth: 1, branch: testBranch, singleBranch: true });
+    const headCommit = repo.getCurrentHash();
+    repo.checkout('--detach');
+    gitSpy.mockClear();
+
+    ensureSharedHistory({
+      path: repo.rootPath,
+      branch: defaultRemoteBranchName,
+      fetch: true,
+      depth: 2,
+      verbose: true,
+    });
+
+    const deepen = `fetch --no-tags --deepen=2 origin ${defaultRefSpec} ${headCommit}`;
+    expect(filteredGitCalls()).toEqual([`fetch --no-tags --depth=2 origin ${defaultRefSpec}`, deepen, deepen, deepen]);
+    expect(logs.getMockLines('all')).not.toMatch('Unshallowing');
+  });
+
   it('unshallows if deepening attempts fail', () => {
     const repo = repositoryFactory.cloneRepository({ depth: 1, branch: testBranch, singleBranch: true });
     gitSpy.mockClear();

--- a/packages/beachball/src/__functional__/git/fetch.test.ts
+++ b/packages/beachball/src/__functional__/git/fetch.test.ts
@@ -235,6 +235,21 @@ describe('gitFetch', () => {
     );
   });
 
+  it('includes additional refspecs', () => {
+    gitOverride = noOpSuccess;
+    const additionalRefspec = '0123456789abcdef';
+    const res = gitFetch({
+      ...commonOptions,
+      cwd: repo.rootPath,
+      additionalRefspecs: [additionalRefspec],
+      verbose: true,
+    });
+    expect(res).toMatchObject({ success: true });
+
+    expect(gitSpy).toHaveBeenCalledWith([...fetchArgs(), additionalRefspec], expect.anything());
+    expect(logs.mocks.log).toHaveBeenCalledWith(`${defaultLogPrefix} (${refspec()} ${additionalRefspec})...`);
+  });
+
   it('preserves the tracking ref after a real fetch', () => {
     // With a bare branch name like 'master' as the refspec source, git can fail to resolve it
     // on the remote and treat it as absent, pruning refs/remotes/origin/master (exit code 0).

--- a/packages/beachball/src/git/ensureSharedHistory.ts
+++ b/packages/beachball/src/git/ensureSharedHistory.ts
@@ -99,17 +99,26 @@ function deepenHistory(
 
   // git fetch --deepen only deepens the histories of the refs explicitly listed in the
   // refspec args, not other local refs. To find the common ancestor, both the target branch
-  // and HEAD (when on a different branch) need enough history to reach it. We pass both
-  // refspecs to a single git invocation so one --deepen / --unshallow covers both refs in one
-  // network round-trip.
+  // and HEAD (when on a different branch or detached) need enough history to reach it. We pass
+  // both refspecs to a single git invocation so one --deepen / --unshallow covers both refs in
+  // one network round-trip. (For detached head, include its commit ID directly.)
   const headBranch = getHeadBranch(cwd);
   const branchesToFetch = headBranch && headBranch !== remoteBranch ? [remoteBranch, headBranch] : [remoteBranch];
+  const additionalRefspecs = headBranch ? undefined : [getHeadCommit(cwd)];
 
   // Iteratively deepen the history
   const maxAttempts = 3;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     console.log(`Deepening by ${depth} more commits (attempt ${attempt}/${maxAttempts})...`);
-    const result = gitFetch({ remote, branch: branchesToFetch, deepen: depth, cwd, verbose, gitToken });
+    const result = gitFetch({
+      remote,
+      branch: branchesToFetch,
+      additionalRefspecs,
+      deepen: depth,
+      cwd,
+      verbose,
+      gitToken,
+    });
     if (!result.success) {
       throw new BeachballError(`Failed to fetch more history (see above for details)`);
     }
@@ -125,7 +134,15 @@ function deepenHistory(
 
   // No common commit was found and the repo is still shallow, so fully unshallow it
   console.log(`Still didn't find a common commit after deepening by ${depth * maxAttempts}. Unshallowing...`);
-  const result = gitFetch({ remote, branch: branchesToFetch, unshallow: true, cwd, verbose, gitToken });
+  const result = gitFetch({
+    remote,
+    branch: branchesToFetch,
+    additionalRefspecs,
+    unshallow: true,
+    cwd,
+    verbose,
+    gitToken,
+  });
   if (!result.success) {
     throw new BeachballError(`Failed to unshallow repo (see above for details)`);
   }
@@ -184,6 +201,10 @@ function getHeadBranch(cwd: string): string | undefined {
   const result = git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
   const branch = result.stdout.trim();
   return result.success && branch !== 'HEAD' ? branch : undefined;
+}
+
+function getHeadCommit(cwd: string): string {
+  return git(['rev-parse', 'HEAD'], { cwd }).stdout.trim();
 }
 
 function isShallowRepository(cwd: string): boolean {

--- a/packages/beachball/src/git/fetch.ts
+++ b/packages/beachball/src/git/fetch.ts
@@ -17,6 +17,11 @@ export type GitFetchParams = {
    * and the target branch need deepening).
    */
   branch: string | string[];
+  /**
+   * Additional refspecs or object IDs (such as a detached HEAD) whose histories should also be
+   * fetched or deepened.
+   */
+  additionalRefspecs?: string[];
   /** Set depth to this number of commits (mutually exclusive with `deepen` and `unshallow`) */
   depth?: number;
   /** Deepen a shallow clone by this number of commits (mutually exclusive with `depth` and `unshallow`) */
@@ -43,7 +48,17 @@ export type GitFetchParams = {
  * the remote branch is tracked or not in the local repository.
  */
 export function gitFetch(params: GitFetchParams): GitProcessOutput & { errorMessage?: string } {
-  const { remote, depth, deepen, unshallow, cwd, verbose, gitToken, env = process.env } = params;
+  const {
+    remote,
+    depth,
+    deepen,
+    unshallow,
+    cwd,
+    verbose,
+    gitToken,
+    additionalRefspecs = [],
+    env = process.env,
+  } = params;
   const branches = Array.isArray(params.branch) ? params.branch : [params.branch];
   const { shouldLog } = getGitEnv(verbose);
 
@@ -57,7 +72,8 @@ export function gitFetch(params: GitFetchParams): GitProcessOutput & { errorMess
 
   const extraArgs = depth ? [`--depth=${depth}`] : deepen ? [`--deepen=${deepen}`] : unshallow ? ['--unshallow'] : [];
 
-  // Be specific with each ref being fetched, so we don't have to worry about tracking configs.
+  // Use explicit refspecs so branch resolution doesn't depend on tracking config and --deepen
+  // applies to every requested history.
   // In git fetch <remote> +<src>:<dst>...
   // - The + means allow non-fast-forward updates (in case the remote was force pushed).
   // - <src> refs/heads/${branch} is resolved against the remote's advertised refs. The fully
@@ -65,7 +81,10 @@ export function gitFetch(params: GitFetchParams): GitProcessOutput & { errorMess
   //   causing git to treat the ref as absent and delete the local tracking ref.
   // - <dst> refs/remotes/${remote}/${branch} is resolved locally and only moves the tracking ref
   //   for the remote branch, not the local refs/heads/${branch} or its tracking config.
-  const resolvedRefspecs = branches.map(b => `+refs/heads/${b}:refs/remotes/${remote}/${b}`);
+  const resolvedRefspecs = [
+    ...branches.map(b => `+refs/heads/${b}:refs/remotes/${remote}/${b}`),
+    ...additionalRefspecs,
+  ];
 
   const branchLabel =
     branches.length > 1 ? `branches ${branches.map(b => `"${b}"`).join(', ')}` : `branch "${branches[0]}"`;


### PR DESCRIPTION
Maybe this is a change in a recent git version (or an artifact of previous fix attempt #1232/#1231), but now if running in a PR with a detached HEAD, it's necessary to explicitly deepen the detached HEAD ref too.

(Note: this PR intentionally has change type "none" because the change will be cherry-picked to v2 and released there first.)