### PR TITLE
ESRP: support multiple users, clarify docs, retry transient submit failures

### DIFF
--- a/change/@microsoft-esrp-npm-release-b66dea30-7381-4b55-a98b-a0b79dc9c08a.json
+++ b/change/@microsoft-esrp-npm-release-b66dea30-7381-4b55-a98b-a0b79dc9c08a.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Accept multiple emails as ESRP_USER and clarify docs",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/change/@microsoft-esrp-npm-release-b7d0e7c6-9f2a-49e5-b785-7fbd783c8eca.json
+++ b/change/@microsoft-esrp-npm-release-b7d0e7c6-9f2a-49e5-b785-7fbd783c8eca.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Retry submit release on transient errors",
+  "packageName": "@microsoft/esrp-npm-release",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/esrp-npm-release/README.md
+++ b/packages/esrp-npm-release/README.md
@@ -72,16 +72,16 @@ See setup steps in later sections and [sample pipelines](#publish-stage) at the 
 
 ### Contact info
 
-`ESRP_USER` is optional and provides a default value for all the other fields in this group (so those become optional if it's set).
+`ESRP_USER` is optional and provides comma-separated default values for all the other fields in this group (so those become optional if it's set).
 
 <!-- prettier-ignore -->
 | Variable | Description |
 | -------- | ----------- |
-| `ESRP_USER` | _Optional._ Default value for the fields below. |
-| `ESRP_CREATED_BY` | Email of the user creating the release. |
-| `ESRP_DRI_EMAIL` | Email of the DRI for the team creating the release. |
-| `ESRP_OWNERS` | Owner email(s), comma-separated. |
-| `ESRP_APPROVERS` | Approver email(s), comma-separated (all non-mandatory and auto-approved). |
+| `ESRP_USER` | _Optional._ Comma-separated individual user emails (DL/SG not supported) used as default values for the fields below. The first email is used as `ESRP_CREATED_BY`. |
+| `ESRP_CREATED_BY` | Email of the user creating the release. DL/SG not supported. |
+| `ESRP_DRI_EMAIL` | DRI email(s) for the team creating the release, comma-separated. This _does_ support DL/SG. |
+| `ESRP_OWNERS` | Individual owner email(s), comma-separated. DL/SG not supported. |
+| `ESRP_APPROVERS` | Individual approver email(s), comma-separated (all non-mandatory and auto-approved). DL/SG not supported. |
 
 ### ESRP resources
 
@@ -92,8 +92,8 @@ ESRP resources are set up per their guides. Correspondence with official `EsrpRe
 | -------- | ----------- |
 | `ESRP_TENANT_ID` | Production tenant ID for your ESRP app registration or managed identity. (`EsrpRelease` task: `domaintenantid`) |
 | `ESRP_CLIENT_ID` | Client ID for your ESRP app registration or ESRP-allowlisted managed identity. (`EsrpRelease` task: `clientid`) |
-| `ESRP_AUTH_CERT` | Base64-encoded PFX certificate for authenticating to ESRP AAD. Set exactly one of this and `ESRP_ID_TOKEN`. |
-| `ESRP_ID_TOKEN` | Federated ID token for authenticating as an ESRP-allowlisted managed identity. Set exactly one of this and `ESRP_AUTH_CERT`. |
+| `ESRP_AUTH_CERT` | Base64-encoded PFX certificate for authenticating to ESRP AAD. Set exactly one of this or `ESRP_ID_TOKEN`. |
+| `ESRP_ID_TOKEN` | Federated ID token for authenticating as an ESRP-allowlisted managed identity. Set exactly one of this or `ESRP_AUTH_CERT`. |
 | `ESRP_REQUEST_SIGNING_CERT` | Base64-encoded PFX certificate for signing JWS release requests. Required for both authentication methods. |
 
 The request signing certificate and optional auth certificate are typically retrieved by a prior `AzureKeyVault` task step (as shown in the [example pipeline](#publish-stage)):
@@ -580,11 +580,11 @@ Add one of the following publish stages to the pipeline (under `extends.paramete
             # Release info (must be unique per invocation if publishing multiple times per build)
             ESRP_PRODUCT_NAME: <friendly product name>
             ESRP_NPM_TAG: <npm dist-tag> # optional
-            ESRP_USER: <email>
-            ESRP_CREATED_BY: <email> # optional if ESRP_USER is set
-            ESRP_APPROVERS: <email> # optional if ESRP_USER is set
-            ESRP_OWNERS: <email> # optional if ESRP_USER is set
-            ESRP_DRI_EMAIL: <email> # optional if ESRP_USER is set
+            ESRP_USER: <user email(s), comma-separated>
+            ESRP_CREATED_BY: <user email> # optional if ESRP_USER is set
+            ESRP_APPROVERS: <user email(s), comma-separated> # optional if ESRP_USER is set
+            ESRP_OWNERS: <user email(s), comma-separated> # optional if ESRP_USER is set
+            ESRP_DRI_EMAIL: <email(s), comma-separated> # optional if ESRP_USER is set
 ```
 
 </details>
@@ -685,11 +685,11 @@ Add one of the following publish stages to the pipeline (under `extends.paramete
             # Release info (must be unique per invocation if publishing multiple times per build)
             ESRP_PRODUCT_NAME: <friendly product name>
             ESRP_NPM_TAG: <npm dist-tag> # optional
-            ESRP_USER: <email>
-            ESRP_CREATED_BY: <email> # optional if ESRP_USER is set
-            ESRP_APPROVERS: <email> # optional if ESRP_USER is set
-            ESRP_OWNERS: <email> # optional if ESRP_USER is set
-            ESRP_DRI_EMAIL: <email> # optional if ESRP_USER is set
+            ESRP_USER: <user email(s), comma-separated>
+            ESRP_CREATED_BY: <user email> # optional if ESRP_USER is set
+            ESRP_APPROVERS: <user email(s), comma-separated> # optional if ESRP_USER is set
+            ESRP_OWNERS: <user email(s), comma-separated> # optional if ESRP_USER is set
+            ESRP_DRI_EMAIL: <email(s), comma-separated> # optional if ESRP_USER is set
 ```
 
 </details>

--- a/packages/esrp-npm-release/src/__tests__/errorHelpers.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/errorHelpers.test.ts
@@ -19,8 +19,8 @@ describe('isRetryableAzureError', () => {
     expect(isRetryableAzureError(new ReleaseError('token failure', { retryable }))).toBe(retryable);
   });
 
-  it.each([RestError.REQUEST_SEND_ERROR, RestError.PARSE_ERROR])('retries pipeline error %s', code => {
-    expect(isRetryableAzureError(new RestError('pipeline failure', { code }))).toBe(true);
+  it('retries pipeline error REQUEST_SEND_ERROR', () => {
+    expect(isRetryableAzureError(new RestError('pipeline failure', { code: RestError.REQUEST_SEND_ERROR }))).toBe(true);
   });
 
   it.each([408, 429, 500, 503, 599])('retries HTTP status %s', statusCode => {

--- a/packages/esrp-npm-release/src/__tests__/generateJwsToken.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/generateJwsToken.test.ts
@@ -1,7 +1,10 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import jws from 'jws';
 import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtures__/testCert.ts';
-import { generateJwsToken } from '../auth/generateJwsToken.ts';
+import { generateJwsToken, type ReleaseJwsHeader } from '../auth/generateJwsToken.ts';
+import type { ReleaseRequestMessage } from '../types/api.ts';
+
+type ReleaseJwsSignature = Omit<jws.Signature, 'header'> & { header: ReleaseJwsHeader };
 
 // eslint-disable-next-line no-restricted-properties -- intentional skip when openssl is unavailable
 const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
@@ -14,15 +17,15 @@ describeIfOpenssl('generateJwsToken', () => {
   });
 
   /** `jws.decode` returns `null | undefined` for invalid tokens; throw to keep test types simple. */
-  function decodeOrThrow(token: string): jws.Signature {
+  function decodeOrThrow(token: string): ReleaseJwsSignature {
     const decoded = jws.decode(token);
     if (!decoded) throw new Error('Could not decode JWS token');
-    return decoded;
+    return decoded as ReleaseJwsSignature;
   }
 
   function makeToken(): string {
     return generateJwsToken({
-      releaseRequest: { driEmail: ['dri@example.com'] },
+      releaseRequest: { driEmail: ['dri@example.com'] } as ReleaseRequestMessage,
       certificates: [testCert.leafCertPem],
       privateKey: testCert.keyPem,
     });
@@ -35,17 +38,17 @@ describeIfOpenssl('generateJwsToken', () => {
 
   it("includes the leaf cert's hex SHA1 thumbprint as x5t", () => {
     const decoded = decodeOrThrow(makeToken());
-    expect((decoded.header as Record<string, unknown>).x5t).toBe(testCert.sha1ThumbprintHex);
+    expect(decoded.header.x5t).toBe(testCert.sha1ThumbprintHex);
   });
 
   it('includes the certificate chain as a "."-separated x5c (non-standard ESRP format)', () => {
     const decoded = decodeOrThrow(makeToken());
-    const x5c = (decoded.header as Record<string, unknown>).x5c as string;
+    const x5c = decoded.header.x5c;
     expect(typeof x5c).toBe('string');
     // Single-cert chain so no separator should appear
-    expect(x5c.includes('.')).toBe(false);
+    expect(x5c?.includes('.')).toBe(false);
     // The base64url-decoded value matches the leaf cert DER
-    const der = Buffer.from(x5c, 'base64url').toString('hex');
+    const der = Buffer.from(x5c!, 'base64url').toString('hex');
     const certDer = Buffer.from(
       testCert.leafCertPem.replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ''),
       'base64'
@@ -55,13 +58,13 @@ describeIfOpenssl('generateJwsToken', () => {
 
   it('joins multi-certificate chains with "." in leaf-then-CA order', () => {
     const token = generateJwsToken({
-      releaseRequest: { driEmail: ['test@example.com'] },
+      releaseRequest: { driEmail: ['test@example.com'] } as ReleaseRequestMessage,
       certificates: [testCert.leafCertPem, testCert.caCertPem],
       privateKey: testCert.keyPem,
     });
     const decoded = decodeOrThrow(token);
-    const x5c = (decoded.header as Record<string, unknown>).x5c as string;
-    const parts = x5c.split('.');
+    const x5c = decoded.header.x5c;
+    const parts = x5c!.split('.');
     expect(parts).toHaveLength(2);
 
     const leafDer = Buffer.from(parts[0], 'base64url').toString('hex');
@@ -81,14 +84,14 @@ describeIfOpenssl('generateJwsToken', () => {
   it('sets exp using .NET ticks (greater than Date.now() in milliseconds)', () => {
     const now = Date.now();
     const decoded = decodeOrThrow(makeToken());
-    const exp = (decoded.header as Record<string, unknown>).exp as number;
+    const exp = decoded.header.exp;
     // .NET ticks since 1/1/0001, which is far larger than any reasonable ms-since-epoch.
     expect(exp).toBeGreaterThan(now);
     expect(exp).toBeGreaterThan(621355968000000000);
   });
 
   it('serializes the release request as the JWS payload', () => {
-    const releaseRequest = { driEmail: ['custom@test.com'] };
+    const releaseRequest = { driEmail: ['custom@test.com'] } as ReleaseRequestMessage;
     const token = generateJwsToken({
       releaseRequest,
       certificates: [testCert.leafCertPem],

--- a/packages/esrp-npm-release/src/__tests__/getEnvOptions.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/getEnvOptions.test.ts
@@ -40,7 +40,7 @@ describe('getEnvOptions', () => {
   it('uses ESRP_USER as fallback for createdBy/driEmail/owners/approvers when those are unset', () => {
     const env = getEnvOptions(
       createMockProcessEnv({
-        ESRP_USER: 'fallback@example.com',
+        ESRP_USER: 'first@example.com, second@example.com',
         ESRP_CREATED_BY: undefined,
         ESRP_DRI_EMAIL: undefined,
         ESRP_OWNERS: undefined,
@@ -48,10 +48,10 @@ describe('getEnvOptions', () => {
       })
     );
 
-    expect(env.esrp.createdBy).toBe('fallback@example.com');
-    expect(env.esrp.driEmail).toEqual(['fallback@example.com']);
-    expect(env.esrp.owners).toEqual(['fallback@example.com']);
-    expect(env.esrp.approvers).toEqual(['fallback@example.com']);
+    expect(env.esrp.createdBy).toBe('first@example.com');
+    expect(env.esrp.driEmail).toEqual(['first@example.com', 'second@example.com']);
+    expect(env.esrp.owners).toEqual(['first@example.com', 'second@example.com']);
+    expect(env.esrp.approvers).toEqual(['first@example.com', 'second@example.com']);
   });
 
   it('prefers explicit values over ESRP_USER fallback', () => {
@@ -59,12 +59,14 @@ describe('getEnvOptions', () => {
       createMockProcessEnv({
         ESRP_USER: 'fallback@example.com',
         ESRP_CREATED_BY: 'creator@example.com',
+        ESRP_DRI_EMAIL: 'dri-a@example.com,dri-b@example.com',
         ESRP_OWNERS: 'a@example.com,b@example.com',
         ESRP_APPROVERS: 'c@example.com,d@example.com',
       })
     );
 
     expect(env.esrp.createdBy).toBe('creator@example.com');
+    expect(env.esrp.driEmail).toEqual(['dri-a@example.com', 'dri-b@example.com']);
     expect(env.esrp.owners).toEqual(['a@example.com', 'b@example.com']);
     expect(env.esrp.approvers).toEqual(['c@example.com', 'd@example.com']);
   });

--- a/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/npmRelease.test.ts
@@ -5,27 +5,32 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { generateTestCert, isOpensslAvailable, type TestCert } from '../__fixtures__/testCert.ts';
 import { createNpmReleaseRequest, formatReleaseRequestForLog, redactReleaseRequest } from '../esrpApi/npmRelease.ts';
-import { FileHashType, type ReleaseFileInfo, type ReleaseRequestMessage } from '../types/api.ts';
+import { FileHashType, type ReleaseRequestMessage } from '../types/api.ts';
 import { ReleaseError } from '../utils/ReleaseError.ts';
 
 // eslint-disable-next-line no-restricted-properties -- intentional skip when openssl is unavailable
 const describeIfOpenssl = (await isOpensslAvailable()) ? describe : describe.skip;
 
+const blobUrl = 'https://acct.blob.core.windows.net/staging/someblob';
+const blobSasUrl = `${blobUrl}?sv=2021-01-01&sig=SECRET&se=2099-01-01T00:00:00Z`;
+
+/** Build a minimal ReleaseRequestMessage shape with potentially-sensitive fields populated. */
+function makeMessage(): ReleaseRequestMessage {
+  return {
+    driEmail: ['dri@example.com'],
+    jwsToken: 'abc123.payload.signature',
+    files: [
+      {
+        name: 'pkg.tgz',
+        hash: 'jcxnJw==',
+        tenantFileLocation: blobSasUrl,
+        sourceLocation: { type: 'azureBlob', blobUrl: blobSasUrl },
+      },
+    ],
+  } as ReleaseRequestMessage;
+}
+
 describe('redactReleaseRequest', () => {
-  const blobUrl = 'https://acct.blob.core.windows.net/staging/someblob';
-  const blobSasUrl = `${blobUrl}?sv=2021-01-01&sig=SECRET&se=2099-01-01T00:00:00Z`;
-
-  /** Build a minimal ReleaseRequestMessage shape with potentially-sensitive fields populated. */
-  function makeMessage(): ReleaseRequestMessage {
-    return {
-      driEmail: ['dri@example.com'],
-      jwsToken: 'abc123.payload.signature',
-      files: [
-        { name: 'pkg.tgz', tenantFileLocation: blobSasUrl, sourceLocation: { type: 'azureBlob', blobUrl: blobSasUrl } },
-      ] as ReleaseFileInfo[],
-    };
-  }
-
   it('replaces the JWS token with "***"', () => {
     const redacted = redactReleaseRequest(makeMessage());
     expect(redacted.jwsToken).toBe('***');
@@ -68,23 +73,10 @@ describe('redactReleaseRequest', () => {
 });
 
 describe('formatReleaseRequestForLog', () => {
-  it('formats file hashes on one line while retaining pretty JSON', () => {
-    const message = {
-      files: [
-        {
-          name: 'pkg.tgz',
-          hash: [141, 204, 103, 39],
-          tenantFileLocation: 'https://example.com/file',
-          tenantFileLocationType: 'AzureBlob' as const,
-          sourceLocation: { type: 'azureBlob' as const },
-        },
-      ],
-    };
-
-    const formatted = formatReleaseRequestForLog(message);
-
-    expect(formatted).toContain('\n  "files": [');
-    expect(formatted).toContain('"hash": [141,204,103,39]');
+  it('formats as pretty JSON and redacts secrets', () => {
+    const formatted = formatReleaseRequestForLog(makeMessage());
+    expect(formatted).not.toContain('SECRET');
+    expect(formatted).toContain('{\n'); // uses pretty formatting (newlines)
   });
 });
 
@@ -154,7 +146,7 @@ describeIfOpenssl('createNpmReleaseRequest', () => {
           tenantFileLocationType: 'AzureBlob',
           sourceLocation: { type: 'azureBlob', blobUrl: params.file.sasBlobUrl },
           hashType: FileHashType.sha256,
-          hash: Array.from(crypto.createHash('sha256').update('hello world').digest()),
+          hash: crypto.createHash('sha256').update('hello world').digest('base64'),
           sizeInBytes: 11,
         },
       ],

--- a/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
+++ b/packages/esrp-npm-release/src/__tests__/releaseHttp.test.ts
@@ -51,21 +51,18 @@ describe('releaseHttp', () => {
       });
     });
 
-    it.each([
-      ['a transient HTTP response', () => makeFetchResponse({ status: 503, body: 'unavailable' })],
-      ['a network error', () => Promise.reject(new Error('fetch failed'))],
-    ])('does not retry or mark %s as retryable', async (_description, getFailure) => {
+    it('retries transient failures up to three attempts', async () => {
       jest.useFakeTimers();
-      fetchMock.mockImplementation(() => Promise.resolve(getFailure()).then(result => result));
+      fetchMock
+        .mockResolvedValueOnce(makeFetchResponse({ status: 503, body: 'unavailable' }))
+        .mockRejectedValueOnce(new Error('fetch failed'))
+        .mockResolvedValueOnce(makeFetchResponse({ body: '{"operationId":"op-1"}' }));
 
-      const error = (await expectError(
-        submitRelease({ ...defaultParams, releaseRequest: mockRequest }),
-        ReleaseError,
-        'Failed to submit release'
-      )) as ReleaseError;
+      const promise = submitRelease({ ...defaultParams, releaseRequest: mockRequest });
+      await jest.runAllTimersAsync();
 
-      expect(error.retryable).toBe(false);
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await expect(promise).resolves.toEqual({ operationId: 'op-1' });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/esrp-npm-release/src/auth/generateJwsToken.ts
+++ b/packages/esrp-npm-release/src/auth/generateJwsToken.ts
@@ -9,28 +9,33 @@ export interface JwsTokenParams {
   privateKey: string;
 }
 
-export function generateJwsToken(params: JwsTokenParams & { releaseRequest: ReleaseRequestMessage }): string {
+export type ReleaseJwsHeader = Pick<jws.Header, 'alg' | 'crit'> & {
+  /** X.509 certificate chain in non-standard '.' separated base64url format */
+  x5c?: string;
+  /** Expiration time in .NET ticks */
+  exp: bigint;
+  /** X.509 certificate thumbprint in hex format */
+  x5t: string;
+};
+
+export function generateJwsToken(
+  params: JwsTokenParams & { releaseRequest: Omit<ReleaseRequestMessage, 'jwsToken'> }
+): string {
   const { releaseRequest, certificates, privateKey } = params;
 
-  const expTicks = (BigInt(Date.now()) + 6n * 60n * 1000n) * 10000n + 621355968000000000n;
-
-  // Create header with properly typed properties, then override x5c with the non-standard string format
-  const header: jws.Header = {
+  const header: ReleaseJwsHeader = {
     alg: 'RS256',
     crit: ['exp', 'x5t'],
     // Release service uses .NET ticks, not milliseconds (https://stackoverflow.com/a/7968483)
-    exp: expTicks,
+    exp: (BigInt(Date.now()) + 6n * 60n * 1000n) * 10000n + 621355968000000000n,
     // Release service uses hex format for thumbprint
     x5t: getThumbprint(certificates[0], 'sha1').toString('hex'),
+    // Release service expects x5c as a '.' separated string, not the standard array format
+    x5c: certificates.map((c: string) => pemToDer(c).toString('base64url')).join('.'),
   };
 
-  // Release service expects x5c as a '.' separated string, not the standard array format
-  (header as Record<string, unknown>)['x5c'] = certificates
-    .map((c: string) => pemToDer(c).toString('base64url'))
-    .join('.');
-
   return jws.sign({
-    header,
+    header: header as jws.Header,
     payload: releaseRequest,
     privateKey,
   });

--- a/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
+++ b/packages/esrp-npm-release/src/esrpApi/npmRelease.ts
@@ -23,13 +23,13 @@ export type GeneratedReleaseRequestMessage = ReleaseRequestMessage &
 
 export interface CreateNpmReleaseRequestMessageParams {
   correlationId: string;
-  /** email of the DRI for the team creating this release */
+  /** email of the DRI for the team creating this release, possibly used if a release request fails */
   driEmail: string[];
   /** created by email */
   createdBy: string;
-  /** owner emails */
+  /** individual owner emails (DL/SG not supported) */
   owners: string[];
-  /** approver emails (all non-mandatory and auto-approved) */
+  /** individual approver emails (DL/SG not supported; all are non-mandatory and auto-approved) */
   approvers: string[];
   /** your release title */
   releaseTitle: string;
@@ -101,7 +101,7 @@ export async function createNpmReleaseRequest(
         tenantFileLocationType: 'AzureBlob',
         sourceLocation: { type: 'azureBlob', blobUrl: file.sasBlobUrl },
         hashType: FileHashType.sha256,
-        hash: Array.from(hash),
+        hash: hash.toString('base64'),
         sizeInBytes: size,
       },
     ],
@@ -135,21 +135,9 @@ export function redactReleaseRequest<TMessage extends Pick<ReleaseRequestMessage
   return message;
 }
 
-/** Redact a release message and format file hash arrays compactly for logging. */
+/** Redact a release message and format it for logging. */
 export function formatReleaseRequestForLog<TMessage extends Pick<ReleaseRequestMessage, 'files' | 'jwsToken'>>(
   message: TMessage
 ): string {
-  const redacted = redactReleaseRequest(message);
-  const hashes: (number[] | string)[] = [];
-  redacted.files = redacted.files?.map(file => {
-    const hashPlaceholder = `__ESRP_FILE_HASH_${hashes.length}__`;
-    hashes.push(file.hash);
-    return { ...file, hash: hashPlaceholder };
-  });
-
-  let formatted = JSON.stringify(redacted, null, 2);
-  hashes.forEach((hash, index) => {
-    formatted = formatted.replace(JSON.stringify(`__ESRP_FILE_HASH_${index}__`), JSON.stringify(hash));
-  });
-  return formatted;
+  return JSON.stringify(redactReleaseRequest(message), null, 2);
 }

--- a/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
+++ b/packages/esrp-npm-release/src/esrpApi/releaseHttp.ts
@@ -25,9 +25,7 @@ const esrpBaseUrl = `https://${esrpApiDomain}/api/v3/releaseservices/clients/`;
 /**
  * Submit a release request.
  * Throws a `ReleaseError` if the request fails or the response can't be parsed.
- *
- * This only attempts to submit the request once: the meaning of a failed submit request is unclear,
- * so the safest retry approach is for the user to re-run the stage.
+ * Retries transient request failures up to three attempts.
  */
 export async function submitRelease(
   params: Omit<ReleaseHttpParams, 'releaseId'> & { releaseRequest: ReleaseRequestMessage }
@@ -41,9 +39,9 @@ export async function submitRelease(
       bearerToken,
       method: 'POST',
       body: releaseRequest,
+      maxAttempts: 3,
     });
   } catch (err) {
-    // see function comment for why it doesn't retry
     throw new ReleaseError(`Failed to submit release`, { cause: err, retryable: false });
   }
 

--- a/packages/esrp-npm-release/src/types/EnvOptions.ts
+++ b/packages/esrp-npm-release/src/types/EnvOptions.ts
@@ -27,9 +27,9 @@ export interface EsrpEnvOptions {
   createdBy: string;
   /** Email of the DRI for the team creating the release */
   driEmail: string[];
-  /** Owner emails */
+  /** Individual owner emails (DL/SG not supported) */
   owners: string[];
-  /** Approver emails (all non-mandatory and auto-approved) */
+  /** Individual approver emails (DL/SG not supported; all are non-mandatory and auto-approved) */
   approvers: string[];
 
   /** Production tenant ID used for your ESRP app registration or managed identity */

--- a/packages/esrp-npm-release/src/types/api.ts
+++ b/packages/esrp-npm-release/src/types/api.ts
@@ -1,4 +1,7 @@
-// These types are derived from the ESRP OpenAPI specification
+// These types are derived from the ESRP OpenAPI specification.
+// It doesn't appear to correctly specify which properties are required or optional, so what's below
+// is the best guess based on what's been observed for usage with npm.
+// Enum format also appears to be flexible with casing or numeric/string in some cases.
 
 // Enums (in a format that allows running TS in Node natively)
 
@@ -23,46 +26,41 @@ export type StatusCode = (typeof StatusCode)[keyof typeof StatusCode];
 
 export const FileHashType = Object.freeze({
   sha256: 0,
-  sha1: 1,
 });
 export type FileHashType = (typeof FileHashType)[keyof typeof FileHashType];
 
-export const FileLocationType = Object.freeze({
-  AzureBlob: 'azureBlob',
-});
-export type FileLocationType = (typeof FileLocationType)[keyof typeof FileLocationType];
+export type FileLocationType = 'azureBlob';
 
 // Interfaces
 
 export interface UserInfo {
-  /** user email */
-  userPrincipalName?: string;
+  /** Individual user email (DL/SG not supported) */
+  userPrincipalName: string;
 }
 
 export interface ApproverInfo {
-  approver?: UserInfo;
+  /** Individual user (DL/SG not supported) */
+  approver: UserInfo;
   isAutoApproved?: boolean;
   isMandatory?: boolean;
 }
 
 export interface OwnerInfo {
-  owner?: UserInfo;
+  /** Individual user (DL/SG not supported) */
+  owner: UserInfo;
 }
 
 export interface AccessPermissionsInfo {
-  /** @example 'ESRPRelTest' */
+  /** Your team's publisher value, e.g. `ESRPRELPACMAN` (npm), `ESRPRelTest` */
   mainPublisher?: string;
-  /** @deprecated */
-  releasePublishers?: string[];
   /** @example { AllDownloadEntities: ['CBDSTEST'] } */
   channelDownloadEntityDetails?: Record<string, string[]>;
 }
 
 export interface FileLocation {
   type: FileLocationType;
-  // these are not marked with NullValueHandling annotations, but aren't always provided in reality (not sure about blobUrl)
-  /** blob URL for type AzureBlob */
-  blobUrl?: string;
+  /** blob SAS URL */
+  blobUrl: string;
   /** URI */
   uncPath?: string;
   /** URI */
@@ -75,17 +73,20 @@ export interface FileDownloadDetails {
 }
 
 export interface ReleaseFileInfo {
+  /** Arbitrary file name */
   name: string;
-  /** sha256 hash of file (array of bytes or a string) */
-  hash: number[] | string;
+  /** sha256 hash of file as a base64 string */
+  hash: string;
+  /** file blob location */
   sourceLocation: FileLocation;
-  sizeInBytes?: number;
-  hashType?: FileHashType;
+  sizeInBytes: number;
+  hashType: FileHashType;
   fileId?: unknown;
   distributionRelativePath?: string;
   partNumber?: string;
   friendlyFileName?: string;
-  tenantFileLocationType: 'AzureBlob' | '1';
+  tenantFileLocationType: 'AzureBlob';
+  /** blob SAS URL for updated file */
   tenantFileLocation: string;
   signedEngineeringCopyLocation?: string;
   encryptedDistributionBlobLocation?: string;
@@ -100,35 +101,38 @@ export interface ReleaseFileInfo {
 }
 
 export interface ReleaseInfo {
-  title?: string;
-  minimumNumberOfApprovers?: number;
-  /**
-   * @example { ReleaseContentType: 'sw electronic' }
-   * @example { ReleaseContentType: 'InstallPackage' }
-   * @example { ReleaseContentType: 'npm', IsRsm: 'false' }
-   */
-  properties?: Record<string, string>;
+  title: string;
+  minimumNumberOfApprovers: number;
+  properties:
+    | {
+        /** may be case-insensitive; other values may exist */
+        ReleaseContentType: 'sw electronic' | 'InstallPackage' | 'npm';
+        IsRsm: 'false';
+      }
+    | Record<string, string>;
   isRevision?: boolean;
   revisionNumber?: string;
 }
 
 export interface ProductInfo {
   /** Name of the product */
-  name?: string;
+  name: string;
   /** Version of the product (for npm, this is arbitrary, not the package version) */
-  version?: string;
+  version: string;
   /** Description of the product */
-  description?: string;
+  description: string;
 }
 
 export interface RoutingInfo {
   /**
    * intent per onboarding
+   * - `'packagedistribution'` or `'PackageDistribution'` for publishing to npm or other package manager
    * - `'Product Release'` for compliance or download center
-   * - `'filedownloadlinkgeneration'` for static link release
-   * - `'packagedistribution'` for npm release
+   * - `'filedownloadlinkgeneration'` or `'FileLinkGeneration'` for static link release
+   * - `'Winget'` for publishing to Windows Package Manager
    */
-  intent?: string;
+  intent: string;
+  /** `'npm'` for npm */
   contentType?: string;
   contentOrigin?: string;
   /** for npm releases, this is the dist-tag */
@@ -163,23 +167,40 @@ export interface DownloadCenterInfo {
 }
 
 export interface ReleaseRequestMessage {
-  /** email of the DRI for the team creating this release */
+  /**
+   * email(s) of the DRI for the team creating this release, possibly used if a release request fails
+   * (supports DL/SG)
+   */
   driEmail?: string[];
   groupId?: string;
+  /** your unique correlation ID for this release request */
   customerCorrelationId?: string;
+  /** same as `customerCorrelationId` */
   esrpCorrelationId?: string;
   contextData?: Record<string, string>;
-  releaseInfo?: ReleaseInfo;
-  productInfo?: ProductInfo;
+  /** release title, content type, etc */
+  releaseInfo: ReleaseInfo;
+  /** product name, version, description */
+  productInfo: ProductInfo;
+  /** files to release */
   files?: ReleaseFileInfo[];
-  routingInfo?: RoutingInfo;
-  createdBy?: UserInfo;
-  owners?: OwnerInfo[];
-  approvers?: ApproverInfo[];
+  /** info about how to handle the release */
+  routingInfo: RoutingInfo;
+  /** created by user (DL/SG not supported) */
+  createdBy: UserInfo;
+  /** individual owners (DL/SG not supported) */
+  owners: OwnerInfo[];
+  /** individual approvers (DL/SG not supported; all are non-mandatory and auto-approved) */
+  approvers: ApproverInfo[];
+  /** publisher and channel info */
   accessPermissionsInfo?: AccessPermissionsInfo;
-  jwsToken?: string;
   publisherId?: string;
   downloadCenterInfo?: DownloadCenterInfo;
+  /**
+   * JSON Web Signature token for the release request (must generate before sending).
+   * This is created with the request signing certificate from initial options.
+   */
+  jwsToken?: string;
 }
 
 export interface ReleaseSubmitResponse {

--- a/packages/esrp-npm-release/src/utils/errorHelpers.ts
+++ b/packages/esrp-npm-release/src/utils/errorHelpers.ts
@@ -17,8 +17,9 @@ export function isRetryableAzureError(error: unknown): boolean {
 
   return (
     error instanceof RestError &&
-    // Note: PARSE_ERROR is considered non-retryable because it means the request was received,
-    // but something went wrong parsing the response, so the state is indeterminate.
+    // Note: PARSE_ERROR is considered non-retryable (unless the accompanying status is transient)
+    // because it means the request was received, but something went wrong parsing the response, so
+    // the state is indeterminate.
     (error.code === RestError.REQUEST_SEND_ERROR || isTransientHttpStatus(error.statusCode))
   );
 }

--- a/packages/esrp-npm-release/src/utils/errorHelpers.ts
+++ b/packages/esrp-npm-release/src/utils/errorHelpers.ts
@@ -17,9 +17,9 @@ export function isRetryableAzureError(error: unknown): boolean {
 
   return (
     error instanceof RestError &&
-    (error.code === RestError.REQUEST_SEND_ERROR ||
-      error.code === RestError.PARSE_ERROR ||
-      isTransientHttpStatus(error.statusCode))
+    // Note: PARSE_ERROR is considered non-retryable because it means the request was received,
+    // but something went wrong parsing the response, so the state is indeterminate.
+    (error.code === RestError.REQUEST_SEND_ERROR || isTransientHttpStatus(error.statusCode))
   );
 }
 

--- a/packages/esrp-npm-release/src/utils/getEnvOptions.ts
+++ b/packages/esrp-npm-release/src/utils/getEnvOptions.ts
@@ -23,8 +23,9 @@ export function getEnvOptions(env: NodeJS.ProcessEnv = process.env): EnvOptions 
     return '';
   }
 
-  // ESRP_USER serves as a fallback default for the contact email fields below
-  const defaultUser = getEnv('ESRP_USER', { isOptional: true });
+  // ESRP_USER contains individual users and serves as a fallback for the contact email fields below
+  const defaultUsers = getEnv('ESRP_USER', { isOptional: true });
+  const defaultCreatedBy = defaultUsers && splitString(defaultUsers)[0];
 
   const result: EnvOptions = {
     packedPackagesPath: getEnv('PACKED_PACKAGES_PATH'),
@@ -32,10 +33,10 @@ export function getEnvOptions(env: NodeJS.ProcessEnv = process.env): EnvOptions 
       productName: getEnv('ESRP_PRODUCT_NAME'),
       // skip if unspecified so ESRP will read publishConfig
       npmTag: getEnv('ESRP_NPM_TAG', { isOptional: true }),
-      createdBy: getEnv('ESRP_CREATED_BY', { defaultValue: defaultUser }),
-      driEmail: [getEnv('ESRP_DRI_EMAIL', { defaultValue: defaultUser })],
-      owners: splitString(getEnv('ESRP_OWNERS', { defaultValue: defaultUser })),
-      approvers: splitString(getEnv('ESRP_APPROVERS', { defaultValue: defaultUser })),
+      createdBy: getEnv('ESRP_CREATED_BY', { defaultValue: defaultCreatedBy }),
+      driEmail: splitString(getEnv('ESRP_DRI_EMAIL', { defaultValue: defaultUsers })),
+      owners: splitString(getEnv('ESRP_OWNERS', { defaultValue: defaultUsers })),
+      approvers: splitString(getEnv('ESRP_APPROVERS', { defaultValue: defaultUsers })),
       tenantId: getEnv('ESRP_TENANT_ID'),
       clientId: getEnv('ESRP_CLIENT_ID'),
       authCertificatePfx: getEnv('ESRP_AUTH_CERT', { isOptional: true }),


### PR DESCRIPTION
- Update `ESRP_USER` to accept multiple user emails, and clarify where DLs are and are not allowed
- Clarify internal types about what API properties appear to be required or optional
- Retry a transient release submit failure up to 3 times
- Reclassify an azure storage response parse error as non-retryable