### PR TITLE
ESRP wrapper: improve logging, retries, and error handling

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -46,6 +46,7 @@ variables:
   # TODO (release): remove all canary artifacts
   canaryArtifactName: packed-packages-canary
   releaseToolArtifactName: release-api-tool
+  tgzScanTestArtifactName: tgz-scan-test
 
 # Temporary workaround to publish two groups of packages with different versioning strategies
 # TODO (release): go back to a single publish step
@@ -98,6 +99,7 @@ extends:
               packagesArtifactPath: $(Build.StagingDirectory)/${{ variables.packagesArtifactName }}
               canaryArtifactPath: $(Build.StagingDirectory)/${{ variables.canaryArtifactName }}
               releaseToolArtifactPath: $(Build.StagingDirectory)/${{ variables.releaseToolArtifactName }}
+              tgzScanTestArtifactPath: $(Build.StagingDirectory)/${{ variables.tgzScanTestArtifactName }}
 
             templateContext:
               outputParentDirectory: $(Build.StagingDirectory)
@@ -111,6 +113,9 @@ extends:
                 - output: pipelineArtifact
                   artifactName: ${{ variables.releaseToolArtifactName }}
                   path: $(releaseToolArtifactPath)
+                - output: pipelineArtifact
+                  artifactName: ${{ variables.tgzScanTestArtifactName }}
+                  path: $(tgzScanTestArtifactPath)
 
             steps:
               - template: /.ado/templates/setup.yml@self
@@ -131,6 +136,14 @@ extends:
 
               - script: yarn beachball:release publish --no-push --pack-to-path "$(packagesArtifactPath)"
                 displayName: Pack packages (others)
+
+              - script: |
+                  mkdir -p "$(tgzScanTestArtifactPath)"
+                  echo "This file exists only inside the tgz scan test artifact." > "$(Agent.TempDirectory)/beachball-tgz-only-sentinel.txt"
+                  tar -czf "$(tgzScanTestArtifactPath)/tgz-expansion-test.tgz" \
+                    -C "$(Agent.TempDirectory)" beachball-tgz-only-sentinel.txt
+                  rm "$(Agent.TempDirectory)/beachball-tgz-only-sentinel.txt"
+                displayName: Create tgz scanning test artifact
 
               - script: |
                   mkdir -p '$(releaseToolArtifactPath)'
@@ -156,6 +169,7 @@ extends:
               packagesArtifactPath: $(Agent.BuildDirectory)/${{ variables.packagesArtifactName }}
               canaryArtifactPath: $(Agent.BuildDirectory)/${{ variables.canaryArtifactName }}
               releaseToolArtifactPath: $(Agent.BuildDirectory)/${{ variables.releaseToolArtifactName }}
+              tgzScanTestArtifactPath: $(Agent.BuildDirectory)/${{ variables.tgzScanTestArtifactName }}
               toolArtifactBin: $(releaseToolArtifactPath)/index.mjs
 
             templateContext:
@@ -171,6 +185,9 @@ extends:
                 - input: pipelineArtifact
                   artifactName: ${{ variables.releaseToolArtifactName }}
                   targetPath: $(releaseToolArtifactPath)
+                - input: pipelineArtifact
+                  artifactName: ${{ variables.tgzScanTestArtifactName }}
+                  targetPath: $(tgzScanTestArtifactPath)
 
             steps:
               - task: UseNode@1
@@ -184,6 +201,7 @@ extends:
                   ls -R '$(packagesArtifactPath)'
                   ls -R '$(canaryArtifactPath)'
                   ls -R '$(releaseToolArtifactPath)'
+                  ls -R '$(tgzScanTestArtifactPath)'
                 displayName: Show artifact contents
 
               # Get credentials that will be used to temporarily upload zips to ogxesrptempstorage

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -217,7 +217,6 @@ extends:
               - ${{ each publish in parameters.npmPublishes }}:
                   - script: node "$(toolArtifactBin)"
                     displayName: '(${{ publish.groupName }}) npm publish using ESRP Release API'
-                    retryCountOnTaskFailure: 3
                     env:
                       PACKED_PACKAGES_PATH: $(${{ publish.artifactPathVariable }})
                       # ideally would be "beachball" but isn't used anywhere meaningful

--- a/change/@microsoft-esrp-npm-release-1b47fefb-6d1f-49e9-abac-cbc632fe2f2b.json
+++ b/change/@microsoft-esrp-npm-release-1b47fefb-6d1f-49e9-abac-cbc632fe2f2b.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Improve logging, retries, and error handling",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -33,7 +33,7 @@ For each layer, the tool:
 3. Calls the ESRP release API to publish the layer, waiting for it to complete before moving on to the next layer.
 4. Deletes the staged zip.
 
-If a layer release fails, the tool retries that layer up to three times, unless the status from ESRP was `failDoNotRetry` or there was an unrecognized error. It's also safe to manually re-run the whole stage.
+The tool retries transient initialization failures and failed layer releases up to three times. Permanent or unrecognized errors, including the ESRP status `failDoNotRetry`, fail immediately. It's also safe to manually re-run the whole stage.
 
 The tool relies on the following inputs and resources:
 

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -33,6 +33,8 @@ For each layer, the tool:
 3. Calls the ESRP release API to publish the layer, waiting for it to complete before moving on to the next layer.
 4. Deletes the staged zip.
 
+If a layer release fails, the tool retries that layer up to three times, unless the status from ESRP was `failDoNotRetry` or there was an unrecognized error. It's also safe to manually re-run the whole stage.
+
 The tool relies on the following inputs and resources:
 
 - [**Packed packages**](#packed-packages-format): Output folder from `beachball publish --pack-to-path <path>` or in the same format.
@@ -166,6 +168,8 @@ Running `beachball publish --pack-to-path <path>` produces a directory with this
 ```
 
 Each numbered directory is a **dependency-topological layer**: the packages in layer 1 have no internal dependencies, or none within the set of packages being published. Packages in layer `N` may only depend on packages in layers `1..N-1`. The tool releases layers in numeric order, so that by the time a layer is published, every internal dependency version it references is already on the registry.
+
+[More detailed example of the packed packages format](https://gist.github.com/ecraig12345/d197b9bd0dc704d242d53d35771933ff)
 
 ## Staging resource setup
 
@@ -555,7 +559,6 @@ Add one of the following publish stages to the pipeline (under `extends.paramete
         # Run the tool (see "Tool inputs" below for details on each variable)
         - script: node '$(toolArtifactBin)'
           displayName: Publish using ESRP Release API
-          retryCountOnTaskFailure: 3
           env:
             PACKED_PACKAGES_PATH: $(packagesArtifactPath)
 
@@ -661,7 +664,6 @@ Add one of the following publish stages to the pipeline (under `extends.paramete
         # Run the tool (see "Tool inputs" below for details on each variable)
         - script: node '$(toolArtifactBin)'
           displayName: Publish using ESRP Release API
-          retryCountOnTaskFailure: 3
           env:
             PACKED_PACKAGES_PATH: $(packagesArtifactPath)
 

--- a/packages/esrp-npm-release/src/ESRPReleaseService.ts
+++ b/packages/esrp-npm-release/src/ESRPReleaseService.ts
@@ -11,7 +11,7 @@ import { getAadToken, type AccessToken, type GetAadTokenParams } from './auth/ge
 import { getKeyAndCertificatesFromPFX } from './auth/signing.ts';
 import {
   createNpmReleaseRequest,
-  redactReleaseRequest,
+  formatReleaseRequestForLog,
   type CreateNpmReleaseRequestMessageParams,
 } from './esrpApi/npmRelease.ts';
 import { esrpApiScope, getReleaseDetails, getReleaseStatus, submitRelease } from './esrpApi/releaseHttp.ts';
@@ -251,7 +251,7 @@ export class ESRPReleaseService {
       file: { path: filePath, sasBlobUrl },
     });
 
-    this.#logger.log(`Sending request to ESRP API: ${JSON.stringify(redactReleaseRequest(request), null, 2)}`);
+    this.#logger.log(`Sending request to ESRP API: ${formatReleaseRequestForLog(request)}`);
 
     const submitReleaseResult = await submitRelease({
       clientId: this.#clientId,
@@ -304,7 +304,7 @@ export class ESRPReleaseService {
         bearerToken: esrpAccessToken.token,
         releaseId: submitReleaseResult.operationId,
       });
-      this.#logger.log('Release details:', JSON.stringify(redactReleaseRequest(releaseDetails), null, 2));
+      this.#logger.log('Release details:', formatReleaseRequestForLog(releaseDetails));
     } catch (err) {
       this.#logger.warn(
         `Release ${submitReleaseResult.operationId} succeeded but fetching details failed; ` +
@@ -336,28 +336,79 @@ export class ESRPReleaseService {
   #checkReleaseStatus(releaseStatus: ReleaseResultMessage, releaseId: string): boolean {
     const releaseStr = JSON.stringify(releaseStatus, null, 2);
     const fullStatusApiResponse = `Full status API response: ${releaseStr}`;
+    const releaseErrorSummary =
+      releaseStatus.releaseError?.errorMessages?.map(message => `- ${message}`).join('\n') || '';
 
     if (releaseStatus.status === 'pass') {
       this.#logger.log(`Release ${releaseId} passed. Last status details: ${releaseStr}`);
       return true;
     }
 
-    // Check for a 404 on publish and give a specific error
-    const errorDetails = (releaseStatus.errorInfo || releaseStatus.errorinfo)?.details?.errors;
-    if (errorDetails && /^404.*?PUT.*?registry\.npmjs\.org/.test(errorDetails)) {
+    if (releaseStatus.status === 'failCanRetry') {
       throw new ReleaseError(
-        `Release failed with 404 on npm publish: ${errorDetails}\nThis usually indicates an auth issue, ` +
-          `such as expired credentials or missing permissions. Please contact the ESRP team for help.\n\n` +
-          fullStatusApiResponse
+        [`Release failed with a retryable error.`, releaseErrorSummary, fullStatusApiResponse]
+          .filter(Boolean)
+          .join('\n')
+      );
+    }
+
+    // Check for a 404 on publish and give a specific error
+    const publishError = getNpmPublishError(releaseStatus);
+    if (publishError) {
+      throw new ReleaseError(
+        `Release failed with 404 on npm publish: ${publishError}\nThis usually means the ESRP npm account ` +
+          `has not been added as a package/org owner, or possibly there was an auth issue (e.g. expired ` +
+          `credentials). Please verify npm package owners or contact the ESRP team for further help.\n\n` +
+          fullStatusApiResponse,
+        { retryable: false }
       );
     }
     // TODO: mismatch with values included in provided types
     if ((releaseStatus.status as unknown) === 'aborted' || releaseStatus.status === 'cancelled') {
-      throw new ReleaseError(`Release was aborted. ${fullStatusApiResponse}`);
+      throw new ReleaseError(
+        [`Release was aborted.`, releaseErrorSummary, fullStatusApiResponse].filter(Boolean).join('\n'),
+        { retryable: false }
+      );
     }
-    if (releaseStatus.status !== 'inprogress') {
-      throw new ReleaseError(`Unexpected release status "${releaseStatus.status}". ${fullStatusApiResponse}`);
+    if (releaseStatus.status !== 'inprogress' && releaseStatus.status !== 'pendingAnalysis') {
+      throw new ReleaseError(
+        [`Unexpected release status "${releaseStatus.status}".`, releaseErrorSummary, fullStatusApiResponse]
+          .filter(Boolean)
+          .join('\n'),
+        { retryable: false }
+      );
     }
     return false;
+  }
+}
+
+const npmPublish404Pattern = /^404.*?PUT.*?registry\.npmjs\.org/;
+
+function getNpmPublishError(releaseStatus: ReleaseResultMessage): string | undefined {
+  const topLevelError = (releaseStatus.errorInfo || releaseStatus.errorinfo)?.details?.errors;
+  if (topLevelError && npmPublish404Pattern.test(topLevelError)) {
+    return topLevelError;
+  }
+
+  // Based on the most recent observed shape for an npm 404:
+  // {
+  //   "activityType": "PackageManager",
+  //   "status": "Failed",
+  //   "errorMessages": [
+  //     "{\"code\":null,\"details\":{\"errors:\":\"404 Not Found - PUT https://registry.npmjs.org/some-pkg - Not found\"},\"innerError\":null}"
+  //   ],
+  // }
+  for (const message of releaseStatus.activities
+    ?.filter(activity => activity.activityType === 'PackageManager')
+    .flatMap(activity => activity.errorMessages || []) || []) {
+    try {
+      const activityError = JSON.parse(message) as { details?: Record<string, string> };
+      const error = activityError.details?.errors || activityError.details?.['errors:'];
+      if (error && npmPublish404Pattern.test(error)) {
+        return error;
+      }
+    } catch {
+      // Ignore non-JSON activity errors; the full response is included in the fallback error.
+    }
   }
 }

--- a/packages/esrp-npm-release/src/ESRPReleaseService.ts
+++ b/packages/esrp-npm-release/src/ESRPReleaseService.ts
@@ -19,6 +19,7 @@ import type { ReleaseResultMessage } from './types/api.ts';
 import type { EsrpEnvOptions } from './types/EnvOptions.ts';
 import type { Logger } from './utils/Logger.ts';
 import { ReleaseError } from './utils/ReleaseError.ts';
+import { isRetryableAzureError, retryReleaseError } from './utils/errorHelpers.ts';
 
 interface CreateESRPReleaseServiceParams extends Pick<
   EsrpEnvOptions,
@@ -65,15 +66,34 @@ export class ESRPReleaseService {
    * (unclear if this would be an issue in practice).
    */
   public static async create(params: CreateESRPReleaseServiceParams): Promise<ESRPReleaseService> {
+    return retryReleaseError(
+      params.logger,
+      attempt => `ESRP initialization ${attempt}`,
+      () => this.#createAttempt(params)
+    );
+  }
+
+  static async #createAttempt(params: CreateESRPReleaseServiceParams): Promise<ESRPReleaseService> {
     const { logger } = params;
     let stagingContainerClient: ContainerClient;
     try {
       logger.log(`Getting client and ensuring staging container "${stagingContainerName}" exists`);
       stagingContainerClient = params.stagingBlobServiceClient.getContainerClient(stagingContainerName);
+    } catch (err) {
+      throw new ReleaseError(`Error initializing client for staging container "${stagingContainerName}"`, {
+        cause: err,
+        retryable: false,
+      });
+    }
+
+    try {
       // this async operation can't be done in the constructor
       await stagingContainerClient.createIfNotExists();
     } catch (err) {
-      throw new ReleaseError(`Error ensuring staging container "${stagingContainerName}" exists`, { cause: err });
+      throw new ReleaseError(`Error ensuring staging container "${stagingContainerName}" exists`, {
+        cause: err,
+        retryable: isRetryableAzureError(err),
+      });
     }
 
     try {
@@ -86,7 +106,10 @@ export class ESRPReleaseService {
         requestSigningCertificates: certificates,
       });
     } catch (err) {
-      throw new ReleaseError(`Error extracting request signing key and certificates from PFX`, { cause: err });
+      throw new ReleaseError(`Error extracting request signing key and certificates from PFX`, {
+        cause: err,
+        retryable: false,
+      });
     }
   }
 
@@ -110,14 +133,14 @@ export class ESRPReleaseService {
     this.#clientId = params.clientId;
     this.#tenantId = params.tenantId;
     if (params.authCertificatePfx && params.idToken) {
-      throw new ReleaseError('ESRP auth requires exactly one of authCertificatePfx or idToken');
+      throw new ReleaseError('ESRP auth requires exactly one of authCertificatePfx or idToken', { retryable: false });
     }
     if (params.idToken) {
       this.#esrpAuth = { idToken: params.idToken };
     } else if (params.authCertificatePfx) {
       this.#esrpAuth = { certPfxContent: params.authCertificatePfx };
     } else {
-      throw new ReleaseError('ESRP auth requires exactly one of authCertificatePfx or idToken');
+      throw new ReleaseError('ESRP auth requires exactly one of authCertificatePfx or idToken', { retryable: false });
     }
     this.#stagingBlobServiceClient = params.stagingBlobServiceClient;
     this.#stagingContainerClient = params.stagingContainerClient;
@@ -139,6 +162,14 @@ export class ESRPReleaseService {
    * after a given window (3 days as of writing).
    */
   public async createRelease(params: CreateReleaseParams): Promise<void> {
+    await retryReleaseError(
+      this.#logger,
+      attempt => `Release ${attempt}`,
+      () => this.#createReleaseAttempt(params)
+    );
+  }
+
+  async #createReleaseAttempt(params: CreateReleaseParams): Promise<void> {
     const { filePath, releaseRequestParams, repoName } = params;
 
     // Acquire fresh credentials for each release in case earlier slow operations caused
@@ -154,13 +185,16 @@ export class ESRPReleaseService {
     try {
       blobClient = this.#stagingContainerClient.getBlockBlobClient(blobName);
     } catch (err) {
-      throw new ReleaseError(`Error initializing blob client for staging upload`, { cause: err });
+      throw new ReleaseError(`Error initializing blob client for staging upload`, { cause: err, retryable: false });
     }
 
     try {
       this.#logger.log(`Uploading ${filePath} to ${blobClient.url}`);
       await blobClient.uploadFile(filePath).catch(err => {
-        throw new ReleaseError(`Error uploading file to staging storage`, { cause: err });
+        throw new ReleaseError(`Error uploading file to staging storage`, {
+          cause: err,
+          retryable: isRetryableAzureError(err),
+        });
       });
 
       await this.#submitAndPollRelease({
@@ -193,7 +227,10 @@ export class ESRPReleaseService {
         new Date(now + oneHour)
       );
     } catch (err) {
-      throw new ReleaseError(`Error acquiring user delegation key for staging blob access`, { cause: err });
+      throw new ReleaseError(`Error acquiring user delegation key for staging blob access`, {
+        cause: err,
+        retryable: isRetryableAzureError(err),
+      });
     }
   }
 
@@ -208,7 +245,10 @@ export class ESRPReleaseService {
       auth: this.#esrpAuth,
       logger: this.#logger,
     }).catch(err => {
-      throw new ReleaseError(`Error acquiring access token for ESRP API`, { cause: err });
+      throw new ReleaseError(`Error acquiring access token for ESRP API`, {
+        cause: err,
+        retryable: err instanceof ReleaseError && err.retryable,
+      });
     });
   }
 
@@ -267,16 +307,27 @@ export class ESRPReleaseService {
     for (let i = 0; i < 720; i++) {
       await new Promise(c => setTimeout(c, 5000));
 
-      // AAD client-credential tokens are typically valid for ~1 hour. Since polling can run
-      // for up to 60 minutes (and was preceded by upload + submit), the original token can
-      // expire mid-poll. Refresh proactively when within 5 minutes of expiry.
-      esrpAccessToken = await this.#refreshEsrpAccessTokenIfNeeded(esrpAccessToken);
+      try {
+        // AAD client-credential tokens are typically valid for ~1 hour. Since polling can run
+        // for up to 60 minutes (and was preceded by upload + submit), the original token can
+        // expire mid-poll. Refresh proactively when within 5 minutes of expiry.
+        esrpAccessToken = await this.#refreshEsrpAccessTokenIfNeeded(esrpAccessToken);
 
-      releaseStatus = await getReleaseStatus({
-        clientId: this.#clientId,
-        bearerToken: esrpAccessToken.token,
-        releaseId: submitReleaseResult.operationId,
-      });
+        releaseStatus = await getReleaseStatus({
+          clientId: this.#clientId,
+          bearerToken: esrpAccessToken.token,
+          releaseId: submitReleaseResult.operationId,
+        });
+      } catch (err) {
+        if (err instanceof ReleaseError && err.retryable) {
+          this.#logger.warn(
+            `Transient error polling release ${submitReleaseResult.operationId} (will retry polling):`,
+            err
+          );
+          continue;
+        }
+        throw err;
+      }
 
       // Log only on status changes to avoid spamming the log on every poll
       if (releaseStatus.status !== lastLoggedStatus) {
@@ -291,7 +342,9 @@ export class ESRPReleaseService {
 
     if (releaseStatus?.status !== 'pass') {
       throw new ReleaseError(
-        `Timed out waiting for release. Most recent status API response: ${JSON.stringify(releaseStatus, null, 2)}`
+        `Timed out waiting for release. Most recent status API response: ${JSON.stringify(releaseStatus, null, 2)}`,
+        // It's not clear what went wrong in this case, so require a manual re-run of the stage to retry
+        { retryable: false }
       );
     }
 
@@ -348,7 +401,8 @@ export class ESRPReleaseService {
       throw new ReleaseError(
         [`Release failed with a retryable error.`, releaseErrorSummary, fullStatusApiResponse]
           .filter(Boolean)
-          .join('\n')
+          .join('\n'),
+        { retryable: true }
       );
     }
 

--- a/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
@@ -252,6 +252,14 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     ]);
   });
 
+  it('continues polling while a release is pending analysis', async () => {
+    mockEsrpHttp.queueStatuses(['pendingAnalysis', 'pass']);
+
+    await runCreateRelease();
+
+    expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     ['aborted', 'Release was aborted'],
     ['cancelled', 'Release was aborted'],
@@ -263,21 +271,66 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(blobClient.delete).toHaveBeenCalledTimes(1);
   });
 
+  it('marks failCanRetry as retryable', async () => {
+    mockEsrpHttp.queueStatuses(['failCanRetry']);
+
+    const err = (await expectError(
+      runCreateRelease(),
+      ReleaseError,
+      'Release failed with a retryable error'
+    )) as ReleaseError;
+
+    expect(err.retryable).toBe(true);
+  });
+
+  it('marks failDoNotRetry as non-retryable', async () => {
+    mockEsrpHttp.getReleaseStatus.mockResolvedValue({
+      status: 'failDoNotRetry',
+      releaseError: {
+        errorCode: 2201,
+        errorMessages: ['Release failed due to activity failure.', 'Failed Activity : Package Manager.'],
+      },
+    });
+
+    const err = (await expectError(runCreateRelease(), ReleaseError, [
+      'Unexpected release status "failDoNotRetry"',
+      /- Release failed due to activity failure\.\n- Failed Activity : Package Manager\./,
+    ])) as ReleaseError;
+
+    expect(err.retryable).toBe(false);
+  });
+
   it('throws a custom auth-focused message for npm registry 404 errors', async () => {
     mockEsrpHttp.getReleaseStatus.mockResolvedValue({
-      // Based on an actual failure response
       status: 'failDoNotRetry',
-      errorInfo: {
-        details: {
-          errors: '404 Not Found - PUT https://registry.npmjs.org/@microsoft%2fsome-lib - Not found',
-        },
+      releaseError: {
+        errorCode: 2201,
+        errorMessages: ['Release failed due to activity failure.', 'Failed Activity : Package Manager.'],
       },
+      activities: [
+        {
+          activityType: 'PackageManager',
+          name: 'Package Manager',
+          status: 'Failed',
+          errorCode: 1004,
+          // ESRP returns a JSON object as a string, including the observed "errors:" property typo.
+          errorMessages: [
+            JSON.stringify({
+              code: null,
+              details: {
+                'errors:': '404 Not Found - PUT https://registry.npmjs.org/@microsoft%2fsome-lib - Not found',
+              },
+              innerError: null,
+            }),
+          ],
+        },
+      ],
     });
 
     await expectError(
       () => runCreateRelease(),
       ReleaseError,
-      /Release failed with 404 on npm publish:[\s\S]*?Full status API response/
+      /Release failed with 404 on npm publish:[\s\S]*?Please verify npm package owners or contact the ESRP team for further help\.[\s\S]*?Full status API response/
     );
     expect(blobClient.delete).toHaveBeenCalledTimes(1);
   });

--- a/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ESRPReleaseService.test.ts
@@ -1,4 +1,4 @@
-import type { BlobServiceClient } from '@azure/storage-blob';
+import { RestError, type BlobServiceClient } from '@azure/storage-blob';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { expectError, setupTempDir } from '@microsoft/beachball-test-utilities';
 import jws from 'jws';
@@ -115,8 +115,30 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
   }
 
   async function expectReleaseError(message: string, originalError?: Error) {
-    await expectError(runCreateRelease(), ReleaseError, message, originalError);
+    return (await expectError(runCreateRelease(), ReleaseError, message, originalError)) as ReleaseError;
   }
+
+  it('retries transient initialization failures', async () => {
+    containerClient.createIfNotExists.mockClear();
+    containerClient.createIfNotExists.mockRejectedValueOnce(
+      new RestError('temporary container failure', { statusCode: 503 })
+    );
+
+    const create = ESRPReleaseService.create({
+      logger,
+      clientId: 'cid',
+      tenantId: 'tid',
+      authCertificatePfx: 'auth-pfx-not-parsed',
+      requestSigningCertificatePfx: testCert.pfxBase64,
+      stagingBlobServiceClient: blobServiceClient as unknown as BlobServiceClient,
+    });
+    create.catch(() => undefined);
+    await jest.runAllTimersAsync();
+    await create;
+
+    expect(containerClient.createIfNotExists).toHaveBeenCalledTimes(2);
+    expect(logger.lines).toContainEqual(expect.stringContaining('ESRP initialization attempt 1 of 4 failed'));
+  });
 
   it('acquires creds, uploads blob, signs+submits, polls until pass, deletes blob', async () => {
     logger.addPath(fileDir.getTempDir(), '<temp>');
@@ -221,6 +243,25 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(logger.lines.some(l => l.includes('AAD access token near expiry, refreshing'))).toBe(true);
   });
 
+  it('continues polling the accepted operation after a transient token refresh failure', async () => {
+    mockGetAadToken
+      .mockResolvedValueOnce({ token: 'aad-token-1', expiresOnTimestamp: Date.now() + 10_000 })
+      .mockRejectedValueOnce(new ReleaseError('temporary token failure', { retryable: true }))
+      .mockResolvedValueOnce({ token: 'aad-token-2', expiresOnTimestamp: Date.now() + 24 * 60 * 60 * 1000 });
+
+    await runCreateRelease();
+
+    expect(mockGetAadToken).toHaveBeenCalledTimes(3);
+    expect(mockEsrpHttp.submitRelease).toHaveBeenCalledTimes(1);
+    expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(1);
+    expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ releaseId: 'mock-op-id', bearerToken: 'aad-token-2' })
+    );
+    expect(logger.lines).toContainEqual(
+      expect.stringContaining('Transient error polling release mock-op-id (will retry polling)')
+    );
+  });
+
   it('polls every 5 seconds', async () => {
     mockEsrpHttp.queueStatuses(['inprogress', 'inprogress', 'pass']);
 
@@ -260,6 +301,35 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(2);
   });
 
+  it('continues polling the accepted operation after a transient status failure', async () => {
+    mockEsrpHttp.getReleaseStatus
+      .mockRejectedValueOnce(new ReleaseError('temporary status failure', { retryable: true }))
+      .mockResolvedValueOnce({ status: 'pass' });
+
+    await runCreateRelease();
+
+    expect(mockEsrpHttp.submitRelease).toHaveBeenCalledTimes(1);
+    expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(2);
+    expect(mockEsrpHttp.getReleaseStatus.mock.calls.map(([params]) => params.releaseId)).toEqual([
+      'mock-op-id',
+      'mock-op-id',
+    ]);
+    expect(logger.lines).toContainEqual(
+      expect.stringContaining('Transient error polling release mock-op-id (will retry polling)')
+    );
+  });
+
+  it('does not hide a non-retryable status failure', async () => {
+    const originalError = new ReleaseError('invalid status request', { retryable: false });
+    mockEsrpHttp.getReleaseStatus.mockRejectedValue(originalError);
+
+    const error = await runCreateRelease().catch(caught => caught as unknown);
+
+    expect(error).toBe(originalError);
+    expect(mockEsrpHttp.submitRelease).toHaveBeenCalledTimes(1);
+    expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ['aborted', 'Release was aborted'],
     ['cancelled', 'Release was aborted'],
@@ -271,16 +341,15 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(blobClient.delete).toHaveBeenCalledTimes(1);
   });
 
-  it('marks failCanRetry as retryable', async () => {
-    mockEsrpHttp.queueStatuses(['failCanRetry']);
+  it('retries the full release after failCanRetry', async () => {
+    mockEsrpHttp.queueStatuses(['failCanRetry', 'pass']);
 
-    const err = (await expectError(
-      runCreateRelease(),
-      ReleaseError,
-      'Release failed with a retryable error'
-    )) as ReleaseError;
+    await runCreateRelease();
 
-    expect(err.retryable).toBe(true);
+    expect(mockEsrpHttp.submitRelease).toHaveBeenCalledTimes(2);
+    expect(blobClient.uploadFile).toHaveBeenCalledTimes(2);
+    expect(blobClient.delete).toHaveBeenCalledTimes(2);
+    expect(logger.lines).toContainEqual(expect.stringContaining('Release attempt 1 of 4 failed'));
   });
 
   it('marks failDoNotRetry as non-retryable', async () => {
@@ -300,31 +369,46 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(err.retryable).toBe(false);
   });
 
-  it('throws a custom auth-focused message for npm registry 404 errors', async () => {
+  it.each<{ format: string; response: object }>([
+    {
+      format: 'legacy top-level errorInfo',
+      response: {
+        errorInfo: {
+          details: { errors: '404 Not Found - PUT https://registry.npmjs.org/@microsoft%2fsome-lib - Not found' },
+        },
+      },
+    },
+    {
+      format: 'PackageManager activity',
+      response: {
+        activities: [
+          {
+            activityType: 'PackageManager',
+            name: 'Package Manager',
+            status: 'Failed',
+            errorCode: 1004,
+            // ESRP returns a JSON object as a string, including the observed "errors:" property typo.
+            errorMessages: [
+              JSON.stringify({
+                code: null,
+                details: {
+                  'errors:': '404 Not Found - PUT https://registry.npmjs.org/@microsoft%2fsome-lib - Not found',
+                },
+                innerError: null,
+              }),
+            ],
+          },
+        ],
+      },
+    },
+  ])('throws a custom auth-focused message for npm registry 404 errors in $format format', async ({ response }) => {
     mockEsrpHttp.getReleaseStatus.mockResolvedValue({
       status: 'failDoNotRetry',
       releaseError: {
         errorCode: 2201,
         errorMessages: ['Release failed due to activity failure.', 'Failed Activity : Package Manager.'],
       },
-      activities: [
-        {
-          activityType: 'PackageManager',
-          name: 'Package Manager',
-          status: 'Failed',
-          errorCode: 1004,
-          // ESRP returns a JSON object as a string, including the observed "errors:" property typo.
-          errorMessages: [
-            JSON.stringify({
-              code: null,
-              details: {
-                'errors:': '404 Not Found - PUT https://registry.npmjs.org/@microsoft%2fsome-lib - Not found',
-              },
-              innerError: null,
-            }),
-          ],
-        },
-      ],
+      ...response,
     });
 
     await expectError(
@@ -335,16 +419,16 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     expect(blobClient.delete).toHaveBeenCalledTimes(1);
   });
 
-  it('throws ReleaseError after polling timeout (720 iterations of inprogress)', async () => {
+  it('throws ReleaseError after 720 inprogress polls', async () => {
     mockEsrpHttp.getReleaseStatus.mockResolvedValue({ status: 'inprogress' });
 
     await expectReleaseError('Timed out waiting for release. Most recent status');
     expect(mockEsrpHttp.getReleaseStatus).toHaveBeenCalledTimes(720);
   });
 
-  it.each(['submitRelease', 'getReleaseStatus'] as const)('propagates %s failures', async method => {
-    const originalError = new ReleaseError(`${method} failed`);
-    mockEsrpHttp[method].mockRejectedValue(originalError);
+  it('propagates submitRelease failures', async () => {
+    const originalError = new ReleaseError('submitRelease failed', { retryable: false });
+    mockEsrpHttp.submitRelease.mockRejectedValue(originalError);
     const err = await runCreateRelease().catch(e => e as unknown);
     expect(err).toBe(originalError);
   });
@@ -359,10 +443,18 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     );
   });
 
-  it('wraps SAS token generation failures with ReleaseError', async () => {
-    const originalError = new Error('sas failed');
+  it.each([
+    [503, true],
+    [403, false],
+  ])('classifies user delegation key status %s as retryable=%s', async (statusCode, retryable) => {
+    const originalError = new RestError('delegation key failed', { statusCode });
     blobServiceClient.getUserDelegationKey.mockRejectedValue(originalError);
-    await expectReleaseError('Error acquiring user delegation key for staging blob access', originalError);
+    const error = await expectReleaseError(
+      'Error acquiring user delegation key for staging blob access',
+      originalError
+    );
+
+    expect(error.retryable).toBe(retryable);
   });
 
   it('authenticates with a managed identity federated token when configured instead of a certificate', async () => {
@@ -396,10 +488,15 @@ describeIfOpenssl('ESRPReleaseService.createRelease', () => {
     await expectReleaseError('Error acquiring access token for ESRP API', originalError);
   });
 
-  it('wraps blob upload failures with ReleaseError', async () => {
-    const originalError = new Error('upload failed');
+  it.each([
+    [503, true],
+    [403, false],
+  ])('classifies blob upload status %s as retryable=%s', async (statusCode, retryable) => {
+    const originalError = new RestError('upload failed', { statusCode });
     blobClient.uploadFile.mockRejectedValue(originalError);
-    await expectReleaseError('Error uploading file to staging storage', originalError);
+    const error = await expectReleaseError('Error uploading file to staging storage', originalError);
+
+    expect(error.retryable).toBe(retryable);
   });
 
   it('logs blob deletion failure as a warning but preserves the original outcome', async () => {

--- a/packages/esrp-npm-release/src/__tests__/ReleaseState.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/ReleaseState.test.ts
@@ -1,5 +1,5 @@
-import type { BlobServiceClient } from '@azure/storage-blob';
-import { describe, expect, it } from '@jest/globals';
+import { RestError, type BlobServiceClient } from '@azure/storage-blob';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { expectError } from '@microsoft/beachball-test-utilities';
 import {
   createMockBlobServiceClient,
@@ -7,15 +7,21 @@ import {
   createMockContainerClient,
   type MockBlockBlobClient,
 } from '../__fixtures__/mockAzure.ts';
+import { MockLogger } from '../__fixtures__/MockLogger.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
 import { ReleaseState } from '../utils/ReleaseState.ts';
 
 describe('ReleaseState', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   const params = {
     repoName: 'repo1',
     buildSourceVersion: 'abc',
     productName: 'prod1',
     npmTag: undefined,
+    logger: new MockLogger(),
   };
 
   describe('create', () => {
@@ -100,12 +106,16 @@ describe('ReleaseState', () => {
       );
     });
 
-    it('wraps errors from createIfNotExists with ReleaseError mentioning the container and account', async () => {
+    it.each([
+      [503, true],
+      [403, false],
+    ])('classifies status %s from createIfNotExists as retryable=%s', async (statusCode, retryable) => {
+      retryable && jest.useFakeTimers();
       const containerClient = createMockContainerClient({ accountName: 'myacct' });
-      const originalError = new Error('synthetic createIfNotExists failure');
+      const originalError = new RestError('synthetic createIfNotExists failure', { statusCode });
       containerClient.createIfNotExists.mockRejectedValue(originalError);
 
-      await expectError(
+      const errorPromise = expectError(
         () =>
           ReleaseState.create({
             blobServiceClient: createMockBlobServiceClient({
@@ -118,6 +128,11 @@ describe('ReleaseState', () => {
         'Error creating or accessing container "release-state" in storage account "myacct"',
         originalError
       );
+      retryable && (await jest.runAllTimersAsync());
+      const error = (await errorPromise) as ReleaseError;
+
+      expect(error.retryable).toBe(retryable);
+      expect(containerClient.createIfNotExists).toHaveBeenCalledTimes(retryable ? 4 : 1);
     });
 
     it('wraps errors from listBlobsFlat with ReleaseError mentioning the prefix', async () => {
@@ -163,9 +178,23 @@ describe('ReleaseState', () => {
       expect(state.publishedCount).toBe(1);
     });
 
-    it('wraps upload failures with ReleaseError mentioning the layer and account', async () => {
+    it('retries an upload failure', async () => {
+      jest.useFakeTimers();
+      const { state, blobClient } = await newState();
+      blobClient.upload.mockRejectedValueOnce(new RestError('temporary upload failure', { statusCode: 503 }));
+
+      const markPublished = state.markPublished('5');
+      await jest.runAllTimersAsync();
+      await markPublished;
+
+      expect(blobClient.upload).toHaveBeenCalledTimes(2);
+      expect(state.hasPublished('5')).toBe(true);
+    });
+
+    it('wraps upload failures after four attempts with ReleaseError mentioning the layer and account', async () => {
+      jest.useFakeTimers();
       const blobClient = createMockBlockBlobClient();
-      const originalError = new Error('synthetic upload failure');
+      const originalError = new RestError('synthetic upload failure', { statusCode: 503 });
       blobClient.upload.mockRejectedValue(originalError);
       const containerClient = createMockContainerClient({ accountName: 'myacct', blobClient });
       const state = await ReleaseState.create({
@@ -176,13 +205,36 @@ describe('ReleaseState', () => {
         ...params,
       });
 
-      await expectError(
+      const markPublished = expectError(
         () => state.markPublished('5'),
         ReleaseError,
-        'Error marking layer 5 as published in persisted release state (container "release-state" in storage account "myacct")',
+        'Error marking layer 5 as published in persisted release state ' +
+          '(container "release-state" in storage account "myacct")',
         originalError
       );
+      await jest.runAllTimersAsync();
+      await markPublished;
+
+      expect(blobClient.upload).toHaveBeenCalledTimes(4);
       // Did not record the layer as published since upload failed
+      expect(state.hasPublished('5')).toBe(false);
+    });
+
+    it('does not retry a permanent upload failure', async () => {
+      const { state, blobClient } = await newState();
+      const originalError = new RestError('forbidden', { statusCode: 403 });
+      blobClient.upload.mockRejectedValue(originalError);
+
+      const error = (await expectError(
+        () => state.markPublished('5'),
+        ReleaseError,
+        'Error marking layer 5 as published in persisted release state ' +
+          '(container "release-state" in storage account "mockaccount")',
+        originalError
+      )) as ReleaseError;
+
+      expect(error.retryable).toBe(false);
+      expect(blobClient.upload).toHaveBeenCalledTimes(1);
       expect(state.hasPublished('5')).toBe(false);
     });
   });

--- a/packages/esrp-npm-release/src/__tests__/errorHelpers.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/errorHelpers.test.ts
@@ -1,0 +1,104 @@
+import { RestError } from '@azure/storage-blob';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { MockLogger } from '../__fixtures__/MockLogger.ts';
+import { isRetryableAzureError, isTransientHttpStatus, retryReleaseError } from '../utils/errorHelpers.ts';
+import { ReleaseError } from '../utils/ReleaseError.ts';
+
+describe('isTransientHttpStatus', () => {
+  it.each([408, 429, 500, 503, 599])('returns true for transient status %s', statusCode => {
+    expect(isTransientHttpStatus(statusCode)).toBe(true);
+  });
+
+  it.each([undefined, 400, 401, 403, 404, 409, 499, 600])('returns false for status %s', statusCode => {
+    expect(isTransientHttpStatus(statusCode)).toBe(false);
+  });
+});
+
+describe('isRetryableAzureError', () => {
+  it.each([true, false])('preserves ReleaseError retryable=%s', retryable => {
+    expect(isRetryableAzureError(new ReleaseError('token failure', { retryable }))).toBe(retryable);
+  });
+
+  it.each([RestError.REQUEST_SEND_ERROR, RestError.PARSE_ERROR])('retries pipeline error %s', code => {
+    expect(isRetryableAzureError(new RestError('pipeline failure', { code }))).toBe(true);
+  });
+
+  it.each([408, 429, 500, 503, 599])('retries HTTP status %s', statusCode => {
+    expect(isRetryableAzureError(new RestError('transient response', { statusCode }))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 409, 499])('does not retry HTTP status %s', statusCode => {
+    expect(isRetryableAzureError(new RestError('permanent response', { statusCode }))).toBe(false);
+  });
+
+  it('does not retry an unknown RestError', () => {
+    expect(isRetryableAzureError(new RestError('unknown failure'))).toBe(false);
+  });
+
+  it('does not retry errors outside the Azure SDK', () => {
+    expect(isRetryableAzureError(new Error('unexpected failure'))).toBe(false);
+  });
+});
+
+describe('retryReleaseError', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('retries retryable errors with exponential backoff and returns the successful result', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const logger = new MockLogger();
+    const operation = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new ReleaseError('first failure', { retryable: true }))
+      .mockRejectedValueOnce(new ReleaseError('second failure', { retryable: true }))
+      .mockResolvedValueOnce('success');
+
+    const result = retryReleaseError(logger, attempt => `Test operation ${attempt}`, operation);
+    await jest.advanceTimersByTimeAsync(499);
+    expect(operation).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(operation).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(999);
+    expect(operation).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toBe('success');
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(logger.lines).toEqual([
+      expect.stringContaining('Test operation attempt 1 of 4 failed; retrying in 500ms:'),
+      expect.stringContaining('Test operation attempt 2 of 4 failed; retrying in 1000ms:'),
+    ]);
+  });
+
+  it.each([
+    ['a non-retryable ReleaseError', new ReleaseError('permanent failure', { retryable: false })],
+    ['an unknown error', new Error('unexpected failure')],
+  ])('does not retry %s', async (_description, error) => {
+    const logger = new MockLogger();
+    const operation = jest.fn<() => Promise<void>>().mockRejectedValue(error);
+
+    await expect(retryReleaseError(logger, attempt => `Test operation ${attempt}`, operation)).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(logger.lines).toEqual([]);
+  });
+
+  it('rethrows the last error after four attempts', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const logger = new MockLogger();
+    const error = new ReleaseError('temporary failure', { retryable: true });
+    const operation = jest.fn<() => Promise<void>>().mockRejectedValue(error);
+
+    const result = retryReleaseError(logger, attempt => `Test operation ${attempt}`, operation);
+    result.catch(() => undefined);
+    await jest.runAllTimersAsync();
+
+    await expect(result).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(4);
+    expect(logger.lines).toHaveLength(3);
+    expect(logger.lines[2]).toContain('Test operation attempt 3 of 4 failed; retrying in 2000ms:');
+  });
+});

--- a/packages/esrp-npm-release/src/__tests__/getAadToken.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/getAadToken.test.ts
@@ -8,8 +8,12 @@ import { ReleaseError } from '../utils/ReleaseError.ts';
 
 let lastAuthOptions: NodeAuthOptions | undefined;
 const acquireTokenByClientCredential = jest.fn<ConfidentialClientApplication['acquireTokenByClientCredential']>();
+const { ServerError, AuthError, ClientAuthErrorCodes } = await import('@azure/msal-node');
 
 jest.unstable_mockModule('@azure/msal-node', () => ({
+  ServerError,
+  AuthError,
+  ClientAuthErrorCodes,
   ConfidentialClientApplication: jest.fn((opts: { auth: NodeAuthOptions }) => {
     lastAuthOptions = opts.auth;
     return { acquireTokenByClientCredential };
@@ -122,16 +126,54 @@ describe('getAadToken', () => {
   });
 
   describe('error handling', () => {
-    it('wraps acquireTokenByClientCredential failures with ReleaseError preserving the cause', async () => {
-      const originalError = new Error('oh no');
+    it.each([
+      ['network error', new AuthError(ClientAuthErrorCodes.networkError, '')],
+      ['no network connectivity', new AuthError(ClientAuthErrorCodes.noNetworkConnectivity, '')],
+      ['request timeout', new ServerError('unknown', '', undefined, undefined, undefined, 408)],
+      ['throttling', new ServerError('unknown', '', undefined, undefined, undefined, 429)],
+      ['server HTTP error', new ServerError('unknown', '', undefined, undefined, undefined, 599)],
+    ])('marks transient MSAL %s failures as retryable', async (_description, originalError) => {
       acquireTokenByClientCredential.mockRejectedValue(originalError);
 
-      await expectError(
+      const error = (await expectError(
         () => getAadToken({ ...baseParams, auth: { idToken: 'tok' }, logger }),
         ReleaseError,
         `Failed to acquire token for client "client-id" in tenant "tenant-id" with scope ${JSON.stringify(scopes)}`,
         originalError
-      );
+      )) as ReleaseError;
+
+      expect(error.retryable).toBe(true);
+    });
+
+    it.each([
+      ['invalid client', new ServerError('invalid_client', '')],
+      ['invalid tenant', new ServerError('invalid_tenant', '')],
+      ['invalid scope', new ServerError('invalid_scope', '')],
+      ['non-transient HTTP error', new ServerError('unknown', '', undefined, undefined, undefined, 400)],
+      ['out-of-range HTTP status', new ServerError('unknown', '', undefined, undefined, undefined, 600)],
+    ])('marks permanent MSAL %s failures as non-retryable', async (_description, originalError) => {
+      acquireTokenByClientCredential.mockRejectedValue(originalError);
+
+      const error = (await expectError(
+        () => getAadToken({ ...baseParams, auth: { idToken: 'tok' }, logger }),
+        ReleaseError,
+        `Failed to acquire token for client "client-id" in tenant "tenant-id" with scope ${JSON.stringify(scopes)}`,
+        originalError
+      )) as ReleaseError;
+
+      expect(error.retryable).toBe(false);
+    });
+
+    it('marks unknown token acquisition failures as non-retryable', async () => {
+      acquireTokenByClientCredential.mockRejectedValue(new Error('oh no'));
+
+      const error = (await expectError(
+        () => getAadToken({ ...baseParams, auth: { idToken: 'tok' }, logger }),
+        ReleaseError,
+        'Failed to acquire token'
+      )) as ReleaseError;
+
+      expect(error.retryable).toBe(false);
     });
 
     it('throws ReleaseError when MSAL returns null (no token)', async () => {

--- a/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtures__/testCert.ts';
-import { createNpmReleaseRequest, redactReleaseRequest } from '../esrpApi/npmRelease.ts';
+import { createNpmReleaseRequest, formatReleaseRequestForLog, redactReleaseRequest } from '../esrpApi/npmRelease.ts';
 import { FileHashType, type ReleaseFileInfo, type ReleaseRequestMessage } from '../types/api.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
 
@@ -64,6 +64,27 @@ describe('redactReleaseRequest', () => {
     const redacted = redactReleaseRequest(msg);
     expect(redacted.files![0].tenantFileLocation).toBe(blobUrl);
     expect(redacted.files![0].sourceLocation.blobUrl).toBe(blobUrl);
+  });
+});
+
+describe('formatReleaseRequestForLog', () => {
+  it('formats file hashes on one line while retaining pretty JSON', () => {
+    const message = {
+      files: [
+        {
+          name: 'pkg.tgz',
+          hash: [141, 204, 103, 39],
+          tenantFileLocation: 'https://example.com/file',
+          tenantFileLocationType: 'AzureBlob' as const,
+          sourceLocation: { type: 'azureBlob' as const },
+        },
+      ],
+    };
+
+    const formatted = formatReleaseRequestForLog(message);
+
+    expect(formatted).toContain('\n  "files": [');
+    expect(formatted).toContain('"hash": [141,204,103,39]');
   });
 });
 

--- a/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
@@ -32,6 +32,7 @@ describe('releaseHttp', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   describe('submitRelease', () => {
@@ -48,6 +49,23 @@ describe('releaseHttp', () => {
         body: JSON.stringify(mockRequest),
         signal: expect.anything(),
       });
+    });
+
+    it.each([
+      ['a transient HTTP response', () => makeFetchResponse({ status: 503, body: 'unavailable' })],
+      ['a network error', () => Promise.reject(new Error('fetch failed'))],
+    ])('does not retry or mark %s as retryable', async (_description, getFailure) => {
+      jest.useFakeTimers();
+      fetchMock.mockImplementation(() => Promise.resolve(getFailure()).then(result => result));
+
+      const error = (await expectError(
+        submitRelease({ ...defaultParams, releaseRequest: mockRequest }),
+        ReleaseError,
+        'Failed to submit release'
+      )) as ReleaseError;
+
+      expect(error.retryable).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -79,6 +97,20 @@ describe('releaseHttp', () => {
         signal: expect.anything(),
       });
     });
+
+    it('retries transient failures up to three attempts', async () => {
+      jest.useFakeTimers();
+      fetchMock
+        .mockResolvedValueOnce(makeFetchResponse({ status: 503, body: 'unavailable' }))
+        .mockRejectedValueOnce(new Error('fetch failed'))
+        .mockResolvedValueOnce(makeFetchResponse({ body: '{"foo":"bar"}' }));
+
+      const promise = getReleaseDetails(defaultGetParams);
+      await jest.runAllTimersAsync();
+
+      await expect(promise).resolves.toEqual({ foo: 'bar' });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('error handling', () => {
@@ -96,35 +128,18 @@ describe('releaseHttp', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('retries on transient HTTP status and eventually succeeds', async () => {
-      jest.useFakeTimers();
-      fetchMock
-        .mockResolvedValueOnce(makeFetchResponse({ status: 503, body: 'unavailable' }))
-        .mockResolvedValueOnce(makeFetchResponse({ status: 429, body: 'slow down' }))
-        .mockResolvedValueOnce(makeFetchResponse({ body: '{"status":"pass"}' }));
-
-      const promise = getReleaseStatus(defaultGetParams);
-      await jest.runAllTimersAsync();
-
-      await expect(promise).resolves.toEqual({ status: 'pass' });
-      expect(fetchMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('throws after exhausting retries on transient HTTP status', async () => {
-      jest.useFakeTimers();
+    it('marks a transient HTTP status as retryable without retrying', async () => {
       fetchMock.mockResolvedValue(makeFetchResponse({ status: 500, body: 'internal server error' }));
 
-      const promise = expectError(
+      const err = (await expectError(
         getReleaseStatus(defaultGetParams),
         ReleaseError,
         'Failed to get release status',
-        /failed after 10 attempts[\s\S]*status 500[\s\S]*internal server error/
-      );
-      await jest.runAllTimersAsync();
+        /failed after 1 attempt[\s\S]*status 500[\s\S]*internal server error/
+      )) as ReleaseError;
 
-      const err = (await promise) as ReleaseError;
       expect(err.retryable).toBe(true);
-      expect(fetchMock).toHaveBeenCalledTimes(10);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('throws when response body is not valid JSON', async () => {
@@ -141,35 +156,40 @@ describe('releaseHttp', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('retries on retryable network errors and eventually succeeds', async () => {
+    it('marks an aborted request as retryable without retrying', async () => {
       jest.useFakeTimers();
-      fetchMock
-        .mockRejectedValueOnce(new Error('fetch failed'))
-        .mockRejectedValueOnce(new Error('socket hang up'))
-        .mockResolvedValueOnce(makeFetchResponse({ body: '{"status":"pass"}' }));
+      jest.spyOn(AbortSignal, 'timeout').mockImplementation(milliseconds => {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(new DOMException('Request timed out', 'TimeoutError')), milliseconds);
+        return controller.signal;
+      });
+      fetchMock.mockImplementationOnce((_input, init) => {
+        const signal = init?.signal;
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('unrelated abort message')));
+        });
+      });
 
-      const promise = getReleaseStatus(defaultGetParams);
-      await jest.runAllTimersAsync();
-
-      await expect(promise).resolves.toEqual({ status: 'pass' });
-      expect(fetchMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('throws after exhausting retries', async () => {
-      jest.useFakeTimers();
-      fetchMock.mockRejectedValue(new Error('fetch failed'));
-
-      const promise = expectError(
-        getReleaseStatus(defaultGetParams),
-        ReleaseError,
-        'Failed to get release status',
-        /failed after 10 attempts[\s\S]*fetch failed/
-      );
+      const promise = expectError(getReleaseStatus(defaultGetParams), ReleaseError, 'Failed to get release status');
       await jest.runAllTimersAsync();
 
       const err = (await promise) as ReleaseError;
       expect(err.retryable).toBe(true);
-      expect(fetchMock).toHaveBeenCalledTimes(10);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks a retryable network error without retrying', async () => {
+      fetchMock.mockRejectedValue(new Error('fetch failed'));
+
+      const err = (await expectError(
+        getReleaseStatus(defaultGetParams),
+        ReleaseError,
+        'Failed to get release status',
+        /failed after 1 attempt[\s\S]*fetch failed/
+      )) as ReleaseError;
+
+      expect(err.retryable).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('throws immediately on non-retryable errors without retrying', async () => {
@@ -184,6 +204,22 @@ describe('releaseHttp', () => {
 
       expect(err.retryable).toBe(false);
       expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks failures outside HttpRequestError as non-retryable', async () => {
+      jest.spyOn(AbortSignal, 'timeout').mockImplementation(() => {
+        throw new Error('unexpected timeout setup failure');
+      });
+
+      const err = (await expectError(
+        getReleaseStatus(defaultGetParams),
+        ReleaseError,
+        'Failed to get release status',
+        /unexpected timeout setup failure/
+      )) as ReleaseError;
+
+      expect(err.retryable).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
@@ -85,12 +85,14 @@ describe('releaseHttp', () => {
     it('throws immediately on non-transient HTTP status, including status and body in message', async () => {
       fetchMock.mockResolvedValue(makeFetchResponse({ status: 403, body: 'auth error' }));
 
-      await expectError(
-        () => getReleaseStatus(defaultGetParams),
+      const err = (await expectError(
+        getReleaseStatus(defaultGetParams),
         ReleaseError,
         'Failed to get release status',
         /failed with status 403[\s\S]*auth error/
-      );
+      )) as ReleaseError;
+
+      expect(err.retryable).toBe(false);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
@@ -112,27 +114,30 @@ describe('releaseHttp', () => {
       jest.useFakeTimers();
       fetchMock.mockResolvedValue(makeFetchResponse({ status: 500, body: 'internal server error' }));
 
-      const promise = getReleaseStatus(defaultGetParams).catch(e => e as unknown);
-      await jest.runAllTimersAsync();
-
-      const err = await promise;
-      expect(err).toBeInstanceOf(ReleaseError);
-      expect((err as ReleaseError).message).toBe('Failed to get release status');
-      expect(((err as ReleaseError).cause as Error).message).toMatch(
+      const promise = expectError(
+        getReleaseStatus(defaultGetParams),
+        ReleaseError,
+        'Failed to get release status',
         /failed after 10 attempts[\s\S]*status 500[\s\S]*internal server error/
       );
+      await jest.runAllTimersAsync();
+
+      const err = (await promise) as ReleaseError;
+      expect(err.retryable).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(10);
     });
 
     it('throws when response body is not valid JSON', async () => {
       fetchMock.mockResolvedValue(makeFetchResponse({ body: 'not json' }));
 
-      await expectError(
-        () => getReleaseStatus(defaultGetParams),
+      const err = (await expectError(
+        getReleaseStatus(defaultGetParams),
         ReleaseError,
         'Failed to get release status',
         /did not return valid JSON[\s\S]*not json/
-      );
+      )) as ReleaseError;
+
+      expect(err.retryable).toBe(false);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
@@ -154,25 +159,30 @@ describe('releaseHttp', () => {
       jest.useFakeTimers();
       fetchMock.mockRejectedValue(new Error('fetch failed'));
 
-      const promise = getReleaseStatus(defaultGetParams).catch(e => e as unknown);
+      const promise = expectError(
+        getReleaseStatus(defaultGetParams),
+        ReleaseError,
+        'Failed to get release status',
+        /failed after 10 attempts[\s\S]*fetch failed/
+      );
       await jest.runAllTimersAsync();
 
-      const err = await promise;
-      expect(err).toBeInstanceOf(ReleaseError);
-      expect((err as ReleaseError).message).toBe('Failed to get release status');
-      expect(((err as ReleaseError).cause as Error).message).toMatch(/failed after 10 attempts[\s\S]*fetch failed/);
+      const err = (await promise) as ReleaseError;
+      expect(err.retryable).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(10);
     });
 
     it('throws immediately on non-retryable errors without retrying', async () => {
       fetchMock.mockRejectedValue(new Error('noooooooooooooo'));
 
-      await expectError(
-        () => getReleaseStatus(defaultGetParams),
+      const err = (await expectError(
+        getReleaseStatus(defaultGetParams),
         ReleaseError,
         'Failed to get release status',
         /noooooooooooooo/
-      );
+      )) as ReleaseError;
+
+      expect(err.retryable).toBe(false);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
@@ -183,13 +183,58 @@ describe('runRelease', () => {
     expect(mockReleaseStateCreate).toHaveBeenCalledWith(expect.objectContaining({ repoName: 'bare-repo' }));
   });
 
-  it('propagates failures from createRelease', async () => {
-    const originalError = new Error('oh no');
+  it('retries a failed layer and marks it published after a later attempt succeeds', async () => {
+    jest.useFakeTimers();
+    let firstAttemptStarted!: () => void;
+    const firstAttempt = new Promise<void>(resolve => (firstAttemptStarted = resolve));
+    releaseService.createRelease
+      .mockImplementationOnce(() => {
+        firstAttemptStarted();
+        return Promise.reject(new ReleaseError('temporary failure'));
+      })
+      .mockResolvedValueOnce(undefined);
+    const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
+
+    const release = runRelease({ env, logger });
+    await firstAttempt;
+    await jest.runAllTimersAsync();
+    await release;
+
+    expect(releaseService.createRelease).toHaveBeenCalledTimes(2);
+    expect(state.markPublished).toHaveBeenCalledTimes(1);
+    expect(state.markPublished).toHaveBeenCalledWith('1');
+    expect(logger.lines).toContainEqual(expect.stringContaining('attempt 1 of 4 for layer 1 failed'));
+  });
+
+  it('propagates a layer failure after four attempts', async () => {
+    jest.useFakeTimers();
+    let firstAttemptStarted!: () => void;
+    const firstAttempt = new Promise<void>(resolve => (firstAttemptStarted = resolve));
+    const originalError = new ReleaseError('oh no');
+    releaseService.createRelease.mockImplementation(() => {
+      firstAttemptStarted();
+      return Promise.reject(originalError);
+    });
+    const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
+
+    const release = runRelease({ env, logger }).catch(e => e as unknown);
+    await firstAttempt;
+    await jest.runAllTimersAsync();
+    const err = await release;
+
+    expect(err).toBe(originalError);
+    expect(releaseService.createRelease).toHaveBeenCalledTimes(4);
+    expect(state.markPublished).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a layer after a non-retryable failure', async () => {
+    const originalError = new ReleaseError('invalid release', { retryable: false });
     releaseService.createRelease.mockRejectedValue(originalError);
     const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
 
     const err = await runRelease({ env, logger }).catch(e => e as unknown);
     expect(err).toBe(originalError);
+    expect(releaseService.createRelease).toHaveBeenCalledTimes(1);
     expect(state.markPublished).not.toHaveBeenCalled();
   });
 

--- a/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { createTestFileStructure, expectError, setupTempDir } from '@microsoft/beachball-test-utilities';
+import { createTestFileStructure, setupTempDir } from '@microsoft/beachball-test-utilities';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ESRPReleaseService } from '../ESRPReleaseService.ts';
@@ -14,6 +14,7 @@ import type { ReleaseState } from '../utils/ReleaseState.ts';
 //
 
 jest.unstable_mockModule('@azure/storage-blob', () => ({
+  RestError: jest.requireActual<typeof import('@azure/storage-blob')>('@azure/storage-blob').RestError,
   BlobServiceClient: class {
     public accountName = 'stagingaccount';
   },
@@ -25,8 +26,9 @@ jest.unstable_mockModule('../utils/ReleaseState.ts', () => ({
 }));
 
 const releaseService = { createRelease: jest.fn() } as unknown as jest.Mocked<typeof ESRPReleaseService.prototype>;
+const mockReleaseServiceCreate = jest.fn<typeof ESRPReleaseService.create>();
 jest.unstable_mockModule('../ESRPReleaseService.ts', () => ({
-  ESRPReleaseService: { create: () => releaseService },
+  ESRPReleaseService: { create: mockReleaseServiceCreate },
 }));
 
 jest.unstable_mockModule<typeof import('../auth/getAadToken.ts')>('../auth/getAadToken.ts', () => ({
@@ -82,6 +84,7 @@ describe('runRelease', () => {
     logger = new MockLogger();
     state = makeReleaseState();
     mockReleaseStateCreate.mockImplementation(() => Promise.resolve(state));
+    mockReleaseServiceCreate.mockResolvedValue(releaseService);
   });
 
   afterEach(() => {
@@ -183,47 +186,42 @@ describe('runRelease', () => {
     expect(mockReleaseStateCreate).toHaveBeenCalledWith(expect.objectContaining({ repoName: 'bare-repo' }));
   });
 
-  it('retries a failed layer and marks it published after a later attempt succeeds', async () => {
-    jest.useFakeTimers();
-    let firstAttemptStarted!: () => void;
-    const firstAttempt = new Promise<void>(resolve => (firstAttemptStarted = resolve));
-    releaseService.createRelease
-      .mockImplementationOnce(() => {
-        firstAttemptStarted();
-        return Promise.reject(new ReleaseError('temporary failure'));
-      })
-      .mockResolvedValueOnce(undefined);
-    const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
+  it('passes the logger used for release state retries', async () => {
+    await runRelease({ env: envWithTempPaths({}), logger });
 
-    const release = runRelease({ env, logger });
-    await firstAttempt;
-    await jest.runAllTimersAsync();
-    await release;
-
-    expect(releaseService.createRelease).toHaveBeenCalledTimes(2);
-    expect(state.markPublished).toHaveBeenCalledTimes(1);
-    expect(state.markPublished).toHaveBeenCalledWith('1');
-    expect(logger.lines).toContainEqual(expect.stringContaining('attempt 1 of 4 for layer 1 failed'));
+    expect(mockReleaseStateCreate).toHaveBeenCalledWith(expect.objectContaining({ logger }));
   });
 
-  it('propagates a layer failure after four attempts', async () => {
-    jest.useFakeTimers();
-    let firstAttemptStarted!: () => void;
-    const firstAttempt = new Promise<void>(resolve => (firstAttemptStarted = resolve));
-    const originalError = new ReleaseError('oh no');
-    releaseService.createRelease.mockImplementation(() => {
-      firstAttemptStarted();
-      return Promise.reject(originalError);
-    });
+  it('leaves initialization retries to ESRPReleaseService', async () => {
+    const originalError = new ReleaseError('temporary ESRP failure', { retryable: true });
+    mockReleaseServiceCreate.mockRejectedValue(originalError);
+
+    const error = await runRelease({ env: envWithTempPaths({}), logger }).catch(caught => caught as unknown);
+
+    expect(error).toBe(originalError);
+    expect(mockReleaseServiceCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a non-retryable initialization failure', async () => {
+    const originalError = new ReleaseError('invalid storage configuration', { retryable: false });
+    mockReleaseStateCreate.mockRejectedValue(originalError);
+
+    const error = await runRelease({ env: envWithTempPaths({}), logger }).catch(caught => caught as unknown);
+
+    expect(error).toBe(originalError);
+    expect(mockReleaseStateCreate).toHaveBeenCalledTimes(1);
+    expect(mockReleaseServiceCreate).not.toHaveBeenCalled();
+  });
+
+  it('leaves release retries to ESRPReleaseService', async () => {
+    const originalError = new ReleaseError('oh no', { retryable: true });
+    releaseService.createRelease.mockRejectedValue(originalError);
     const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
 
-    const release = runRelease({ env, logger }).catch(e => e as unknown);
-    await firstAttempt;
-    await jest.runAllTimersAsync();
-    const err = await release;
+    const err = await runRelease({ env, logger }).catch(e => e as unknown);
 
     expect(err).toBe(originalError);
-    expect(releaseService.createRelease).toHaveBeenCalledTimes(4);
+    expect(releaseService.createRelease).toHaveBeenCalledTimes(1);
     expect(state.markPublished).not.toHaveBeenCalled();
   });
 
@@ -236,6 +234,18 @@ describe('runRelease', () => {
     expect(err).toBe(originalError);
     expect(releaseService.createRelease).toHaveBeenCalledTimes(1);
     expect(state.markPublished).not.toHaveBeenCalled();
+  });
+
+  it('does not republish a layer if persisting its completed state fails', async () => {
+    const originalError = new ReleaseError('state write failed', { retryable: true });
+    state.markPublished.mockRejectedValue(originalError);
+    const env = envWithTempPaths({ '1': ['pkg-a.tgz'] });
+
+    const err = await runRelease({ env, logger }).catch(e => e as unknown);
+
+    expect(err).toBe(originalError);
+    expect(releaseService.createRelease).toHaveBeenCalledTimes(1);
+    expect(state.markPublished).toHaveBeenCalledTimes(1);
   });
 
   it('warns and succeeds when no layer directories are found', async () => {
@@ -278,20 +288,21 @@ describe('runRelease', () => {
     expect(logger.lines.some(l => l.includes('_manifest'))).toBe(false);
   });
 
-  it('throws when a layer directory contains no .tgz files', async () => {
+  it('warns and skips a layer directory containing no .tgz files', async () => {
     const env = envWithTempPaths({
       '1': ['pkg-a-1.0.0.tgz'],
       '2': ['README.md'], // no .tgz
     });
 
-    await expectError(
-      () => runRelease({ env, logger }),
-      ReleaseError,
-      /No \.tgz files found in layer directory.*[/\\]2$/
-    );
-    // Layer 1 was released before the failure was hit
+    await expect(runRelease({ env, logger })).resolves.toBeUndefined();
+
     expect(releaseService.createRelease).toHaveBeenCalledTimes(1);
     expect(state.markPublished).toHaveBeenCalledWith('1');
     expect(state.markPublished).not.toHaveBeenCalledWith('2');
+    expect(logger.mocks.warn).toHaveBeenCalledWith(
+      '##vso[task.logissue type=warning]',
+      '[layer-2]',
+      expect.stringMatching(/No \.tgz files found in layer directory.*[/\\]2; skipping layer$/)
+    );
   });
 });

--- a/packages/esrp-npm-release/src/auth/getAadToken.ts
+++ b/packages/esrp-npm-release/src/auth/getAadToken.ts
@@ -1,9 +1,17 @@
 import type { AccessToken } from '@azure/core-auth';
-import { ConfidentialClientApplication, type AuthenticationResult, type NodeAuthOptions } from '@azure/msal-node';
+import {
+  AuthError,
+  ClientAuthErrorCodes,
+  ConfidentialClientApplication,
+  ServerError,
+  type AuthenticationResult,
+  type NodeAuthOptions,
+} from '@azure/msal-node';
 import type { Logger } from '../utils/Logger.ts';
 import type { ReleaseHttpParams } from '../esrpApi/releaseHttp.ts';
 import { getKeyAndCertificatesFromPFX, getThumbprint } from './signing.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
+import { isTransientHttpStatus } from '../utils/errorHelpers.ts';
 
 export interface GetAadTokenParams extends Pick<ReleaseHttpParams, 'clientId'> {
   tenantId: string;
@@ -38,7 +46,7 @@ export async function getAadToken(params: GetAadTokenParams): Promise<AccessToke
         x5c: certificates[0],
       };
     } catch (err) {
-      throw new ReleaseError(`Error parsing cert info to acquire token`, { cause: err });
+      throw new ReleaseError(`Error parsing cert info to acquire token`, { cause: err, retryable: false });
     }
   }
 
@@ -48,11 +56,11 @@ export async function getAadToken(params: GetAadTokenParams): Promise<AccessToke
     const cca = new ConfidentialClientApplication({ auth: authOptions });
     result = await cca.acquireTokenByClientCredential({ scopes });
   } catch (ex) {
-    throw new ReleaseError(errorMessageBase, { cause: ex });
+    throw new ReleaseError(errorMessageBase, { cause: ex, retryable: isTransientMsalError(ex) });
   }
 
   if (!result || !result.expiresOn) {
-    throw new ReleaseError(`${errorMessageBase}: no result returned`);
+    throw new ReleaseError(`${errorMessageBase}: no result returned`, { retryable: false });
   }
 
   return {
@@ -60,4 +68,16 @@ export async function getAadToken(params: GetAadTokenParams): Promise<AccessToke
     expiresOnTimestamp: result.expiresOn.getTime(),
     refreshAfterTimestamp: result.refreshOn?.getTime(),
   };
+}
+
+function isTransientMsalError(error: unknown): boolean {
+  if (!(error instanceof AuthError)) {
+    return false;
+  }
+
+  return (
+    error.errorCode === ClientAuthErrorCodes.networkError ||
+    error.errorCode === ClientAuthErrorCodes.noNetworkConnectivity ||
+    (error instanceof ServerError && isTransientHttpStatus(error.status))
+  );
 }

--- a/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
+++ b/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
@@ -61,7 +61,7 @@ export async function createNpmReleaseRequest(
     // Hash the file with a stream--most package tarballs are small, but some are not
     hash = await hashFileStream('sha256', file.path);
   } catch (err) {
-    throw new ReleaseError(`Failed to stat or hash file ${file.path}`, { cause: err });
+    throw new ReleaseError(`Failed to stat or hash file ${file.path}`, { cause: err, retryable: false });
   }
 
   const message: Omit<GeneratedReleaseRequestMessage, 'jwsToken'> = {
@@ -115,7 +115,7 @@ export async function createNpmReleaseRequest(
     });
     return { ...message, jwsToken };
   } catch (err) {
-    throw new ReleaseError(`Failed to generate JWS token for release request`, { cause: err });
+    throw new ReleaseError(`Failed to generate JWS token for release request`, { cause: err, retryable: false });
   }
 }
 

--- a/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
+++ b/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
@@ -134,3 +134,22 @@ export function redactReleaseRequest<TMessage extends Pick<ReleaseRequestMessage
   }));
   return message;
 }
+
+/** Redact a release message and format file hash arrays compactly for logging. */
+export function formatReleaseRequestForLog<TMessage extends Pick<ReleaseRequestMessage, 'files' | 'jwsToken'>>(
+  message: TMessage
+): string {
+  const redacted = redactReleaseRequest(message);
+  const hashes: (number[] | string)[] = [];
+  redacted.files = redacted.files?.map(file => {
+    const hashPlaceholder = `__ESRP_FILE_HASH_${hashes.length}__`;
+    hashes.push(file.hash);
+    return { ...file, hash: hashPlaceholder };
+  });
+
+  let formatted = JSON.stringify(redacted, null, 2);
+  hashes.forEach((hash, index) => {
+    formatted = formatted.replace(JSON.stringify(`__ESRP_FILE_HASH_${index}__`), JSON.stringify(hash));
+  });
+  return formatted;
+}

--- a/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
+++ b/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
@@ -5,6 +5,7 @@ import type {
   ReleaseDetailsMessage,
 } from '../types/api.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
+import { isTransientHttpStatus } from '../utils/errorHelpers.ts';
 
 export interface ReleaseHttpParams {
   /** ESRP onboarded AAD app client ID */
@@ -24,6 +25,9 @@ const esrpBaseUrl = `https://${esrpApiDomain}/api/v3/releaseservices/clients/`;
 /**
  * Submit a release request.
  * Throws a `ReleaseError` if the request fails or the response can't be parsed.
+ *
+ * This only attempts to submit the request once: the meaning of a failed submit request is unclear,
+ * so the safest retry approach is for the user to re-run the stage.
  */
 export async function submitRelease(
   params: Omit<ReleaseHttpParams, 'releaseId'> & { releaseRequest: ReleaseRequestMessage }
@@ -39,7 +43,8 @@ export async function submitRelease(
       body: releaseRequest,
     });
   } catch (err) {
-    throw new ReleaseError(`Failed to submit release`, { cause: err, retryable: isRetryableHttpError(err) });
+    // see function comment for why it doesn't retry
+    throw new ReleaseError(`Failed to submit release`, { cause: err, retryable: false });
   }
 
   if (!response.operationId) {
@@ -53,6 +58,8 @@ export async function submitRelease(
 /**
  * Get the status of a release request.
  * Throws a `ReleaseError` if the request fails or the response can't be parsed.
+ *
+ * This will only attempt to get the status once, and callers can handle retryable errors.
  */
 export async function getReleaseStatus(params: ReleaseHttpParams): Promise<ReleaseResultMessage> {
   const { clientId, bearerToken, releaseId } = params;
@@ -64,12 +71,15 @@ export async function getReleaseStatus(params: ReleaseHttpParams): Promise<Relea
       method: 'GET',
     });
   } catch (err) {
-    throw new ReleaseError(`Failed to get release status`, { cause: err, retryable: isRetryableHttpError(err) });
+    throw new ReleaseError(`Failed to get release status`, {
+      cause: err,
+      retryable: err instanceof HttpRequestError && err.retryable,
+    });
   }
 }
 
 /**
- * Get the details of a release request.
+ * Get the details of a release request, with retries on transient request failures.
  * Throws an `Error` (not `ReleaseError`) if the request fails or the response can't be parsed.
  */
 export function getReleaseDetails(params: ReleaseHttpParams): Promise<ReleaseDetailsMessage> {
@@ -79,38 +89,39 @@ export function getReleaseDetails(params: ReleaseHttpParams): Promise<ReleaseDet
     apiUrl: `${esrpBaseUrl}${clientId}/workflows/release/operations/grd/${releaseId}`,
     bearerToken,
     method: 'GET',
+    maxAttempts: 3,
   });
 }
 
 class HttpRequestError extends Error {
   public readonly retryable: boolean;
-  public constructor(message: string, retryable: boolean, options?: ErrorOptions) {
+  public constructor(message: string, options: ErrorOptions & { retryable: boolean }) {
     super(message, options);
-    this.retryable = retryable;
+    this.retryable = options.retryable;
   }
 }
 
-function isRetryableHttpError(error: unknown): boolean {
-  return error instanceof HttpRequestError ? error.retryable : true;
-}
-
+/**
+ * Perform an HTTP request, optionally with automatic retries for transient errors.
+ */
 async function doHttpRequest<TResult>(
   params: Pick<ReleaseHttpParams, 'bearerToken'> & {
     apiUrl: string;
     method: 'GET' | 'POST';
     body?: object;
+    maxAttempts?: number;
   }
 ): Promise<TResult> {
-  const { apiUrl, bearerToken, method } = params;
+  const { apiUrl, bearerToken, method, maxAttempts = 1 } = params;
 
   const body = params.body && JSON.stringify(params.body);
 
-  const maxRetries = 10;
   let lastError = '';
   let responseText = '';
 
-  for (let run = 1; run <= maxRetries; run++) {
+  for (let run = 1; run <= maxAttempts; run++) {
     let response: Response | undefined;
+    const signal = AbortSignal.timeout(60_000);
     try {
       // start the request - resolves when headers are received, and rejects on initial network errors
       response = await fetch(apiUrl, {
@@ -120,7 +131,7 @@ async function doHttpRequest<TResult>(
           ...(body && { 'Content-Type': 'application/json' }),
         },
         ...(body && { body }),
-        signal: AbortSignal.timeout(60_000),
+        signal,
       });
       // wait for the whole response body
       responseText = await response.text();
@@ -131,30 +142,31 @@ async function doHttpRequest<TResult>(
       const message = (err as Error).message || String(err);
       // retry on transient errors, throw otherwise
       if (
-        !/fetch failed|terminated|aborted|timeout|TimeoutError|Timeout Error|RestError|Client network socket disconnected|socket hang up|ECONNRESET/i.test(
-          message
-        )
+        !signal.aborted &&
+        !/fetch failed|terminated|timeout|RestError|socket disconnected|socket hang up|ECONNRESET/i.test(message)
       ) {
-        throw new HttpRequestError(`Request to ${apiUrl} failed: ${message}`, false, { cause: err });
+        throw new HttpRequestError(`Request to ${apiUrl} failed: ${message}`, { retryable: false, cause: err });
       }
       lastError = message;
     }
 
     if (response) {
       const status = response.status;
-      // ignore transient errors: 408 Request Timeout, 429 Too Many Requests, and any 5xx
-      if (!(status === 408 || status === 429 || (status >= 500 && status < 600))) {
+      // ignore transient errors
+      if (!isTransientHttpStatus(status)) {
         // Intentionally not a ReleaseError so caller can add more context
-        throw new HttpRequestError(`Request to ${apiUrl} failed with status ${status}:\n${responseText}`, false);
+        throw new HttpRequestError(`Request to ${apiUrl} failed with status ${status}:\n${responseText}`, {
+          retryable: false,
+        });
       } else {
         lastError = `status ${status}: ${responseText}`;
       }
     }
 
-    if (run === maxRetries) {
+    if (run === maxAttempts) {
       throw new HttpRequestError(
-        `Request to ${apiUrl} failed after ${maxRetries} attempts. Last error:\n${lastError}`,
-        true
+        `Request to ${apiUrl} failed after ${maxAttempts} attempts. Last error:\n${lastError}`,
+        { retryable: true }
       );
     }
 
@@ -168,7 +180,7 @@ async function doHttpRequest<TResult>(
   } catch {
     throw new HttpRequestError(
       `Request to ${apiUrl} succeeded but did not return valid JSON. Received:\n${responseText}`,
-      false
+      { retryable: false }
     );
   }
 }

--- a/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
+++ b/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
@@ -148,6 +148,8 @@ async function doHttpRequest<TResult>(
         throw new HttpRequestError(`Request to ${apiUrl} failed: ${message}`, { retryable: false, cause: err });
       }
       lastError = message;
+      // Clear the response in case fetch() resolved but response.text() rejected on a network error
+      response = undefined;
     }
 
     if (response) {

--- a/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
+++ b/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
@@ -39,12 +39,12 @@ export async function submitRelease(
       body: releaseRequest,
     });
   } catch (err) {
-    throw new ReleaseError(`Failed to submit release`, { cause: err });
+    throw new ReleaseError(`Failed to submit release`, { cause: err, retryable: isRetryableHttpError(err) });
   }
 
   if (!response.operationId) {
     // probably impossible?
-    throw new ReleaseError('Missing operationId on submitReleaseResult');
+    throw new ReleaseError('Missing operationId on submitReleaseResult', { retryable: false });
   }
 
   return response as ReleaseSubmitResponse & Required<Pick<ReleaseSubmitResponse, 'operationId'>>;
@@ -64,7 +64,7 @@ export async function getReleaseStatus(params: ReleaseHttpParams): Promise<Relea
       method: 'GET',
     });
   } catch (err) {
-    throw new ReleaseError(`Failed to get release status`, { cause: err });
+    throw new ReleaseError(`Failed to get release status`, { cause: err, retryable: isRetryableHttpError(err) });
   }
 }
 
@@ -80,6 +80,18 @@ export function getReleaseDetails(params: ReleaseHttpParams): Promise<ReleaseDet
     bearerToken,
     method: 'GET',
   });
+}
+
+class HttpRequestError extends Error {
+  public readonly retryable: boolean;
+  public constructor(message: string, retryable: boolean, options?: ErrorOptions) {
+    super(message, options);
+    this.retryable = retryable;
+  }
+}
+
+function isRetryableHttpError(error: unknown): boolean {
+  return error instanceof HttpRequestError ? error.retryable : true;
 }
 
 async function doHttpRequest<TResult>(
@@ -123,8 +135,7 @@ async function doHttpRequest<TResult>(
           message
         )
       ) {
-        // Intentionally not a ReleaseError so caller can add more context
-        throw new Error(`Request to ${apiUrl} failed: ${message}`, { cause: err });
+        throw new HttpRequestError(`Request to ${apiUrl} failed: ${message}`, false, { cause: err });
       }
       lastError = message;
     }
@@ -134,14 +145,17 @@ async function doHttpRequest<TResult>(
       // ignore transient errors: 408 Request Timeout, 429 Too Many Requests, and any 5xx
       if (!(status === 408 || status === 429 || (status >= 500 && status < 600))) {
         // Intentionally not a ReleaseError so caller can add more context
-        throw new Error(`Request to ${apiUrl} failed with status ${status}:\n${responseText}`);
+        throw new HttpRequestError(`Request to ${apiUrl} failed with status ${status}:\n${responseText}`, false);
       } else {
         lastError = `status ${status}: ${responseText}`;
       }
     }
 
     if (run === maxRetries) {
-      throw new Error(`Request to ${apiUrl} failed after ${maxRetries} attempts. Last error:\n${lastError}`);
+      throw new HttpRequestError(
+        `Request to ${apiUrl} failed after ${maxRetries} attempts. Last error:\n${lastError}`,
+        true
+      );
     }
 
     // schedule a retry (maximum delay is ~3 seconds)
@@ -152,6 +166,9 @@ async function doHttpRequest<TResult>(
   try {
     return JSON.parse(responseText) as TResult;
   } catch {
-    throw new Error(`Request to ${apiUrl} succeeded but did not return valid JSON. Received:\n${responseText}`);
+    throw new HttpRequestError(
+      `Request to ${apiUrl} succeeded but did not return valid JSON. Received:\n${responseText}`,
+      false
+    );
   }
 }

--- a/packages/esrp-npm-release/src/runRelease.ts
+++ b/packages/esrp-npm-release/src/runRelease.ts
@@ -43,14 +43,17 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
           logger.error(
             `Error acquiring token for staging storage account "${env.staging.storageAccountName}":\n${err.getMessageWithCause()}`
           );
-          throw new ReleaseError('Error acquiring token (see above)', { alreadyLogged: true });
+          throw new ReleaseError('Error acquiring token (see above)', {
+            alreadyLogged: true,
+            retryable: err.retryable,
+          });
         });
       },
     });
   } catch (err) {
     throw new ReleaseError(
       `Failed to initialize BlobServiceClient for staging storage account "${env.staging.storageAccountName}"`,
-      { cause: err }
+      { cause: err, retryable: false }
     );
   }
 
@@ -66,6 +69,7 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
     buildSourceVersion: env.ado.buildSourceVersion,
     productName: env.esrp.productName,
     npmTag: env.esrp.npmTag,
+    logger,
   });
   logger.log(`Release state loaded: ${state.publishedCount} layer(s) already published`);
 
@@ -117,7 +121,9 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
       .filter(file => file.endsWith('.tgz'))
       .map(file => path.join(layerDir, file));
     if (!tgzFiles.length) {
-      throw new ReleaseError(`No .tgz files found in layer directory ${layerDir}`);
+      logger.warn(`No .tgz files found in layer directory ${layerDir}; skipping layer`);
+      logger.endGroup();
+      continue;
     }
 
     const zipPath = path.join(zipsDir, `${layerPrefix}-${Date.now()}.zip`);
@@ -133,64 +139,41 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
       }
       zipfile.end();
     }).catch(err => {
-      throw new ReleaseError(`Error creating zip file for layer ${layerNum}`, { cause: err });
+      throw new ReleaseError(`Error creating zip file for layer ${layerNum}`, { cause: err, retryable: false });
     });
 
-    await retryLayer(layerNum, logger, async () => {
-      logger.log(`Submitting release for layer ${layerNum} via ESRP`);
-      // From testing, this succeeds even if the versions already exist in the registry,
-      // with no way to distinguish...
-      await releaseService.createRelease({
-        filePath: zipPath,
-        repoName,
-        releaseRequestParams: {
-          createdBy: env.esrp.createdBy,
-          driEmail: env.esrp.driEmail,
-          owners: env.esrp.owners,
-          approvers: env.esrp.approvers,
-          productInfo: {
-            name: env.esrp.productName,
-            // This is an arbitrary string, not used as the published version
-            version: `${env.ado.buildSourceVersion}-${layerNum}`,
-            description: `${env.esrp.productName} packages - ${layerNum}`,
-          },
-          releaseTitle: env.esrp.productName,
-          npmTag: env.esrp.npmTag,
+    logger.log(`Submitting release for layer ${layerNum} via ESRP`);
+    // From testing, this succeeds even if the versions already exist in the registry,
+    // with no way to distinguish...
+    await releaseService.createRelease({
+      filePath: zipPath,
+      repoName,
+      releaseRequestParams: {
+        createdBy: env.esrp.createdBy,
+        driEmail: env.esrp.driEmail,
+        owners: env.esrp.owners,
+        approvers: env.esrp.approvers,
+        productInfo: {
+          name: env.esrp.productName,
+          // This is an arbitrary string, not used as the published version
+          version: `${env.ado.buildSourceVersion}-${layerNum}`,
+          description: `${env.esrp.productName} packages - ${layerNum}`,
         },
-      });
-      logger.log('📦 Packages were successfully published to npm');
-
-      // This is done AFTER piercing to prevent silently trying to re-publish the same versions
-      // if there's a failure in any later step (since ESRP won't error on re-publishes)
-      logger.log(`Marking layer as published in release state`);
-      await state.markPublished(layerNum);
+        releaseTitle: env.esrp.productName,
+        npmTag: env.esrp.npmTag,
+      },
     });
+    logger.log('📦 Packages were successfully published to npm');
+
+    // TODO: ideally we would pierce the package into the feed here, but the build token may not have
+    // packaging "write" permissions
+
+    // Mark as published outside the retries so we only do it once.
+    logger.log(`Marking layer as published in release state`);
+    await state.markPublished(layerNum);
 
     logger.endGroup();
   }
 
   logger.log(`All ${state.publishedCount} artifacts published!`);
-}
-
-const maxLayerAttempts = 4;
-
-async function retryLayer(layerNum: string, logger: Logger, release: () => Promise<void>): Promise<void> {
-  for (let attempt = 1; attempt <= maxLayerAttempts; attempt++) {
-    try {
-      await release();
-      return;
-    } catch (error) {
-      if (!(error instanceof ReleaseError) || !error.retryable || attempt === maxLayerAttempts) {
-        throw error;
-      }
-
-      const baseDelay = 1000 * 2 ** (attempt - 1);
-      const delay = Math.floor(baseDelay / 2 + Math.random() * (baseDelay / 2));
-      logger.warn(
-        `Release attempt ${attempt} of ${maxLayerAttempts} for layer ${layerNum} failed; ` + `retrying in ${delay}ms:`,
-        error
-      );
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
 }

--- a/packages/esrp-npm-release/src/runRelease.ts
+++ b/packages/esrp-npm-release/src/runRelease.ts
@@ -109,7 +109,7 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
     }
 
     const layerPrefix = 'layer-' + layerNum;
-    logger.startGroup(layerPrefix, `Starting release for layer ${layerNum} of ${layers.length}`);
+    logger.startGroup(layerPrefix, `Releasing layer ${layerNum} of ${layers.length}`);
 
     const layerDir = path.join(env.packedPackagesPath, layerNum);
     const tgzFiles = fs
@@ -136,37 +136,61 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
       throw new ReleaseError(`Error creating zip file for layer ${layerNum}`, { cause: err });
     });
 
-    logger.log(`Submitting release for layer ${layerNum} via ESRP`);
-    // From testing, this succeeds even if the versions already exist in the registry,
-    // with no way to distinguish...
-    await releaseService.createRelease({
-      filePath: zipPath,
-      repoName,
-      releaseRequestParams: {
-        createdBy: env.esrp.createdBy,
-        driEmail: env.esrp.driEmail,
-        owners: env.esrp.owners,
-        approvers: env.esrp.approvers,
-        productInfo: {
-          name: env.esrp.productName,
-          // This is an arbitrary string, not used as the published version
-          version: `${env.ado.buildSourceVersion}-${layerNum}`,
-          description: `${env.esrp.productName} packages - ${layerNum}`,
+    await retryLayer(layerNum, logger, async () => {
+      logger.log(`Submitting release for layer ${layerNum} via ESRP`);
+      // From testing, this succeeds even if the versions already exist in the registry,
+      // with no way to distinguish...
+      await releaseService.createRelease({
+        filePath: zipPath,
+        repoName,
+        releaseRequestParams: {
+          createdBy: env.esrp.createdBy,
+          driEmail: env.esrp.driEmail,
+          owners: env.esrp.owners,
+          approvers: env.esrp.approvers,
+          productInfo: {
+            name: env.esrp.productName,
+            // This is an arbitrary string, not used as the published version
+            version: `${env.ado.buildSourceVersion}-${layerNum}`,
+            description: `${env.esrp.productName} packages - ${layerNum}`,
+          },
+          releaseTitle: env.esrp.productName,
+          npmTag: env.esrp.npmTag,
         },
-        releaseTitle: env.esrp.productName,
-        npmTag: env.esrp.npmTag,
-      },
-    });
-    logger.log('📦 Packages were successfully published to npm');
+      });
+      logger.log('📦 Packages were successfully published to npm');
 
-    // This is done AFTER piercing to prevent silently trying to re-publish the same versions
-    // if there's a failure in any later step (since ESRP won't error on re-publishes)
-    logger.log(`Marking layer as published in release state`);
-    await state.markPublished(layerNum);
+      // This is done AFTER piercing to prevent silently trying to re-publish the same versions
+      // if there's a failure in any later step (since ESRP won't error on re-publishes)
+      logger.log(`Marking layer as published in release state`);
+      await state.markPublished(layerNum);
+    });
 
     logger.endGroup();
-    logger.log(`✅ layer ${layerNum}`);
   }
 
   logger.log(`All ${state.publishedCount} artifacts published!`);
+}
+
+const maxLayerAttempts = 4;
+
+async function retryLayer(layerNum: string, logger: Logger, release: () => Promise<void>): Promise<void> {
+  for (let attempt = 1; attempt <= maxLayerAttempts; attempt++) {
+    try {
+      await release();
+      return;
+    } catch (error) {
+      if (!(error instanceof ReleaseError) || !error.retryable || attempt === maxLayerAttempts) {
+        throw error;
+      }
+
+      const baseDelay = 1000 * 2 ** (attempt - 1);
+      const delay = Math.floor(baseDelay / 2 + Math.random() * (baseDelay / 2));
+      logger.warn(
+        `Release attempt ${attempt} of ${maxLayerAttempts} for layer ${layerNum} failed; ` + `retrying in ${delay}ms:`,
+        error
+      );
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
 }

--- a/packages/esrp-npm-release/src/types/api.ts
+++ b/packages/esrp-npm-release/src/types/api.ts
@@ -228,6 +228,7 @@ export interface ReleaseResultMessage {
   lastModifiedAt?: string;
   operationId?: string;
   releaseError?: ReleaseError;
+  releaseVersion?: number;
   requestSubmittedAt?: string;
   routedRegion?: string;
   status?: StatusCode;

--- a/packages/esrp-npm-release/src/utils/Logger.ts
+++ b/packages/esrp-npm-release/src/utils/Logger.ts
@@ -3,6 +3,7 @@ export type LogMethod = 'log' | 'warn' | 'error';
 export class Logger {
   #prefix: string | undefined;
   #console: Pick<typeof console, LogMethod>;
+  #groupStartTime: number | undefined;
 
   public constructor(prefix?: string, consoleImpl?: Pick<typeof console, LogMethod>) {
     this.#prefix = prefix;
@@ -17,11 +18,20 @@ export class Logger {
   public startGroup(prefix: string | undefined, title: string): void {
     this.#console.log(`##[group]${title}`);
     this.#prefix = prefix;
+    this.#groupStartTime = Date.now();
   }
 
+  /**
+   * End the logging group, then log a separate line with the duration.
+   */
   public endGroup(): void {
-    this.#console.log('##[endgroup]');
+    const groupDuration = this.#groupStartTime && formatDuration(Date.now() - this.#groupStartTime);
+    this.#groupStartTime = undefined;
     this.#prefix = undefined;
+
+    this.#console.log(`##[endgroup]`);
+    groupDuration && this.#console.log(`completed in ${groupDuration}`);
+    this.#console.log('');
   }
 
   /** Log a prefixed message */
@@ -38,4 +48,16 @@ export class Logger {
   public error(...args: unknown[]): void {
     this.#console.error(`##vso[task.logissue type=error]`, ...this.prefix, ...args);
   }
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+
+  const totalSeconds = Math.round(durationMs / 1_000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return minutes ? `${minutes}m ${seconds}s` : `${totalSeconds}s`;
 }

--- a/packages/esrp-npm-release/src/utils/ReleaseError.ts
+++ b/packages/esrp-npm-release/src/utils/ReleaseError.ts
@@ -11,12 +11,18 @@
 export class ReleaseError extends Error {
   /** If true, detailed error info was already logged via console.error before throwing. */
   public alreadyLogged: boolean;
-  /** Whether retrying the current release layer may succeed. Defaults to true. */
+  /** Whether retrying the current release layer may succeed. */
   public retryable: boolean;
 
   public constructor(
     message: string,
-    options?: {
+    options: {
+      /**
+       * Whether retrying the current release layer may succeed.
+       * Generally, network errors should be retryable.
+       * Things that might indicate invalid input, permission issues, or code bugs should not.
+       */
+      retryable: boolean;
       /** If true, the exit handler won't log anything */
       alreadyLogged?: boolean;
       /**
@@ -24,14 +30,12 @@ export class ReleaseError extends Error {
        * is not set.
        */
       cause?: unknown;
-      /** Whether retrying the current release layer may succeed. */
-      retryable?: boolean;
     }
   ) {
-    super(message, { cause: options?.cause });
+    super(message, { cause: options.cause });
     this.name = 'ReleaseError';
-    this.alreadyLogged = !!options?.alreadyLogged;
-    this.retryable = options?.retryable ?? true;
+    this.alreadyLogged = !!options.alreadyLogged;
+    this.retryable = options.retryable;
   }
 
   public getMessageWithCause(): string {

--- a/packages/esrp-npm-release/src/utils/ReleaseError.ts
+++ b/packages/esrp-npm-release/src/utils/ReleaseError.ts
@@ -11,6 +11,8 @@
 export class ReleaseError extends Error {
   /** If true, detailed error info was already logged via console.error before throwing. */
   public alreadyLogged: boolean;
+  /** Whether retrying the current release layer may succeed. Defaults to true. */
+  public retryable: boolean;
 
   public constructor(
     message: string,
@@ -22,11 +24,14 @@ export class ReleaseError extends Error {
        * is not set.
        */
       cause?: unknown;
+      /** Whether retrying the current release layer may succeed. */
+      retryable?: boolean;
     }
   ) {
     super(message, { cause: options?.cause });
     this.name = 'ReleaseError';
     this.alreadyLogged = !!options?.alreadyLogged;
+    this.retryable = options?.retryable ?? true;
   }
 
   public getMessageWithCause(): string {

--- a/packages/esrp-npm-release/src/utils/ReleaseState.ts
+++ b/packages/esrp-npm-release/src/utils/ReleaseState.ts
@@ -1,6 +1,8 @@
 import type { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
 import type { AdoEnvOptions, EsrpEnvOptions } from '../types/EnvOptions.ts';
 import { ReleaseError } from './ReleaseError.ts';
+import { isRetryableAzureError, retryReleaseError } from './errorHelpers.ts';
+import type { Logger } from './Logger.ts';
 
 const stateContainerName = 'release-state';
 
@@ -29,6 +31,7 @@ export class ReleaseState {
   #publishedLayers: Set<string>;
   #containerClient: ContainerClient;
   #prefix: string;
+  #logger: Logger;
 
   /**
    * Initialize the ReleaseState from persisted state in Azure Blob Storage, loading the list of
@@ -41,39 +44,53 @@ export class ReleaseState {
         /** Repo name only (no organization) */
         repoName: string;
         blobServiceClient: BlobServiceClient;
+        logger: Logger;
       }
   ): Promise<ReleaseState> {
-    const { blobServiceClient, repoName, buildSourceVersion: sourceVersion, productName, npmTag } = params;
+    const { blobServiceClient, repoName, buildSourceVersion: sourceVersion, productName, npmTag, logger } = params;
     const desc = getContainerDesc(blobServiceClient.accountName);
 
-    let containerClient: ContainerClient;
-    try {
-      containerClient = blobServiceClient.getContainerClient(stateContainerName);
-    } catch (err) {
-      throw new ReleaseError(`Error initializing client for ${desc}`, { cause: err });
-    }
+    return await retryReleaseError(
+      logger,
+      attempt => `Release state initialization ${attempt}`,
+      async () => {
+        let containerClient: ContainerClient;
+        try {
+          containerClient = blobServiceClient.getContainerClient(stateContainerName);
+        } catch (err) {
+          throw new ReleaseError(`Error initializing client for ${desc}`, { cause: err, retryable: false });
+        }
 
-    await containerClient.createIfNotExists().catch(err => {
-      throw new ReleaseError(`Error creating or accessing ${desc}`, { cause: err });
-    });
+        await containerClient.createIfNotExists().catch(err => {
+          throw new ReleaseError(`Error creating or accessing ${desc}`, {
+            cause: err,
+            retryable: isRetryableAzureError(err),
+          });
+        });
 
-    const prefix = `${repoName}/${sourceVersion}/${productName}/${npmTag ? `${npmTag}/` : ''}`;
-    const publishedLayers = new Set<string>();
-    try {
-      for await (const blob of containerClient.listBlobsFlat({ prefix })) {
-        publishedLayers.add(blob.name.slice(prefix.length));
+        const prefix = `${repoName}/${sourceVersion}/${productName}/${npmTag ? `${npmTag}/` : ''}`;
+        const publishedLayers = new Set<string>();
+        try {
+          for await (const blob of containerClient.listBlobsFlat({ prefix })) {
+            publishedLayers.add(blob.name.slice(prefix.length));
+          }
+        } catch (err) {
+          throw new ReleaseError(`Error listing blobs with prefix "${prefix}" in ${desc}`, {
+            cause: err,
+            retryable: isRetryableAzureError(err),
+          });
+        }
+
+        return new ReleaseState(containerClient, prefix, publishedLayers, logger);
       }
-    } catch (err) {
-      throw new ReleaseError(`Error listing blobs with prefix "${prefix}" in ${desc}`, { cause: err });
-    }
-
-    return new ReleaseState(containerClient, prefix, publishedLayers);
+    );
   }
 
-  private constructor(containerClient: ContainerClient, prefix: string, publishedLayers: Set<string>) {
+  private constructor(containerClient: ContainerClient, prefix: string, publishedLayers: Set<string>, logger: Logger) {
     this.#containerClient = containerClient;
     this.#prefix = prefix;
     this.#publishedLayers = publishedLayers;
+    this.#logger = logger;
   }
 
   /** Number of layers published */
@@ -89,16 +106,22 @@ export class ReleaseState {
   /** Marks the layer as published (throws `ReleaseError` on any issue) */
   public async markPublished(layerNum: string): Promise<void> {
     const blobName = this.#prefix + layerNum;
-    try {
-      const blobClient = this.#containerClient.getBlockBlobClient(blobName);
-      await blobClient.upload('', 0);
-      this.#publishedLayers.add(layerNum);
-    } catch (err) {
-      throw new ReleaseError(
-        `Error marking layer ${layerNum} as published in persisted release state ` +
-          `(${getContainerDesc(this.#containerClient.accountName)})`,
-        { cause: err }
-      );
-    }
+    await retryReleaseError(
+      this.#logger,
+      attempt => `Persisting release state for layer ${layerNum} ${attempt}`,
+      async () => {
+        try {
+          const blobClient = this.#containerClient.getBlockBlobClient(blobName);
+          await blobClient.upload('', 0);
+          this.#publishedLayers.add(layerNum);
+        } catch (err) {
+          throw new ReleaseError(
+            `Error marking layer ${layerNum} as published in persisted release state ` +
+              `(${getContainerDesc(this.#containerClient.accountName)})`,
+            { cause: err, retryable: isRetryableAzureError(err) }
+          );
+        }
+      }
+    );
   }
 }

--- a/packages/esrp-npm-release/src/utils/errorHelpers.ts
+++ b/packages/esrp-npm-release/src/utils/errorHelpers.ts
@@ -1,0 +1,60 @@
+import { RestError } from '@azure/storage-blob';
+import { ReleaseError } from './ReleaseError';
+import type { Logger } from './Logger';
+
+/** Returns whether an HTTP status indicates a transient failure. */
+export function isTransientHttpStatus(statusCode: number | undefined): boolean {
+  return (
+    statusCode === 408 || statusCode === 429 || (statusCode !== undefined && statusCode >= 500 && statusCode < 600)
+  );
+}
+
+/** Returns whether an Azure operation failed for a transient reason. */
+export function isRetryableAzureError(error: unknown): boolean {
+  if (error instanceof ReleaseError) {
+    return error.retryable;
+  }
+
+  return (
+    error instanceof RestError &&
+    (error.code === RestError.REQUEST_SEND_ERROR ||
+      error.code === RestError.PARSE_ERROR ||
+      isTransientHttpStatus(error.statusCode))
+  );
+}
+
+const maxAttempts = 4;
+
+/**
+ * Runs an operation up to four times, retrying only explicitly retryable `ReleaseError`s with
+ * exponential backoff and jitter starting from a one-second base delay. All other errors are
+ * rethrown immediately.
+ */
+export async function retryReleaseError<T>(
+  logger: Logger,
+  getAttemptDescription: (
+    /** Will be `attempt X of Y` */
+    attempt: string
+  ) => string,
+  operation: () => Promise<T>
+): Promise<T> {
+  let attempt = 1;
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!(error instanceof ReleaseError) || !error.retryable || attempt === maxAttempts) {
+        throw error;
+      }
+
+      const baseDelay = 1000 * 2 ** (attempt - 1);
+      const delay = Math.floor(baseDelay / 2 + Math.random() * (baseDelay / 2));
+      logger.warn(
+        `${getAttemptDescription(`attempt ${attempt} of ${maxAttempts}`)} failed; retrying in ${delay}ms:`,
+        error
+      );
+      await new Promise(resolve => setTimeout(resolve, delay));
+      attempt++;
+    }
+  }
+}

--- a/packages/esrp-npm-release/src/utils/errorHelpers.ts
+++ b/packages/esrp-npm-release/src/utils/errorHelpers.ts
@@ -1,6 +1,6 @@
 import { RestError } from '@azure/storage-blob';
-import { ReleaseError } from './ReleaseError';
-import type { Logger } from './Logger';
+import { ReleaseError } from './ReleaseError.ts';
+import type { Logger } from './Logger.ts';
 
 /** Returns whether an HTTP status indicates a transient failure. */
 export function isTransientHttpStatus(statusCode: number | undefined): boolean {

--- a/packages/esrp-npm-release/src/utils/getEnvOptions.ts
+++ b/packages/esrp-npm-release/src/utils/getEnvOptions.ts
@@ -69,7 +69,7 @@ export function getEnvOptions(env: NodeJS.ProcessEnv = process.env): EnvOptions 
   }
 
   if (validationErrors.length) {
-    throw new ReleaseError(validationErrors.join('\n\n'));
+    throw new ReleaseError(validationErrors.join('\n\n'), { retryable: false });
   }
   return result;
 }

--- a/scripts/bundleNode.ts
+++ b/scripts/bundleNode.ts
@@ -33,6 +33,7 @@ await bundleNode({
     splitting: false,
   },
   unacceptableLicenseTest: license => unacceptableLicenseTest(license) && !extraLicenses.includes(license),
+  errorDupePackages: [/^@azure/, /^@actions/],
   excludeFromNotice: dep => dep.name.startsWith('@azure/') && dep.license === 'MIT',
 }).catch(err => {
   if (!(err instanceof BundleError && err.alreadyLogged)) {


### PR DESCRIPTION
- If a layer fails, retry it within the tool (only if a non-fatal error) instead of relying primarily on task retries, which won't respect fatal error codes or other fatal issues. Each step now has its own retry handling as appropriate.
- Log how long each layer took
- Properly detect the current format of npm 404 errors