### PR TITLE
Update auth helper to accept env vars

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -299,12 +299,12 @@ extends:
                   scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: yarn beachball-auth-helper create-github-app-token
-                  env:
-                    APP_CLIENT_ID: $(ghaClientId)
-                    APP_KEY_ID: $(ghaTokenKeyId)
-                    REPOSITORY: $(Build.Repository.Name)
-                    PERMISSIONS: contents:write
-                    CI_OUTPUT_NAME: GITHUB_APP_TOKEN
+                env:
+                  APP_CLIENT_ID: $(ghaClientId)
+                  APP_KEY_ID: $(ghaTokenKeyId)
+                  REPOSITORY: $(Build.Repository.Name)
+                  PERMISSIONS: contents:write
+                  CI_OUTPUT_NAME: GITHUB_APP_TOKEN
 
               # Run publish. Beachball reads `BEACHBALL_GIT_TOKEN` to authenticate the git push.
               - script: yarn beachball:release publish --no-publish

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -301,7 +301,7 @@ extends:
                   inlineScript: yarn beachball-auth-helper create-github-app-token
                 env:
                   APP_CLIENT_ID: $(ghaClientId)
-                  APP_KEY_ID: $(ghaTokenKeyId)
+                  KEY_ID: $(ghaTokenKeyId)
                   REPOSITORY: $(Build.Repository.Name)
                   PERMISSIONS: contents:write
                   CI_OUTPUT_NAME: GITHUB_APP_TOKEN

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -96,8 +96,8 @@ extends:
         enabledOnNonDefaultBranches: false
     settings:
       # If any job has `type: releaseJob`, it applies strict network isolation to the whole pipeline.
-      # Re-enable the access needed.
-      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
+      # Re-enable the access needed. (For some reason DefaultDeny actually enables contacting ADO...)
+      networkIsolationPolicy: DefaultDeny,AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
 
     stages:
       - stage: build
@@ -298,13 +298,13 @@ extends:
                   azureSubscription: $(ghaTokenAzureSubscription)
                   scriptType: bash
                   scriptLocation: inlineScript
-                  inlineScript: |
-                    yarn beachball-auth-helper create-github-app-token \
-                      --app-client-id '$(ghaClientId)' \
-                      --key-id '$(ghaTokenKeyId)' \
-                      --repository '$(Build.Repository.Name)' \
-                      --permissions contents:write \
-                      --ci-output-name GITHUB_APP_TOKEN
+                  inlineScript: yarn beachball-auth-helper create-github-app-token
+                  env:
+                    APP_CLIENT_ID: $(ghaClientId)
+                    APP_KEY_ID: $(ghaTokenKeyId)
+                    REPOSITORY: $(Build.Repository.Name)
+                    PERMISSIONS: contents:write
+                    CI_OUTPUT_NAME: GITHUB_APP_TOKEN
 
               # Run publish. Beachball reads `BEACHBALL_GIT_TOKEN` to authenticate the git push.
               - script: yarn beachball:release publish --no-publish

--- a/change/@microsoft-esrp-npm-release-1dbd592d-3e12-4f4c-b114-9addcef154a9.json
+++ b/change/@microsoft-esrp-npm-release-1dbd592d-3e12-4f4c-b114-9addcef154a9.json
@@ -1,0 +1,6 @@
+{
+  "type": "none",
+  "comment": "update readme",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/change/beachball-0b106fce-ad3d-48c1-a040-aec31ca7e354.json
+++ b/change/beachball-0b106fce-ad3d-48c1-a040-aec31ca7e354.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "(delete for release) Update auth helper to accept env vars",
+  "packageName": "beachball",
+  "email": "elcraig@microsoft.com"
+}

--- a/docs/concepts/ci-integration/auth-helper.md
+++ b/docs/concepts/ci-integration/auth-helper.md
@@ -163,13 +163,13 @@ steps:
       azureSubscription: <your service connection name>
       scriptType: bash
       scriptLocation: inlineScript
-      inlineScript: |
-        yarn beachball-auth-helper create-github-app-token \
-          --app-client-id "<app client id>" \
-          --key-id "<key vault key URL>" \
-          --repository "$(Build.Repository.Name)" \
-          --permissions "<perms>" \
-          --ci-output-name MY_TOKEN
+      inlineScript: yarn beachball-auth-helper create-github-app-token
+    env:
+      APP_CLIENT_ID: <app client id>
+      APP_KEY_ID: <key vault key URL>
+      REPOSITORY: $(Build.Repository.Name)
+      PERMISSIONS: <perms>
+      CI_OUTPUT_NAME: MY_TOKEN
 
   # some script that uses the token
   - script: node scripts/use-token.js

--- a/docs/concepts/ci-integration/auth-helper.md
+++ b/docs/concepts/ci-integration/auth-helper.md
@@ -34,32 +34,34 @@ The generated token is valid for one hour, but it's best to immediately call [`r
 
 #### Options
 
-Exactly one **signing source** is required: either `--key-id` (Azure key vault key ID) or `PRIVATE_KEY` (PEM-encoded GitHub App private key), as configured in the [GitHub App setup steps](#github-app-setup). If using `--key-id`, the `az` CLI must be on `PATH` and authenticated first.
+Exactly one **signing source** is required: either `--key-id`/`KEY_ID` (Azure key vault key ID) or `PRIVATE_KEY` (PEM-encoded GitHub App private key), as configured in the [GitHub App setup steps](#github-app-setup). If using a key ID, the `az` CLI must be on `PATH` and authenticated first.
 
-By default, the token is written to stdout. Use `--ci-output-name` in CI to save it as a task/step output.
+Each option can be provided as a flag or through the uppercase environment variable listed below. Flags take precedence over environment variables.
+
+By default, the token is written to stdout. Use `--ci-output-name`/`CI_OUTPUT_NAME` in CI to save it as a task/step output.
 
 Besides `PRIVATE_KEY`, none of the other inputs need to be handled as secrets.
 
 <!-- prettier-ignore -->
-| Input | Required | Description |
-| ----- | -------- | ----------- |
-| `--app-client-id` | Yes | GitHub App client ID. See [GitHub App setup steps](#github-app-setup) for where to find it in the UI. |
-| `--key-id` | One signing source | Azure Key Vault key ID, e.g. `https://my-vault.vault.azure.net/keys/my-github-app-key` - see [Azure resource setup](#azure-resource-setup). The `az` CLI must be on `PATH` and authenticated to use this option. |
-| `PRIVATE_KEY` (env var) | One signing source | PEM-encoded GitHub App private key. Escaped newlines (`\\n`) in the private key are converted to actual newlines. |
-| `--repository` | Yes | Repository for the app installation and token scope, in `owner/repo` format. |
-| `--permissions` | | Comma-separated `permission:level` entries, such as `contents:read, pull_requests:write` (see [valid `permissions` properties and values](https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app)). Omit to inherit the installation perms. Requested perms cannot exceed those granted to the app installation. Spaces are ignored. |
-| `--ci-output-name` | | Instead of writing the token to stdout, save it as an Azure Pipelines secret step output or masked GitHub Actions step output. Must be a valid environment variable name. |
-| `--github-api-url` | | GitHub REST API URL (customizable for GitHub Enterprise). Defaults to `https://api.github.com`. |
+| Flag | Env var | Required | Description |
+| ---- | ------- | -------- | ----------- |
+| `--app-client-id` | `APP_CLIENT_ID` | Yes | GitHub App client ID. See [GitHub App setup steps](#github-app-setup) for where to find it in the UI. |
+| `--key-id` | `KEY_ID` | One signing source | Azure Key Vault key ID, e.g. `https://my-vault.vault.azure.net/keys/my-github-app-key` - see [Azure resource setup](#azure-resource-setup). The `az` CLI must be on `PATH` and authenticated to use this option. |
+| | `PRIVATE_KEY` | One signing source | PEM-encoded GitHub App private key. Escaped newlines (`\\n`) in the private key are converted to actual newlines. |
+| `--repository` | `REPOSITORY` | Yes | Repository for the app installation and token scope, in `owner/repo` format. |
+| `--permissions` | `PERMISSIONS` | | Comma-separated `permission:level` entries, such as `contents:read, pull_requests:write` (see [valid `permissions` properties and values](https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app)). Omit to inherit the installation perms. Requested perms cannot exceed those granted to the app installation. Spaces are ignored. |
+| `--ci-output-name` | `CI_OUTPUT_NAME` | | Instead of writing the token to stdout, save it as an Azure Pipelines secret step output or masked GitHub Actions step output. Must be a valid environment variable name. |
+| `--github-api-url` | `GITHUB_API_URL` | | GitHub REST API URL (customizable for GitHub Enterprise). Defaults to `https://api.github.com`. |
 
 ### `revoke-github-app-token`
 
 The `revoke-github-app-token` command revokes a token by calling `DELETE /installation/token`. The token authenticates its own revocation. Run this command in an always-running cleanup step (as shown in the [usage examples](#usage-create-github-app-token)) so the token is revoked even if an earlier step fails.
 
 <!-- prettier-ignore -->
-| Input | Description |
-| ----- | ----------- |
-| `TOKEN` (env var) | Installation token to revoke. |
-| `--github-api-url` | (optional) GitHub REST API URL (customizable for GitHub Enterprise). Defaults to `https://api.github.com`. |
+| Flag | Env var | Description |
+| ---- | ------- | ----------- |
+| | `TOKEN` | Installation token to revoke. |
+| `--github-api-url` | `GITHUB_API_URL` | (optional) GitHub REST API URL (customizable for GitHub Enterprise). Defaults to `https://api.github.com`. |
 
 ### `update-lock-registry`
 
@@ -124,14 +126,13 @@ steps:
   # and pass --key-id instead.
   - name: Create GitHub App token
     id: app-token
-    run: |
-      yarn beachball-auth-helper create-github-app-token \
-        --repository "${{ github.repository }}" \
-        --app-client-id "<app client id>" \
-        --permissions "<perms>" \
-        --ci-output-name MY_TOKEN
+    run: yarn beachball-auth-helper create-github-app-token
     env:
+      APP_CLIENT_ID: <app client id>
+      CI_OUTPUT_NAME: MY_TOKEN
       PRIVATE_KEY: ${{ secrets.MY_GITHUB_APP_PRIVATE_KEY }}
+      PERMISSIONS: <perms>
+      REPOSITORY: ${{ github.repository }}
 
   - name: Use token
     run: node scripts/use-token.js

--- a/docs/concepts/ci-integration/auth-helper.md
+++ b/docs/concepts/ci-integration/auth-helper.md
@@ -166,7 +166,7 @@ steps:
       inlineScript: yarn beachball-auth-helper create-github-app-token
     env:
       APP_CLIENT_ID: <app client id>
-      APP_KEY_ID: <key vault key URL>
+      KEY_ID: <key vault key URL>
       REPOSITORY: $(Build.Repository.Name)
       PERMISSIONS: <perms>
       CI_OUTPUT_NAME: MY_TOKEN

--- a/packages/beachball/src/__tests__/authHelper/__snapshots__/authHelperCli.test.ts.snap
+++ b/packages/beachball/src/__tests__/authHelper/__snapshots__/authHelperCli.test.ts.snap
@@ -6,24 +6,25 @@ exports[`authHelperCli shows help text for create-github-app-token 1`] = `
 Create a repository-scoped GitHub App installation token
 
 Options:
-  --app-client-id <id>       GitHub App client ID (not a secret)
-  --key-id <keyId>           Azure Key Vault key ID used to sign the app JWT
+  --app-client-id <id>       GitHub App client ID (not a secret) (env: APP_CLIENT_ID)
+  --key-id <keyId>           Azure Key Vault key ID used to sign the app JWT (env: KEY_ID)
   --private-key <pem>        Provide via PRIVATE_KEY env: PEM-encoded GitHub App private key
                              (escaped newlines are accepted) (env: PRIVATE_KEY)
-  --repository <owner/repo>  Repository to scope the token to, in owner/repo format
+  --repository <owner/repo>  Repository to scope the token to, in owner/repo format (env:
+                             REPOSITORY)
   --permissions <list>       Comma-separated list of "permission:level" entries (e.g. "contents:
-                             read, pull_requests: write")
+                             read, pull_requests: write") (env: PERMISSIONS)
   --ci-output-name <NAME>    Save the token as an Azure Pipelines secret step output or masked
-                             GitHub Actions step output
+                             GitHub Actions step output (env: CI_OUTPUT_NAME)
   --github-api-url <url>     GitHub REST API URL (for GitHub Enterprise Server) (default:
-                             "https://api.github.com")
+                             "https://api.github.com", env: GITHUB_API_URL)
   -h, --help                 display help for command
 
 Signing:
-Provide exactly one signing source: --key-id for Azure Key Vault or PRIVATE_KEY for a PEM-encoded private key.
+Provide exactly one signing source: --key-id/KEY_ID for Azure Key Vault or PRIVATE_KEY for a PEM-encoded private key.
 
 Output:
-By default, the token is written to stdout. With --ci-output-name, it is written as a secret Azure Pipelines output or masked GitHub Actions output.
+By default, the token is written to stdout. With --ci-output-name/CI_OUTPUT_NAME, it is written as a secret Azure Pipelines output or masked GitHub Actions output.
 
 Tokens expire after one hour. Create them immediately before use and revoke them when finished.
 
@@ -38,7 +39,7 @@ Revoke a GitHub App installation token
 Options:
   --token <token>         Provide via TOKEN env: Installation token to revoke (env: TOKEN)
   --github-api-url <url>  GitHub REST API URL (for GitHub Enterprise Server) (default:
-                          "https://api.github.com")
+                          "https://api.github.com", env: GITHUB_API_URL)
   -h, --help              display help for command
 
 Full setup and examples: https://microsoft.github.io/beachball/concepts/ci-integration/auth-helper"

--- a/packages/beachball/src/__tests__/authHelper/authHelperCli.test.ts
+++ b/packages/beachball/src/__tests__/authHelper/authHelperCli.test.ts
@@ -103,14 +103,37 @@ describe('authHelperCli', () => {
       expect(out).toEqual([mockToken]);
     });
 
-    it('does not read non-secret options from environment variables', async () => {
+    it('reads options from environment variables', async () => {
       const context = getContext(['create-github-app-token'], {
         APP_CLIENT_ID: 'Iv1.client',
         KEY_ID: 'key-id',
         REPOSITORY: 'org/repo',
+        PERMISSIONS: 'contents:read,pull_requests:write',
+        CI_OUTPUT_NAME: 'MY_TOKEN',
+        GITHUB_API_URL: 'https://ghe.example.com/api/v3',
+        TF_BUILD: 'true',
       });
-      await expect(runAuthHelperCli(context)).rejects.toThrow(CommanderError);
-      expect(err[0]).toMatch(/required option '--app-client-id <id>' not specified/);
+      await runAuthHelperCli(context);
+
+      expect(createAppToken).toHaveBeenCalledWith({
+        appClientId: 'Iv1.client',
+        githubApiUrl: 'https://ghe.example.com/api/v3',
+        keyInfo: { keyId: 'key-id' },
+        permissions: { contents: 'read', pull_requests: 'write' },
+        repository: { owner: 'org', name: 'repo' },
+      });
+      expect(out).toEqual([`##vso[task.setvariable variable=MY_TOKEN;isSecret=true;isOutput=true]${mockToken}`]);
+    });
+
+    it('prefers flags over environment variables', async () => {
+      const context = getContext([...requiredArgs], {
+        APP_CLIENT_ID: 'Iv1.environment',
+        KEY_ID: 'environment-key-id',
+        REPOSITORY: 'environment/repo',
+      });
+      await runAuthHelperCli(context);
+
+      expect(createAppToken).toHaveBeenCalledWith({ ...defaults, keyInfo: { keyId: 'key-id' } });
     });
 
     it('parses permissions', async () => {
@@ -251,6 +274,19 @@ describe('authHelperCli', () => {
       expect(revokeAppToken).toHaveBeenCalledWith({
         githubApiUrl: 'https://ghe.example.com/api/v3',
         token: 'ghs_revoke_me',
+      });
+    });
+
+    it('reads the GitHub API URL from GITHUB_API_URL', async () => {
+      const context = getContext(['revoke-github-app-token'], {
+        GITHUB_API_URL: 'https://ghe.example.com/api/v3',
+        TOKEN: 'ghs_from_env',
+      });
+      await runAuthHelperCli(context);
+
+      expect(revokeAppToken).toHaveBeenCalledWith({
+        githubApiUrl: 'https://ghe.example.com/api/v3',
+        token: 'ghs_from_env',
       });
     });
 

--- a/packages/beachball/src/authHelper/authHelperCli.ts
+++ b/packages/beachball/src/authHelper/authHelperCli.ts
@@ -73,16 +73,22 @@ function buildProgram(context: CliContext): Command {
   context.outputOptions && program.configureOutput(context.outputOptions);
 
   const githubApiUrlOption = () =>
-    new Option('--github-api-url <url>', 'GitHub REST API URL (for GitHub Enterprise Server)').default(
-      defaultGitHubApiUrl
-    );
+    new Option('--github-api-url <url>', 'GitHub REST API URL (for GitHub Enterprise Server)')
+      .env('GITHUB_API_URL')
+      .default(defaultGitHubApiUrl);
 
   const createCommand = program
     .command('create-github-app-token')
     .description('Create a repository-scoped GitHub App installation token')
-    .addOption(new Option('--app-client-id <id>', 'GitHub App client ID (not a secret)').makeOptionMandatory())
     .addOption(
-      new Option('--key-id <keyId>', 'Azure Key Vault key ID used to sign the app JWT').conflicts('privateKey')
+      new Option('--app-client-id <id>', 'GitHub App client ID (not a secret)')
+        .env('APP_CLIENT_ID')
+        .makeOptionMandatory()
+    )
+    .addOption(
+      new Option('--key-id <keyId>', 'Azure Key Vault key ID used to sign the app JWT')
+        .env('KEY_ID')
+        .conflicts('privateKey')
     )
     .addOption(
       new Option(
@@ -94,6 +100,7 @@ function buildProgram(context: CliContext): Command {
     )
     .addOption(
       new Option('--repository <owner/repo>', 'Repository to scope the token to, in owner/repo format')
+        .env('REPOSITORY')
         .makeOptionMandatory()
         .argParser(value => {
           const parts = value.split('/');
@@ -107,18 +114,22 @@ function buildProgram(context: CliContext): Command {
       new Option(
         '--permissions <list>',
         'Comma-separated list of "permission:level" entries (e.g. "contents: read, pull_requests: write")'
-      ).argParser(parsePermissions)
+      )
+        .env('PERMISSIONS')
+        .argParser(parsePermissions)
     )
     .addOption(
       new Option(
         '--ci-output-name <NAME>',
         'Save the token as an Azure Pipelines secret step output or masked GitHub Actions step output'
-      ).argParser(value => {
-        if (!/^[A-Za-z_]\w*$/.test(value)) {
-          throw new InvalidArgumentError('Must be an environment-style variable name.');
-        }
-        return value;
-      })
+      )
+        .env('CI_OUTPUT_NAME')
+        .argParser(value => {
+          if (!/^[A-Za-z_]\w*$/.test(value)) {
+            throw new InvalidArgumentError('Must be an environment-style variable name.');
+          }
+          return value;
+        })
     )
     .addOption(githubApiUrlOption())
     .action((options: TokenCliOptions, command: Command) =>
@@ -129,10 +140,10 @@ function buildProgram(context: CliContext): Command {
     'after',
     `
 Signing:
-Provide exactly one signing source: --key-id for Azure Key Vault or PRIVATE_KEY for a PEM-encoded private key.
+Provide exactly one signing source: --key-id/KEY_ID for Azure Key Vault or PRIVATE_KEY for a PEM-encoded private key.
 
 Output:
-By default, the token is written to stdout. With --ci-output-name, it is written as a secret Azure Pipelines output or masked GitHub Actions output.
+By default, the token is written to stdout. With --ci-output-name/CI_OUTPUT_NAME, it is written as a secret Azure Pipelines output or masked GitHub Actions output.
 
 Tokens expire after one hour. Create them immediately before use and revoke them when finished.`
   );

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -727,7 +727,7 @@ If your repo has traditionally pushed packages directly back to GitHub with a pe
             inlineScript: yarn beachball-auth-helper create-github-app-token
           env:
             APP_CLIENT_ID: <GitHub App client ID>
-            APP_KEY_ID: <key vault key URL>
+            KEY_ID: <key vault key URL>
             REPOSITORY: $(Build.Repository.Name)
             PERMISSIONS: contents:write
             CI_OUTPUT_NAME: GITHUB_APP_TOKEN

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -439,8 +439,8 @@ extends:
 
     settings:
       # If any job has `type: releaseJob`, it applies strict network isolation to the whole pipeline.
-      # Re-enable the access needed.
-      networkIsolationPolicy: AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
+      # Re-enable the access needed. (For some reason DefaultDeny actually enables contacting ADO...)
+      networkIsolationPolicy: DefaultDeny,AzureActiveDirectory,AzureKeyVault,AzureStorage,GitHub
 
     stages:
       - stage: build
@@ -724,13 +724,13 @@ If your repo has traditionally pushed packages directly back to GitHub with a pe
             azureSubscription: <GitHub App service connection name>
             scriptType: bash
             scriptLocation: inlineScript
-            inlineScript: |
-              yarn beachball-auth-helper create-github-app-token \
-                --app-client-id <GitHub App client ID> \
-                --key-id "<key vault key URL>" \
-                --repository "$(Build.Repository.Name)" \
-                --permissions contents:write \
-                --ci-output-name GITHUB_APP_TOKEN
+            inlineScript: yarn beachball-auth-helper create-github-app-token
+            env:
+              APP_CLIENT_ID: <GitHub App client ID>
+              APP_KEY_ID: <key vault key URL>
+              REPOSITORY: $(Build.Repository.Name)
+              PERMISSIONS: contents:write
+              CI_OUTPUT_NAME: GITHUB_APP_TOKEN
 
         # Run publish without publishing to npm. Beachball reads `BEACHBALL_GIT_TOKEN` to authenticate the git push.
         # Update the command as needed for your repo.

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -725,12 +725,12 @@ If your repo has traditionally pushed packages directly back to GitHub with a pe
             scriptType: bash
             scriptLocation: inlineScript
             inlineScript: yarn beachball-auth-helper create-github-app-token
-            env:
-              APP_CLIENT_ID: <GitHub App client ID>
-              APP_KEY_ID: <key vault key URL>
-              REPOSITORY: $(Build.Repository.Name)
-              PERMISSIONS: contents:write
-              CI_OUTPUT_NAME: GITHUB_APP_TOKEN
+          env:
+            APP_CLIENT_ID: <GitHub App client ID>
+            APP_KEY_ID: <key vault key URL>
+            REPOSITORY: $(Build.Repository.Name)
+            PERMISSIONS: contents:write
+            CI_OUTPUT_NAME: GITHUB_APP_TOKEN
 
         # Run publish without publishing to npm. Beachball reads `BEACHBALL_GIT_TOKEN` to authenticate the git push.
         # Update the command as needed for your repo.


### PR DESCRIPTION
In .yml files, it ends up cleaner and less error-prone to have `beachball-auth-helper` accept its options from env vars instead of flags (the flags are still supported).