### PR TITLE
More release updates

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -33,20 +33,41 @@ resources:
       ref: refs/tags/release
 
 variables:
-  nodeVersion: 24
-  tags: production
-  # Internal npm feed (with npmjs.org as upstream) for build/publish in 1ES PT
-  REGISTRY_URL: https://pkgs.dev.azure.com/office/_packaging/Office/npm/registry/
-  # Yarn v4 doesn't respect .npmrc, so set config with YARN_* env
-  YARN_NPM_REGISTRY_SERVER: $(REGISTRY_URL)
-  # Using 1 instead of 'true' avoids any issues with weird ADO boolean handling
-  YARN_NPM_ALWAYS_AUTH: 1
-  YARN_NPMRC_AUTH_ENABLED: 1
-  packagesArtifactName: packed-packages
-  # TODO (release): remove all canary artifacts
-  canaryArtifactName: packed-packages-canary
-  releaseToolArtifactName: release-api-tool
-  tgzScanTestArtifactName: tgz-scan-test
+  - group: ogx-oss-release
+  - template: /.ado/templates/readonly-variables.yml
+    parameters:
+      variables:
+        tags: production
+        nodeVersion: 24
+        # Force multiline bash scripts to exit with an error if any line fails
+        # (includes ADO defaults plus errexit:errtrace)
+        SHELLOPTS: braceexpand:hashall:interactive-comments:errexit:errtrace
+
+        # Internal npm feed (with npmjs.org as upstream) for build/publish in 1ES PT
+        REGISTRY_URL: https://pkgs.dev.azure.com/office/_packaging/Office/npm/registry/
+        # Yarn v4 doesn't respect .npmrc, so set config with YARN_* env
+        YARN_NPM_REGISTRY_SERVER: $(REGISTRY_URL)
+        YARN_NPM_ALWAYS_AUTH: 1
+        YARN_NPMRC_AUTH_ENABLED: 1
+
+        packagesArtifactName: packed-packages
+        # TODO (release): remove all canary artifacts
+        canaryArtifactName: packed-packages-canary
+        releaseToolArtifactName: release-api-tool
+        tgzScanTestArtifactName: tgz-scan-test
+
+        # Map in variable group values as readonly (with this syntax, they'll be empty strings if unset)
+        esrpReleaseAzureSubscription: $[variables.grp_esrpReleaseAzureSubscription]
+        esrpReleaseClientId: $[variables.grp_esrpReleaseClientId]
+        esrpReleaseKeyVaultName: $[variables.grp_esrpReleaseKeyVaultName]
+        esrpReleaseTenantId: $[variables.grp_esrpReleaseTenantId]
+        esrpStagingAzureSubscription: $[variables.grp_esrpStagingAzureSubscription]
+        esrpStagingStorageAccount: $[variables.grp_esrpStagingStorageAccount]
+        ghaClientId: $[variables.grp_ghaClientId]
+        ghaTokenAzureSubscription: $[variables.grp_ghaTokenAzureSubscription]
+        ghaTokenKeyId: $[variables.grp_ghaTokenKeyId]
+        ghaUserName: $[variables.grp_ghaUserName]
+        ghaUserEmail: $[variables.grp_ghaUserEmail]
 
 # Temporary workaround to publish two groups of packages with different versioning strategies
 # TODO (release): go back to a single publish step
@@ -78,7 +99,7 @@ extends:
     settings:
       # If any job has `type: releaseJob`, it applies strict network isolation to the whole pipeline.
       # Re-enable the access needed.
-      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureResourceManager,AzureStorage,GitHub
+      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
 
     stages:
       - stage: build
@@ -119,8 +140,6 @@ extends:
 
             steps:
               - template: /.ado/templates/setup.yml@self
-                parameters:
-                  nodeVersion: ${{ variables.nodeVersion }}
 
               - script: yarn build --verbose
                 displayName: Build
@@ -139,10 +158,13 @@ extends:
 
               - script: |
                   mkdir -p "$(tgzScanTestArtifactPath)"
-                  echo "This file exists only inside the tgz scan test artifact." > "$(Agent.TempDirectory)/beachball-tgz-only-sentinel.txt"
+                  rm -rf "$(Agent.TempDirectory)/tgz-expansion-test"
+                  mkdir -p "$(Agent.TempDirectory)/tgz-expansion-test"
+                  echo "console.log(require('@microsoft/fake-package'))" > "$(Agent.TempDirectory)/tgz-expansion-test/tgz-main.js"
+                  echo '{ "name": "tgz-sentinel", "version": "1.0.0", "main": "tgz-main.js", "dependencies": { "@microsoft/fake-package": "1.0.0" } }' > "$(Agent.TempDirectory)/tgz-expansion-test/package.json"
                   tar -czf "$(tgzScanTestArtifactPath)/tgz-expansion-test.tgz" \
-                    -C "$(Agent.TempDirectory)" beachball-tgz-only-sentinel.txt
-                  rm "$(Agent.TempDirectory)/beachball-tgz-only-sentinel.txt"
+                    -C "$(Agent.TempDirectory)/tgz-expansion-test" .
+                  rm -rf "$(Agent.TempDirectory)/tgz-expansion-test"
                 displayName: Create tgz scanning test artifact
 
               - script: |
@@ -210,7 +232,7 @@ extends:
                 displayName: Get credentials for staging blob storage
                 inputs:
                   # this is the service connection name
-                  azureSubscription: ogx-esrp-infra-bot
+                  azureSubscription: $(esrpStagingAzureSubscription)
                   scriptType: bash
                   scriptLocation: inlineScript
                   addSpnToEnvironment: true
@@ -224,10 +246,11 @@ extends:
                 displayName: Get ESRP certificates from Key Vault
                 inputs:
                   # torus service connection name ("connectedservicename" from EsrpRelease task)
-                  azureSubscription: ESRP-JSHost3
+                  azureSubscription: $(esrpReleaseAzureSubscription)
                   # "keyvaultname" from EsrpRelease task
-                  KeyVaultName: OGX-JSHost-KV
+                  KeyVaultName: $(esrpReleaseKeyVaultName)
                   # "authcertname" and "signcertname" from EsrpRelease task
+                  # (can't specify these in variables since they're used as secret names in the next step)
                   SecretsFilter: OGX-JSHost-Auth4,OGX-JSHost-Sign3
 
               # Publish each set of packed packages under its npm dist-tag.
@@ -242,13 +265,13 @@ extends:
                       ESRP_NPM_TAG: ${{ publish.npmTag }}
                       ESRP_USER: elcraig@microsoft.com
                       ESRP_APPROVERS: dannyvv@microsoft.com
-                      # torus tenant ID ("domaintenantid" from EsrpRelease task, same as service connection "ESRP-JSHost3")
-                      ESRP_TENANT_ID: cdc5aeea-15c5-4db6-b079-fcadd2505dc2
+                      # torus tenant ID ("domaintenantid" from EsrpRelease task, same as service connection esrpReleaseAzureSubscription)
+                      ESRP_TENANT_ID: $(esrpReleaseTenantId)
                       # "clientid" from EsrpRelease task
-                      ESRP_CLIENT_ID: 0a35e01f-eadf-420a-a2bf-def002ba898d
+                      ESRP_CLIENT_ID: $(esrpReleaseClientId)
                       ESRP_AUTH_CERT: $(OGX-JSHost-Auth4)
                       ESRP_REQUEST_SIGNING_CERT: $(OGX-JSHost-Sign3)
-                      STAGING_STORAGE_ACCOUNT_NAME: ogxesrptempstorage
+                      STAGING_STORAGE_ACCOUNT_NAME: $(esrpStagingStorageAccount)
                       STAGING_CLIENT_ID: $(STAGING_CLIENT_ID)
                       STAGING_TENANT_ID: $(STAGING_TENANT_ID)
                       STAGING_ID_TOKEN: $(STAGING_ID_TOKEN)
@@ -265,8 +288,6 @@ extends:
               os: linux
             steps:
               - template: /.ado/templates/setup.yml@self
-                parameters:
-                  nodeVersion: ${{ variables.nodeVersion }}
 
               # Have to build local beachball before using it!
               - script: yarn build --verbose --to beachball
@@ -276,14 +297,14 @@ extends:
                 name: createToken
                 displayName: Create GitHub App token
                 inputs:
-                  azureSubscription: ogx-oss-release-bot
+                  azureSubscription: $(ghaTokenAzureSubscription)
                   scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: |
                     yarn beachball-auth-helper create-github-app-token \
-                      --app-client-id Iv23ligBoU5jc9SIFnGR \
-                      --key-id https://ogx-oss-release-keyvault.vault.azure.net/keys/office-ogx-auth-helper-key \
-                      --repository $(Build.Repository.Name) \
+                      --app-client-id '$(ghaClientId)' \
+                      --key-id '$(ghaTokenKeyId)' \
+                      --repository '$(Build.Repository.Name)' \
                       --permissions contents:write \
                       --ci-output-name GITHUB_APP_TOKEN
 

--- a/.ado/templates/readonly-variables.yml
+++ b/.ado/templates/readonly-variables.yml
@@ -1,0 +1,11 @@
+# This template is a helper to declare many readonly variables in a readable manner.
+parameters:
+  - name: variables
+    type: object
+    default: {}
+
+variables:
+  - ${{ each variable in parameters.variables }}:
+      - name: ${{ variable.key }}
+        value: ${{ variable.value }}
+        readonly: true

--- a/.ado/templates/setup.yml
+++ b/.ado/templates/setup.yml
@@ -1,34 +1,20 @@
 # Shared setup steps: check out the repo, install Node and dependencies, and configure the
 # private npm registry auth.
 
-parameters:
-  # Node.js major version to install (e.g. "24").
-  - name: nodeVersion
-    type: string
-
 steps:
   - checkout: self
     fetchTags: false
 
   - task: UseNode@1
-    displayName: Install Node.js ${{ parameters.nodeVersion }}
+    displayName: Install Node.js $(nodeVersion)
     retryCountOnTaskFailure: 1
     inputs:
-      version: ${{ parameters.nodeVersion }}.x
+      version: $(nodeVersion).x
       checkLatest: false
 
-  # For multiline scripts, we want the whole task to fail if any line of the script fails.
-  # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
-  # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
-  # The options below include ADO defaults (braceexpand:hashall:interactive-comments) plus
-  # errexit:errtrace for better error behavior.
   - script: |
-      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace"
-    displayName: Force exit on error (bash)
-
-  - script: |
-      git config user.name "OGX bot"
-      git config user.email "257645319+office-ogx-auth-helper[bot]@users.noreply.github.com"
+      git config user.name '$(ghaUserName)'
+      git config user.email '$(ghaUserEmail)'
     displayName: Configure git user
 
   - script: |

--- a/change/@microsoft-esrp-npm-release-5a310926-964b-4508-bc7d-4e0a4a431de7.json
+++ b/change/@microsoft-esrp-npm-release-5a310926-964b-4508-bc7d-4e0a4a431de7.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Minor logging updates",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -438,7 +438,7 @@ extends:
     settings:
       # If any job has `type: releaseJob`, it applies strict network isolation to the whole pipeline.
       # Re-enable the access needed.
-      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureResourceManager,AzureStorage,GitHub
+      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
 
     stages:
       - stage: build

--- a/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/runRelease.test.ts
@@ -301,8 +301,7 @@ describe('runRelease', () => {
     expect(state.markPublished).not.toHaveBeenCalledWith('2');
     expect(logger.mocks.warn).toHaveBeenCalledWith(
       '##vso[task.logissue type=warning]',
-      '[layer-2]',
-      expect.stringMatching(/No \.tgz files found in layer directory.*[/\\]2; skipping layer$/)
+      expect.stringMatching(/No \.tgz files found in layer directory.*[/\\]2; skipping layer/)
     );
   });
 });

--- a/packages/esrp-npm-release/src/runRelease.ts
+++ b/packages/esrp-npm-release/src/runRelease.ts
@@ -113,7 +113,6 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
     }
 
     const layerPrefix = 'layer-' + layerNum;
-    logger.startGroup(layerPrefix, `Releasing layer ${layerNum} of ${layers.length}`);
 
     const layerDir = path.join(env.packedPackagesPath, layerNum);
     const tgzFiles = fs
@@ -121,10 +120,11 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
       .filter(file => file.endsWith('.tgz'))
       .map(file => path.join(layerDir, file));
     if (!tgzFiles.length) {
-      logger.warn(`No .tgz files found in layer directory ${layerDir}; skipping layer`);
-      logger.endGroup();
+      logger.warn(`No .tgz files found in layer directory ${layerDir}; skipping layer\n`);
       continue;
     }
+
+    logger.startGroup(layerPrefix, `Releasing layer ${layerNum} of ${layers.length} (${tgzFiles.length} package(s))`);
 
     const zipPath = path.join(zipsDir, `${layerPrefix}-${Date.now()}.zip`);
     logger.log(`Zipping layer contents to ${zipPath}`);
@@ -175,5 +175,5 @@ export async function runRelease({ env, logger }: RunReleaseOptions): Promise<vo
     logger.endGroup();
   }
 
-  logger.log(`All ${state.publishedCount} artifacts published!`);
+  logger.log(`All ${state.publishedCount} layers published!`);
 }


### PR DESCRIPTION
- Add a helper template to declare many readonly variables
- Use a variable group for most common values. Annoyingly there's no way to mark an entire group as readonly, so each value is copied into a readonly variable.
- Remove AzureResourceManager network policy which causes a warning and is apparently not needed