### PR TITLE
Move update-lock-registry command to beachball-auth-helper

### DIFF
--- a/change/@microsoft-esrp-npm-release-58af9747-619e-4f05-9d82-46e45ad4b1bc.json
+++ b/change/@microsoft-esrp-npm-release-58af9747-619e-4f05-9d82-46e45ad4b1bc.json
@@ -1,0 +1,6 @@
+{
+  "type": "none",
+  "comment": "Update readme",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/change/beachball-1e7655e2-96ee-4b39-a442-3f99d5efb270.json
+++ b/change/beachball-1e7655e2-96ee-4b39-a442-3f99d5efb270.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add experimental `publish-helpers update-lock-registry` command",
+  "comment": "Add `beachball-auth-helper update-lock-registry` command",
   "packageName": "beachball",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/docs/concepts/ci-integration/auth-helper.md
+++ b/docs/concepts/ci-integration/auth-helper.md
@@ -20,6 +20,7 @@ The available commands are:
 
 - [`create-github-app-token`](#create-github-app-token): create a GitHub App installation token.
 - [`revoke-github-app-token`](#revoke-github-app-token): revoke a previously created GitHub App installation token.
+- [`update-lock-registry`](#update-lock-registry): update npm or yarn v1 lock file URLs for a private registry.
 
 ### `create-github-app-token`
 
@@ -57,6 +58,20 @@ The `revoke-github-app-token` command revokes a token by calling `DELETE /instal
 | ----- | ----------- |
 | `TOKEN` (env var) | Installation token to revoke. |
 | `--github-api-url` | (optional) GitHub REST API URL (customizable for GitHub Enterprise). Defaults to `https://api.github.com`. |
+
+### `update-lock-registry`
+
+For npm or yarn v1, update public registry URLs in the repo's lock file to point to a private registry. This command is a no-op for other package managers, yarn v2 and later, or the default public registry. It errors if the lock file does not contain the expected registry URL.
+
+<!-- prettier-ignore -->
+| Input | Description |
+| ----- | ----------- |
+| `--registry` | Private npm registry URL. |
+| `--revert` | (optional) Restore lock file URLs to the default public registry. |
+
+```bash
+yarn beachball-auth-helper update-lock-registry --registry "https://registry.example.com/"
+```
 
 ## Usage: `create-github-app-token`
 

--- a/docs/overview/v3-migration.md
+++ b/docs/overview/v3-migration.md
@@ -154,15 +154,17 @@ The config file is now **only** resolved at the project root. Support for search
 
 ### New options
 
+- Support authenticating with a git token from [`BEACHBALL_GIT_TOKEN`](../concepts/ci-integration).
 - Add `getGitTag` option, a function used to generate per-package git tags.
 - Add `commitMessage` option, a function used to generate the commit message for the `change` and `publish` commands (overridden by `--message` for `publish`).
-- Support authenticating with a git token from [`BEACHBALL_GIT_TOKEN`](../concepts/ci-integration).
 
-### New commands
+### Add `beachball-auth-helper`
 
-- Add experimental `beachball publish-helpers update-lock-registry` command
+[`beachball-auth-helper`](../concepts/ci-integration/auth-helper) is a second binary within the `beachball` package that provides authentication-related utilities for CI workflows:
 
-<!-- - Add functionality for creating a GitHub app installation token from a key stored in an Azure key vault (create-github-app-token-via-key-vault fork) -->
+- `create-github-app-token`: Create a repository-scoped GitHub App installation token
+- `revoke-github-app-token`: Revoke a GitHub App installation token
+- `update-lock-registry`: For npm / yarn v1 only: Update lock file registry URLs to point to a private registry
 
 ### Other features
 

--- a/packages/beachball/src/__functional__/authHelper/updateLockFileRegistry.test.ts
+++ b/packages/beachball/src/__functional__/authHelper/updateLockFileRegistry.test.ts
@@ -1,9 +1,17 @@
-import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { createTestFileStructure, expectErrorSync, removeTempDir } from '@microsoft/beachball-test-utilities';
 import fs from 'node:fs';
 import path from 'node:path';
-import { updateLockFileRegistry } from '../../commands/updateLockFileRegistry';
+import { getWorkspaceManagerAndRoot } from 'workspace-tools';
+import { updateLockFileRegistry } from '../../authHelper/updateLockFileRegistry';
 import { BeachballError } from '../../types/BeachballError';
+
+jest.mock('workspace-tools', () => ({
+  ...jest.requireActual<typeof import('workspace-tools')>('workspace-tools'),
+  getWorkspaceManagerAndRoot: jest.fn(),
+}));
+
+const mockGetWorkspaceManagerAndRoot = jest.mocked(getWorkspaceManagerAndRoot);
 
 const fixturesDir = path.join(__dirname, '../../__fixtures__/lockfiles');
 
@@ -24,6 +32,10 @@ describe('updateLockFileRegistry', () => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
+  beforeEach(() => {
+    mockGetWorkspaceManagerAndRoot.mockReset().mockImplementation(() => ({ manager: 'npm', root: tempDir }));
+  });
+
   afterEach(() => {
     removeTempDir(tempDir);
     tempDir = '';
@@ -35,7 +47,7 @@ describe('updateLockFileRegistry', () => {
     tempDir = createTestFileStructure({});
 
     expectErrorSync(
-      () => updateLockFileRegistry({ path: tempDir, registry: '' }),
+      () => updateLockFileRegistry({ cwd: tempDir, registry: '' }),
       BeachballError,
       'The "registry" option is required'
     );
@@ -43,8 +55,9 @@ describe('updateLockFileRegistry', () => {
 
   it('skips yarn berry (yarn.lock alongside .yarnrc.yml)', () => {
     tempDir = createTestFileStructure({ 'yarn.lock': '', '.yarnrc.yml': 'nodeLinker: node-modules\n' });
+    mockGetWorkspaceManagerAndRoot.mockReturnValueOnce({ manager: 'yarn', root: tempDir });
 
-    updateLockFileRegistry({ path: tempDir, registry });
+    updateLockFileRegistry({ cwd: tempDir, registry });
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Skipping lock file update for current package manager which does not embed URLs'
     );
@@ -52,8 +65,19 @@ describe('updateLockFileRegistry', () => {
 
   it('skips pnpm (pnpm-lock.yaml does not embed default registry URLs)', () => {
     tempDir = createTestFileStructure({ 'pnpm-lock.yaml': '' });
+    mockGetWorkspaceManagerAndRoot.mockReturnValueOnce({ manager: 'pnpm', root: tempDir });
 
-    updateLockFileRegistry({ path: tempDir, registry });
+    updateLockFileRegistry({ cwd: tempDir, registry });
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'Skipping lock file update for current package manager which does not embed URLs'
+    );
+  });
+
+  it('skips when the package manager cannot be determined', () => {
+    tempDir = createTestFileStructure({});
+    mockGetWorkspaceManagerAndRoot.mockReturnValueOnce(undefined);
+
+    updateLockFileRegistry({ cwd: tempDir, registry });
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Skipping lock file update for current package manager which does not embed URLs'
     );
@@ -63,7 +87,7 @@ describe('updateLockFileRegistry', () => {
     const original = readFixture('npm.package-lock.json.fixture');
     tempDir = createTestFileStructure({ 'package-lock.json': original });
 
-    updateLockFileRegistry({ path: tempDir, registry: npmjsRegistry });
+    updateLockFileRegistry({ cwd: tempDir, registry: npmjsRegistry });
     expect(consoleLogSpy).toHaveBeenCalledWith('Skipping lock file update for default registry');
   });
 
@@ -71,7 +95,7 @@ describe('updateLockFileRegistry', () => {
     const original = readFixture('npm.package-lock.json.fixture');
     tempDir = createTestFileStructure({ 'package-lock.json': original });
 
-    updateLockFileRegistry({ path: tempDir, registry: registry.replace(/\/$/, '') });
+    updateLockFileRegistry({ cwd: tempDir, registry: registry.replace(/\/$/, '') });
 
     const updated = read('package-lock.json');
     expect(updated).toBe(original.replaceAll(npmjsRegistry, registry));
@@ -81,7 +105,7 @@ describe('updateLockFileRegistry', () => {
     tempDir = createTestFileStructure({ 'package-lock.json': '{}\n' });
 
     expectErrorSync(
-      () => updateLockFileRegistry({ path: tempDir, registry }),
+      () => updateLockFileRegistry({ cwd: tempDir, registry }),
       BeachballError,
       'does not contain https://registry.npmjs.org/'
     );
@@ -89,9 +113,14 @@ describe('updateLockFileRegistry', () => {
 
   it('rewrites registry URLs in an npm package-lock.json', () => {
     const original = readFixture('npm.package-lock.json.fixture');
-    tempDir = createTestFileStructure({ 'package-lock.json': original });
+    tempDir = createTestFileStructure({
+      'package.json': '{ "workspaces": ["packages/*"] }',
+      'package-lock.json': original,
+      'packages/foo/package.json': '{ "name": "foo" }',
+    });
 
-    updateLockFileRegistry({ path: tempDir, registry });
+    updateLockFileRegistry({ cwd: path.join(tempDir, 'packages/foo'), registry });
+    expect(mockGetWorkspaceManagerAndRoot).toHaveBeenCalledWith(path.join(tempDir, 'packages/foo'));
 
     const updated = read('package-lock.json');
     expect(updated).toBe(original.replaceAll(npmjsRegistry, registry));
@@ -99,11 +128,26 @@ describe('updateLockFileRegistry', () => {
     expect(updated).toContain(`${registry}is-number/-/is-number-7.0.0.tgz`);
   });
 
+  it('updates a single-package npm repo', () => {
+    const original = readFixture('npm.package-lock.json.fixture');
+    tempDir = createTestFileStructure({
+      'package.json': '{ "name": "foo" }',
+      'package-lock.json': original,
+    });
+    mockGetWorkspaceManagerAndRoot.mockReturnValueOnce({ manager: 'npm', root: tempDir });
+
+    updateLockFileRegistry({ cwd: tempDir, registry });
+
+    expect(mockGetWorkspaceManagerAndRoot).toHaveBeenCalledWith(tempDir);
+    expect(read('package-lock.json')).toBe(original.replaceAll(npmjsRegistry, registry));
+  });
+
   it('rewrites registry URLs in a yarn v1 yarn.lock', () => {
     const original = readFixture('yarn-v1.yarn.lock.fixture');
     tempDir = createTestFileStructure({ 'yarn.lock': original });
+    mockGetWorkspaceManagerAndRoot.mockReturnValueOnce({ manager: 'yarn', root: tempDir });
 
-    updateLockFileRegistry({ path: tempDir, registry });
+    updateLockFileRegistry({ cwd: tempDir, registry });
 
     const updated = read('yarn.lock');
     expect(updated).toBe(original.replaceAll(yarnpkgRegistry, registry));
@@ -117,7 +161,7 @@ describe('updateLockFileRegistry', () => {
     const withPrivateRegistry = original.replaceAll(npmjsRegistry, registry);
     tempDir = createTestFileStructure({ 'package-lock.json': withPrivateRegistry });
 
-    updateLockFileRegistry({ path: tempDir, registry, revert: true });
+    updateLockFileRegistry({ cwd: tempDir, registry, revert: true });
 
     const updated = read('package-lock.json');
     expect(updated).toBe(original);

--- a/packages/beachball/src/__functional__/options/__snapshots__/getCliOptions.test.ts.snap
+++ b/packages/beachball/src/__functional__/options/__snapshots__/getCliOptions.test.ts.snap
@@ -353,48 +353,6 @@ Common options:
 "
 `;
 
-exports[`getCliOptions shows "publish-helpers update-lock-registry" command help text 1`] = `
-"Usage: beachball publish-helpers update-lock-registry [options]
-
-(experimental) For npm / yarn v1 only: Update lock file registry URL references to point to the
-private registry.
-
-Requires the --registry option. No-op if the command is irrelevant for the package manager or the
-registry is already the default. Errors if the lock file does not contain the given registry.
-
-Most options can also be specified in the beachball config (command line options override the
-config). See https://microsoft.github.io/beachball/overview/configuration for more info.
-
-npm options:
-  -r, --registry <value>  npm registry (must be set with option or config file)
-
-Common options:
-  -c, --config <value>    custom beachball config path (default: cosmiconfig-like paths)
-  --[no-]verbose          print additional information to the console
-  -h, --help              display help for command
-"
-`;
-
-exports[`getCliOptions shows "publish-helpers" command help text 1`] = `
-"Usage: beachball publish-helpers <update-lock-registry>
-
-Experimental helper commands for publishing pipelines (requires a sub-command).
-
-Most options can also be specified in the beachball config (command line options override the
-config). See https://microsoft.github.io/beachball/overview/configuration for more info.
-
-Commands:
-  update-lock-registry  (experimental) For npm / yarn v1 only: Update lock file registry URL
-                          references to point to the private registry
-  help [command]        display help for command
-
-Common options:
-  -c, --config <value>  custom beachball config path (default: cosmiconfig-like paths)
-  --[no-]verbose        print additional information to the console
-  -h, --help            display help for command
-"
-`;
-
 exports[`getCliOptions shows "sync" command help text 1`] = `
 "Usage: beachball sync [options]
 

--- a/packages/beachball/src/__tests__/authHelper/__snapshots__/authHelperCli.test.ts.snap
+++ b/packages/beachball/src/__tests__/authHelper/__snapshots__/authHelperCli.test.ts.snap
@@ -55,7 +55,22 @@ Options:
 Commands:
   create-github-app-token [options]  Create a repository-scoped GitHub App installation token
   revoke-github-app-token [options]  Revoke a GitHub App installation token
+  update-lock-registry [options]     For npm / yarn v1 only: Update lock file registry URLs to point
+                                     to a private registry
   help [command]                     display help for command
+
+Full setup and examples: https://microsoft.github.io/beachball/concepts/ci-integration/auth-helper"
+`;
+
+exports[`authHelperCli shows help text for update-lock-registry 1`] = `
+"Usage: beachball-auth-helper update-lock-registry [options]
+
+For npm / yarn v1 only: Update lock file registry URLs to point to a private registry
+
+Options:
+  --registry <url>  Private npm registry URL
+  --revert          Restore lock file URLs to the default public registry
+  -h, --help        display help for command
 
 Full setup and examples: https://microsoft.github.io/beachball/concepts/ci-integration/auth-helper"
 `;

--- a/packages/beachball/src/__tests__/authHelper/authHelperCli.test.ts
+++ b/packages/beachball/src/__tests__/authHelper/authHelperCli.test.ts
@@ -5,13 +5,16 @@ import { runAuthHelperCli, type CliContext } from '../../authHelper/authHelperCl
 import * as authModule from '../../authHelper/createAppToken';
 import { defaultGitHubApiUrl } from '../../authHelper/requestHelpers';
 import * as revokeModule from '../../authHelper/revokeAppToken';
+import { updateLockFileRegistry } from '../../authHelper/updateLockFileRegistry';
 
 jest.mock('../../authHelper/createAppToken');
 jest.mock('../../authHelper/revokeAppToken');
+jest.mock('../../authHelper/updateLockFileRegistry');
 jest.mock('node:fs');
 
 const { createAppToken } = jest.mocked(authModule);
 const { revokeAppToken } = jest.mocked(revokeModule);
+const mockUpdateLockFileRegistry = jest.mocked(updateLockFileRegistry);
 const mockAppendFileSync = jest.mocked(fs.appendFileSync);
 
 describe('authHelperCli', () => {
@@ -22,6 +25,7 @@ describe('authHelperCli', () => {
   function getContext(args: string[], env?: NodeJS.ProcessEnv): CliContext {
     return {
       argv: ['node', 'authHelperCli.js', ...args],
+      cwd: '/test/project',
       env: env || {},
       outputOptions: {
         writeOut: message => out.push(message.trim()),
@@ -43,7 +47,7 @@ describe('authHelperCli', () => {
     err = [];
   });
 
-  it.each(['top level', 'create-github-app-token', 'revoke-github-app-token'])(
+  it.each(['top level', 'create-github-app-token', 'revoke-github-app-token', 'update-lock-registry'])(
     'shows help text for %s',
     async command => {
       const context = getContext([...(command === 'top level' ? [] : [command]), '--help']);
@@ -253,6 +257,33 @@ describe('authHelperCli', () => {
     it('requires a token', async () => {
       const context = getContext(['revoke-github-app-token']);
       await expect(runAuthHelperCli(context)).rejects.toThrow(/--token/);
+    });
+  });
+
+  describe('update lock registry command', () => {
+    it('passes provided cwd through', async () => {
+      await runAuthHelperCli(getContext(['update-lock-registry', '--registry', 'https://registry.example.com/']));
+
+      expect(mockUpdateLockFileRegistry).toHaveBeenCalledWith({
+        cwd: '/test/project',
+        registry: 'https://registry.example.com/',
+      });
+    });
+
+    it('passes the revert option through', async () => {
+      await runAuthHelperCli(
+        getContext(['update-lock-registry', '--registry', 'https://registry.example.com/', '--revert'])
+      );
+
+      expect(mockUpdateLockFileRegistry).toHaveBeenCalledWith({
+        cwd: '/test/project',
+        registry: 'https://registry.example.com/',
+        revert: true,
+      });
+    });
+
+    it('requires a registry', async () => {
+      await expect(runAuthHelperCli(getContext(['update-lock-registry']))).rejects.toThrow(/--registry/);
     });
   });
 });

--- a/packages/beachball/src/authHelper/authHelperBin.ts
+++ b/packages/beachball/src/authHelper/authHelperBin.ts
@@ -2,8 +2,11 @@ import { env } from '../env';
 import { BeachballError } from '../types/BeachballError';
 import { runAuthHelperCli } from './authHelperCli';
 
+// eslint-disable-next-line no-restricted-properties -- top-level call
+const processCwd = process.cwd();
+
 // This is a separate file so most of the CLI can be tested in Jest
-void runAuthHelperCli({ argv: process.argv }).catch((err: unknown) => {
+void runAuthHelperCli({ argv: process.argv, cwd: processCwd }).catch((err: unknown) => {
   let message: string;
   let shouldLog = true;
   if (err instanceof BeachballError) {

--- a/packages/beachball/src/authHelper/authHelperCli.ts
+++ b/packages/beachball/src/authHelper/authHelperCli.ts
@@ -1,5 +1,6 @@
 import { Command, InvalidArgumentError, Option, type OutputConfiguration } from 'commander';
 import fs from 'node:fs';
+import { updateLockFileRegistry } from './updateLockFileRegistry';
 import { BeachballError } from '../types/BeachballError';
 import { createAppToken } from './createAppToken';
 import { defaultGitHubApiUrl } from './requestHelpers';
@@ -13,6 +14,8 @@ const authHelperDocsUrl = 'https://microsoft.github.io/beachball/concepts/ci-int
 export interface CliContext {
   /** Full argv (including `node` and the script path), e.g. `process.argv`. */
   argv: string[];
+  /** Current working directory. */
+  cwd: string;
   /** Environment override for tests */
   env?: NodeJS.ProcessEnv;
   outputOptions?: OutputConfiguration;
@@ -145,6 +148,15 @@ Tokens expire after one hour. Create them immediately before use and revoke them
     .addOption(githubApiUrlOption())
     .action(async (options: RevokeAppTokenOptions) => {
       await revokeAppToken(options);
+    });
+
+  program
+    .command('update-lock-registry')
+    .description('For npm / yarn v1 only: Update lock file registry URLs to point to a private registry')
+    .addOption(new Option('--registry <url>', 'Private npm registry URL').makeOptionMandatory())
+    .addOption(new Option('--revert', 'Restore lock file URLs to the default public registry'))
+    .action((options: { registry: string; revert?: boolean }) => {
+      updateLockFileRegistry({ ...options, cwd: context.cwd });
     });
 
   return program;

--- a/packages/beachball/src/authHelper/updateLockFileRegistry.ts
+++ b/packages/beachball/src/authHelper/updateLockFileRegistry.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BeachballOptions } from '../types/BeachballOptions';
 import { BeachballError } from '../types/BeachballError';
+import { getWorkspaceManagerAndRoot } from 'workspace-tools';
 
 // registries MUST have a trailing slash
 const defaultNpmRegistry = 'https://registry.npmjs.org/';
@@ -20,25 +21,34 @@ const defaultYarnRegistry = 'https://registry.yarnpkg.com/';
  *   without modifying the lock file.
  */
 export function updateLockFileRegistry(
-  params: Pick<BeachballOptions, 'registry' | 'path'> & {
+  params: Pick<BeachballOptions, 'registry'> & {
+    /** Current working directory (will find the project root from here). */
+    cwd: string;
     /** If true, revert from `registry` to the default registry. Otherwise apply `registry` to the lock file. */
     revert?: boolean;
   }
 ): void {
-  const { path: cwd, revert } = params;
+  const { revert } = params;
+
   let registry = params.registry;
   if (!registry) {
     throw new BeachballError('The "registry" option is required to update lock files');
   }
   registry = registry.replace(/(?<!\/)$/, '/');
 
-  const managerFile = ['yarn.lock', 'package-lock.json'].find(file => fs.existsSync(path.join(cwd, file)));
-  if (!managerFile || (managerFile === 'yarn.lock' && fs.existsSync(path.join(cwd, '.yarnrc.yml')))) {
+  const workspace = getWorkspaceManagerAndRoot(params.cwd);
+  if (
+    !workspace ||
+    !['npm', 'yarn'].includes(workspace.manager) ||
+    (workspace.manager === 'yarn' && fs.existsSync(path.join(workspace.root, '.yarnrc.yml')))
+  ) {
     console.log('Skipping lock file update for current package manager which does not embed URLs');
     return;
   }
+  const { manager, root } = workspace;
 
-  const defaultRegistry = managerFile === 'yarn.lock' ? defaultYarnRegistry : defaultNpmRegistry;
+  const managerFile = manager === 'yarn' ? 'yarn.lock' : 'package-lock.json';
+  const defaultRegistry = manager === 'yarn' ? defaultYarnRegistry : defaultNpmRegistry;
   if (registry === defaultRegistry) {
     console.log('Skipping lock file update for default registry');
     return;
@@ -46,7 +56,7 @@ export function updateLockFileRegistry(
   const oldRegistry = revert ? registry : defaultRegistry;
   const newRegistry = revert ? defaultRegistry : registry;
 
-  const lockFilePath = path.join(cwd, managerFile);
+  const lockFilePath = path.join(root, managerFile);
   const lockFileContent = fs.readFileSync(lockFilePath, 'utf-8');
   if (!lockFileContent.includes(oldRegistry)) {
     throw new BeachballError(`Lock file ${lockFilePath} does not contain ${oldRegistry}`);

--- a/packages/beachball/src/cli.ts
+++ b/packages/beachball/src/cli.ts
@@ -8,7 +8,6 @@ import { init } from './commands/init';
 import { migrate } from './commands/migrate';
 import { publish } from './commands/publish';
 import { sync } from './commands/sync';
-import { updateLockFileRegistry } from './commands/updateLockFileRegistry';
 
 import { getOptions } from './options/getOptions';
 import { validate } from './validation/validate';
@@ -94,10 +93,6 @@ const version = getPackageInfo(findPackageRoot(__dirname)!)?.version;
 
     case 'config list':
       configList(options, createBasicCommandContext(parsedOptions));
-      break;
-
-    case 'publish-helpers update-lock-registry':
-      updateLockFileRegistry(options);
       break;
 
     default:

--- a/packages/beachball/src/options/commandDefinitions.ts
+++ b/packages/beachball/src/options/commandDefinitions.ts
@@ -17,10 +17,10 @@ export interface CommandDefinition {
 
 /** Main subcommand names */
 export type MainCommandName =
-  'change' | 'check' | 'bump' | 'publish' | 'sync' | 'config' | 'init' | 'canary' | 'migrate' | 'publish-helpers';
+  'change' | 'check' | 'bump' | 'publish' | 'sync' | 'config' | 'init' | 'canary' | 'migrate';
 
 /** All subcommand names including nested */
-export type CommandName = MainCommandName | 'config get' | 'config list' | 'publish-helpers update-lock-registry';
+export type CommandName = MainCommandName | 'config get' | 'config list';
 
 const changeExtra = 'Considers committed and staged changes, but not unstaged or untracked changes.';
 
@@ -56,24 +56,11 @@ export const commandDefinitions: Record<MainCommandName, CommandDefinition> = {
     desc: 'Initialize a new beachball config file in the current directory',
     hidden: true,
   },
-  'publish-helpers': {
-    desc: 'Experimental helper commands for publishing pipelines (requires a sub-command)',
-    hidden: true,
-    subcommands: {
-      'update-lock-registry': {
-        desc: '(experimental) For npm / yarn v1 only: Update lock file registry URL references to point to the private registry',
-        extraDesc:
-          '\n\nRequires the --registry option. No-op if the command is irrelevant for the package manager ' +
-          'or the registry is already the default. Errors if the lock file does not contain the given registry.',
-      },
-    },
-  },
 };
 
 const extraCommandNames = Object.keys({
   'config get': true,
   'config list': true,
-  'publish-helpers update-lock-registry': true,
 } satisfies Record<Exclude<CommandName, MainCommandName>, true>);
 
 /** All command names including nested */

--- a/packages/beachball/src/options/optionDefinitions.ts
+++ b/packages/beachball/src/options/optionDefinitions.ts
@@ -239,11 +239,8 @@ export const optionDefinitions: Record<
   ...makeOptions('npm', ['publish', 'canary', 'sync', 'init'], {
     registry: {
       short: 'r',
-      desc: cmd =>
-        cmd === 'publish-helpers update-lock-registry'
-          ? 'npm registry (must be set with option or config file)'
-          : 'npm registry (respects npm settings)',
-      commands: ['publish', 'canary', 'sync', 'init', 'publish-helpers update-lock-registry'],
+      desc: 'npm registry (respects npm settings)',
+      commands: ['publish', 'canary', 'sync', 'init'],
     },
     token: {
       short: 'n',

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -322,7 +322,7 @@ These package managers save resolved URLs in the lock file, which requires an ex
 1. In your pipeline, _after_ `npmAuthenticate` but _before_ installing dependencies, add a step to update the lock file:
 
    ```yml
-   - script: npx beachball@next publish-helpers update-lock-registry --registry '$(REGISTRY_URL)'
+   - script: npx --package beachball@next beachball-auth-helper update-lock-registry --registry '$(REGISTRY_URL)'
      displayName: Prepare npm registry settings
    ```
 
@@ -377,15 +377,15 @@ steps:
     inputs:
       workingFile: $(Build.SourcesDirectory)/.npmrc
 
-  # ONLY for npm / yarn v1: rewrite lock file URLs to the private registry.
-  # `npx beachball` is fetched from the private registry.
-  - script: npx beachball@next publish-helpers update-lock-registry --registry '$(REGISTRY_URL)'
-    displayName: (npm or yarn v1) Update registry in lock file
-
   # This isn't used, it's just a clear way to check that auth is working
   # (yarn install's auth errors can be very unclear)
   - script: yarn npm info beachball
     displayName: Get package to verify registry auth
+
+  # ONLY for npm / yarn v1: rewrite lock file URLs to the private registry.
+  # `npx` fetches the `beachball-auth-helper` binary from the `beachball` package in the private registry.
+  - script: npx --package beachball@next beachball-auth-helper update-lock-registry --registry '$(REGISTRY_URL)'
+    displayName: (npm or yarn v1) Update registry in lock file
 
   # Modify as appropriate
   - script: yarn --immutable


### PR DESCRIPTION
`update-lock-registry` is a logically better fit under `beachball-auth-helper` than `beachball`.