### PR TITLE
[v2] Support dotted names in config get

### DIFF
--- a/change/beachball-11e7de66-b3d3-45f4-ac43-430a74c17887.json
+++ b/change/beachball-11e7de66-b3d3-45f4-ac43-430a74c17887.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "comment": "Support dotted names in `config get`",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com"
+}

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -12,12 +12,23 @@ The `config` command has two subcommands: `get` and `list`. (There's no plan to 
 
 ## `config get <name>`
 
-Get the value of a specific config setting. If the setting can be overridden per-package or per-group, any overrides are also shown.
+Get the value of a specific config setting. Use dot notation to get a nested setting. If the setting can be overridden per-package or per-group, any overrides are also shown.
 
 ```bash
 $ beachball config get branch
 # "origin/main"
 
+# Nested key of an object:
+$ beachball config get changeFile.includeEmail
+# false
+
+# All keys of an object:
+$ beachball config get changelog
+# maxVersions: 10
+# includeCommitHashes: false
+
+
+# Values at multiple levels:
 $ beachball config get disallowedChangeTypes
 # Main value: null
 

--- a/docs/cli/options.md
+++ b/docs/cli/options.md
@@ -7,7 +7,7 @@ category: doc
 
 # Beachball CLI options
 
-For the latest full list of supported options, see `CliOptions` [in this file](https://github.com/microsoft/beachball/blob/main/src/types/BeachballOptions.ts).
+For the latest full list of supported options, see `CliOptions` [in this file](https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/BeachballOptions.ts).
 
 **Most options can also be specified in the [configuration file](../overview/configuration)**, which is generally preferable as it's easier to read and maintain.
 

--- a/docs/concepts/groups.md
+++ b/docs/concepts/groups.md
@@ -26,7 +26,7 @@ For cases where it's necessary to bump packages together, `beachball` also provi
 
 ### Configuring version groups
 
-Groups can be added to the [configuration file](../overview/configuration). See the [`VersionGroupOptions` source](https://github.com/microsoft/beachball/blob/main/src/types/ChangelogOptions.ts) for full details.
+Groups can be added to the [configuration file](../overview/configuration). See the [`VersionGroupOptions` source](https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/ChangelogOptions.ts) for full details.
 
 | Name                    | Type                         | Description                                                                                                                                             |
 | ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -56,7 +56,7 @@ If you only want to publish or record changes for certain packages, you should u
 
 ## Grouped changelogs
 
-To show changes for multiple packages in one change file, use the `changelog.groups` option. See the [`ChangelogGroupOptions` source](https://github.com/microsoft/beachball/blob/main/src/types/ChangelogOptions.ts) for full details.
+To show changes for multiple packages in one change file, use the `changelog.groups` option. See the [`ChangelogGroupOptions` source](https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/ChangelogOptions.ts) for full details.
 
 | Name                | Type                         | Description                                                                                                                                             |
 | ------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -67,7 +67,7 @@ To change the `disallowedChangeTypes` for package `foo`, you could add the follo
 
 ## Options
 
-For the latest full list of supported options, see `RepoOptions` [in this file](https://github.com/microsoft/beachball/blob/main/src/types/BeachballOptions.ts).
+For the latest full list of supported options, see `RepoOptions` [in this file](https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/BeachballOptions.ts).
 
 "Applies to" indicates where the settings can be specified: repo-level config or package-level config.
 
@@ -104,10 +104,10 @@ For the latest full list of supported options, see `RepoOptions` [in this file](
 | `tag` | `string` | `'latest'` | repo, package | `dist-tag` for npm when published |
 | `transform` | [`TransformOptions`][4] | | repo | Transformations for change files |
 
-[1]: https://github.com/microsoft/beachball/blob/main/src/types/ChangeFilePrompt.ts
-[2]: https://github.com/microsoft/beachball/blob/main/src/types/ChangelogOptions.ts
+[1]: https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/ChangeFilePrompt.ts
+[2]: https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/ChangelogOptions.ts
 [3]: ../concepts/groups#version-groups
-[4]: https://github.com/microsoft/beachball/blob/main/src/types/BeachballOptions.ts
+[4]: https://github.com/microsoft/beachball/blob/v2/packages/beachball/src/types/BeachballOptions.ts
 [5]: #specifying-the-target-branch-and-remote
 [6]: #glob-matching
 

--- a/packages/beachball/src/__tests__/commands/configGet.test.ts
+++ b/packages/beachball/src/__tests__/commands/configGet.test.ts
@@ -70,6 +70,17 @@ describe('configGet', () => {
         'Unknown config setting: "branc" - did you mean "branch"?'
       );
     });
+
+    it('validates and suggests dotted config names within their parent', async () => {
+      await expectBeachballError(
+        () => configGetArgs(['get', 'changelog.maxVer']),
+        'Unknown config setting: "changelog.maxVer" - did you mean "changelog.maxVersions"?'
+      );
+      await expectBeachballError(
+        () => configGetArgs(['get', 'changelog.prepublish']),
+        'Unknown config setting: "changelog.prepublish"'
+      );
+    });
   });
 
   describe('basic values', () => {
@@ -96,6 +107,28 @@ describe('configGet', () => {
     it('displays an empty string config value', () => {
       configGetWrapper('tag', { options: { tag: '' } });
       expect(logs.getMockLines('log')).toBe('""');
+    });
+
+    it('displays a dotted config value', () => {
+      configGetWrapper('changelog.maxVersions', { options: { changelog: { maxVersions: 2 } } });
+      expect(logs.getMockLines('log')).toBe('2');
+    });
+
+    it('displays an unset dotted config value', () => {
+      configGetWrapper('changelog.maxVersions', { options: {} });
+      expect(logs.getMockLines('log')).toBe('undefined');
+    });
+
+    it('displays a deeply nested config value', () => {
+      configGetWrapper('changelog.customRenderers.renderEntry', {
+        options: { changelog: { customRenderers: { renderEntry: () => '' } } },
+      });
+      expect(logs.getMockLines('log')).toBe('(Function)');
+    });
+
+    it('displays an unset deeply nested config value', () => {
+      configGetWrapper('changelog.customRenderers.renderEntry', { options: {} });
+      expect(logs.getMockLines('log')).toBe('undefined');
     });
   });
 

--- a/packages/beachball/src/commands/configGet.ts
+++ b/packages/beachball/src/commands/configGet.ts
@@ -5,6 +5,23 @@ import { BeachballError } from '../types/BeachballError';
 import type { BeachballOptions, PackageOptions, RepoOptions, VersionGroupOptions } from '../types/BeachballOptions';
 import type { BasicCommandContext } from '../types/CommandContext';
 
+type GroupOptionName = Exclude<keyof VersionGroupOptions, 'name' | 'include' | 'exclude'>;
+const groupOptionsKeys: Record<string, true> = {
+  disallowedChangeTypes: true,
+} satisfies Record<GroupOptionName, true>;
+
+interface ConfigNameTree {
+  [key: string]: true | ConfigNameTree;
+}
+
+type ConfigNames<T> = {
+  [Key in keyof T]-?: NonNullable<T[Key]> extends readonly unknown[] | ((...args: never[]) => unknown)
+    ? true
+    : NonNullable<T[Key]> extends object
+    ? ConfigNames<NonNullable<T[Key]>>
+    : true;
+};
+
 /** Keys that can be overridden per-package (exhaustive via Record) */
 const packageOptionKeys: Record<string, true> = {
   tag: true,
@@ -14,18 +31,32 @@ const packageOptionKeys: Record<string, true> = {
   shouldPublish: true,
 } satisfies Record<keyof PackageOptions, true>;
 
-/** Keys from RepoOptions (the full set of valid config file settings, exhaustive via Record) */
-const repoOptionKeys: Record<string, true> = {
+/** The full set of valid config file settings (recursively exhaustive) */
+const validConfigNames: ConfigNameTree = {
   access: true,
   authType: true,
   branch: true,
   bump: true,
   bumpDeps: true,
   canaryName: true,
-  changeFilePrompt: true,
+  changeFilePrompt: { changePrompt: true },
   changehint: true,
   changeDir: true,
-  changelog: true,
+  changelog: {
+    groups: true,
+    renderPackageChangelog: true,
+    customRenderers: {
+      renderHeader: true,
+      renderChangeTypeSection: true,
+      renderChangeTypeHeader: true,
+      renderEntries: true,
+      renderEntry: true,
+    },
+    renderMainHeader: true,
+    uniqueFilenames: true,
+    maxVersions: true,
+    includeCommitHashes: true,
+  },
   commit: true,
   concurrency: true,
   npmReadConcurrency: true,
@@ -37,7 +68,7 @@ const repoOptionKeys: Record<string, true> = {
   generateChangelog: true,
   groups: true,
   gitTags: true,
-  hooks: true,
+  hooks: { prepublish: true, postpublish: true, prebump: true, postbump: true, precommit: true },
   ignorePatterns: true,
   keepChangeFiles: true,
   message: true,
@@ -54,23 +85,11 @@ const repoOptionKeys: Record<string, true> = {
   tag: true,
   timeout: true,
   gitTimeout: true,
-  transform: true,
+  transform: { changeFiles: true },
   groupChanges: true,
   depth: true,
   new: true,
-} satisfies Record<keyof RepoOptions, true>;
-
-type GroupOptionName = Exclude<keyof VersionGroupOptions, 'name' | 'include' | 'exclude'>;
-const groupOptionsKeys: Record<string, true> = {
-  disallowedChangeTypes: true,
-} satisfies Record<GroupOptionName, true>;
-
-/** All valid config names that can be queried */
-const validConfigNames = new Set<string>([
-  ...Object.keys(repoOptionKeys),
-  ...Object.keys(packageOptionKeys),
-  ...Object.keys(groupOptionsKeys),
-]);
+} satisfies ConfigNames<RepoOptions>;
 
 /**
  * Handles the `beachball config get <name>` command.
@@ -90,14 +109,7 @@ export function configGet(options: BeachballOptions, context: BasicCommandContex
   }
 
   const name = extraArgs[1];
-  if (!validConfigNames.has(name)) {
-    const suggestion = findSimilar(name, [...validConfigNames]);
-    throw new BeachballError(
-      suggestion
-        ? `Unknown config setting: "${name}" - did you mean "${suggestion}"?`
-        : `Unknown config setting: "${name}"`
-    );
-  }
+  validateConfigName(name);
 
   // Validate any provided package names
   const packageNames = Array.isArray(options.package) ? options.package : options.package ? [options.package] : [];
@@ -133,7 +145,7 @@ function printForPackages(
   context: BasicCommandContext
 ): void {
   const { originalPackageInfos: packageInfos, packageGroups } = context;
-  const mainValue = (options as unknown as Record<string, unknown>)[name];
+  const mainValue = getConfigValue(options, name);
 
   const results: Record<string, unknown> = {};
   for (const pkgName of packageNames) {
@@ -158,7 +170,7 @@ function printForPackages(
 /** Print the repo-level value of a setting, plus any package or group overrides */
 function printDefault(name: string, options: BeachballOptions, context: BasicCommandContext): void {
   const { originalPackageInfos: packageInfos, scopedPackages, packageGroups } = context;
-  const mainValue = (options as unknown as Record<string, unknown>)[name];
+  const mainValue = getConfigValue(options, name);
 
   // Collect package overrides
   const pkgOverrides: Record<string, unknown> = {};
@@ -201,6 +213,36 @@ function printDefault(name: string, options: BeachballOptions, context: BasicCom
   if (hasGroupOverrides) {
     console.log('\nGroup overrides:');
     console.log(formatValue(groupOverrides, { level: 1 }));
+  }
+}
+
+function getConfigValue(options: BeachballOptions, name: string): unknown {
+  let value: unknown = options;
+  for (const key of name.split('.')) {
+    if (typeof value !== 'object' || value === null) {
+      return undefined;
+    }
+    value = (value as Record<string, unknown>)[key];
+  }
+  return value;
+}
+
+function validateConfigName(name: string): void {
+  const keys = name.split('.');
+  let validNames = validConfigNames;
+
+  for (const [index, key] of keys.entries()) {
+    if (!Object.prototype.hasOwnProperty.call(validNames, key)) {
+      const similarKey = findSimilar(key, Object.keys(validNames));
+      const suggestion = similarKey ? [...keys.slice(0, index), similarKey].join('.') : undefined;
+      throw new BeachballError(
+        suggestion
+          ? `Unknown config setting: "${name}" - did you mean "${suggestion}"?`
+          : `Unknown config setting: "${name}"`
+      );
+    }
+    const childNames = validNames[key];
+    validNames = typeof childNames === 'object' ? childNames : {};
   }
 }
 


### PR DESCRIPTION
Port part of #1394 to v2 so you can run e.g. `beachball config get changelog.maxVersions`. This is mainly to ensure the change files skill stays compatible with v2.